### PR TITLE
.NET: Fix ETag handling on read before write

### DIFF
--- a/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Storage.CosmosDB/CosmosActorStateStorage.cs
+++ b/dotnet/src/Microsoft.Extensions.AI.Agents.Runtime.Storage.CosmosDB/CosmosActorStateStorage.cs
@@ -230,8 +230,8 @@ public class CosmosActorStateStorage : IActorStateStorage
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            // No root document means no actor state exists
-            return Guid.NewGuid().ToString("N");
+            // No root document means no actor state exists - return initial ETag
+            return InitialEtag;
         }
     }
 }


### PR DESCRIPTION
This fixes a bug where reading state from a new (not saved before) actor would return a newly generated ETag, causing subsequent writes to fail since they were passing back the bogus ETag. The read-then-write workflow now works correctly for both existing and non-existent actors.