### PR TITLE
.Net: Fix AgentRunResponse serialization

### DIFF
--- a/dotnet/samples/HelloHttpApi/HelloHttpApi.ApiService/ChatClientAgentActor.cs
+++ b/dotnet/samples/HelloHttpApi/HelloHttpApi.ApiService/ChatClientAgentActor.cs
@@ -99,7 +99,7 @@ internal sealed class ChatClientAgentActor(
 
             var serializedRunResponse = JsonSerializer.SerializeToElement(
                 updates.ToAgentRunResponse(),
-                AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(AgentRunResponseUpdate)));
+                AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(AgentRunResponse)));
             var writeResponse = await context.WriteAsync(
                 new(this._etag, [new UpdateRequestOperation(requestId, RequestStatus.Completed, serializedRunResponse)]), cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Just noticed this, probably a copy/paste error.