### PR TITLE
samples: add api_key for Ollama sample usage

### DIFF
--- a/python/samples/getting_started/agents/ollama/README.md
+++ b/python/samples/getting_started/agents/ollama/README.md
@@ -21,6 +21,9 @@ The examples use environment variables for configuration:
 ### Environment Variables
 
 Set the following environment variables before running the examples:
+- `OLLAMA_API_KEY`: Random string for api key
+  - Example: `export OLLAMA_API_KEY="ollama"`
+  - It is required but unused.
 
 - `OLLAMA_ENDPOINT`: The base URL for your Ollama server
   - Example: `export OLLAMA_ENDPOINT="http://localhost:11434/v1/"`

--- a/python/samples/getting_started/agents/ollama/ollama_with_openai_chat_client.py
+++ b/python/samples/getting_started/agents/ollama/ollama_with_openai_chat_client.py
@@ -33,6 +33,7 @@ async def non_streaming_example() -> None:
     print("=== Non-streaming Response Example ===")
 
     agent = OpenAIChatClient(
+        api_key=os.getenv("OLLAMA_API_KEY"),
         base_url=os.getenv("OLLAMA_ENDPOINT"),
         model_id=os.getenv("OLLAMA_MODEL"),
     ).create_agent(
@@ -52,6 +53,7 @@ async def streaming_example() -> None:
     print("=== Streaming Response Example ===")
 
     agent = OpenAIChatClient(
+        api_key=os.getenv("OLLAMA_API_KEY"),
         base_url=os.getenv("OLLAMA_ENDPOINT"),
         model_id=os.getenv("OLLAMA_MODEL"),
     ).create_agent(


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. Why is this change required? 
- The current sample for Ollama usage is not working because lacking of `api_key` containing in the `OpenAIChatClient()`, which breaks the program.
2. What problem does it solve? 
- It provides a correct quickstart instruction for new users.
3. What scenario does it contribute to?
- When new user want to have a quick sample for Ollama usage case
4. If it fixes an open issue, please link to the issue here.
#1218 

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Ollama provides compatible API endpoints with OpenAI. But the initialization of `OpenAIChatClient()` is mandatory to provide `api_key`, or the assertion won't pass and throw out an exception like the following:
```bash
agent_framework.exceptions.ServiceInitializationError: OpenAI API key is required. Set via 'api_key' parameter or 'OPENAI_API_KEY' environment variable.
```
The solution here is to provide **random** `api_key` for the class, which also follows the official sample on Ollama documentation ([link](https://ollama.com/blog/openai-compatibility)).


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.