### PR TITLE
Python: replaced HEADERS with user_agent

### DIFF
--- a/python/packages/foundry/tests/test_foundry_chat_client.py
+++ b/python/packages/foundry/tests/test_foundry_chat_client.py
@@ -23,7 +23,6 @@ from agent_framework import (
     TextContent,
     UriContent,
 )
-from agent_framework import __version__ as AF_VERSION
 from agent_framework.exceptions import ServiceInitializationError
 from agent_framework.foundry import FoundryChatClient, FoundrySettings
 from azure.ai.agents.models import (
@@ -315,9 +314,7 @@ async def test_foundry_chat_client_cleanup_agent_if_needed_should_delete(
 
     await chat_client._cleanup_agent_if_needed()  # type: ignore
     # Verify agent deletion was called
-    mock_ai_project_client.agents.delete_agent.assert_called_once_with(
-        "agent-to-delete", headers={"User-Agent": f"agent-framework-python/{AF_VERSION}"}
-    )
+    mock_ai_project_client.agents.delete_agent.assert_called_once_with("agent-to-delete")
     assert not chat_client._should_delete_agent  # type: ignore
 
 
@@ -358,9 +355,7 @@ async def test_foundry_chat_client_aclose(mock_ai_project_client: MagicMock) -> 
     await chat_client.close()
 
     # Verify agent deletion was called
-    mock_ai_project_client.agents.delete_agent.assert_called_once_with(
-        "agent-to-delete", headers={"User-Agent": f"agent-framework-python/{AF_VERSION}"}
-    )
+    mock_ai_project_client.agents.delete_agent.assert_called_once_with("agent-to-delete")
 
 
 async def test_foundry_chat_client_async_context_manager(mock_ai_project_client: MagicMock) -> None:
@@ -374,9 +369,7 @@ async def test_foundry_chat_client_async_context_manager(mock_ai_project_client:
         pass  # Just test that we can enter and exit
 
     # Verify cleanup was called on exit
-    mock_ai_project_client.agents.delete_agent.assert_called_once_with(
-        "agent-to-delete", headers={"User-Agent": f"agent-framework-python/{AF_VERSION}"}
-    )
+    mock_ai_project_client.agents.delete_agent.assert_called_once_with("agent-to-delete")
 
 
 def test_foundry_chat_client_create_run_options_basic(mock_ai_project_client: MagicMock) -> None:
@@ -562,9 +555,7 @@ async def test_foundry_chat_client_prepare_thread_cancels_active_run(mock_ai_pro
     result = await chat_client._prepare_thread("test-thread", mock_thread_run, run_options)  # type: ignore
 
     assert result == "test-thread"
-    mock_ai_project_client.agents.runs.cancel.assert_called_once_with(
-        "test-thread", "run_123", headers={"User-Agent": f"agent-framework-python/{AF_VERSION}"}
-    )
+    mock_ai_project_client.agents.runs.cancel.assert_called_once_with("test-thread", "run_123")
 
 
 def test_foundry_chat_client_create_function_call_contents_basic(mock_ai_project_client: MagicMock) -> None:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
After connecting with the Foundry team, found the user_agent param on the client, implemented that instead of headers on each call.

#654 closed for Python

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.