### PR TITLE
Fix handoff function names

### DIFF
--- a/dotnet/src/Microsoft.Agents.Orchestration/Handoff/HandoffActor.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/Handoff/HandoffActor.cs
@@ -189,6 +189,6 @@ internal sealed partial class HandoffActor : AgentActor
     private static partial Regex InvalidNameCharsRegex();
 #else
     private static Regex InvalidNameCharsRegex() => s_invalidNameCharsRegex;
-    private static readonly Regex s_invalidNameCharsRegex = new("[^0-9A-Za-z_]", RegexOptions.Compiled);
+    private static readonly Regex s_invalidNameCharsRegex = new("[^0-9A-Za-z_]+", RegexOptions.Compiled);
 #endif
 }


### PR DESCRIPTION
Handoffs are including the agent name in the function name. But the agent name can include characters that are invalid for a function name, which results in errors. Replace them.