### PR TITLE
Python: Updating python DEV_SETUP to add brew-based uv installation.

### DIFF
--- a/python/DEV_SETUP.md
+++ b/python/DEV_SETUP.md
@@ -47,7 +47,6 @@ For MacOS users, Homebrew provides an easy installation of uv with the [uv Formu
 brew install uv
 ```
 
-##
 
 ### After installing uv
 


### PR DESCRIPTION
### Motivation and Context

The current guidance for installing uv on MacOS is:

Check the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/) for the installation instructions. At the time of writing this is the command to install uv:

```bash
curl -LsSf https://astral.sh/uv/install.sh | sh
```

But many users see installation errors with this approach on MacOS. This PR adds an alternative installation for MacOS using `Homebrew` that generally works without issue. The new guidance is:

For MacOS users, Homebrew provides an easy installation of uv with the [uv Formulae](https://formulae.brew.sh/formula/uv)

```bash
brew install uv
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.