### PR TITLE
Python: AzureAI Bing Connection Name Support

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
@@ -858,7 +858,8 @@ class AzureAIAgentClient(BaseChatClient):
                         config_args["market"] = market
                     if set_lang := additional_props.get("set_lang"):
                         config_args["set_lang"] = set_lang
-                    # Bing Grounding
+                    # Bing Grounding (support both connection_id and connection_name)
+                    connection_id = additional_props.get("connection_id") or os.getenv("BING_CONNECTION_ID")
                     connection_name = additional_props.get("connection_name") or os.getenv("BING_CONNECTION_NAME")
                     # Custom Bing Search
                     custom_connection_name = additional_props.get("custom_connection_name") or os.getenv(
@@ -868,16 +869,26 @@ class AzureAIAgentClient(BaseChatClient):
                         "BING_CUSTOM_INSTANCE_NAME"
                     )
                     bing_search: BingGroundingTool | BingCustomSearchTool | None = None
-                    if connection_name and not custom_connection_name and not custom_configuration_name:
-                        try:
-                            bing_connection = await self.project_client.connections.get(name=connection_name)
-                        except HttpResponseError as err:
-                            raise ServiceInitializationError(
-                                f"Bing connection '{connection_name}' not found in the Azure AI Project.",
-                                err,
-                            ) from err
+                    if (
+                        (connection_id or connection_name)
+                        and not custom_connection_name
+                        and not custom_configuration_name
+                    ):
+                        if connection_id:
+                            conn_id = connection_id
+                        elif connection_name:
+                            try:
+                                bing_connection = await self.project_client.connections.get(name=connection_name)
+                            except HttpResponseError as err:
+                                raise ServiceInitializationError(
+                                    f"Bing connection '{connection_name}' not found in the Azure AI Project.",
+                                    err,
+                                ) from err
+                            else:
+                                conn_id = bing_connection.id
                         else:
-                            bing_search = BingGroundingTool(connection_id=bing_connection.id, **config_args)
+                            raise ServiceInitializationError("Neither connection_id nor connection_name provided.")
+                        bing_search = BingGroundingTool(connection_id=conn_id, **config_args)
                     if custom_connection_name and custom_configuration_name:
                         try:
                             bing_custom_connection = await self.project_client.connections.get(
@@ -896,10 +907,11 @@ class AzureAIAgentClient(BaseChatClient):
                             )
                     if not bing_search:
                         raise ServiceInitializationError(
-                            "Bing search tool requires either a 'connection_id' for Bing Grounding "
+                            "Bing search tool requires either 'connection_id' or 'connection_name' for Bing Grounding "
                             "or both 'custom_connection_name' and 'custom_instance_name' for Custom Bing Search. "
-                            "These can be provided via the tool's additional_properties or environment variables: "
-                            "'BING_CONNECTION_ID', 'BING_CUSTOM_CONNECTION_NAME', 'BING_CUSTOM_INSTANCE_NAME'"
+                            "These can be provided via additional_properties or environment variables: "
+                            "'BING_CONNECTION_ID', 'BING_CONNECTION_NAME', 'BING_CUSTOM_CONNECTION_NAME', "
+                            "'BING_CUSTOM_INSTANCE_NAME'"
                         )
                     tool_definitions.extend(bing_search.definitions)
                 case HostedCodeInterpreterTool():

--- a/python/samples/getting_started/agents/azure_ai/README.md
+++ b/python/samples/getting_started/agents/azure_ai/README.md
@@ -38,16 +38,18 @@ Before running the examples, you need to set up your environment variables. You 
    AZURE_AI_MODEL_DEPLOYMENT_NAME="your-model-deployment-name"
    ```
 
-3. For samples using Bing Grounding search (like `azure_ai_with_bing_grounding.py` and `azure_ai_with_multiple_tools.py`), you'll also need:
+3. For samples using Bing Grounding search (like `azure_ai_with_bing_grounding.py` and `azure_ai_with_multiple_tools.py`), you'll also need either:
    ```
    BING_CONNECTION_NAME="bing-grounding-connection"
+   # OR
+   BING_CONNECTION_ID="your-bing-connection-id"
    ```
 
-   To get your Bing connection name:
+   To get your Bing connection details:
    - Go to [Azure AI Foundry portal](https://ai.azure.com)
    - Navigate to your project's "Connected resources" section
    - Add a new connection for "Grounding with Bing Search"
-   - Copy the connection name
+   - Copy either the connection name or ID
 
 ### Option 2: Using environment variables directly
 
@@ -57,6 +59,8 @@ Set the environment variables in your shell:
 export AZURE_AI_PROJECT_ENDPOINT="your-project-endpoint"
 export AZURE_AI_MODEL_DEPLOYMENT_NAME="your-model-deployment-name"
 export BING_CONNECTION_NAME="your-bing-connection-name"  # Optional, only needed for web search samples
+# OR
+export BING_CONNECTION_ID="your-bing-connection-id"  # Alternative to BING_CONNECTION_NAME
 ```
 
 ### Required Variables
@@ -66,4 +70,4 @@ export BING_CONNECTION_NAME="your-bing-connection-name"  # Optional, only needed
 
 ### Optional Variables
 
-- `BING_CONNECTION_NAME`: Your Bing connection name (required for `azure_ai_with_bing_grounding.py` and `azure_ai_with_multiple_tools.py`)
+- `BING_CONNECTION_NAME` or `BING_CONNECTION_ID`: Your Bing connection name or ID (required for `azure_ai_with_bing_grounding.py` and `azure_ai_with_multiple_tools.py`)

--- a/python/samples/getting_started/agents/azure_ai/azure_ai_with_bing_grounding.py
+++ b/python/samples/getting_started/agents/azure_ai/azure_ai_with_bing_grounding.py
@@ -12,21 +12,22 @@ uses Bing Grounding search to find real-time information from the web.
 
 Prerequisites:
 1. A connected Grounding with Bing Search resource in your Azure AI project
-2. Set the BING_CONNECTION_NAME environment variable to your Bing connection name
+2. Set either BING_CONNECTION_NAME or BING_CONNECTION_ID environment variable
    Example: BING_CONNECTION_NAME="bing-grounding-connection"
+   Example: BING_CONNECTION_ID="your-bing-connection-id"
 
 To set up Bing Grounding:
 1. Go to Azure AI Foundry portal (https://ai.azure.com)
 2. Navigate to your project's "Connected resources" section
 3. Add a new connection for "Grounding with Bing Search"
-4. Copy the connection name and set it as the BING_CONNECTION_NAME environment variable
+4. Copy either the connection name or ID and set the appropriate environment variable
 """
 
 
 async def main() -> None:
     """Main function demonstrating Azure AI agent with Bing Grounding search."""
     # 1. Create Bing Grounding search tool using HostedWebSearchTool
-    # The connection_name will be automatically picked up from BING_CONNECTION_NAME environment variable
+    # The connection_name or ID will be automatically picked up from environment variable
     bing_search_tool = HostedWebSearchTool(
         name="Bing Grounding Search",
         description="Search the web for current information using Bing",


### PR DESCRIPTION
### Motivation and Context
Simplifies Bing Grounding configuration by using connection names instead of complex connection IDs, following the Azure SDK pattern.

### Key Changes
- Updated environment variable from `BING_CONNECTION_ID` to `BING_CONNECTION_NAME` 
- Modified the chat client to resolve connection names to IDs automatically
- Updated documentation and sample code to reflect the new naming convention

## Before
```bash
# Complex connection ID format
BING_CONNECTION_ID="/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.CognitiveServices/accounts/{ai-service-name}/projects/{project-name}/connections/{connection-name}"
```
## After
```bash
# Simple connection name
BING_CONNECTION_NAME="bing-grounding-connection"
```
Closes #1323 
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.