### PR TITLE
.NET: Expose wrapped Request/Response API

### DIFF
--- a/dotnet/src/Microsoft.Agents.Workflows/Executor.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Executor.cs
@@ -25,9 +25,15 @@ public abstract class Executor : IIdentified
     /// </summary>
     /// <param name="id">A optional unique identifier for the executor. If <c>null</c>, a type-tagged
     /// UUID will be generated.</param>
-    protected Executor(string? id = null)
+    protected Executor(string? id = null) : this(ExecutorOptions.Default, id)
+    {
+    }
+
+    private readonly ExecutorOptions _options;
+    internal Executor(ExecutorOptions options, string? id = null)
     {
         this.Id = id ?? $"{this.GetType().Name}/{Guid.NewGuid():N}";
+        this._options = options;
     }
 
     /// <summary>
@@ -96,7 +102,7 @@ public abstract class Executor : IIdentified
         }
 
         // If we had a real return type, raise it as a SendMessage; TODO: Should we have a way to disable this behaviour?
-        if (result.Result != null && ExecutorOptions.Default.AutoSendMessageHandlerResultObject)
+        if (result.Result != null && this._options.AutoSendMessageHandlerResultObject)
         {
             await context.SendMessageAsync(result.Result).ConfigureAwait(false);
         }

--- a/dotnet/src/Microsoft.Agents.Workflows/ExecutorIsh.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ExecutorIsh.cs
@@ -110,7 +110,7 @@ public sealed class ExecutorIsh :
     {
         Type.Unbound => throw new InvalidOperationException($"Executor with ID '{this.Id}' is unbound."),
         Type.Executor => () => this._executorValue!,
-        Type.InputPort => () => new RequestInputExecutor(this._inputPortValue!),
+        Type.InputPort => () => new RequestInfoExecutor(this._inputPortValue!),
         Type.Agent => () => new AIAgentHostExecutor(this._aiAgentValue!),
         _ => throw new InvalidOperationException($"Unknown ExecutorIsh type: {this.ExecutorType}")
     };

--- a/dotnet/src/Microsoft.Agents.Workflows/ExecutorOptions.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ExecutorOptions.cs
@@ -12,7 +12,7 @@ public sealed class ExecutorOptions
     /// </summary>
     public static ExecutorOptions Default { get; } = new();
 
-    private ExecutorOptions() { }
+    internal ExecutorOptions() { }
 
     /// <summary>
     /// If <see langword="true"/>, the result of a message handler that returns a value will be sent as a message to the workflow.

--- a/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunnerContext.cs
@@ -34,7 +34,7 @@ internal class InProcessRunnerContext<TExternalInput> : IRunnerContext
 
             this._executors[executorId] = executor = provider();
 
-            if (executor is RequestInputExecutor requestInputExecutor)
+            if (executor is RequestInfoExecutor requestInputExecutor)
             {
                 requestInputExecutor.AttachRequestSink(this);
             }


### PR DESCRIPTION
* Allows creation of ExternalRequest objects directly to control the requestId
* Allows receiving ExternalResponse objects rather than unwrapped Data
* Normalizing naming