### PR TITLE
.NET: Change RootNamespace for Agent abstractions project

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(ProjectsTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">$(ProjectsDebugTargetFrameworks)</TargetFrameworks>
-    <RootNamespace>Microsoft.Extensions.AI.Agents</RootNamespace>
+    <RootNamespace>Microsoft.Agents.AI</RootNamespace>
     <NoWarn>$(NoWarn);CA1716;IDE0009;MEAI001</NoWarn>
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
Looks like this was missed as part of the abstractions rename.

cc @markwallace-microsoft 