### PR TITLE
.NET: Support SubWorkflow as Executor

### DIFF
--- a/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/InMemoryCheckpointManager.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/InMemoryCheckpointManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Workflows.Checkpointing;
@@ -11,6 +13,14 @@ namespace Microsoft.Agents.Workflows.Checkpointing;
 internal sealed class InMemoryCheckpointManager : ICheckpointManager
 {
     private readonly Dictionary<string, RunCheckpointCache<Checkpoint>> _store = [];
+
+    public InMemoryCheckpointManager() { }
+
+    [JsonConstructor]
+    internal InMemoryCheckpointManager(Dictionary<string, RunCheckpointCache<Checkpoint>> store)
+    {
+        this._store = store;
+    }
 
     private RunCheckpointCache<Checkpoint> GetRunStore(string runId)
     {
@@ -44,4 +54,9 @@ internal sealed class InMemoryCheckpointManager : ICheckpointManager
 
         return new(value);
     }
+
+    internal bool HasCheckpoints(string runId) => this.GetRunStore(runId).HasCheckpoints;
+
+    public bool TryGetLastCheckpoint(string runId, [NotNullWhen(true)] out CheckpointInfo? checkpoint)
+        => this.GetRunStore(runId).TryGetLastCheckpointInfo(out checkpoint);
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/RunCheckpointCache.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/RunCheckpointCache.cs
@@ -2,17 +2,28 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Agents.Workflows.Checkpointing;
 
 internal sealed class RunCheckpointCache<TStoreObject>
 {
-    private readonly HashSet<CheckpointInfo> _checkpointIndex = [];
+    private readonly List<CheckpointInfo> _checkpointIndex = [];
     private readonly Dictionary<CheckpointInfo, TStoreObject> _cache = [];
 
+    public RunCheckpointCache() { }
+
+    [JsonConstructor]
+    internal RunCheckpointCache(List<CheckpointInfo> checkpointIndex, Dictionary<CheckpointInfo, TStoreObject> cache)
+    {
+        this._checkpointIndex = checkpointIndex;
+        this._cache = cache;
+    }
+
+    [JsonIgnore]
     public IEnumerable<CheckpointInfo> Index => this._checkpointIndex;
 
-    public bool IsInIndex(CheckpointInfo key) => this._checkpointIndex.Contains(key);
+    public bool IsInIndex(CheckpointInfo key) => this._cache.ContainsKey(key);
     public bool TryGet(CheckpointInfo key, [MaybeNullWhen(false)] out TStoreObject value) => this._cache.TryGetValue(key, out value);
 
     public CheckpointInfo Add(string runId, TStoreObject value)
@@ -29,12 +40,26 @@ internal sealed class RunCheckpointCache<TStoreObject>
 
     public bool Add(CheckpointInfo key, TStoreObject value)
     {
-        bool added = this._checkpointIndex.Add(key);
-        if (added)
+        if (this.IsInIndex(key))
         {
-            this._cache[key] = value;
+            return false;
         }
 
-        return added;
+        this._cache[key] = value;
+        this._checkpointIndex.Add(key);
+        return true;
+    }
+
+    [JsonIgnore]
+    public bool HasCheckpoints => this._checkpointIndex.Count > 0;
+    public bool TryGetLastCheckpointInfo([NotNullWhen(true)] out CheckpointInfo? checkpointInfo)
+    {
+        if (this.HasCheckpoints)
+        {
+            checkpointInfo = this._checkpointIndex[this._checkpointIndex.Count - 1];
+            return true;
+        }
+        checkpointInfo = default;
+        return false;
     }
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Config.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Config.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Agents.Workflows;
 /// Represents a configuration for an object with a string identifier. For example, <see cref="IIdentified"/> object.
 /// </summary>
 /// <param name="id">A unique identifier for the configurable object.</param>
-public class Config(string? id = null)
+public class Config(string id)
 {
     /// <summary>
     /// Gets a unique identifier for the configurable object.
@@ -14,16 +14,16 @@ public class Config(string? id = null)
     /// <remarks>
     /// If not provided, the configured object will generate its own identifier.
     /// </remarks>
-    public string? Id => id;
+    public string Id => id;
 }
 
 /// <summary>
 /// Represents a configuration for an object with a string identifier and options of type <typeparamref name="TOptions"/>.
 /// </summary>
 /// <typeparam name="TOptions">The type of options for the configurable object.</typeparam>
-/// <param name="options">The options for the configurable object.</param>
 /// <param name="id">A unique identifier for the configurable object.</param>
-public class Config<TOptions>(TOptions? options = default, string? id = null) : Config(id)
+/// <param name="options">The options for the configurable object.</param>
+public class Config<TOptions>(string id, TOptions? options = default) : Config(id)
 {
     /// <summary>
     /// Gets the options for the configured object.

--- a/dotnet/src/Microsoft.Agents.Workflows/ConfigurationExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ConfigurationExtensions.cs
@@ -16,7 +16,7 @@ public static class ConfigurationExtensions
     /// <param name="configured">The existing configuration for the subject type to be upcast to its parent type. Cannot be null.</param>
     /// <returns>A new <see cref="Configured{TParent}"/> instance that applies the original configuration logic to the parent type.</returns>
     public static Configured<TParent> Super<TSubject, TParent>(this Configured<TSubject> configured) where TSubject : TParent
-        => new(async config => await configured.FactoryAsync(config).ConfigureAwait(false), configured.Id, configured.Raw);
+        => new(async (config, runId) => await configured.FactoryAsync(config, runId).ConfigureAwait(false), configured.Id, configured.Raw);
 
     /// <summary>
     /// Creates a new configuration that treats the subject as its base type, allowing configuration to be applied at

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/IRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/IRunnerContext.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
-internal interface IRunnerContext : IExternalRequestSink
+internal interface IRunnerContext : IExternalRequestSink, ISuperStepJoinContext
 {
     ValueTask AddEventAsync(WorkflowEvent workflowEvent);
     ValueTask SendMessageAsync(string sourceId, object message, string? targetId = null);

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepJoinContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepJoinContext.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Workflows.Execution;
+
+internal interface ISuperStepJoinContext
+{
+    bool WithCheckpointing { get; }
+
+    ValueTask ForwardWorkflowEventAsync(WorkflowEvent workflowEvent, CancellationToken cancellation = default);
+    ValueTask SendMessageAsync<TMessage>(string senderId, [DisallowNull] TMessage message, CancellationToken cancellation = default);
+
+    ValueTask AttachSuperstepAsync(ISuperStepRunner superStepRunner, CancellationToken cancellation = default);
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepRunner.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepRunner.cs
@@ -15,6 +15,7 @@ internal interface ISuperStepRunner
 
     ValueTask EnqueueResponseAsync(ExternalResponse response);
     ValueTask<bool> EnqueueMessageAsync<T>(T message);
+    ValueTask<bool> EnqueueMessageUntypedAsync(object message, Type declaredType);
 
     event EventHandler<WorkflowEvent>? WorkflowEvent;
 

--- a/dotnet/src/Microsoft.Agents.Workflows/Executor.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Executor.cs
@@ -23,8 +23,6 @@ public abstract class Executor : IIdentified
     /// </summary>
     public string Id { get; }
 
-    private readonly ExecutorOptions _options;
-
     /// <summary>
     /// Initialize the executor with a unique identifier
     /// </summary>
@@ -33,8 +31,13 @@ public abstract class Executor : IIdentified
     protected Executor(string id, ExecutorOptions? options = null)
     {
         this.Id = id;
-        this._options = options ?? ExecutorOptions.Default;
+        this.Options = options ?? ExecutorOptions.Default;
     }
+
+    /// <summary>
+    /// Gets the configuration options for the executor.
+    /// </summary>
+    protected ExecutorOptions Options { get; }
 
     /// <summary>
     /// Override this method to register handlers for the executor.
@@ -53,7 +56,7 @@ public abstract class Executor : IIdentified
     /// <returns></returns>
     protected virtual ISet<Type> ConfigureYieldTypes()
     {
-        if (this._options.AutoYieldOutputHandlerResultObject)
+        if (this.Options.AutoYieldOutputHandlerResultObject)
         {
             return this.Router.DefaultOutputTypes;
         }
@@ -122,11 +125,11 @@ public abstract class Executor : IIdentified
         }
 
         // If we had a real return type, raise it as a SendMessage; TODO: Should we have a way to disable this behaviour?
-        if (result.Result is not null && this._options.AutoSendMessageHandlerResultObject)
+        if (result.Result is not null && this.Options.AutoSendMessageHandlerResultObject)
         {
             await context.SendMessageAsync(result.Result).ConfigureAwait(false);
         }
-        if (result.Result is not null && this._options.AutoYieldOutputHandlerResultObject)
+        if (result.Result is not null && this.Options.AutoYieldOutputHandlerResultObject)
         {
             await context.YieldOutputAsync(result.Result).ConfigureAwait(false);
         }

--- a/dotnet/src/Microsoft.Agents.Workflows/ExecutorRegistration.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ExecutorRegistration.cs
@@ -4,7 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
 
-using ExecutorFactoryF = System.Func<System.Threading.Tasks.ValueTask<Microsoft.Agents.Workflows.Executor>>;
+using ExecutorFactoryF = System.Func<string, System.Threading.Tasks.ValueTask<Microsoft.Agents.Workflows.Executor>>;
 
 namespace Microsoft.Agents.Workflows;
 
@@ -12,7 +12,7 @@ internal sealed class ExecutorRegistration(string id, Type executorType, Executo
 {
     public string Id { get; } = Throw.IfNullOrEmpty(id);
     public Type ExecutorType { get; } = Throw.IfNull(executorType);
-    public ExecutorFactoryF ProviderAsync { get; } = Throw.IfNull(provider);
+    private ExecutorFactoryF ProviderAsync { get; } = Throw.IfNull(provider);
     public bool IsNotExecutorInstance { get; } = rawData is not Executor;
     public bool IsUnresettableSharedInstance { get; } = rawData is Executor && rawData is not IResettableExecutor;
 
@@ -58,5 +58,5 @@ internal sealed class ExecutorRegistration(string id, Type executorType, Executo
         return executor;
     }
 
-    public async ValueTask<Executor> CreateInstanceAsync() => this.CheckId(await this.ProviderAsync().ConfigureAwait(false));
+    public async ValueTask<Executor> CreateInstanceAsync(string runId) => this.CheckId(await this.ProviderAsync(runId).ConfigureAwait(false));
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcStepTracer.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcStepTracer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,11 +17,11 @@ internal sealed class InProcStepTracer : IStepTracer
     public bool StateUpdated { get; private set; }
     public CheckpointInfo? Checkpoint { get; private set; }
 
-    public HashSet<string> Instantiated { get; } = [];
-    public HashSet<string> Activated { get; } = [];
+    public ConcurrentDictionary<string, string> Instantiated { get; } = new();
+    public ConcurrentDictionary<string, string> Activated { get; } = new();
 
-    public void TraceIntantiated(string executorId) => this.Instantiated.Add(executorId);
-    public void TraceActivated(string executorId) => this.Activated.Add(executorId);
+    public void TraceIntantiated(string executorId) => this.Instantiated.TryAdd(executorId, executorId);
+    public void TraceActivated(string executorId) => this.Activated.TryAdd(executorId, executorId);
     public void TraceStatePublished() => this.StateUpdated = true;
     public void TraceCheckpointCreated(CheckpointInfo checkpoint) => this.Checkpoint = checkpoint;
 
@@ -60,7 +61,7 @@ internal sealed class InProcStepTracer : IStepTracer
         });
     }
 
-    public SuperStepCompletedEvent Complete(bool nextStepHasActions, bool hasPendingRequests) => new(this.StepNumber, new SuperStepCompletionInfo(this.Activated, this.Instantiated)
+    public SuperStepCompletedEvent Complete(bool nextStepHasActions, bool hasPendingRequests) => new(this.StepNumber, new SuperStepCompletionInfo(this.Activated.Keys, this.Instantiated.Keys)
     {
         HasPendingMessages = nextStepHasActions,
         HasPendingRequests = hasPendingRequests,
@@ -72,19 +73,19 @@ internal sealed class InProcStepTracer : IStepTracer
     {
         StringBuilder sb = new();
 
-        if (this.Instantiated.Count != 0)
+        if (this.Instantiated.Keys.Count != 0)
         {
-            sb.Append("Instantiated: ").Append(string.Join(", ", this.Instantiated.OrderBy(id => id, StringComparer.Ordinal)));
+            sb.Append("Instantiated: ").Append(string.Join(", ", this.Instantiated.Keys.OrderBy(id => id, StringComparer.Ordinal)));
         }
 
-        if (this.Activated.Count != 0)
+        if (this.Activated.Keys.Count != 0)
         {
             if (sb.Length != 0)
             {
                 sb.AppendLine();
             }
 
-            sb.Append("Activated: ").Append(string.Join(", ", this.Activated.OrderBy(id => id, StringComparer.Ordinal)));
+            sb.Append("Activated: ").Append(string.Join(", ", this.Activated.Keys.OrderBy(id => id, StringComparer.Ordinal)));
         }
 
         return sb.ToString();

--- a/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunnerContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,17 +29,20 @@ internal sealed class InProcessRunnerContext : IRunnerContext
 
     private readonly ConcurrentDictionary<string, Task<Executor>> _executors = new();
     private readonly ConcurrentQueue<Func<ValueTask>> _queuedExternalDeliveries = new();
+    private readonly ConcurrentQueue<ISuperStepRunner> _joinedSubworkflowRunners = new();
 
     private readonly Dictionary<string, ExternalRequest> _externalRequests = new();
 
-    public InProcessRunnerContext(Workflow workflow, string runId, IStepTracer? stepTracer, ILogger? logger = null)
+    public InProcessRunnerContext(Workflow workflow, string runId, bool withCheckpointing, IStepTracer? stepTracer, object? workflowOwnership = null, bool subworkflow = false, ILogger? logger = null)
     {
-        workflow.TakeOwnership(this);
+        workflow.TakeOwnership(this, existingOwnershipSignoff: workflowOwnership);
         this._workflow = workflow;
         this._runId = runId;
 
         this._edgeMap = new(this, this._workflow, stepTracer);
         this._outputFilter = new(workflow);
+
+        this.WithCheckpointing = withCheckpointing;
     }
 
     public async ValueTask<Executor> EnsureExecutorAsync(string executorId, IStepTracer? tracer)
@@ -53,7 +57,7 @@ internal sealed class InProcessRunnerContext : IRunnerContext
                 throw new InvalidOperationException($"Executor with ID '{executorId}' is not registered.");
             }
 
-            Executor executor = await registration.ProviderAsync().ConfigureAwait(false);
+            Executor executor = await registration.CreateInstanceAsync(this._runId).ConfigureAwait(false);
             tracer?.TraceActivated(executorId);
 
             if (executor is RequestInfoExecutor requestInputExecutor)
@@ -61,10 +65,23 @@ internal sealed class InProcessRunnerContext : IRunnerContext
                 requestInputExecutor.AttachRequestSink(this);
             }
 
+            if (executor is WorkflowHostExecutor workflowHostExecutor)
+            {
+                await workflowHostExecutor.AttachSuperStepContextAsync(this).ConfigureAwait(false);
+            }
+
             return executor;
         }
 
         return await executorTask.ConfigureAwait(false);
+    }
+
+    public async ValueTask<IEnumerable<Type>> GetStartingExecutorInputTypesAsync(CancellationToken cancellation = default)
+    {
+        Executor startingExecutor = await this.EnsureExecutorAsync(this._workflow.StartExecutorId, tracer: null)
+                                              .ConfigureAwait(false);
+
+        return startingExecutor.InputTypes;
     }
 
     public ValueTask AddExternalMessageAsync(object message, Type declaredType)
@@ -210,6 +227,8 @@ internal sealed class InProcessRunnerContext : IRunnerContext
             => RunnerContext.StateManager.ClearStateAsync(ExecutorId, scopeName);
     }
 
+    public bool WithCheckpointing { get; }
+
     internal Task PrepareForCheckpointAsync(CancellationToken cancellation = default)
     {
         this.CheckEnded();
@@ -299,7 +318,7 @@ internal sealed class InProcessRunnerContext : IRunnerContext
         await Task.WhenAll(executorTasks).ConfigureAwait(false);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1513:Use ObjectDisposedException throw helper",
+    [SuppressMessage("Maintainability", "CA1513:Use ObjectDisposedException throw helper",
         Justification = "Does not exist in NetFx 4.7.2")]
     internal void CheckEnded()
     {
@@ -316,4 +335,20 @@ internal sealed class InProcessRunnerContext : IRunnerContext
             await this._workflow.ReleaseOwnershipAsync(this).ConfigureAwait(false);
         }
     }
+
+    public IEnumerable<ISuperStepRunner> JoinedSubworkflowRunners => this._joinedSubworkflowRunners;
+
+    public ValueTask AttachSuperstepAsync(ISuperStepRunner superStepRunner, CancellationToken cancellation = default)
+    {
+        // This needs to be a thread-safe ordered collection because we can potentially instantiate executors
+        // in parallel, which means multiple sub-workflows could be attaching at the same time.
+        this._joinedSubworkflowRunners.Enqueue(superStepRunner);
+        return default;
+    }
+
+    ValueTask ISuperStepJoinContext.ForwardWorkflowEventAsync(WorkflowEvent workflowEvent, CancellationToken cancellation)
+        => this.AddEventAsync(workflowEvent);
+
+    ValueTask ISuperStepJoinContext.SendMessageAsync<TMessage>(string senderId, [DisallowNull] TMessage message, CancellationToken cancellation)
+        => this.SendMessageAsync(senderId, Throw.IfNull(message));
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/InProcessExecution.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/InProcessExecution.cs
@@ -2,6 +2,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.Workflows.Checkpointing;
 using Microsoft.Agents.Workflows.InProc;
 
 namespace Microsoft.Agents.Workflows;
@@ -12,12 +13,12 @@ namespace Microsoft.Agents.Workflows;
 /// </summary>
 public static class InProcessExecution
 {
-    internal static InProcessRunner CreateRunner(Workflow workflow, CheckpointManager? checkpointManager, string? runId)
+    internal static InProcessRunner CreateRunner(Workflow workflow, ICheckpointManager? checkpointManager, string? runId)
         => new(workflow, checkpointManager, runId);
 
-    internal static InProcessRunner CreateRunner<TInput>(Workflow<TInput> checkedWorkflow, CheckpointManager? checkpointManager, string? runId)
+    internal static InProcessRunner CreateRunner<TInput>(Workflow<TInput> checkedWorkflow, ICheckpointManager? checkpointManager, string? runId)
         where TInput : notnull
-        => new(checkedWorkflow, checkpointManager, runId, [typeof(TInput)]);
+        => new(checkedWorkflow, checkpointManager, runId, knownValidInputTypes: [typeof(TInput)]);
 
     private static ValueTask<StreamingRun> StreamAsync<TInput>(InProcessRunner runner, TInput input, CancellationToken cancellation = default)
         => runner.StreamAsync(input, cancellation);

--- a/dotnet/src/Microsoft.Agents.Workflows/Specialized/WorkflowHostExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Specialized/WorkflowHostExecutor.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.Workflows.Checkpointing;
+using Microsoft.Agents.Workflows.Execution;
+using Microsoft.Agents.Workflows.InProc;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.Workflows.Specialized;
+
+internal class WorkflowHostExecutor : Executor, IResettableExecutor
+{
+    private readonly string _runId;
+    private readonly Workflow _workflow;
+    private readonly object _ownershipToken;
+
+    private InProcessRunner? _activeRunner;
+    private InMemoryCheckpointManager? _checkpointManager;
+    private readonly ExecutorOptions _options;
+
+    private ISuperStepJoinContext? _joinContext;
+    private StreamingRun? _run;
+
+    [MemberNotNullWhen(true, nameof(_checkpointManager))]
+    private bool WithCheckpointing => this._checkpointManager != null;
+
+    public WorkflowHostExecutor(string id, Workflow workflow, string runId, object ownershipToken, ExecutorOptions? options = null) : base(id, options)
+    {
+        this._options = options ?? new();
+
+        Throw.IfNull(workflow);
+        this._runId = Throw.IfNull(runId);
+        this._ownershipToken = Throw.IfNull(ownershipToken);
+        this._workflow = Throw.IfNull(workflow);
+    }
+
+    protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+    {
+        return routeBuilder.AddCatchAll(this.QueueExternalMessageAsync);
+    }
+
+    private async ValueTask QueueExternalMessageAsync(PortableValue portableValue, IWorkflowContext context)
+    {
+        if (portableValue.Is(out ExternalResponse? response))
+        {
+            response = this.CheckAndUnqualifyResponse(response);
+            await this.EnsureRunSendMessageAsync(response).ConfigureAwait(false);
+        }
+        else
+        {
+            InProcessRunner runner = await this.EnsureRunnerAsync().ConfigureAwait(false);
+            IEnumerable<Type> validInputTypes = await runner.RunContext.GetStartingExecutorInputTypesAsync().ConfigureAwait(false);
+            foreach (Type candidateType in validInputTypes)
+            {
+                if (portableValue.IsType(candidateType, out object? message))
+                {
+                    await this.EnsureRunSendMessageAsync(message, candidateType).ConfigureAwait(false);
+                    return;
+                }
+            }
+        }
+    }
+
+    private ISuperStepJoinContext JoinContext => Throw.IfNull(this._joinContext, "Must attach to a join context before starting the run.");
+
+    internal async ValueTask<InProcessRunner> EnsureRunnerAsync()
+    {
+        if (this._activeRunner == null)
+        {
+            if (this.JoinContext.WithCheckpointing)
+            {
+                // Use a seprate in-memory checkpoint manager for scoping purposes. We do not need to worry about
+                // serialization because we will be relying on the parent workflow's checkpoint manager to do that,
+                // if needed. For our purposes, all we need is to keep a faithful representation of the checkpointed
+                // objects so we can emit them back to the parent workflow on checkpoint creation.
+                this._checkpointManager = new InMemoryCheckpointManager();
+            }
+
+            this._activeRunner = new(this._workflow, this._checkpointManager, this._runId, this._ownershipToken, subworkflow: true);
+        }
+
+        return this._activeRunner;
+    }
+
+    internal async ValueTask<StreamingRun> EnsureRunSendMessageAsync(object? incomingMessage = null, Type? incomingMessageType = null, bool resume = false, CancellationToken cancellation = default)
+    {
+        Debug.Assert(this._joinContext != null, "Must attach to a join context before starting the run.");
+
+        if (this._run != null)
+        {
+            if (incomingMessage != null)
+            {
+                await this._run.TrySendMessageUntypedAsync(incomingMessage, incomingMessageType ?? incomingMessage.GetType()).ConfigureAwait(false);
+            }
+
+            return this._run;
+        }
+
+        InProcessRunner activeRunner = await this.EnsureRunnerAsync().ConfigureAwait(false);
+
+        if (this.WithCheckpointing)
+        {
+            if (resume)
+            {
+                // Attempting to resume from checkpoint
+                if (!this._checkpointManager.TryGetLastCheckpoint(this._runId, out CheckpointInfo? lastCheckpoint))
+                {
+                    throw new InvalidOperationException("No checkpoints available to resume from.");
+                }
+
+                this._run = await activeRunner.ResumeStreamAsync(lastCheckpoint!, cancellation)
+                                              .ConfigureAwait(false);
+
+                if (incomingMessage != null)
+                {
+                    await this._run.TrySendMessageAsync(incomingMessage).ConfigureAwait(false);
+                }
+            }
+            else if (incomingMessage != null)
+            {
+                this._run = await activeRunner.StreamAsync(Throw.IfNull(incomingMessage), cancellation)
+                                              .ConfigureAwait(false);
+            }
+            else
+            {
+                throw new InvalidOperationException("Cannot start a checkpointed workflow run without an incoming message or resume flag.");
+            }
+        }
+        else
+        {
+            this._run = await activeRunner.StreamAsync(Throw.IfNull(incomingMessage), cancellation)
+                                          .ConfigureAwait(false);
+        }
+
+        await this._joinContext.AttachSuperstepAsync(activeRunner, cancellation).ConfigureAwait(false);
+        activeRunner.WorkflowEvent += this.ForwardWorkflowEventAsync;
+
+        return this._run;
+    }
+
+    private ExternalResponse? CheckAndUnqualifyResponse([DisallowNull] ExternalResponse response)
+    {
+        if (Throw.IfNull(response).PortInfo.PortId.StartsWith($"{this.Id}.", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        InputPortInfo unqualifiedPort = response.PortInfo with { PortId = response.PortInfo.PortId.Substring(this.Id.Length + 1) };
+        return response with { PortInfo = unqualifiedPort };
+    }
+
+    private ExternalRequest QualifyRequestPortId(ExternalRequest internalRequest)
+    {
+        InputPortInfo requestPort = internalRequest.PortInfo with { PortId = $"{this.Id}.{internalRequest.PortInfo.PortId}" };
+        return internalRequest with { PortInfo = requestPort };
+    }
+
+    [SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "This is used as an EventHandler and catches all catchable Exceptions.")]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "This analyzer is misfiring.")]
+    private async void ForwardWorkflowEventAsync(object? sender, WorkflowEvent evt)
+    {
+        // Note that we are explicitly not using the checked JoinContext property here, because this is an async callback.
+        try
+        {
+            Task resultTask = Task.CompletedTask;
+            switch (evt)
+            {
+                case RequestInfoEvent requestInfoEvt:
+                    ExternalRequest request = requestInfoEvt.Request;
+                    resultTask = this._joinContext?.SendMessageAsync(this.Id, this.QualifyRequestPortId(request)).AsTask() ?? Task.CompletedTask;
+                    break;
+                case WorkflowErrorEvent errorEvent:
+                    resultTask = this._joinContext?.ForwardWorkflowEventAsync(new SubWorkflowErrorEvent(this.Id, errorEvent.Data as Exception)).AsTask() ?? Task.CompletedTask;
+                    break;
+                case WorkflowOutputEvent outputEvent:
+                    if (this._joinContext != null &&
+                        this._options.AutoSendMessageHandlerResultObject
+                        && outputEvent.Data != null)
+                    {
+                        resultTask = this._joinContext.SendMessageAsync(this.Id, outputEvent.Data).AsTask();
+                    }
+                    break;
+                case RequestHaltEvent requestHaltEvent:
+                    resultTask = this._joinContext?.ForwardWorkflowEventAsync(new RequestHaltEvent()).AsTask() ?? Task.CompletedTask;
+                    break;
+                case WorkflowWarningEvent warningEvent:
+                    if (warningEvent.Data is string warningMessage)
+                    {
+                        resultTask = this._joinContext?.ForwardWorkflowEventAsync(new SubworkflowWarningEvent(this.Id, warningMessage)).AsTask() ?? Task.CompletedTask;
+                    }
+                    break;
+                default:
+                    resultTask = this._joinContext?.ForwardWorkflowEventAsync(evt).AsTask() ?? Task.CompletedTask;
+                    break;
+            }
+
+            await resultTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // We want to avoid throwing from an event handler, as that can crash the process. Unfortunately that also
+            // means we cannot await this, but this is okay, because it definitely does not involve sending a message,
+            // and thus does not need to be coordinated with SuperSteps, except when running in lockstep mode (which
+            // will make it do so automatically because events will not pump when the subworkflow is not running a
+            // superstep, and those are driven by the parent through the ISuperStepJoinContext).
+            try
+            {
+                _ = this._joinContext?.ForwardWorkflowEventAsync(new SubWorkflowErrorEvent(this.Id, ex)).AsTask();
+            }
+            catch
+            { }
+        }
+    }
+
+    internal async ValueTask AttachSuperStepContextAsync(ISuperStepJoinContext joinContext)
+    {
+        this._joinContext = Throw.IfNull(joinContext);
+    }
+
+    protected internal override async ValueTask OnCheckpointingAsync(IWorkflowContext context, CancellationToken cancellation = default)
+    {
+        await context.QueueStateUpdateAsync(nameof(CheckpointManager), this._checkpointManager).ConfigureAwait(false);
+
+        await base.OnCheckpointingAsync(context, cancellation).ConfigureAwait(false);
+    }
+
+    protected internal override async ValueTask OnCheckpointRestoredAsync(IWorkflowContext context, CancellationToken cancellation = default)
+    {
+        await base.OnCheckpointRestoredAsync(context, cancellation).ConfigureAwait(false);
+
+        InMemoryCheckpointManager manager = await context.ReadStateAsync<InMemoryCheckpointManager>(nameof(InMemoryCheckpointManager)).ConfigureAwait(false) ?? new();
+        if (this._checkpointManager == manager)
+        {
+            // We are restoring in the context of the same run; not need to rebuild the entire execution stack.
+        }
+        else
+        {
+            this._checkpointManager = manager;
+
+            await this.ResetAsync().ConfigureAwait(false);
+        }
+
+        StreamingRun run = await this.EnsureRunSendMessageAsync(cancellation: cancellation).ConfigureAwait(false);
+    }
+
+    public async ValueTask ResetAsync()
+    {
+        this._run = null;
+
+        if (this._activeRunner != null)
+        {
+            this._activeRunner.WorkflowEvent -= this.ForwardWorkflowEventAsync;
+            await this._activeRunner.RequestEndRunAsync().ConfigureAwait(false);
+            this._activeRunner = InProcessExecution.CreateRunner(this._workflow, this._checkpointManager, this._runId);
+        }
+    }
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/StreamingRun.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/StreamingRun.cs
@@ -73,6 +73,19 @@ public sealed class StreamingRun
         return await this._stepRunner.EnqueueMessageAsync(message).ConfigureAwait(false);
     }
 
+    internal async ValueTask<bool> TrySendMessageUntypedAsync(object message, Type messageType)
+    {
+        Throw.IfNull(message);
+
+        if (message is ExternalResponse response)
+        {
+            await this.SendResponseAsync(response).ConfigureAwait(false);
+            return true;
+        }
+
+        return await this._stepRunner.EnqueueMessageUntypedAsync(message, messageType).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Asynchronously streams workflow events as they occur during workflow execution.
     /// </summary>

--- a/dotnet/src/Microsoft.Agents.Workflows/SubworkflowErrorEvent.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/SubworkflowErrorEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+
+namespace Microsoft.Agents.Workflows;
+
+/// <summary>
+/// Event triggered when a workflow encounters an error.
+/// </summary>
+/// <param name="subworkflowId">The ID of the subworkflow that encountered the error.</param>
+/// <param name="e">Optionally, the <see cref="Exception"/> representing the error.</param>
+public sealed class SubWorkflowErrorEvent(string subworkflowId, Exception? e) : WorkflowErrorEvent(e)
+{
+    /// <summary>
+    /// Gets the ID of the subworkflow that encountered the error.
+    /// </summary>
+    public string SubworkflowId { get; } = subworkflowId;
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/SubworkflowWarningEvent.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/SubworkflowWarningEvent.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Agents.Workflows;
+
+/// <summary>
+/// Event triggered when a subworkflow encounters a warning-confition.
+/// sub-workflow.
+/// </summary>
+/// <param name="message">The warning message.</param>
+/// <param name="subWorkflowId">The unique identifier of the sub-workflow that triggered the warning. Cannot be null or empty.</param>
+public sealed class SubworkflowWarningEvent(string message, string subWorkflowId) : WorkflowWarningEvent(message)
+{
+    /// <summary>
+    /// The unique identifier of the sub-workflow that triggered the warning.
+    /// </summary>
+    public string SubWorkflowId { get; } = subWorkflowId;
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/SuperStepCompletionInfo.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/SuperStepCompletionInfo.cs
@@ -8,17 +8,17 @@ namespace Microsoft.Agents.Workflows;
 /// <summary>
 /// Debug information about the SuperStep that finished running.
 /// </summary>
-public sealed class SuperStepCompletionInfo(HashSet<string> activatedExecutors, HashSet<string>? instantiatedExecutors = null)
+public sealed class SuperStepCompletionInfo(IEnumerable<string> activatedExecutors, IEnumerable<string>? instantiatedExecutors = null)
 {
     /// <summary>
     /// The unique identifiers of <see cref="Executor"/> instances that processed messages during this SuperStep
     /// </summary>
-    public HashSet<string> ActivatedExecutors { get; } = Throw.IfNull(activatedExecutors);
+    public HashSet<string> ActivatedExecutors { get; } = [.. Throw.IfNull(activatedExecutors)];
 
     /// <summary>
     /// The unique identifiers of <see cref="Executor"/> instances newly created during this SuperStep
     /// </summary>
-    public HashSet<string> InstantiatedExecutors { get; } = instantiatedExecutors ?? [];
+    public HashSet<string> InstantiatedExecutors { get; } = [.. instantiatedExecutors ?? []];
 
     /// <summary>
     /// A flag indicating whether the managed state was written to during this SuperStep. If the run was started

--- a/dotnet/src/Microsoft.Agents.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Workflow.cs
@@ -84,7 +84,7 @@ public class Workflow
 
         // TODO: Can we cache this somehow to avoid having to instantiate a new one when running?
         // Does that break some user expectations?
-        Executor startExecutor = await startRegistration.ProviderAsync().ConfigureAwait(false);
+        Executor startExecutor = await startRegistration.CreateInstanceAsync(string.Empty).ConfigureAwait(false);
 
         if (!startExecutor.InputTypes.Any(t => t.IsAssignableFrom(typeof(TInput))))
         {
@@ -125,9 +125,16 @@ public class Workflow
     }
 
     private object? _ownerToken;
-    internal void TakeOwnership(object ownerToken)
+    private bool _ownedAsSubworkflow;
+    internal void TakeOwnership(object ownerToken, bool subworkflow = false, object? existingOwnershipSignoff = null)
     {
-        object? maybeToken = Interlocked.CompareExchange(ref this._ownerToken, ownerToken, null);
+        object? maybeToken = Interlocked.CompareExchange(ref this._ownerToken, ownerToken, existingOwnershipSignoff);
+        if (maybeToken == null && existingOwnershipSignoff != null)
+        {
+            // We expected to already be owned, but we were not
+            throw new InvalidOperationException("Existing ownership token was provided, but the workflow is unowned.");
+        }
+
         if (maybeToken == null && this._needsReset)
         {
             // There is no owner, but the workflow failed to reset on ownership release (because there are
@@ -137,14 +144,22 @@ public class Workflow
                 );
         }
 
-        if (maybeToken != null && !ReferenceEquals(maybeToken, ownerToken))
+        if (!ReferenceEquals(maybeToken, existingOwnershipSignoff) && !ReferenceEquals(maybeToken, ownerToken))
         {
             // Someone else owns the workflow
             Debug.Assert(maybeToken != null);
-            throw new InvalidOperationException("Cannot use a Workflow in multiple simultaneous (Streaming)Runs.");
+            throw new InvalidOperationException(
+                (subworkflow, this._ownedAsSubworkflow) switch
+                {
+                    (true, true) => "Cannot use a Workflow as a subworkflow of multiple parent workflows.",
+                    (true, false) => "Cannot use a running Workflow as a subworkflow.",
+                    (false, true) => "Cannot directly run a Workflow that is a subworkflow of another workflow.",
+                    (false, false) => "Cannot use a Workflow that is already owned by another runner or parent workflow.",
+                });
         }
 
         this._needsReset = true;
+        this._ownedAsSubworkflow = subworkflow;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1513:Use ObjectDisposedException throw helper",

--- a/dotnet/src/Microsoft.Agents.Workflows/WorkflowErrorEvent.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/WorkflowErrorEvent.cs
@@ -10,4 +10,4 @@ namespace Microsoft.Agents.Workflows;
 /// <param name="e">
 /// Optionally, the <see cref="Exception"/> representing the error.
 /// </param>
-public sealed class WorkflowErrorEvent(Exception? e) : WorkflowEvent(e);
+public class WorkflowErrorEvent(Exception? e) : WorkflowEvent(e);

--- a/dotnet/src/Microsoft.Agents.Workflows/WorkflowWarningEvent.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/WorkflowWarningEvent.cs
@@ -6,4 +6,4 @@ namespace Microsoft.Agents.Workflows;
 /// Event triggered when a workflow encounters a warning-condition.
 /// </summary>
 /// <param name="message">The warning message.</param>
-public sealed class WorkflowWarningEvent(string message) : WorkflowEvent(message);
+public class WorkflowWarningEvent(string message) : WorkflowEvent(message);

--- a/dotnet/src/Microsoft.Agents.Workflows/WorkflowsJsonUtilities.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/WorkflowsJsonUtilities.cs
@@ -67,6 +67,7 @@ internal static partial class WorkflowsJsonUtilities
     [JsonSerializable(typeof(CheckpointInfo))]
     [JsonSerializable(typeof(PortableValue))]
     [JsonSerializable(typeof(PortableMessageEnvelope))]
+    [JsonSerializable(typeof(InMemoryCheckpointManager))]
 
     // Runtime State Types
     [JsonSerializable(typeof(ScopeKey))]

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/RepresentationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/RepresentationTests.cs
@@ -44,7 +44,7 @@ public class RepresentationTests
         ExecutorRegistration registration = target.Registration;
         ExecutorInfo info = registration.ToExecutorInfo();
 
-        info.IsMatch(await registration.ProviderAsync()).Should().BeTrue();
+        info.IsMatch(await registration.CreateInstanceAsync(runId: string.Empty)).Should().BeTrue();
     }
 
     [Fact]
@@ -54,6 +54,7 @@ public class RepresentationTests
         await RunExecutorishTestAsync(new TestExecutor());
         await RunExecutorishTestAsync(TestInputPort);
         await RunExecutorishTestAsync(new TestAgent());
+        await RunExecutorishTestAsync(Step1EntryPoint.WorkflowInstance.ConfigureSubWorkflow(nameof(Step1EntryPoint)));
 
         Func<int, IWorkflowContext, CancellationToken, ValueTask> function = MessageHandlerAsync;
         await RunExecutorishTestAsync(function.AsExecutor("FunctionExecutor"));

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/08_Subworkflow_Simple.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/08_Subworkflow_Simple.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Microsoft.Agents.Workflows.Sample;
+
+internal sealed record class TextProcessingRequest(string Text, string TaskId);
+internal sealed record class TextProcessingResult(string TaskId, string Text, int WordCount, int ChatCount);
+
+internal sealed class AllTasksCompletedEvent(IEnumerable<TextProcessingResult> results) : WorkflowEvent(results);
+
+internal static class Step8EntryPoint
+{
+    public static List<string> TextsToProcess => [
+            "Hello world! This is a simple test.",
+            "Python is a powerful programming language used for many applications.",
+            "Short text.",
+            "This is a longer text with multiple sentences. It contains more words and characters. We use it to test our text processing workflow.",
+            "",
+            "   Spaces   around   text   ",
+        ];
+
+    public static async ValueTask<List<TextProcessingResult>> RunAsync(TextWriter writer, List<string> textsToProcess)
+    {
+        Func<TextProcessingRequest, IWorkflowContext, CancellationToken, ValueTask> processTextAsyncFunc = ProcessTextAsync;
+        ExecutorIsh processText = processTextAsyncFunc.AsExecutor("TextProcessor");
+
+        Workflow subWorkflow = new WorkflowBuilder(processText).WithOutputFrom(processText).Build();
+
+        ExecutorIsh textProcessor = subWorkflow.ConfigureSubWorkflow("TextProcessor");
+        TextProcessingOrchestrator orchestrator = new();
+
+        Workflow workflow = new WorkflowBuilder(orchestrator)
+            .AddEdge(orchestrator, textProcessor)
+            .AddEdge(textProcessor, orchestrator)
+            .Build();
+
+        Run workflowRun = await InProcessExecution.RunAsync(workflow, textsToProcess);
+
+        workflowRun.Status.Should().Be(RunStatus.Idle);
+
+        List<TextProcessingResult> results = orchestrator.Results;
+        results.Sort((left, right) => StringComparer.Ordinal.Compare(left.TaskId, right.TaskId));
+
+        // This is a placeholder for the entry point of Step 8.
+        return results;
+    }
+
+    private static ValueTask ProcessTextAsync(TextProcessingRequest request, IWorkflowContext context, CancellationToken cancellation = default)
+    {
+        int wordCount = 0;
+        int charCount = 0;
+
+        if (request.Text.Length != 0)
+        {
+            wordCount = request.Text.Split([' '], StringSplitOptions.RemoveEmptyEntries).Length;
+            charCount = request.Text.Length;
+        }
+
+        return context.YieldOutputAsync(new TextProcessingResult(request.TaskId, request.Text, wordCount, charCount));
+    }
+
+    private sealed class TextProcessingOrchestrator() : Executor("TextOrchestrator")
+    {
+        public List<TextProcessingResult> Results { get; } = new();
+        public HashSet<string> PendingTaskIds { get; } = new();
+
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+        {
+            return routeBuilder.AddHandler<List<string>>(this.StartProcessingAsync)
+                               .AddHandler<TextProcessingResult>(this.CollectResultAsync);
+        }
+
+        private async ValueTask StartProcessingAsync(List<string> texts, IWorkflowContext context)
+        {
+            foreach (TextProcessingRequest request in texts.Select((string value, int index) => new TextProcessingRequest(Text: value, TaskId: $"Task{index}")))
+            {
+                this.PendingTaskIds.Add(request.TaskId);
+                await context.SendMessageAsync(request).ConfigureAwait(false);
+            }
+        }
+
+        private ValueTask CollectResultAsync(TextProcessingResult result, IWorkflowContext context)
+        {
+            if (this.PendingTaskIds.Remove(result.TaskId))
+            {
+                this.Results.Add(result);
+            }
+
+            if (this.PendingTaskIds.Count == 0)
+            {
+                return context.AddEventAsync(new AllTasksCompletedEvent(this.Results));
+            }
+
+            return default;
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/SampleSmokeTest.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/SampleSmokeTest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Agents.Workflows.Sample;
 
 namespace Microsoft.Agents.Workflows.UnitTests;
@@ -176,6 +178,42 @@ public class SampleSmokeTest
             line => Assert.Contains($"{HelloAgent.DefaultId}: {HelloAgent.Greeting}", line),
             line => Assert.Contains($"{EchoAgent.DefaultId}: {EchoAgent.Prefix}{HelloAgent.Greeting}", line)
         );
+    }
+
+    [Fact]
+    public async Task Test_RunSample_Step8Async()
+    {
+        List<string> textsToProcess = [
+            "Hello world! This is a simple test.",
+            "Python is a powerful programming language used for many applications.",
+            "Short text.",
+            "This is a longer text with multiple sentences. It contains more words and characters. We use it to test our text processing workflow.",
+            "",
+            "   Spaces   around   text   ",
+        ];
+
+        using StringWriter writer = new();
+
+        List<TextProcessingResult> results = await Step8EntryPoint.RunAsync(writer, textsToProcess);
+        Assert.Equal(textsToProcess.Count, results.Count);
+
+        Assert.Collection(results,
+                          textsToProcess.Select(CreateValidator).ToArray());
+
+        Action<TextProcessingResult> CreateValidator(string textToProcess, int index)
+        {
+            return result =>
+            {
+                TextProcessingResult expected = new(
+                    TaskId: $"Task{index}",
+                    Text: textToProcess,
+                    WordCount: textToProcess.Split([' '], StringSplitOptions.RemoveEmptyEntries).Length,
+                    ChatCount: textToProcess.Length
+                );
+
+                result.Should().Be(expected);
+            };
+        }
     }
 }
 

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/TestRunContext.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/TestRunContext.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Agents.Workflows.Execution;
 
@@ -68,8 +70,29 @@ public class TestRunContext : IRunnerContext
     ValueTask<StepContext> IRunnerContext.AdvanceAsync() =>
         throw new NotImplementedException();
 
-    public Dictionary<string, Executor> Executors { get; } = [];
+    public Dictionary<string, Executor> Executors { get; set; } = [];
+    public string StartingExecutorId { get; set; } = string.Empty;
+
+    public bool WithCheckpointing => throw new NotSupportedException();
 
     ValueTask<Executor> IRunnerContext.EnsureExecutorAsync(string executorId, IStepTracer? tracer) =>
         new(this.Executors[executorId]);
+
+    public ValueTask<IEnumerable<Type>> GetStartingExecutorInputTypesAsync(CancellationToken cancellation = default)
+    {
+        if (this.Executors.TryGetValue(this.StartingExecutorId, out Executor? executor))
+        {
+            return new(executor.InputTypes);
+        }
+
+        throw new InvalidOperationException($"No executor with ID '{this.StartingExecutorId}' is registered in this context.");
+    }
+
+    public ValueTask ForwardWorkflowEventAsync(WorkflowEvent workflowEvent, CancellationToken cancellation = default)
+        => this.AddEventAsync(workflowEvent);
+
+    public ValueTask SendMessageAsync<TMessage>(string senderId, [DisallowNull] TMessage message, CancellationToken cancellation = default)
+        => this.SendMessageAsync(senderId, message, cancellation);
+
+    ValueTask ISuperStepJoinContext.AttachSuperstepAsync(ISuperStepRunner superStepRunner, CancellationToken cancellation) => default;
 }


### PR DESCRIPTION
* Makes input-type annotation optional
* Add WorkflowHostExecutor and Workflow-type ExecutorIsh

TODO:
- [x] Route Subworkflow Outputs through SendMessage
- [ ] Validate external requests work right
- [ ] Validate checkpointing works right
- [ ] ~~Multi-output Refactoring~~