### PR TITLE
.NET: Solidify Concurrency Model for Inproc Workflows

### DIFF
--- a/dotnet/src/Microsoft.Agents.Workflows/ChatProtocolExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ChatProtocolExecutor.cs
@@ -18,6 +18,14 @@ internal abstract class ChatProtocolExecutor(string id, ChatProtocolExecutorOpti
     private List<ChatMessage> _pendingMessages = [];
     private readonly ChatRole? _stringMessageChatRole = options?.StringMessageChatRole;
 
+    // Note that we explicitly do not implement IResettableExecutor here, as we want to allow derived classes to
+    // implement it if they want to be resettable, but do not want to opt them into it.
+    protected ValueTask ResetAsync()
+    {
+        this._pendingMessages = [];
+        return default;
+    }
+
     protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
     {
         if (this._stringMessageChatRole.HasValue)

--- a/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/PortableMessageEnvelope.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/PortableMessageEnvelope.cs
@@ -9,13 +9,15 @@ internal sealed class PortableMessageEnvelope
 {
     public TypeId MessageType { get; }
     public PortableValue Message { get; }
+    public ExecutorIdentity Source { get; }
     public string? TargetId { get; }
 
     [JsonConstructor]
-    internal PortableMessageEnvelope(TypeId messageType, PortableValue message, string? targetId)
+    internal PortableMessageEnvelope(TypeId messageType, ExecutorIdentity source, PortableValue message, string? targetId)
     {
         this.MessageType = messageType;
         this.Message = message;
+        this.Source = source;
         this.TargetId = targetId;
     }
 
@@ -28,6 +30,6 @@ internal sealed class PortableMessageEnvelope
 
     public MessageEnvelope ToMessageEnvelope()
     {
-        return new MessageEnvelope(this.Message, this.MessageType, this.TargetId);
+        return new MessageEnvelope(this.Message, this.Source, this.MessageType, this.TargetId);
     }
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/PortableValueConverter.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Checkpointing/PortableValueConverter.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Agents.Workflows.Checkpointing;
 /// at the time of initial deserialization, e.g. user-defined state types.
 ///
 /// This operates in conjuction with <see cref="IDelayedDeserialization"/> and <see cref="PortableValue"/> to abstract
-/// away the speicfics of a given serialization format in favor of <see cref="PortableValue.As{TValue}"/> and
-/// <see cref="PortableValue.Is{TValue}"/>.
+/// away the speicfics of a given serialization format in favor of <see cref="PortableValue.As{TValue}()"/> and
+/// <see cref="PortableValue.Is{TValue}()"/> and related methods.
 /// </summary>
 /// <param name="marshaller"></param>
 internal sealed class PortableValueConverter(JsonMarshaller marshaller) : JsonConverter<PortableValue>

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/DeliveryMapping.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/DeliveryMapping.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.Workflows.Execution;
+
+internal sealed class DeliveryMapping
+{
+    private readonly IEnumerable<MessageEnvelope> _envelopes;
+    private readonly IEnumerable<Executor> _targets;
+
+    public DeliveryMapping(IEnumerable<MessageEnvelope> envelopes, IEnumerable<Executor> targets)
+    {
+        this._envelopes = Throw.IfNull(envelopes);
+        this._targets = Throw.IfNull(targets);
+    }
+
+    public DeliveryMapping(MessageEnvelope envelope, Executor target) : this([envelope], [target]) { }
+    public DeliveryMapping(MessageEnvelope envelope, IEnumerable<Executor> targets) : this([envelope], targets) { }
+    public DeliveryMapping(IEnumerable<MessageEnvelope> envelopes, Executor target) : this(envelopes, [target]) { }
+
+    public IEnumerable<MessageDelivery> Deliveries => from target in this._targets
+                                                      from envelope in this._envelopes
+                                                      select new MessageDelivery(envelope, target);
+
+    public void MapInto(StepContext nextStep)
+    {
+        foreach (Executor target in this._targets)
+        {
+            nextStep.MessagesFor(target.Id).AddRange(this._envelopes.Select(envelope => envelope));
+        }
+    }
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/EdgeRunner.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/EdgeRunner.cs
@@ -1,11 +1,24 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
+internal interface IStatefulEdgeRunner
+{
+    ValueTask<PortableValue> ExportStateAsync();
+    ValueTask ImportStateAsync(PortableValue state);
+}
+
+internal abstract class EdgeRunner
+{
+    // TODO: Can this be sync?
+    protected internal abstract ValueTask<DeliveryMapping?> ChaseEdgeAsync(MessageEnvelope envelope, IStepTracer? stepTracer);
+}
+
 internal abstract class EdgeRunner<TEdgeData>(
-    IRunnerContext runContext, TEdgeData edgeData)
+    IRunnerContext runContext, TEdgeData edgeData) : EdgeRunner()
 {
     protected IRunnerContext RunContext { get; } = Throw.IfNull(runContext);
     protected TEdgeData EdgeData { get; } = Throw.IfNull(edgeData);

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/FanInEdgeRunner.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/FanInEdgeRunner.cs
@@ -1,58 +1,56 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
 internal sealed class FanInEdgeRunner(IRunnerContext runContext, FanInEdgeData edgeData) :
-    EdgeRunner<FanInEdgeData>(runContext, edgeData)
+    EdgeRunner<FanInEdgeData>(runContext, edgeData),
+    IStatefulEdgeRunner
 {
-    private IWorkflowContext BoundContext { get; } = runContext.Bind(edgeData.SinkId);
+    private FanInEdgeState _state = new(edgeData);
 
-    public FanInEdgeState CreateState() => new(this.EdgeData);
-
-    public ValueTask<IEnumerable<object?>> ChaseAsync(string sourceId, MessageEnvelope envelope, FanInEdgeState state, IStepTracer? tracer)
+    protected internal override async ValueTask<DeliveryMapping?> ChaseEdgeAsync(MessageEnvelope envelope, IStepTracer? stepTracer)
     {
+        Debug.Assert(!envelope.IsExternal, "FanIn edges should never be chased from external input");
+
         if (envelope.TargetId is not null && this.EdgeData.SinkId != envelope.TargetId)
         {
-            // This message is not for us.
-            return new([]);
+            return null;
         }
 
-        IEnumerable<MessageEnvelope>? releasedMessages = state.ProcessMessage(sourceId, envelope);
+        // source.Id is guaranteed to be non-null here because source is not None.
+        IEnumerable<MessageEnvelope>? releasedMessages = this._state.ProcessMessage(envelope.SourceId, envelope);
         if (releasedMessages is null)
         {
             // Not ready to process yet.
-            return new([]);
+            return null;
         }
 
-        return this.ForwardReleasedMessagesAsync(releasedMessages, tracer);
-    }
-
-    private async ValueTask<IEnumerable<object?>> ForwardReleasedMessagesAsync(IEnumerable<MessageEnvelope> releasedMessages, IStepTracer? tracer)
-    {
-        Executor target = await this.RunContext.EnsureExecutorAsync(this.EdgeData.SinkId, tracer)
+        // TODO: Filter messages based on accepted input types?
+        Executor target = await this.RunContext.EnsureExecutorAsync(this.EdgeData.SinkId, stepTracer)
                                                .ConfigureAwait(false);
 
-        List<Task<object?>> messageTasks = [];
+        return new DeliveryMapping(releasedMessages.Where(envelope => target.CanHandle(envelope.MessageType)), target);
+    }
 
-        foreach (MessageEnvelope releasedEnvelope in releasedMessages)
+    public ValueTask<PortableValue> ExportStateAsync()
+    {
+        return new(new PortableValue(this._state));
+    }
+
+    public ValueTask ImportStateAsync(PortableValue state)
+    {
+        if (state.Is(out FanInEdgeState? importedState))
         {
-            object message = releasedEnvelope.Message;
-            Debug.Assert(message is PortableValue, "It should not be possible to get messages released without roundtripping them through" +
-                "PortableValue via PortableMessageEnvelope.");
-
-            PortableValue portable = message as PortableValue ?? new PortableValue(releasedEnvelope.MessageType, message);
-
-            if (target.CanHandle(portable.TypeId))
-            {
-                tracer?.TraceActivated(target.Id);
-                messageTasks.Add(target.ExecuteAsync(portable, releasedEnvelope.MessageType, this.BoundContext).AsTask());
-            }
+            this._state = importedState;
+            return default;
         }
 
-        return await Task.WhenAll(messageTasks.ToArray()).ConfigureAwait(false);
+        throw new InvalidOperationException($"Unsupported exported state type: {state.GetType()}; {this.EdgeData.Id}");
     }
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/IRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/IRunnerContext.cs
@@ -9,7 +9,7 @@ internal interface IRunnerContext : IExternalRequestSink
     ValueTask AddEventAsync(WorkflowEvent workflowEvent);
     ValueTask SendMessageAsync(string sourceId, object message, string? targetId = null);
 
-    StepContext Advance();
+    ValueTask<StepContext> AdvanceAsync();
     IWorkflowContext Bind(string executorId);
     ValueTask<Executor> EnsureExecutorAsync(string executorId, IStepTracer? tracer);
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepRunner.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/ISuperStepRunner.cs
@@ -19,4 +19,6 @@ internal interface ISuperStepRunner
     event EventHandler<WorkflowEvent>? WorkflowEvent;
 
     ValueTask<bool> RunSuperStepAsync(CancellationToken cancellation);
+
+    ValueTask RequestEndRunAsync();
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/MessageDelivery.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/MessageDelivery.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.Workflows.Execution;
+
+internal sealed class MessageDelivery
+{
+    [JsonConstructor]
+    internal MessageDelivery(MessageEnvelope envelope, string targetId)
+    {
+        this.Envelope = Throw.IfNull(envelope);
+        this.TargetId = Throw.IfNull(targetId);
+    }
+
+    internal MessageDelivery(MessageEnvelope envelope, Executor target)
+        : this(envelope, target.Id)
+    {
+        this.TargetCache = Throw.IfNull(target);
+    }
+
+    public string TargetId { get; }
+    public MessageEnvelope Envelope { get; }
+
+    [JsonIgnore]
+    internal Executor? TargetCache { get; set; }
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/MessageEnvelope.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/MessageEnvelope.cs
@@ -1,18 +1,25 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Agents.Workflows.Checkpointing;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
-internal sealed class MessageEnvelope(object message, TypeId? declaredType = null, string? targetId = null)
+internal sealed class MessageEnvelope(object message, ExecutorIdentity source, TypeId? declaredType = null, string? targetId = null)
 {
     public TypeId MessageType => declaredType ?? new(message.GetType());
     public object Message => message;
+    public ExecutorIdentity Source => source;
     public string? TargetId => targetId;
 
-    internal MessageEnvelope(object message, Type declaredType, string? targetId = null)
-        : this(message, new TypeId(declaredType), targetId)
+    [MemberNotNullWhen(false, nameof(SourceId))]
+    public bool IsExternal => this.Source == ExecutorIdentity.None;
+
+    public string? SourceId => this.Source.Id;
+
+    internal MessageEnvelope(object message, ExecutorIdentity source, Type declaredType, string? targetId = null)
+        : this(message, source, new TypeId(declaredType), targetId)
     {
         if (!declaredType.IsAssignableFrom(message.GetType()))
         {

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/RunnerStateData.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/RunnerStateData.cs
@@ -5,9 +5,9 @@ using Microsoft.Agents.Workflows.Checkpointing;
 
 namespace Microsoft.Agents.Workflows.Execution;
 
-internal sealed class RunnerStateData(HashSet<string> instantiatedExecutors, Dictionary<ExecutorIdentity, List<PortableMessageEnvelope>> queuedMessages, List<ExternalRequest> outstandingRequests)
+internal sealed class RunnerStateData(HashSet<string> instantiatedExecutors, Dictionary<string, List<PortableMessageEnvelope>> queuedMessages, List<ExternalRequest> outstandingRequests)
 {
     public HashSet<string> InstantiatedExecutors { get; } = instantiatedExecutors;
-    public Dictionary<ExecutorIdentity, List<PortableMessageEnvelope>> QueuedMessages { get; } = queuedMessages;
+    public Dictionary<string, List<PortableMessageEnvelope>> QueuedMessages { get; } = queuedMessages;
     public List<ExternalRequest> OutstandingRequests { get; } = outstandingRequests;
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/Execution/StepContext.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Execution/StepContext.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Agents.Workflows.Execution;
 
 internal sealed class StepContext
 {
-    public Dictionary<ExecutorIdentity, List<MessageEnvelope>> QueuedMessages { get; } = [];
+    public Dictionary<string, List<MessageEnvelope>> QueuedMessages { get; } = [];
 
     public bool HasMessages => this.QueuedMessages.Values.Any(messageList => messageList.Count > 0);
 
-    public List<MessageEnvelope> MessagesFor(string? executorId)
+    public List<MessageEnvelope> MessagesFor(string target)
     {
-        if (!this.QueuedMessages.TryGetValue(executorId, out var messages))
+        if (!this.QueuedMessages.TryGetValue(target, out var messages))
         {
-            this.QueuedMessages[executorId] = messages = [];
+            this.QueuedMessages[target] = messages = [];
         }
 
         return messages;
@@ -24,7 +24,7 @@ internal sealed class StepContext
 
     // TODO: Create a MessageEnvelope class that extends from the ExportedState object (with appropriate rename) to avoid
     // unnecessary wrapping and unwrapping of messages during checkpointing.
-    internal Dictionary<ExecutorIdentity, List<PortableMessageEnvelope>> ExportMessages()
+    internal Dictionary<string, List<PortableMessageEnvelope>> ExportMessages()
     {
         return this.QueuedMessages.Keys.ToDictionary(
             keySelector: identity => identity,
@@ -33,9 +33,9 @@ internal sealed class StepContext
         );
     }
 
-    internal void ImportMessages(Dictionary<ExecutorIdentity, List<PortableMessageEnvelope>> messages)
+    internal void ImportMessages(Dictionary<string, List<PortableMessageEnvelope>> messages)
     {
-        foreach (ExecutorIdentity identity in messages.Keys)
+        foreach (string identity in messages.Keys)
         {
             this.QueuedMessages[identity] = messages[identity].ConvertAll(UnwrapExportedState);
         }

--- a/dotnet/src/Microsoft.Agents.Workflows/ExecutorRegistration.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/ExecutorRegistration.cs
@@ -13,6 +13,35 @@ internal sealed class ExecutorRegistration(string id, Type executorType, Executo
     public string Id { get; } = Throw.IfNullOrEmpty(id);
     public Type ExecutorType { get; } = Throw.IfNull(executorType);
     public ExecutorFactoryF ProviderAsync { get; } = Throw.IfNull(provider);
+    public bool IsNotExecutorInstance { get; } = rawData is not Executor;
+    public bool IsUnresettableSharedInstance { get; } = rawData is Executor && rawData is not IResettableExecutor;
+
+    internal async ValueTask<bool> TryResetAsync()
+    {
+        if (this.IsUnresettableSharedInstance)
+        {
+            return false;
+        }
+
+        // If this is not an executor instance, this is a factory, and the expectation is that the factory will
+        // create separate instances of executors.
+        if (this.IsNotExecutorInstance)
+        {
+            return true;
+        }
+
+        // Technically we definitely know this is true, since if rawData is an Executor, if it was not resettable
+        // then we would have returned in the first condition, and if rawData is not an Executor, we would have
+        // returned in the second condition. That only leaves the possibility of rawData is Executor and also
+        // IResettableExecutor.
+        if (this.RawExecutorishData is IResettableExecutor resettableExecutor)
+        {
+            await resettableExecutor.ResetAsync().ConfigureAwait(false);
+            return true;
+        }
+
+        return false;
+    }
 
     internal object? RawExecutorishData { get; } = rawData;
 

--- a/dotnet/src/Microsoft.Agents.Workflows/IResettableExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/IResettableExecutor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Workflows;
+
+/// <summary>
+/// Provides a mechanism to return an executor to a 'reset' state, allowing a workflow containing
+/// shared instances of it to be resued after a run is disposed.
+/// </summary>
+public interface IResettableExecutor
+{
+    /// <summary>
+    /// Reset the executor
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the completion of the reset operation.</returns>
+    ValueTask ResetAsync()
+#if NET
+    {
+        return default;
+    }
+#else
+    ;
+#endif
+}

--- a/dotnet/src/Microsoft.Agents.Workflows/Run.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/Run.cs
@@ -38,7 +38,7 @@ public enum RunStatus
 /// Represents a workflow run that tracks execution status and emitted workflow events, supporting resumption
 /// with responses to <see cref="RequestInfoEvent"/>.
 /// </summary>
-public class Run
+public sealed class Run
 {
     internal static async ValueTask<Run> CaptureStreamAsync(StreamingRun run, CancellationToken cancellation = default)
     {
@@ -147,4 +147,7 @@ public class Run
 
         return await this.RunToNextHaltAsync(cancellation).ConfigureAwait(false);
     }
+
+    /// <inheritdoc cref="StreamingRun.EndRunAsync"/>
+    public ValueTask EndRunAsync() => this._streamingRun.EndRunAsync();
 }

--- a/dotnet/src/Microsoft.Agents.Workflows/StreamingRun.cs
+++ b/dotnet/src/Microsoft.Agents.Workflows/StreamingRun.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Agents.Workflows;
 /// A <see cref="Workflow"/> run instance supporting a streaming form of receiving workflow events, and providing
 /// a mechanism to send responses back to the workflow.
 /// </summary>
-public class StreamingRun
+public sealed class StreamingRun
 {
     private TaskCompletionSource<object>? _waitForResponseSource;
     private readonly ISuperStepRunner _stepRunner;
@@ -157,6 +157,14 @@ public class StreamingRun
             eventSink.Add(e);
         }
     }
+
+    /// <summary>
+    /// Signals the end of the current run and initiates any necessary cleanup operations asynchronously.
+    /// Enables the underlying Workflow instance to be reused in subsequent runs.
+    /// </summary>
+    /// <returns>A ValueTask that represents the asynchronous operation. The task is complete when the run has
+    /// ended and cleanup is finished.</returns>
+    public ValueTask EndRunAsync() => this._stepRunner.RequestEndRunAsync();
 }
 
 /// <summary>

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/InProcessStateTests.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/InProcessStateTests.cs
@@ -103,6 +103,9 @@ public class InProcessStateTests
         Run run = await InProcessExecution.RunAsync<TurnToken>(workflow, new());
 
         run.Status.Should().Be(RunStatus.Idle);
+
+        writer.Completed.Should().BeTrue();
+        validator.Completed.Should().BeTrue();
     }
 
     [Fact]
@@ -129,8 +132,11 @@ public class InProcessStateTests
 
         Checkpointed<Run> checkpointed = await InProcessExecution.RunAsync<TurnToken>(workflow, new(), CheckpointManager.Default);
 
-        checkpointed.Checkpoints.Should().HaveCount(6);
+        checkpointed.Checkpoints.Should().HaveCount(5);
         checkpointed.Run.Status.Should().Be(RunStatus.Idle);
+
+        writer.Completed.Should().BeTrue();
+        validator.Completed.Should().BeTrue();
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/MessageDeliveryValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/MessageDeliveryValidation.cs
@@ -10,6 +10,40 @@ namespace Microsoft.Agents.Workflows.UnitTests;
 
 internal static class MessageDeliveryValidation
 {
+    public static void CheckDeliveries(this DeliveryMapping mapping, HashSet<string> receiverIds, HashSet<object> messages)
+    {
+        HashSet<string> unseenReceivers = [.. receiverIds];
+        HashSet<object> unseenMessages = [.. messages];
+
+        foreach (IGrouping<string, MessageDelivery> grouping in mapping.Deliveries.GroupBy(delivery => delivery.TargetId))
+        {
+            string receiverId = grouping.Key;
+
+            receiverIds.Should().Contain(receiverId);
+            unseenReceivers.Remove(grouping.Key);
+
+            foreach (MessageDelivery delivery in grouping)
+            {
+                object messageValue;
+                if (delivery.Envelope.Message is PortableValue portableValue)
+                {
+                    portableValue.IsDelayedDeserialization.Should().BeFalse();
+                    messageValue = portableValue.Value;
+                }
+                else
+                {
+                    messageValue = delivery.Envelope.Message;
+                }
+
+                messages.Should().Contain(messageValue);
+                unseenMessages.Remove(messageValue);
+            }
+        }
+
+        unseenReceivers.Should().BeEmpty();
+        unseenMessages.Should().BeEmpty();
+    }
+
     public static void CheckForwarded(Dictionary<string, List<MessageEnvelope>> queuedMessages, params (string expectedSender, List<string> expectedMessages)[] expectedForwards)
     {
         queuedMessages.Should().HaveCount(expectedForwards.Length);

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/03_Simple_Workflow_Loop.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/03_Simple_Workflow_Loop.cs
@@ -92,7 +92,7 @@ internal sealed class GuessNumberExecutor : ReflectingExecutor<GuessNumberExecut
     }
 }
 
-internal sealed class JudgeExecutor : ReflectingExecutor<JudgeExecutor>, IMessageHandler<int, NumberSignal>
+internal sealed class JudgeExecutor : ReflectingExecutor<JudgeExecutor>, IMessageHandler<int, NumberSignal>, IResettableExecutor
 {
     private readonly int _targetNumber;
 
@@ -121,5 +121,11 @@ internal sealed class JudgeExecutor : ReflectingExecutor<JudgeExecutor>, IMessag
     protected internal override async ValueTask OnCheckpointRestoredAsync(IWorkflowContext context, CancellationToken cancellation = default)
     {
         this.Tries = await context.ReadStateAsync<int?>("TryCount").ConfigureAwait(false) ?? 0;
+    }
+
+    public ValueTask ResetAsync()
+    {
+        this.Tries = null;
+        return default;
     }
 }

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/05_Simple_Workflow_Checkpointing.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/Sample/05_Simple_Workflow_Checkpointing.cs
@@ -39,6 +39,8 @@ internal static class Step5EntryPoint
 
         if (rehydrateToRestore)
         {
+            await handle.EndRunAsync().ConfigureAwait(false);
+
             checkpointed = await InProcessExecution.ResumeStreamAsync(workflow, targetCheckpoint, checkpointManager, runId: handle.RunId, cancellation: CancellationToken.None)
                                                    .ConfigureAwait(false);
             handle = checkpointed.Run;
@@ -59,7 +61,7 @@ internal static class Step5EntryPoint
         result = await RunStreamToHaltOrMaxStepAsync().ConfigureAwait(false);
 
         result.Should().NotBeNull();
-        checkpoints.Should().HaveCount(7);
+        checkpoints.Should().HaveCount(6);
 
         cancellationSource.Dispose();
 

--- a/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/TestRunContext.cs
+++ b/dotnet/tests/Microsoft.Agents.Workflows.UnitTests/TestRunContext.cs
@@ -61,11 +61,11 @@ public class TestRunContext : IRunnerContext
             this.QueuedMessages[sourceId] = deliveryQueue = [];
         }
 
-        deliveryQueue.Add(new(message, targetId: targetId));
+        deliveryQueue.Add(new(message, sourceId, targetId: targetId));
         return default;
     }
 
-    StepContext IRunnerContext.Advance() =>
+    ValueTask<StepContext> IRunnerContext.AdvanceAsync() =>
         throw new NotImplementedException();
 
     public Dictionary<string, Executor> Executors { get; } = [];


### PR DESCRIPTION
### Motivation and Context

Our initial concurrency model for Workflows was single-threaded async execution (similar to Python). This meant that messages were delivered one at a time to individual executors at a time. It seemed desirable to allow concurrent execution, so we switched to delivering messages concurrently. This causes threading and timing issues, as well as leading to message deliveries being out of order.

The desired fix is detailed in #784

### Description

These changes introduce the new default concurrency model: All executors processing messages run in parallel, but one message at a time. To avoid issues with executors provided as instances -- and thus shared between runs on the same workflow instance, rather than created every run if a factory method is provided -- we disallow running a single workflow instance concurrently. 

After a run is done and disposed, if the Workflow has no shared executor instances or all of the are resettable, it may be reused in another run.

Adding support for fully single-threaded or concurrent execution is not in scope of this change.

* Disallow execution of multiple workflows at once
* Define notion of executor Reset() to allow reuse of workflows with shared executor instances
* Switch to delivering all messages to a single executor sequentially, with executors running in parallel

Technically this is a breaking change because previously it was possible to run the same workflow instance concurrently (but with undefined behaviour). Now this is no longer allowed. 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.