### PR TITLE
.NET: fix sample app startup bugs

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A.AspNetCore/WebApplicationExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A.AspNetCore/WebApplicationExtensions.cs
@@ -63,7 +63,7 @@ public static class WebApplicationExtensions
         // note: current SDK version registers multiple `.well-known/agent.json` handlers here.
         // it makes app return HTTP 500, but will be fixed once new A2A SDK is released.
         // see https://github.com/microsoft/agent-framework/issues/476 for details
-        app.MapA2A(taskManager, path);
+        A2ARouteBuilderExtensions.MapA2A(app, taskManager, path);
 
         app.MapHttpA2A(taskManager, path);
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
@@ -41,7 +41,7 @@ public static class WorkflowHostingExtensions
             throw new InvalidOperationException("Cannot host a workflow that does not accept List<ChatMessage> as an input");
         }
 
-        return maybeTyped.AsAgent();
+        return maybeTyped.AsAgent(id, name);
     }
 
     internal static FunctionCallContent ToFunctionCall(this ExternalRequest request)


### PR DESCRIPTION
Fixing:
1) accidentally introduced recursion while #915 
2) the AIAgent registration via `AsAgentAsync()`
`AgentWorkflowBuilder.BuildConcurrent([knight, knave, narrator]).AsAgentAsync(name: key).AsTask().GetAwaiter().GetResult();`
otherwise `agent.Name` property will not be populated