### PR TITLE
Python: Add message id to OpenAI chat response update

### DIFF
--- a/python/packages/azure/tests/test_azure_chat_client.py
+++ b/python/packages/azure/tests/test_azure_chat_client.py
@@ -580,6 +580,8 @@ async def test_get_streaming(
         messages=chat_history,
     ):
         assert msg is not None
+        assert msg.message_id is not None
+        assert msg.response_id is not None
     mock_create.assert_awaited_once_with(
         model=azure_openai_unit_test_env["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         stream=True,
@@ -683,6 +685,8 @@ async def test_azure_openai_chat_client_streaming() -> None:
     async for chunk in response:
         assert chunk is not None
         assert isinstance(chunk, ChatResponseUpdate)
+        assert chunk.message_id is not None
+        assert chunk.response_id is not None
         for content in chunk.contents:
             if isinstance(content, TextContent) and content.text:
                 full_message += content.text

--- a/python/packages/main/agent_framework/openai/_chat_client.py
+++ b/python/packages/main/agent_framework/openai/_chat_client.py
@@ -208,6 +208,8 @@ class OpenAIChatClientBase(OpenAIHandler, ChatClientBase):
                 contents=[UsageContent(details=self._usage_details_from_openai(chunk.usage), raw_representation=chunk)],
                 ai_model_id=chunk.model,
                 additional_properties=chunk_metadata,
+                response_id=chunk.id,
+                message_id=chunk.id,
             )
         contents: list[AIContents] = []
         finish_reason: ChatFinishReason | None = None
@@ -227,6 +229,8 @@ class OpenAIChatClientBase(OpenAIHandler, ChatClientBase):
             additional_properties=chunk_metadata,
             finish_reason=finish_reason,
             raw_representation=chunk,
+            response_id=chunk.id,
+            message_id=chunk.id,
         )
 
     def _usage_details_from_openai(self, usage: CompletionUsage) -> UsageDetails:

--- a/python/packages/main/tests/openai/test_openai_chat_client.py
+++ b/python/packages/main/tests/openai/test_openai_chat_client.py
@@ -250,6 +250,8 @@ async def test_openai_chat_client_streaming() -> None:
     async for chunk in response:
         assert chunk is not None
         assert isinstance(chunk, ChatResponseUpdate)
+        assert chunk.message_id is not None
+        assert chunk.response_id is not None
         for content in chunk.contents:
             if isinstance(content, TextContent) and content.text:
                 full_message += content.text

--- a/python/packages/main/tests/openai/test_openai_chat_client_base.py
+++ b/python/packages/main/tests/openai/test_openai_chat_client_base.py
@@ -162,6 +162,8 @@ async def test_scmc_chat_options(
         messages=chat_history,
     ):
         assert isinstance(msg, ChatResponseUpdate)
+        assert msg.message_id is not None
+        assert msg.response_id is not None
     mock_create.assert_awaited_once_with(
         model=openai_unit_test_env["OPENAI_CHAT_MODEL_ID"],
         stream=True,


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
When using the OpenAI chat client in streaming mode, the message ID is not set in the `ChatResponseUpdate`. The `ChatResponseUpdate` object represents a chunk in the streaming response.

Because some services may return multiple messages per query, downstream components may rely on the message ID to assemble the fully formed messages from the streaming chunks. Not having the message IDs while using the OpenAI/AzureOpenAI chat client will introduce additional complexity for downstream components.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Ensure the OpenAI chat client includes the message ID and response ID in `ChatResponseUpdate`.
2. Tests.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
