### PR TITLE
.NET: Fix handoff function naming

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
@@ -47,7 +47,7 @@ internal sealed class HandoffAgentExecutor(
                 foreach (HandoffTarget handoff in handoffs)
                 {
                     index++;
-                    var handoffFunc = AIFunctionFactory.CreateDeclaration($"{FunctionPrefix}{index}", handoff.Reason, s_handoffSchema);
+                    var handoffFunc = AIFunctionFactory.CreateDeclaration($"{HandoffsWorkflowBuilder.FunctionPrefix}{index}", handoff.Reason, s_handoffSchema);
 
                     this._handoffFunctionNames.Add(handoffFunc.Name);
 


### PR DESCRIPTION
We don't need the agent's name or a guid in the handoff name... we can just use simple numbering. There's a possibility that someone built an agent with a built-in function tool named "handoff_to_x"; if that turns out to be an issue, we could add back some longer bit of randomness.

Fixes https://github.com/microsoft/agent-framework/issues/1344