### PR TITLE
.NET: Correcting parameter assignment and using parameter naming vs position

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AzureAI/PersistentAgentsClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AzureAI/PersistentAgentsClientExtensions.cs
@@ -110,9 +110,10 @@ public static class PersistentAgentsClientExtensions
         }
 
         var createPersistentAgentResponse = await persistentAgentsClient.Administration.CreateAgentAsync(
-            model,
-            name,
-            instructions,
+            model: model,
+            name: name,
+            description: description,
+            instructions: instructions,
             tools: tools,
             toolResources: toolResources,
             temperature: temperature,
@@ -163,9 +164,10 @@ public static class PersistentAgentsClientExtensions
         }
 
         var createPersistentAgentResponse = persistentAgentsClient.Administration.CreateAgent(
-            model,
-            name,
-            instructions,
+            model: model,
+            name: name,
+            description: description,
+            instructions: instructions,
             tools: tools,
             toolResources: toolResources,
             temperature: temperature,


### PR DESCRIPTION
… on position

### Motivation and Context

This should correct Issue #1238
It leverages parameter naming vs position and also now includes passing of the `description` parameter into the `PersistentAgentsAdministrationClient.CreateAgent` call

### Description

As per Issue #1238, the `instructions` parameter value was getting passed to the `description` value in the `PersistentAgentsAdministrationClient.CreateAgent` call because it relied on incorrect positional assignment.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.