### PR TITLE
.NET Fix - Display thread type name in error message

### DIFF
--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/Agent.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/Agent.cs
@@ -203,7 +203,7 @@ public abstract class Agent
 
         if (thread is not TThreadType concreteThreadType)
         {
-            throw new NotSupportedException($"{this.GetType().Name} currently only supports agent threads of type {nameof(TThreadType)}.");
+            throw new NotSupportedException($"{this.GetType().Name} currently only supports agent threads of type {typeof(TThreadType).Name}.");
         }
 
         return concreteThreadType;


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Error message confusing

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Error message does not display thread type and instead displays the name of the generic parameter: 

`Microsoft.SemanticKernel.KernelException: OpenAIResponseAgent currently only supports agent threads of type TThreadType.`

(Customer reported an error using the erroneous error message.)

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
