### PR TITLE
Round 3 of cleanup

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -9,7 +9,8 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <NoWarn>$(NoWarn);IDE0290;IDE0079</NoWarn>
+    <NoWarn>$(NoWarn);IDE0290;IDE0079;NU5128</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ProjectsTargetFrameworks>net9.0;net8.0;netstandard2.0;net472</ProjectsTargetFrameworks>
     <ProjectsDebugTargetFrameworks>net9.0;net472</ProjectsDebugTargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>

--- a/dotnet/samples/GettingStarted/External/MEAI.OpenAI/NewOpenAIAssistantChatClient.cs
+++ b/dotnet/samples/GettingStarted/External/MEAI.OpenAI/NewOpenAIAssistantChatClient.cs
@@ -609,7 +609,7 @@ internal static class OpenAIClientExtensions2
 
         // Roundtrip the schema through the ToolJson model type to remove extra properties
         // and force missing ones into existence, then return the serialized UTF8 bytes as BinaryData.
-        var tool = JsonSerializer.Deserialize(jsonSchema, OpenAIJsonContext.Default.ToolJson)!;
+        var tool = jsonSchema.Deserialize(OpenAIJsonContext.Default.ToolJson)!;
         var functionParameters = BinaryData.FromBytes(JsonSerializer.SerializeToUtf8Bytes(tool, OpenAIJsonContext.Default.ToolJson));
 
         return functionParameters;

--- a/dotnet/samples/GettingStarted/Orchestration/GroupChatOrchestration_With_AIManager.cs
+++ b/dotnet/samples/GettingStarted/Orchestration/GroupChatOrchestration_With_AIManager.cs
@@ -167,19 +167,19 @@ public class GroupChatOrchestration_With_AIManager(ITestOutputHelper output) : O
         }
 
         /// <inheritdoc/>
-        public override ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default) =>
+        protected override ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default) =>
             this.GetResponseAsync<string>(history, Prompts.Filter(topic), cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default) =>
+        protected override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default) =>
             this.GetResponseAsync<string>(history, Prompts.Selection(topic, team.FormatList()), cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default) =>
+        protected override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default) =>
             new(new GroupChatManagerResult<bool>(false) { Reason = "The AI group chat manager does not request user input." });
 
         /// <inheritdoc/>
-        public override async ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
+        protected override async ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
         {
             GroupChatManagerResult<bool> result = await base.ShouldTerminate(history, cancellationToken);
             if (!result.Value)

--- a/dotnet/samples/GettingStarted/Orchestration/GroupChatOrchestration_With_HumanInTheLoop.cs
+++ b/dotnet/samples/GettingStarted/Orchestration/GroupChatOrchestration_With_HumanInTheLoop.cs
@@ -84,7 +84,7 @@ public class GroupChatOrchestration_With_HumanInTheLoop(ITestOutputHelper output
     /// </remarks>
     private sealed class CustomRoundRobinGroupChatManager : RoundRobinGroupChatManager
     {
-        public override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
+        protected override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
         {
             string? lastAgent = history.LastOrDefault()?.AuthorName;
 

--- a/dotnet/src/LegacySupport/IsExternalInit/IsExternalInit.cs
+++ b/dotnet/src/LegacySupport/IsExternalInit/IsExternalInit.cs
@@ -4,6 +4,4 @@
 
 namespace System.Runtime.CompilerServices;
 
-internal static class IsExternalInit
-{
-}
+internal static class IsExternalInit;

--- a/dotnet/src/Microsoft.Agents.Orchestration/Concurrent/ConcurrentOrchestration.String.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/Concurrent/ConcurrentOrchestration.String.cs
@@ -20,7 +20,7 @@ public sealed class ConcurrentOrchestration : ConcurrentOrchestration<string, st
         : base(members)
     {
         this.ResultTransform =
-            (response, cancellationToken) =>
+            (response, _, cancellationToken) =>
             {
                 string[] result = [.. response.Select(r => r.Text)];
                 return new ValueTask<string[]>(result);

--- a/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/GroupChatManager.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/GroupChatManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,7 +51,7 @@ public abstract class GroupChatManager
     /// <summary>
     /// Gets or sets the callback to be invoked for interactive input.
     /// </summary>
-    public OrchestrationInteractiveCallback? InteractiveCallback { get; init; }
+    public Func<ValueTask<ChatMessage>>? InteractiveCallback { get; init; }
 
     /// <summary>
     /// Filters the results of the group chat based on the provided chat history.
@@ -58,7 +59,7 @@ public abstract class GroupChatManager
     /// <param name="history">The chat history to filter.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="GroupChatManagerResult{TValue}"/> containing the filtered result as a string.</returns>
-    public abstract ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default);
+    protected internal abstract ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Selects the next agent to participate in the group chat based on the provided chat history and team.
@@ -67,7 +68,7 @@ public abstract class GroupChatManager
     /// <param name="team">The group of agents participating in the chat.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="GroupChatManagerResult{TValue}"/> containing the identifier of the next agent as a string.</returns>
-    public abstract ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default);
+    protected internal abstract ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determines whether user input should be requested based on the provided chat history.
@@ -75,7 +76,7 @@ public abstract class GroupChatManager
     /// <param name="history">The chat history to consider.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="GroupChatManagerResult{TValue}"/> indicating whether user input should be requested.</returns>
-    public abstract ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default);
+    protected internal abstract ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determines whether the group chat should be terminated based on the provided chat history and invocation count.
@@ -83,7 +84,7 @@ public abstract class GroupChatManager
     /// <param name="history">The chat history to consider.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A <see cref="GroupChatManagerResult{TValue}"/> indicating whether the chat should be terminated.</returns>
-    public virtual ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
+    protected internal virtual ValueTask<GroupChatManagerResult<bool>> ShouldTerminate(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref this._invocationCount);
 

--- a/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/GroupChatOrchestration.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/GroupChatOrchestration.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
@@ -39,8 +38,9 @@ public class GroupChatOrchestration<TInput, TOutput> :
     {
         if (!entryAgent.HasValue)
         {
-            throw new ArgumentException("Entry agent is not defined.", nameof(entryAgent));
+            Throw.ArgumentException(nameof(entryAgent), "Entry agent is not defined.");
         }
+
         return runtime.PublishMessageAsync(new GroupChatMessages.InputTask(input), entryAgent.Value);
     }
 

--- a/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/RoundRobinGroupChatManager.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/GroupChat/RoundRobinGroupChatManager.cs
@@ -19,14 +19,14 @@ public class RoundRobinGroupChatManager : GroupChatManager
     private int _currentAgentIndex;
 
     /// <inheritdoc/>
-    public override ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
+    protected internal override ValueTask<GroupChatManagerResult<string>> FilterResults(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
     {
         GroupChatManagerResult<string> result = new(history.LastOrDefault()?.Text ?? string.Empty) { Reason = "Default result filter provides the final chat message." };
         return new ValueTask<GroupChatManagerResult<string>>(result);
     }
 
     /// <inheritdoc/>
-    public override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default)
+    protected internal override ValueTask<GroupChatManagerResult<string>> SelectNextAgent(IReadOnlyCollection<ChatMessage> history, GroupChatTeam team, CancellationToken cancellationToken = default)
     {
         string nextAgent = team.Skip(this._currentAgentIndex).First().Key;
         this._currentAgentIndex = (this._currentAgentIndex + 1) % team.Count;
@@ -35,7 +35,7 @@ public class RoundRobinGroupChatManager : GroupChatManager
     }
 
     /// <inheritdoc/>
-    public override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
+    protected internal override ValueTask<GroupChatManagerResult<bool>> ShouldRequestUserInput(IReadOnlyCollection<ChatMessage> history, CancellationToken cancellationToken = default)
     {
         GroupChatManagerResult<bool> result = new(false) { Reason = "The default round-robin group chat manager does not request user input." };
         return new ValueTask<GroupChatManagerResult<bool>>(result);

--- a/dotnet/src/Microsoft.Agents.Orchestration/Handoff/Handoffs.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/Handoff/Handoffs.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.AI.Agents;
 using Microsoft.Extensions.AI.Agents.Runtime;
@@ -82,7 +81,7 @@ public sealed class OrchestrationHandoffs : Dictionary<string, AgentHandoffs>
         {
             if (string.IsNullOrWhiteSpace(target.Description) && string.IsNullOrWhiteSpace(target.Name))
             {
-                throw new InvalidOperationException($"The provided target agent with Id '{target.Id}' has no description or name, and no handoff description has been provided. At least one of these are required to register a handoff so that the appropriate target agent can be chosen.");
+                Throw.InvalidOperationException($"The provided target agent with Id '{target.Id}' has no description or name, and no handoff description has been provided. At least one of these are required to register a handoff so that the appropriate target agent can be chosen.");
             }
 
             this.Agents.Add(target);

--- a/dotnet/src/Microsoft.Agents.Orchestration/Microsoft.Agents.Orchestration.csproj
+++ b/dotnet/src/Microsoft.Agents.Orchestration/Microsoft.Agents.Orchestration.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(ProjectsDebugTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Agents.Orchestration</RootNamespace>
     <VersionSuffix>alpha</VersionSuffix>
-    <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet/src/Microsoft.Agents.Orchestration/Transforms/StructuredOutputTransform.cs
+++ b/dotnet/src/Microsoft.Agents.Orchestration/Transforms/StructuredOutputTransform.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Agents;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.Orchestration;
@@ -42,17 +44,23 @@ public sealed class StructuredOutputTransform<TOutput>
     /// Transforms the provided <see cref="ChatMessage"/> into a strongly-typed structured output by invoking the chat completion service and deserializing the response.
     /// </summary>
     /// <param name="messages">The chat messages to process.</param>
+    /// <param name="serializerOptions">The JSON serializer options to use when performing any JSON serialization.</param>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>The structured output of type <typeparamref name="TOutput"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the response cannot be deserialized into <typeparamref name="TOutput"/>.</exception>
-    public async ValueTask<TOutput> TransformAsync(IList<ChatMessage> messages, CancellationToken cancellationToken = default)
+    public async ValueTask<TOutput> TransformAsync(IList<ChatMessage> messages, JsonSerializerOptions? serializerOptions = null, CancellationToken cancellationToken = default)
     {
-        IEnumerable<ChatMessage> input =
+        Throw.IfNull(messages);
+
+        ChatResponse<TOutput> response = await this._client.GetResponseAsync<TOutput>(
             [
                 new ChatMessage(ChatRole.System, this.Instructions),
                 .. messages,
-            ];
-        ChatResponse<TOutput> response = await this._client.GetResponseAsync<TOutput>(input, this._options, useJsonSchemaResponseFormat: true, cancellationToken).ConfigureAwait(false);
+            ],
+            serializerOptions ?? AgentAbstractionsJsonUtilities.DefaultOptions,
+            this._options,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
         return response.Result;
     }
 }

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AIAgent.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AIAgent.cs
@@ -207,7 +207,9 @@ public abstract class AIAgent
         Func<TThreadType> constructThread)
         where TThreadType : AgentThread
     {
-        thread ??= constructThread is not null ? constructThread() : throw new ArgumentNullException(nameof(constructThread));
+        Throw.IfNull(constructThread);
+
+        thread ??= constructThread();
 
         if (thread is not TThreadType concreteThreadType)
         {

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentAbstractionsJsonUtilities.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentAbstractionsJsonUtilities.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Extensions.AI.Agents;
+
+/// <summary>Provides a collection of utility methods for working with JSON data in the context of agents.</summary>
+public static partial class AgentAbstractionsJsonUtilities
+{
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> singleton used as the default in JSON serialization operations.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For Native AOT or applications disabling <see cref="JsonSerializer.IsReflectionEnabledByDefault"/>, this instance
+    /// includes source generated contracts for all common exchange types contained in this library.
+    /// </para>
+    /// <para>
+    /// It additionally turns on the following settings:
+    /// <list type="number">
+    /// <item>Enables <see cref="JsonSerializerDefaults.Web"/> defaults.</item>
+    /// <item>Enables <see cref="JsonIgnoreCondition.WhenWritingNull"/> as the default ignore condition for properties.</item>
+    /// <item>Enables <see cref="JsonNumberHandling.AllowReadingFromString"/> as the default number handling for number types.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static JsonSerializerOptions DefaultOptions { get; } = CreateDefaultOptions();
+
+    /// <summary>
+    /// Creates default options to use for agents-related serialization.
+    /// </summary>
+    /// <returns>The configured options.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050:RequiresDynamicCode", Justification = "Converter is guarded by IsReflectionEnabledByDefault check.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access", Justification = "Converter is guarded by IsReflectionEnabledByDefault check.")]
+    private static JsonSerializerOptions CreateDefaultOptions()
+    {
+        // Copy the configuration from the source generated context.
+        JsonSerializerOptions options = new(JsonContext.Default.Options);
+
+        // Chain with all supported types from MEAI.
+        options.TypeInfoResolverChain.Add(AIJsonUtilities.DefaultOptions.TypeInfoResolver!);
+
+        options.MakeReadOnly();
+        return options;
+    }
+
+    // Keep in sync with CreateDefaultOptions above.
+    [JsonSourceGenerationOptions(JsonSerializerDefaults.Web,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString)]
+
+    // Agent abstraction types
+    [JsonSerializable(typeof(AgentRunOptions))]
+    [JsonSerializable(typeof(AgentRunResponse))]
+    [JsonSerializable(typeof(AgentRunResponseUpdate))]
+    [JsonSerializable(typeof(AgentThread))]
+
+    [ExcludeFromCodeCoverage]
+    internal sealed partial class JsonContext : JsonSerializerContext;
+}

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/Microsoft.Extensions.AI.Agents.Abstractions.csproj
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/Microsoft.Extensions.AI.Agents.Abstractions.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup>
     <InjectSharedThrow>true</InjectSharedThrow>
+    <InjectTrimAttributesOnLegacy>true</InjectTrimAttributesOnLegacy>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.CopilotStudio/CopilotStudioAgent.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.CopilotStudio/CopilotStudioAgent.cs
@@ -53,12 +53,9 @@ public class CopilotStudioAgent : AIAgent
         Throw.IfNull(messages);
 
         // Ensure that we have a valid thread to work with.
+        // If the thread ID is null, we need to start a new conversation and set the thread ID accordingly.
         CopilotStudioAgentThread copilotStudioAgentThread = base.ValidateOrCreateThreadType(thread, () => new CopilotStudioAgentThread());
-        if (copilotStudioAgentThread.Id is null)
-        {
-            // If the thread ID is null, we need to start a new conversation and set the thread ID accordingly.
-            copilotStudioAgentThread.Id = await this.StartNewConversationAsync(cancellationToken).ConfigureAwait(false);
-        }
+        copilotStudioAgentThread.Id ??= await this.StartNewConversationAsync(cancellationToken).ConfigureAwait(false);
 
         // Invoke the Copilot Studio agent with the provided messages.
         string question = string.Join("\n", messages.Select(m => m.Text));
@@ -89,12 +86,9 @@ public class CopilotStudioAgent : AIAgent
         Throw.IfNull(messages);
 
         // Ensure that we have a valid thread to work with.
+        // If the thread ID is null, we need to start a new conversation and set the thread ID accordingly.
         CopilotStudioAgentThread copilotStudioAgentThread = base.ValidateOrCreateThreadType(thread, () => new CopilotStudioAgentThread());
-        if (copilotStudioAgentThread.Id is null)
-        {
-            // If the thread ID is null, we need to start a new conversation and set the thread ID accordingly.
-            copilotStudioAgentThread.Id = await this.StartNewConversationAsync(cancellationToken).ConfigureAwait(false);
-        }
+        copilotStudioAgentThread.Id ??= await this.StartNewConversationAsync(cancellationToken).ConfigureAwait(false);
 
         // Invoke the Copilot Studio agent with the provided messages.
         string question = string.Join("\n", messages.Select(m => m.Text));

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.CopilotStudio/CopilotStudioAgentThread.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.CopilotStudio/CopilotStudioAgentThread.cs
@@ -5,6 +5,4 @@ namespace Microsoft.Extensions.AI.Agents.CopilotStudio;
 /// <summary>
 /// Represents a thread for interacting with a Copilot Studio agent.
 /// </summary>
-public class CopilotStudioAgentThread : AgentThread
-{
-}
+public class CopilotStudioAgentThread : AgentThread;

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/IdProxyActor.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/IdProxyActor.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Agents.Runtime;
 
@@ -21,6 +22,8 @@ public sealed class IdProxyActor : IRuntimeActor
     /// </summary>
     public IdProxyActor(IAgentRuntime runtime, ActorId actorId)
     {
+        Throw.IfNull(runtime);
+
         this.Id = actorId;
         this._runtime = runtime;
     }

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/InProcessRuntime.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/InProcessRuntime.cs
@@ -73,6 +73,8 @@ public sealed partial class InProcessRuntime : IAgentRuntime, IAsyncDisposable
     /// <inheritdoc/>
     public ValueTask PublishMessageAsync(object message, TopicId topic, ActorId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(message);
+
         MessageToProcess m = new(this, message, messageId, sender, topic, cancellationToken);
 
         this.IncrementRemainingWork();
@@ -84,6 +86,8 @@ public sealed partial class InProcessRuntime : IAgentRuntime, IAsyncDisposable
     /// <inheritdoc/>
     public ValueTask<object?> SendMessageAsync(object message, ActorId recipient, ActorId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(message);
+
         MessageToProcess m = new(this, message, messageId, sender, recipient, cancellationToken);
 
         this.IncrementRemainingWork();
@@ -140,6 +144,7 @@ public sealed partial class InProcessRuntime : IAgentRuntime, IAsyncDisposable
     /// <inheritdoc/>
     public ValueTask AddSubscriptionAsync(ISubscriptionDefinition subscription, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(subscription);
         ThrowIfInvalid(this._subscriptions.ContainsKey(subscription.Id), "Subscription with the specified ID already exists.");
 
         this._subscriptions.Add(subscription.Id, subscription);
@@ -150,6 +155,7 @@ public sealed partial class InProcessRuntime : IAgentRuntime, IAsyncDisposable
     /// <inheritdoc/>
     public ValueTask RemoveSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(subscriptionId);
         ThrowIfInvalid(!this._subscriptions.ContainsKey(subscriptionId), "Subscription with the specified ID does not exist.");
 
         this._subscriptions.Remove(subscriptionId);
@@ -187,6 +193,7 @@ public sealed partial class InProcessRuntime : IAgentRuntime, IAsyncDisposable
     /// <inheritdoc/>
     public async ValueTask<ActorType> RegisterActorFactoryAsync(ActorType type, Func<ActorId, IAgentRuntime, ValueTask<IRuntimeActor>> factoryFunc, CancellationToken cancellationToken = default)
     {
+        Throw.IfNull(factoryFunc);
         ThrowIfInvalid(this._actorFactories.ContainsKey(type), "Actor type already registered.");
 
         this._actorFactories.Add(type, factoryFunc);

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/MessageContext.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/MessageContext.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Text.Json;
 using System.Threading;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Agents.Runtime;
 
@@ -21,15 +23,7 @@ public sealed class MessageContext
     public string MessageId
     {
         get => this._messageId ?? Interlocked.CompareExchange(ref this._messageId, Guid.NewGuid().ToString(), null) ?? this._messageId;
-        set
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException("MessageId cannot be null or empty.", nameof(value));
-            }
-
-            this._messageId = value;
-        }
+        set => this._messageId = Throw.IfNullOrEmpty(value);
     }
 
     /// <summary>
@@ -48,4 +42,7 @@ public sealed class MessageContext
     /// Gets or sets a value indicating whether this message is part of an RPC (Remote Procedure Call).
     /// </summary>
     public bool IsRpc { get; set; }
+
+    /// <summary>Gets or sets the serializer options to be used when performing JSON serialization associated with this message.</summary>
+    public JsonSerializerOptions? SerializerOptions { get; set; }
 }

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/RuntimeActor.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/RuntimeActor.cs
@@ -57,6 +57,8 @@ public abstract class RuntimeActor : IRuntimeActor
         string? description = null,
         ILogger? logger = null)
     {
+        Throw.IfNull(runtime);
+
         this.Id = id;
         this._runtime = runtime;
         this.Logger = logger ?? NullLogger.Instance;

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/TopicId.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/TopicId.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Agents.Runtime;
 
@@ -32,14 +33,11 @@ public readonly partial struct TopicId : IEquatable<TopicId>
     /// <param name="source">The source of the event.</param>
     public TopicId(string type, string? source = null)
     {
-        if (type is null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        Throw.IfNull(type);
 
         if (!TypeRegex().IsMatch(type))
         {
-            throw new ArgumentException("Invalid type format.", nameof(type));
+            Throw.ArgumentException(nameof(type), "Invalid type format.");
         }
 
         // TODO: What validation should be performed on source? The cited cloudevents spec suggests it should be a URI reference.

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/TypeSubscription.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Abstractions/TypeSubscription.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI.Agents.Runtime;
 
@@ -28,6 +29,8 @@ public sealed class TypeSubscription : ISubscriptionDefinition
     /// <param name="id">Unique identifier for the subscription. If not provided, a new UUID will be generated.</param>
     public TypeSubscription(string topicType, ActorType actorType, string? id = null)
     {
+        Throw.IfNullOrEmpty(topicType);
+
         this.TopicType = topicType;
         this.ActorType = actorType;
         this.Id = id ?? Guid.NewGuid().ToString();
@@ -53,10 +56,7 @@ public sealed class TypeSubscription : ISubscriptionDefinition
     /// </summary>
     /// <param name="topic">The topic to check.</param>
     /// <returns><c>true</c> if the topic's type matches exactly, <c>false</c> otherwise.</returns>
-    public bool Matches(TopicId topic)
-    {
-        return topic.Type == this.TopicType;
-    }
+    public bool Matches(TopicId topic) => topic.Type == this.TopicType;
 
     /// <summary>
     /// Maps a <see cref="TopicId"/> to an <see cref="ActorId"/>. Should only be called if <see cref="Matches"/> returns true.
@@ -79,14 +79,9 @@ public sealed class TypeSubscription : ISubscriptionDefinition
     /// </summary>
     /// <param name="obj">The object to compare with the current instance.</param>
     /// <returns><c>true</c> if the specified object is equal to this instance; otherwise, <c>false</c>.</returns>
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return
-            obj is TypeSubscription other &&
-                (this.Id == other.Id ||
-                    (this.ActorType == other.ActorType &&
-                        this.TopicType == other.TopicType));
-    }
+    public override bool Equals([NotNullWhen(true)] object? obj) =>
+        obj is TypeSubscription other &&
+        (this.Id == other.Id || (this.ActorType == other.ActorType && this.TopicType == other.TopicType));
 
     /// <summary>
     /// Determines whether the specified subscription is equal to the current subscription.
@@ -99,8 +94,5 @@ public sealed class TypeSubscription : ISubscriptionDefinition
     /// Returns a hash code for this instance.
     /// </summary>
     /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures.</returns>
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(this.Id, this.ActorType, this.TopicType);
-    }
+    public override int GetHashCode() => HashCode.Combine(this.Id, this.ActorType, this.TopicType);
 }

--- a/dotnet/src/Microsoft.Extensions.AI.Agents/ChatCompletion/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents/ChatCompletion/ChatClientAgent.cs
@@ -360,12 +360,9 @@ public sealed class ChatClientAgent : AIAgent
     private void UpdateThreadWithTypeAndConversationId(ChatClientAgentThread chatClientThread, string? responseConversationId)
     {
         // Set the thread's storage location, the first time that we use it.
-        if (chatClientThread.StorageLocation is null)
-        {
-            chatClientThread.StorageLocation = string.IsNullOrWhiteSpace(responseConversationId)
-                ? ChatClientAgentThreadType.InMemoryMessages
-                : ChatClientAgentThreadType.ConversationId;
-        }
+        chatClientThread.StorageLocation ??= string.IsNullOrWhiteSpace(responseConversationId)
+            ? ChatClientAgentThreadType.InMemoryMessages
+            : ChatClientAgentThreadType.ConversationId;
 
         // If we got a conversation id back from the chat client, it means that the service supports server side thread storage
         // so we should capture the id and update the thread with the new id.

--- a/dotnet/tests/Microsoft.Agents.Orchestration.UnitTests/DefaultTransformsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.Orchestration.UnitTests/DefaultTransformsTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Agents;
 
 namespace Microsoft.Agents.Orchestration.UnitTest;
 
@@ -72,7 +73,7 @@ public class DefaultTransformsTests
         ChatMessage message = result.First();
         Assert.Equal(ChatRole.User, message.Role);
 
-        string expectedJson = JsonSerializer.Serialize(input);
+        string expectedJson = JsonSerializer.Serialize(input, AgentAbstractionsJsonUtilities.DefaultOptions);
         Assert.Equal(expectedJson, message.Text);
     }
 

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunOptionsTests.cs
@@ -13,9 +13,7 @@ public class AgentRunOptionsTests
     public void CloningConstructorCopiesProperties()
     {
         // Arrange
-        var options = new AgentRunOptions
-        {
-        };
+        var options = new AgentRunOptions();
 
         // Act
         var clone = new AgentRunOptions(options);

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseUpdateExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseUpdateExtensionsTests.cs
@@ -145,7 +145,7 @@ public class AgentRunResponseUpdateExtensionsTests
     public async Task ToAgentRunResponseCoalescesTextContentAndTextReasoningContentSeparatelyAsync(bool useAsync)
     {
         AgentRunResponseUpdate[] updates =
-        {
+        [
             new(null, "A"),
             new(null, "B"),
             new(null, "C"),
@@ -162,7 +162,7 @@ public class AgentRunResponseUpdateExtensionsTests
             new(null, "N"),
             new() { Contents = [new TextReasoningContent("O")] },
             new() { Contents = [new TextReasoningContent("P")] },
-        };
+        ];
 
         AgentRunResponse response = useAsync ? await YieldAsync(updates).ToAgentRunResponseAsync() : updates.ToAgentRunResponse();
         ChatMessage message = Assert.Single(response.Messages);
@@ -181,11 +181,11 @@ public class AgentRunResponseUpdateExtensionsTests
     public async Task ToAgentRunResponseUsesContentExtractedFromContentsAsync()
     {
         AgentRunResponseUpdate[] updates =
-        {
+        [
             new(null, "Hello, "),
             new(null, "world!"),
             new() { Contents = [new UsageContent(new() { TotalTokenCount = 42 })] },
-        };
+        ];
 
         AgentRunResponse response = await YieldAsync(updates).ToAgentRunResponseAsync();
 

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.Runtime.Abstractions.UnitTests/TestAgents.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.Runtime.Abstractions.UnitTests/TestAgents.cs
@@ -42,7 +42,7 @@ public sealed class MockAgent : TestAgent
 
     public override ValueTask LoadStateAsync(JsonElement state, CancellationToken cancellationToken = default)
     {
-        this.ReceivedMessages = JsonSerializer.Deserialize<List<object>>(state) ?? throw new InvalidOperationException("Failed to deserialize state");
+        this.ReceivedMessages = state.Deserialize<List<object>>() ?? throw new InvalidOperationException("Failed to deserialize state");
         return default;
     }
 }

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.UnitTests/ChatCompletion/ChatClientAgentRunOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.UnitTests/ChatCompletion/ChatClientAgentRunOptionsTests.cs
@@ -40,9 +40,7 @@ public class ChatClientAgentRunOptionsTests
     public void ConstructorCopiesPropertiesFromSourceAgentRunOptions()
     {
         // Arrange
-        var sourceRunOptions = new AgentRunOptions
-        {
-        };
+        var sourceRunOptions = new AgentRunOptions();
         var chatOptions = new ChatOptions { MaxOutputTokens = 200 };
 
         // Act
@@ -59,9 +57,7 @@ public class ChatClientAgentRunOptionsTests
     public void ConstructorWorksWithSourceButNullChatOptions()
     {
         // Arrange
-        var sourceRunOptions = new AgentRunOptions
-        {
-        };
+        var sourceRunOptions = new AgentRunOptions();
 
         // Act
         var runOptions = new ChatClientAgentRunOptions(sourceRunOptions, null);


### PR DESCRIPTION
- Enable warnings as errors
- Make the remaining src projects NativeAOT compatible
- Use Throw helpers

I was going to do more than this, but want to pivot to address https://github.com/microsoft/agent-framework/issues/184, so just putting up mainly infra related changes to enable warnings as errors and start to get errors if the orchestration layer stops being nativeaot friendly.