### PR TITLE
.NET: Align skill naming in A2A sample

### DIFF
--- a/dotnet/samples/A2AClientServer/A2AServer/HostAgentFactory.cs
+++ b/dotnet/samples/A2AClientServer/A2AServer/HostAgentFactory.cs
@@ -89,7 +89,7 @@ internal static class HostAgentFactory
             PushNotifications = false,
         };
 
-        var invoiceQuery = new AgentSkill()
+        var policyQuery = new AgentSkill()
         {
             Id = "id_policy_agent",
             Name = "PolicyAgent",
@@ -109,7 +109,7 @@ internal static class HostAgentFactory
             DefaultInputModes = ["text"],
             DefaultOutputModes = ["text"],
             Capabilities = capabilities,
-            Skills = [invoiceQuery],
+            Skills = [policyQuery],
         };
     }
 


### PR DESCRIPTION
### Motivation and Context

Fixing what looks like a simple copy-paste naming issue spotted while exploring this sample