### PR TITLE
Python: Add metapackage metadata stub to restore flit builds

### DIFF
--- a/python/agent_framework_meta/__init__.py
+++ b/python/agent_framework_meta/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from importlib import metadata as _metadata
+from pathlib import Path as _Path
+from typing import Any, cast
+
+try:
+    import tomllib as _toml  # type: ignore # Python 3.11+
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as _toml  # type: ignore
+
+
+def _load_pyproject() -> dict[str, Any]:
+    pyproject = (_Path(__file__).resolve().parents[1] / "pyproject.toml").read_text("utf-8")
+    return cast(dict[str, Any], _toml.loads(pyproject))  # type: ignore
+
+
+def _version() -> str:
+    try:
+        return _metadata.version("agent-framework")
+    except _metadata.PackageNotFoundError as ex:
+        data = _load_pyproject()
+        project = cast(dict[str, Any], data.get("project", {}))
+        version = project.get("version")
+        if isinstance(version, str):
+            return version
+        raise RuntimeError("pyproject.toml missing project.version") from ex
+
+
+__version__ = _version()
+__all__ = ["__version__"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -257,6 +257,9 @@ where = ["packages"]
 include = ["agent_framework**"]
 namespaces = true
 
+[tool.flit.module]
+name = "agent_framework_meta"
+
 [build-system]
 requires = ["flit-core >= 3.11,<4.0"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
### Motivation and Context

- Supply agent_framework_meta/__init__.py with a typed version loader so the metapackage exposes a module for flit without touching runtime imports.
- Update [tool.flit.module] in pyproject.toml to reference that helper, fixing get_requires_for_build_wheel.
- Validation: rebuilt the wheelhouse using `uv build --wheel --out-dir dist-local …` to verify the metapackage now installs cleanly alongside the published subpackages.


- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.