### PR TITLE
.NET: fix: Make CheckpointInfo constructor public

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/CheckpointInfo.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/CheckpointInfo.cs
@@ -29,8 +29,13 @@ public sealed class CheckpointInfo : IEquatable<CheckpointInfo>
     /// hexadecimal format  and sets the timestamp to the current UTC time.</remarks>
     internal CheckpointInfo(string runId) : this(runId, Guid.NewGuid().ToString("N")) { }
 
+    /// <summary>
+    /// Initializes a new instance of the CheckpointInfo class with the specified run and checkpoint identifiers.
+    /// </summary>
+    /// <param name="runId">The unique identifier for the run. Cannot be null or empty.</param>
+    /// <param name="checkpointId">The unique identifier for the checkpoint. Cannot be null or empty.</param>
     [JsonConstructor]
-    internal CheckpointInfo(string runId, string checkpointId)
+    public CheckpointInfo(string runId, string checkpointId)
     {
         this.RunId = Throw.IfNullOrEmpty(runId);
         this.CheckpointId = Throw.IfNullOrEmpty(checkpointId);


### PR DESCRIPTION
### Motivation and Context

In order to be able to restore a `StreamingRun/Run` from a checkpoint, it is necessary to pass in a `CheckpointInfo` object. Without a public constructor it can only be used if a `CheckpointInfo` object is generated by the checkpointing system and kept around until the checkpoint needs to be restored, or if JSON serialization is used to produce the object.

### Description

Make the constructor public.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.