### PR TITLE
.NET: Bugfix In OpenTelemetryAgent RawRepresentation Check

### DIFF
--- a/dotnet/samples/GettingStarted/AgentOpenTelemetry/Program.cs
+++ b/dotnet/samples/GettingStarted/AgentOpenTelemetry/Program.cs
@@ -85,7 +85,7 @@ Console.WriteLine("""
     """);
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT environment variable is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-4o-mini";
+var deploymentName = System.Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-4o-mini";
 
 // Log application startup
 appLogger.LogInformation("OpenTelemetry Aspire Demo application started");

--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
@@ -76,7 +76,7 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
 
         var response = await this._otelClient.GetResponseAsync(messages, co, cancellationToken).ConfigureAwait(false);
 
-        return (AgentRunResponse)response.RawRepresentation!;
+        return response.RawRepresentation as AgentRunResponse ?? new AgentRunResponse(response);
     }
 
     /// <inheritdoc/>
@@ -87,7 +87,7 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
 
         await foreach (var update in this._otelClient.GetStreamingResponseAsync(messages, co, cancellationToken).ConfigureAwait(false))
         {
-            yield return (AgentRunResponseUpdate)update.RawRepresentation!;
+            yield return update.RawRepresentation as AgentRunResponseUpdate ?? new AgentRunResponseUpdate(update);
         }
     }
 

--- a/dotnet/src/Shared/Demos/SampleEnvironment.cs
+++ b/dotnet/src/Shared/Demos/SampleEnvironment.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using SystemEnvironment = System.Environment;
 
 namespace SampleHelpers;
+
 internal static class SampleEnvironment
 {
     public static string? GetEnvironmentVariable(string key)


### PR DESCRIPTION
When using the new extensions `AsChatResponseUpdate` the RawRepresentation was used directly which was breaking the existing logic.

<img width="2465" height="1253" alt="image" src="https://github.com/user-attachments/assets/45badbd2-d044-4ccb-8c65-39acff49047e" />

```csharp
 public static ChatResponseUpdate AsChatResponseUpdate(this AgentRunResponseUpdate responseUpdate)
 {
     Throw.IfNull(responseUpdate);

     return
         // When this line is true, the result doesn't have a RawRepresentation to be checked in the OTEL Agent side and can't be always cast to AgentRunResponseUpdate or AgentRunResponse
         responseUpdate.RawRepresentation as ChatResponseUpdate ??
         new()
         {
             AdditionalProperties = responseUpdate.AdditionalProperties,
             AuthorName = responseUpdate.AuthorName,
             Contents = responseUpdate.Contents,
             CreatedAt = responseUpdate.CreatedAt,
             MessageId = responseUpdate.MessageId,
             RawRepresentation = responseUpdate,
             ResponseId = responseUpdate.ResponseId,
             Role = responseUpdate.Role,
         };
 }
```
