### PR TITLE
Python: Correct dependency name for agent-framework-workflow

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "agent-framework",
     "agent-framework-azure",
     "agent-framework-foundry",
-    "agent_framework-workflow",
+    "agent-framework-workflow",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Noticed this typo while working on runtime stuff.

@TaoChenOSU