### PR TITLE
Python: fixed opentelemetry-semantic-conventions-ai module not found error

### DIFF
--- a/python/packages/main/pyproject.toml
+++ b/python/packages/main/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "azure-monitor-opentelemetry>=1.7.0",
     "azure-monitor-opentelemetry-exporter>=1.0.0b41",
     "opentelemetry-exporter-otlp-proto-grpc>=1.36.0",
+    "opentelemetry-semantic-conventions-ai>=0.4.13"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Motivation and Context

Package stability issue--telemetry was breaking the package.

### Description

Module not found error was occurring when importing telemetry module:

```bash
File ".venv\Lib\site-packages\agent_framework\telemetry.py", line 14, in <module>
    from opentelemetry.semconv_ai import GenAISystem, Meters, SpanAttributes
ModuleNotFoundError: No module named 'opentelemetry.semconv_ai'
```

Fixed by adding `opentelemetry.semconv_ai` as dependency for main package.