### PR TITLE
Python: enable uv ecosystem for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 8 * * 4,0" # Every Thursday(4) and Sunday(0) at 8:00 UTC
-    experimental:  
+    experimental:
       nuget-native-updater: false
       enable-cooldown-metrics-collection: false
     ignore:
@@ -27,8 +27,8 @@ updates:
       - ".NET"
       - "dependencies"
 
-  # Maintain dependencies for pip
-  - package-ecosystem: "pip"
+  # Maintain dependencies for python
+  - package-ecosystem: "uv"
     directory: "python/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
set ecosystem to `uv` for python dependabot, this should improve both the accuracy and updates dependabot proposes.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.