### PR TITLE
.NET: Reference the correct JsonUtilities class from ChatClientAgentThread

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentThread.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentThread.cs
@@ -52,7 +52,7 @@ public class ChatClientAgentThread : AgentThread
         }
 
         var state = serializedThreadState.Deserialize(
-            AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ThreadState))) as ThreadState;
+            AgentJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ThreadState))) as ThreadState;
 
         this.AIContextProvider = aiContextProviderFactory?.Invoke(state?.AIContextProviderState ?? default, jsonSerializerOptions);
 
@@ -170,7 +170,7 @@ public class ChatClientAgentThread : AgentThread
             AIContextProviderState = aiContextProviderState
         };
 
-        return JsonSerializer.SerializeToElement(state, AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ThreadState)));
+        return JsonSerializer.SerializeToElement(state, AgentJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ThreadState)));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Description

- ChatClientAgentThread should reference the local JsonUtilities so updated it

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.