### PR TITLE
Python: Removed list_messages method from thread

### DIFF
--- a/python/packages/main/agent_framework/_agents.py
+++ b/python/packages/main/agent_framework/_agents.py
@@ -632,7 +632,8 @@ class ChatClientAgent(AgentBase):
         messages: list[ChatMessage] = []
         if self.instructions:
             messages.append(ChatMessage(role=ChatRole.SYSTEM, text=self.instructions))
-        messages.extend(await thread.list_messages() or [])
+        if thread.message_store:
+            messages.extend(await thread.message_store.list_messages() or [])
         messages.extend(input_messages or [])
         return thread, messages
 

--- a/python/packages/main/agent_framework/_threads.py
+++ b/python/packages/main/agent_framework/_threads.py
@@ -138,10 +138,6 @@ class AgentThread(AFBaseModel):
 
         self._message_store = message_store
 
-    async def list_messages(self) -> list[ChatMessage] | None:
-        """Retrieves any messages stored in ChatMessageStore of the thread, otherwise returns an empty collection."""
-        return await self._message_store.list_messages() if self._message_store is not None else None
-
     async def serialize(self, **kwargs: Any) -> dict[str, Any]:
         """Serializes the current object's state.
 

--- a/python/packages/main/tests/main/test_agents.py
+++ b/python/packages/main/tests/main/test_agents.py
@@ -227,8 +227,9 @@ async def test_chat_client_agent_update_thread_messages(chat_client: ChatClient)
     assert result.text == "test response"
 
     assert thread.service_thread_id is None
+    assert thread.message_store is not None
 
-    chat_messages: list[ChatMessage] | None = await thread.list_messages()
+    chat_messages: list[ChatMessage] = await thread.message_store.list_messages()
 
     assert chat_messages is not None
     assert len(chat_messages) == 2

--- a/python/packages/main/tests/main/test_threads.py
+++ b/python/packages/main/tests/main/test_threads.py
@@ -122,7 +122,9 @@ class TestAgentThread:
         store = ChatMessageList(sample_messages)
         thread = AgentThread(message_store=store)
 
-        messages: list[ChatMessage] | None = await thread.list_messages()
+        assert thread.message_store is not None
+
+        messages: list[ChatMessage] = await thread.message_store.list_messages()
 
         assert messages is not None
         assert len(messages) == 3
@@ -134,9 +136,7 @@ class TestAgentThread:
         """Test get_messages when no message_store is set."""
         thread = AgentThread()
 
-        messages: list[ChatMessage] | None = await thread.list_messages()
-
-        assert messages is None
+        assert thread.message_store is None
 
     async def test_on_new_messages_with_service_thread_id(self, sample_message: ChatMessage) -> None:
         """Test _on_new_messages when service_thread_id is set (should do nothing)."""

--- a/python/samples/getting_started/agents/azure_chat_client/azure_chat_client_with_thread.py
+++ b/python/samples/getting_started/agents/azure_chat_client/azure_chat_client_with_thread.py
@@ -101,10 +101,9 @@ async def example_with_existing_thread_messages() -> None:
     print(f"Agent: {result1.text}")
 
     # The thread now contains the conversation history in memory
-    messages = await thread.list_messages()
-
-    message_count = len(messages or [])
-    print(f"Thread contains {message_count} messages")
+    if thread.message_store:
+        messages = await thread.message_store.list_messages()
+        print(f"Thread contains {len(messages or [])} messages")
 
     print("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -125,8 +124,7 @@ async def example_with_existing_thread_messages() -> None:
     print("\n--- Alternative: Creating a new thread from existing messages ---")
 
     # You can also create a new thread from existing messages
-    messages = await thread.list_messages()
-
+    messages = await thread.message_store.list_messages() if thread.message_store else []
     new_thread = AgentThread(message_store=ChatMessageList(messages))
 
     query3 = "How does the Paris weather compare to London?"

--- a/python/samples/getting_started/agents/azure_responses_client/azure_responses_client_with_thread.py
+++ b/python/samples/getting_started/agents/azure_responses_client/azure_responses_client_with_thread.py
@@ -67,21 +67,18 @@ async def example_with_thread_persistence_in_memory() -> None:
     print(f"User: {query1}")
     result1 = await agent.run(query1, thread=thread)
     print(f"Agent: {result1.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
 
     # Second conversation using the same thread - maintains context
     query2 = "How about London?"
     print(f"\nUser: {query2}")
     result2 = await agent.run(query2, thread=thread)
     print(f"Agent: {result2.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
 
     # Third conversation - agent should remember both previous cities
     query3 = "Which of the cities I asked about has better weather?"
     print(f"\nUser: {query3}")
     result3 = await agent.run(query3, thread=thread)
     print(f"Agent: {result3.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
     print("Note: The agent remembers context from previous messages in the same thread.\n")
 
 
@@ -111,7 +108,6 @@ async def example_with_existing_thread_id() -> None:
     # Enable Azure OpenAI conversation state by setting `store` parameter to True
     result1 = await agent.run(query1, thread=thread, store=True)
     print(f"Agent: {result1.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
 
     # The thread ID is set after the first response
     existing_thread_id = thread.service_thread_id
@@ -133,7 +129,6 @@ async def example_with_existing_thread_id() -> None:
         print(f"User: {query2}")
         result2 = await agent.run(query2, thread=thread, store=True)
         print(f"Agent: {result2.text}")
-        print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
         print("Note: The agent continues the conversation from the previous thread by using thread ID.\n")
 
 

--- a/python/samples/getting_started/agents/openai_chat_client/openai_chat_client_with_thread.py
+++ b/python/samples/getting_started/agents/openai_chat_client/openai_chat_client_with_thread.py
@@ -94,10 +94,9 @@ async def example_with_existing_thread_messages() -> None:
     print(f"Agent: {result1.text}")
 
     # The thread now contains the conversation history in memory
-    messages = await thread.list_messages()
-
-    message_count = len(messages or [])
-    print(f"Thread contains {message_count} messages")
+    if thread.message_store:
+        messages = await thread.message_store.list_messages()
+        print(f"Thread contains {len(messages or [])} messages")
 
     print("\n--- Continuing with the same thread in a new agent instance ---")
 
@@ -118,7 +117,7 @@ async def example_with_existing_thread_messages() -> None:
     print("\n--- Alternative: Creating a new thread from existing messages ---")
 
     # You can also create a new thread from existing messages
-    messages = await thread.list_messages()
+    messages = await thread.message_store.list_messages() if thread.message_store else []
 
     new_thread = AgentThread(message_store=ChatMessageList(messages))
 

--- a/python/samples/getting_started/agents/openai_responses_client/openai_responses_client_with_thread.py
+++ b/python/samples/getting_started/agents/openai_responses_client/openai_responses_client_with_thread.py
@@ -63,22 +63,17 @@ async def example_with_thread_persistence_in_memory() -> None:
     result1 = await agent.run(query1, thread=thread)
     print(f"Agent: {result1.text}")
 
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
-
     # Second conversation using the same thread - maintains context
     query2 = "How about London?"
     print(f"\nUser: {query2}")
     result2 = await agent.run(query2, thread=thread)
     print(f"Agent: {result2.text}")
 
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
-
     # Third conversation - agent should remember both previous cities
     query3 = "Which of the cities I asked about has better weather?"
     print(f"\nUser: {query3}")
     result3 = await agent.run(query3, thread=thread)
     print(f"Agent: {result3.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
     print("Note: The agent remembers context from previous messages in the same thread.\n")
 
 
@@ -106,7 +101,6 @@ async def example_with_existing_thread_id() -> None:
     # Enable OpenAI conversation state by setting `store` parameter to True
     result1 = await agent.run(query1, thread=thread, store=True)
     print(f"Agent: {result1.text}")
-    print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
 
     # The thread ID is set after the first response
     existing_thread_id = thread.service_thread_id
@@ -128,7 +122,6 @@ async def example_with_existing_thread_id() -> None:
         print(f"User: {query2}")
         result2 = await agent.run(query2, thread=thread, store=True)
         print(f"Agent: {result2.text}")
-        print(f"Thread contains {len(await thread.list_messages() or [])} messages in-memory.")
         print("Note: The agent continues the conversation from the previous thread by using thread ID.\n")
 
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/agent-framework/issues/549

The purpose of `thread.list_messages()` method was to return messages in case they are stored in 3P message store or built-in in-memory store. For cases when messages are stored directly in AI provider (e.g. Foundry, Responses API) this method returns an empty collection, which is confusing from API usage point of view. In order to make `thread.list_messages()` also return messages from AI provider, `AgentThread` class should have a separate specialized implementation for each AI provider, which is not currently implemented and not included in current API design (at least for now).

This PR removes `thread.list_messages()` method to avoid confusion, while it's still possible to access messages from 3P message store or built-in in-memory store by using `thread.message_store.list_messages()` syntax. This change may be temporary until we include a possibility to fetch messages from AI providers in API design.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
