### PR TITLE
.NET: Change RawRepresentation for AgentRunResponse/Update to ChatResponse/Update instead of RawRepresentation from that.

### DIFF
--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentRunResponse.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentRunResponse.cs
@@ -54,7 +54,7 @@ public class AgentRunResponse
         this.AdditionalProperties = response.AdditionalProperties;
         this.CreatedAt = response.CreatedAt;
         this.Messages = response.Messages;
-        this.RawRepresentation = response.RawRepresentation;
+        this.RawRepresentation = response;
         this.ResponseId = response.ResponseId;
         this.Usage = response.Usage;
     }

--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentRunResponseUpdate.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Abstractions/AgentRunResponseUpdate.cs
@@ -70,7 +70,7 @@ public class AgentRunResponseUpdate
         this.Contents = chatResponseUpdate.Contents;
         this.CreatedAt = chatResponseUpdate.CreatedAt;
         this.MessageId = chatResponseUpdate.MessageId;
-        this.RawRepresentation = chatResponseUpdate.RawRepresentation;
+        this.RawRepresentation = chatResponseUpdate;
         this.ResponseId = chatResponseUpdate.ResponseId;
         this.Role = chatResponseUpdate.Role;
     }

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseTests.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseTests.cs
@@ -61,7 +61,7 @@ public class AgentRunResponseTests
         Assert.Equal(chatResponse.CreatedAt, response.CreatedAt);
         Assert.Same(chatResponse.Messages, response.Messages);
         Assert.Equal(chatResponse.ResponseId, response.ResponseId);
-        Assert.Same(chatResponse.RawRepresentation, response.RawRepresentation);
+        Assert.Same(chatResponse, response.RawRepresentation as ChatResponse);
         Assert.Same(chatResponse.Usage, response.Usage);
     }
 

--- a/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseUpdatesTests.cs
+++ b/dotnet/tests/Microsoft.Extensions.AI.Agents.Abstractions.UnitTests/AgentRunResponseUpdatesTests.cs
@@ -48,7 +48,7 @@ public class AgentRunResponseUpdateTests
         Assert.Same(chatResponseUpdate.Contents, response.Contents);
         Assert.Equal(chatResponseUpdate.CreatedAt, response.CreatedAt);
         Assert.Equal(chatResponseUpdate.MessageId, response.MessageId);
-        Assert.Same(chatResponseUpdate.RawRepresentation, response.RawRepresentation);
+        Assert.Same(chatResponseUpdate, response.RawRepresentation as ChatResponseUpdate);
         Assert.Equal(chatResponseUpdate.ResponseId, response.ResponseId);
         Assert.Equal(chatResponseUpdate.Role, response.Role);
     }


### PR DESCRIPTION
### Motivation and Context

ChatResponse/Update is the actual RawRepresentation for ChatClientAgent, instead of the RawRepresenation of ChatRespnose/Update.
Skipping this level means we lose some of the useful fields on ChatResponse, like FinishReason.

### Description

Update the mapping constructors for AgentRunResponse/Update to use ChatResponse/Update as it's RawRepresentation.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
