### PR TITLE
fixed incorrect tool.uv.sources config in python package installation…

### DIFF
--- a/user-documentation-python/getting-started/package_installation.md
+++ b/user-documentation-python/getting-started/package_installation.md
@@ -69,10 +69,10 @@ dependencies = [
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
 [tool.uv.sources]
-"agent-framework" = { git = "https://github.com/microsoft/agent-framework.git", ref = "main", subdirectory = "python/packages/main" }
-"agent-framework-azure" = { git = "https://github.com/microsoft/agent-framework.git", ref = "main", subdirectory = "python/packages/azure" }
-"agent-framework-foundry" = { git = "https://github.com/microsoft/agent-framework.git", ref = "main", subdirectory = "python/packages/foundry" }
-"agent-framework-workflow" = { git = "https://github.com/microsoft/agent-framework.git", ref = "main", subdirectory = "python/packages/workflow" }
+"agent-framework" = { git = "https://github.com/microsoft/agent-framework.git", branch = "main", subdirectory = "python/packages/main" }
+"agent-framework-azure" = { git = "https://github.com/microsoft/agent-framework.git", branch = "main", subdirectory = "python/packages/azure" }
+"agent-framework-foundry" = { git = "https://github.com/microsoft/agent-framework.git", branch = "main", subdirectory = "python/packages/foundry" }
+"agent-framework-workflow" = { git = "https://github.com/microsoft/agent-framework.git", branch = "main", subdirectory = "python/packages/workflow" }
 ```
 Then create a virtual environment:
 ```bash


### PR DESCRIPTION
### **Motivation and Context**

This change updates the `uv` package manager installation instructions to use `branch` instead of `ref`. The previous usage caused issues when installing the latest version of `uv`.

*   **Why required?** Ensures compatibility with the newest `uv` version.
*   **Problem solved?** Incorrect parameter (`ref`) prevented proper installation.
*   **Scenario?** Developers following the README or setup guide for `uv`.
*   **Related issue?** Fixes incorrect install instructions (no open issue linked).

***

### **Description**

Replaced `ref` with `branch` in the `uv` installation command to align with the latest `uv` syntax and avoid installation errors. No functional code changes—documentation only.