### PR TITLE
.NET: fix: Fix Checkpoint Restore when Rehydrating Run

### DIFF
--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/RunnerStateData.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/RunnerStateData.cs
@@ -5,8 +5,9 @@ using Microsoft.Agents.Workflows.Checkpointing;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
-internal class RunnerStateData(Dictionary<ExecutorIdentity, List<ExportedState>> queuedMessages, List<ExternalRequest> outstandingRequests)
+internal class RunnerStateData(HashSet<string> instantiatedExecutors, Dictionary<ExecutorIdentity, List<ExportedState>> queuedMessages, List<ExternalRequest> outstandingRequests)
 {
+    public HashSet<string> InstantiatedExecutors { get; } = instantiatedExecutors;
     public Dictionary<ExecutorIdentity, List<ExportedState>> QueuedMessages { get; } = queuedMessages;
     public List<ExternalRequest> OutstandingRequests { get; } = outstandingRequests;
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunner.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/InProc/InProcessRunner.cs
@@ -228,12 +228,12 @@ internal class InProcessRunner<TInput> : ISuperStepRunner, ICheckpointingRunner 
             this._workflowInfoCache = this.Workflow.ToWorkflowInfo();
         }
 
-        RunnerStateData runnerData = await this.RunContext.ExportStateAsync().ConfigureAwait(false);
         Dictionary<EdgeConnection, ExportedState> edgeData = await this.EdgeMap.ExportStateAsync().ConfigureAwait(false);
 
         await prepareTask.ConfigureAwait(false);
         await this.RunContext.StateManager.PublishUpdatesAsync(this.StepTracer).ConfigureAwait(false);
 
+        RunnerStateData runnerData = await this.RunContext.ExportStateAsync().ConfigureAwait(false);
         Dictionary<ScopeKey, ExportedState> stateData = await this.RunContext.StateManager.ExportStateAsync().ConfigureAwait(false);
 
         Checkpoint checkpoint = new(this.StepTracer.StepNumber, this._workflowInfoCache, runnerData, stateData, edgeData);
@@ -261,9 +261,9 @@ internal class InProcessRunner<TInput> : ISuperStepRunner, ICheckpointingRunner 
         }
 
         await this.RunContext.StateManager.ImportStateAsync(checkpoint).ConfigureAwait(false);
-        Task executorNotifyTask = this.RunContext.NotifyCheckpointLoadedAsync(cancellation);
-
         await this.RunContext.ImportStateAsync(checkpoint).ConfigureAwait(false);
+
+        Task executorNotifyTask = this.RunContext.NotifyCheckpointLoadedAsync(cancellation);
         ValueTask republishRequestsTask = this.RunContext.RepublishUnservicedRequestsAsync(cancellation);
 
         await this.EdgeMap.ImportStateAsync(checkpoint).ConfigureAwait(false);

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/SampleSmokeTest.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/SampleSmokeTest.cs
@@ -104,6 +104,25 @@ public class SampleSmokeTest
     }
 
     [Fact]
+    public async Task Test_RunSample_Step5aAsync()
+    {
+        using StringWriter writer = new();
+
+        VerifyingPlaybackResponder<string, int> responder = new(
+            // Iteration 1
+            ("Guess the number.", 50),
+            ("Your guess was too high. Try again.", 23),
+
+            // Iteration 2
+            ("Your guess was too high. Try again.", 23),
+            ("Your guess was too low. Try again.", 42)
+         );
+
+        string guessResult = await Step5EntryPoint.RunAsync(writer, userGuessCallback: responder.InvokeNext, rehydrateToRestore: true);
+        Assert.Equal("You guessed correctly! You Win!", guessResult);
+    }
+
+    [Fact]
     public async Task Test_RunSample_Step6Async()
     {
         using StringWriter writer = new();


### PR DESCRIPTION
### Motivation and Context

When checkpointing we did not persist the set of instantiated executors. This means, in turn, when we restore from a checkpoint when using Resume(Stream) rather than restoring a checkpoint in the context of an already existing (Streaming)Run, the executors never got reinstantiated and there were no executors to notify that a state should be loaded.

### Description

The fix is to ensure we persist the list and reinstantiate the executors on rehydration.

* Changes the ordering in checkpoint/restore slightly to ensure the executor list is loaded in time for executors to be notified of checkpoint restore
* Also adds a rehydration restore test

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
