### PR TITLE
added missing lib/utils.ts in devui frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!python/packages/devui/frontend/src/lib/
 lib64/
 parts/
 sdist/

--- a/python/packages/devui/frontend/src/lib/utils.ts
+++ b/python/packages/devui/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
### Motivation and Context

The DevUI frontend for the python package is missing the `lib/utils` folder for shadcn.

### Description

Added exception in `.gitignore` for devui frontend and fixed shadcn configuration from here: https://ui.shadcn.com/docs/installation/manual.