### PR TITLE
docs: Update References to Agent2Agent protocol to use correct terminology

### DIFF
--- a/TRANSPARENCY_FAQ.md
+++ b/TRANSPARENCY_FAQ.md
@@ -97,7 +97,7 @@ Microsoft Agent Framework relies on existing LLMs. Using the framework retains c
 The framework supports multiple external service types: 
 
 - **Native Functions**: Custom Python/C# functions that agents can invoke
-- **A2A Integration**: Agent-to-agent communication and coordination
+- **A2A (Agent2Agent)Integration**: Agent-to-agent communication and coordination
 - **Model Context Protocol (MCP)**: External tools and data sources through MCP servers
 - **Tools & External Capabilities**: Agent-invokable external services
 
@@ -110,7 +110,7 @@ Microsoft Agent Framework is an open-source framework that allows integration wi
 **Data Access by Service Type**:
 
 - **Native Functions**: Custom functions you develop have access to whatever data you explicitly pass to them as parameters
-- **A2A (Agent-to-Agent)**: External agents can access conversation history, messages, and any data you configure to share through the communication interface
+- **A2A (Agent2Agent)**: External agents can access conversation history, messages, and any data you configure to share through the communication interface
 - **Model Context Protocol (MCP) Servers**: External MCP servers can access data according to the specific MCP server implementation and your configuration
 - **External Tools**: Third-party tools and APIs have access to data you explicitly send to them through function calls
 

--- a/dotnet/samples/A2AClientServer/README.md
+++ b/dotnet/samples/A2AClientServer/README.md
@@ -145,7 +145,7 @@ Sample output from the request to send a message to the agent via A2A protocol:
 
 ### Testing the Agents using the A2A Inspector
 
-The A2A Inspector is a web-based tool designed to help developers inspect, debug, and validate servers that implement the Google A2A (Agent-to-Agent) protocol. It provides a user-friendly interface to interact with an A2A agent, view communication, and ensure specification compliance.
+The A2A Inspector is a web-based tool designed to help developers inspect, debug, and validate servers that implement the Google A2A (Agent2Agent) protocol. It provides a user-friendly interface to interact with an A2A agent, view communication, and ensure specification compliance.
 
 For more information go [here](https://github.com/a2aproject/a2a-inspector).
 
@@ -224,7 +224,7 @@ Agent: The transaction details for **TICKET-XYZ987** are as follows:
   - **Hats:** 200 units at $15.00 each
   - **Glasses:** 300 units at $5.00 each
 
-To proceed with the dispute regarding the quantity of t-shirts delivered, please specify the exact quantity issue – how many t-shirts were actually received compared to the ordered amount.
+To proceed with the dispute regarding the quantity of t-shirts delivered, please specify the exact quantity issue ï¿½ how many t-shirts were actually received compared to the ordered amount.
 
 ### Customer Service Policy for Handling Disputes
 **Short Shipment Dispute Handling Policy V2.1**

--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -52,7 +52,7 @@
         <div class="protocol-select-wrapper">
             <select id="protocol-select" class="protocol-select" @bind="selectedProtocol" disabled="@(isStreaming)">
                 <option value="AgenticFramework">Agentic Framework</option>
-                <option value="A2A">A2A (Agent-to-Agent)</option>
+                <option value="A2A">A2A (Agent2Agent)</option>
             </select>
             <div class="protocol-info">
                 @switch (selectedProtocol)
@@ -902,7 +902,7 @@
     private enum Protocol
     {
         AgenticFramework,
-        A2A // Agent-to-Agent protocol
+        A2A // Agent2Agent protocol
     }
 
     private sealed class Conversation

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A.AspNetCore/WebApplicationExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A.AspNetCore/WebApplicationExtensions.cs
@@ -9,12 +9,12 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Agents.AI.Hosting.A2A.AspNetCore;
 
 /// <summary>
-/// Provides extension methods for configuring A2A (Agent-to-Agent) communication in a host application builder.
+/// Provides extension methods for configuring A2A (Agent2Agent) communication in a host application builder.
 /// </summary>
 public static class WebApplicationExtensions
 {
     /// <summary>
-    /// Attaches A2A (Agent-to-Agent) communication capabilities via Message processing to the specified web application.
+    /// Attaches A2A (Agent2Agent) communication capabilities via Message processing to the specified web application.
     /// </summary>
     /// <param name="app">The web application used to configure the pipeline and routes.</param>
     /// <param name="agentName">The name of the agent to use for A2A protocol integration.</param>
@@ -29,7 +29,7 @@ public static class WebApplicationExtensions
     }
 
     /// <summary>
-    /// Attaches A2A (Agent-to-Agent) communication capabilities via Message processing to the specified web application.
+    /// Attaches A2A (Agent2Agent) communication capabilities via Message processing to the specified web application.
     /// </summary>
     /// <param name="app">The web application used to configure the pipeline and routes.</param>
     /// <param name="agentName">The name of the agent to use for A2A protocol integration.</param>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AIAgentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AIAgentExtensions.cs
@@ -10,12 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Agents.AI.Hosting.A2A;
 
 /// <summary>
-/// Provides extension methods for attaching A2A (Agent-to-Agent) messaging capabilities to an <see cref="AIAgent"/>.
+/// Provides extension methods for attaching A2A (Agent2Agent) messaging capabilities to an <see cref="AIAgent"/>.
 /// </summary>
 public static class AIAgentExtensions
 {
     /// <summary>
-    /// Attaches A2A (Agent-to-Agent) messaging capabilities via Message processing to the specified <see cref="AIAgent"/>.
+    /// Attaches A2A (Agent2Agent) messaging capabilities via Message processing to the specified <see cref="AIAgent"/>.
     /// </summary>
     /// <param name="agent">Agent to attach A2A messaging processing capabilities to.</param>
     /// <param name="taskManager">Instance of <see cref="TaskManager"/> to configure for A2A messaging. New instance will be created if not passed.</param>
@@ -54,7 +54,7 @@ public static class AIAgentExtensions
     }
 
     /// <summary>
-    /// Attaches A2A (Agent-to-Agent) messaging capabilities via Message processing to the specified <see cref="AIAgent"/>.
+    /// Attaches A2A (Agent2Agent) messaging capabilities via Message processing to the specified <see cref="AIAgent"/>.
     /// </summary>
     /// <param name="agent">Agent to attach A2A messaging processing capabilities to.</param>
     /// <param name="agentCard">The agent card to return on query.</param>

--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -58,7 +58,7 @@ def _get_uri_data(uri: str) -> str:
 
 
 class A2AAgent(BaseAgent):
-    """Agent-to-Agent (A2A) protocol implementation.
+    """Agent2Agent (A2A) protocol implementation.
 
     Wraps an A2A Client to connect the Agent Framework with external A2A-compliant agents
     via HTTP/JSON-RPC. Converts framework ChatMessages to A2A Messages on send, and converts

--- a/python/samples/getting_started/agents/a2a/README.md
+++ b/python/samples/getting_started/agents/a2a/README.md
@@ -1,6 +1,6 @@
 # A2A Agent Examples
 
-This folder contains examples demonstrating how to create and use agents with the A2A (Agent-to-Agent) protocol from the `agent_framework` package to communicate with remote A2A agents.
+This folder contains examples demonstrating how to create and use agents with the A2A (Agent2Agent) protocol from the `agent_framework` package to communicate with remote A2A agents.
 
 For more information about the A2A protocol specification, visit: https://a2a-protocol.org/latest/
 ## Examples

--- a/python/samples/getting_started/agents/a2a/agent_with_a2a.py
+++ b/python/samples/getting_started/agents/a2a/agent_with_a2a.py
@@ -8,7 +8,7 @@ from a2a.client import A2ACardResolver
 from agent_framework.a2a import A2AAgent
 
 """
-Agent-to-Agent (A2A) Protocol Integration Sample
+Agent2Agent (A2A) Protocol Integration Sample
 
 This sample demonstrates how to connect to and communicate with external agents using
 the A2A protocol. A2A is a standardized communication protocol that enables interoperability
@@ -53,12 +53,17 @@ async def main():
         resolver = A2ACardResolver(httpx_client=http_client, base_url=a2a_agent_host)
 
         # Get agent card
-        agent_card = await resolver.get_agent_card(relative_card_path="/.well-known/agent.json")
+        agent_card = await resolver.get_agent_card(
+            relative_card_path="/.well-known/agent.json"
+        )
         print(f"Found agent: {agent_card.name} - {agent_card.description}")
 
         # Create A2A agent instance
         agent = A2AAgent(
-            name=agent_card.name, description=agent_card.description, agent_card=agent_card, url=a2a_agent_host
+            name=agent_card.name,
+            description=agent_card.description,
+            agent_card=agent_card,
+            url=a2a_agent_host,
         )
 
         # Invoke the agent and output the result


### PR DESCRIPTION
Should be `Agent2Agent Protocol` not `Agent-to-Agent` unless talking about general agent to agent communication

See https://a2a-protocol.org