### PR TITLE
.NET Workflows - Capture the identifier of the `LastMessage` (the workflow input)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/DeclarativeWorkflowExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/DeclarativeWorkflowExecutor.cs
@@ -40,8 +40,8 @@ internal sealed class DeclarativeWorkflowExecutor<TInput>(
         }
         await declarativeContext.QueueConversationUpdateAsync(conversationId, isExternal: true, cancellationToken).ConfigureAwait(false);
 
-        await options.AgentProvider.CreateMessageAsync(conversationId, input, cancellationToken).ConfigureAwait(false);
-        await declarativeContext.SetLastMessageAsync(input).ConfigureAwait(false);
+        ChatMessage inputMessage = await options.AgentProvider.CreateMessageAsync(conversationId, input, cancellationToken).ConfigureAwait(false);
+        await declarativeContext.SetLastMessageAsync(inputMessage).ConfigureAwait(false);
 
         await context.SendResultMessageAsync(this.Id, cancellationToken).ConfigureAwait(false);
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Kit/RootExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Kit/RootExecutor.cs
@@ -67,8 +67,8 @@ public abstract class RootExecutor<TInput> : Executor<TInput>, IResettableExecut
         }
         await declarativeContext.QueueConversationUpdateAsync(this._conversationId, isExternal: true, cancellationToken).ConfigureAwait(false);
 
-        await this._agentProvider.CreateMessageAsync(this._conversationId, input, cancellationToken).ConfigureAwait(false);
-        await declarativeContext.SetLastMessageAsync(input).ConfigureAwait(false);
+        ChatMessage inputMessage = await this._agentProvider.CreateMessageAsync(this._conversationId, input, cancellationToken).ConfigureAwait(false);
+        await declarativeContext.SetLastMessageAsync(inputMessage).ConfigureAwait(false);
 
         await declarativeContext.SendResultMessageAsync(this.Id, cancellationToken).ConfigureAwait(false);
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowExpressionEngine.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowExpressionEngine.cs
@@ -274,6 +274,13 @@ internal sealed class WorkflowExpressionEngine
             expression.VariableReference?.ToString() :
             expression.ExpressionText;
 
-        return new(this._engine.Eval(expressionText), SensitivityLevel.None);
+        FormulaValue result = this._engine.Eval(expressionText);
+
+        if (result is ErrorValue errorValue)
+        {
+            throw new DeclarativeActionException(errorValue.Format());
+        }
+
+        return new(result, SensitivityLevel.None);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeCodeGenTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeCodeGenTest.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests;
 public sealed class DeclarativeCodeGenTest(ITestOutputHelper output) : WorkflowTest(output)
 {
     [Theory]
+    [InlineData("CheckSystem.yaml", "CheckSystem.json")]
     [InlineData("SendActivity.yaml", "SendActivity.json")]
     [InlineData("InvokeAgent.yaml", "InvokeAgent.json")]
     [InlineData("InvokeAgent.yaml", "InvokeAgent.json", true)]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeWorkflowTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeWorkflowTest.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests;
 public sealed class DeclarativeWorkflowTest(ITestOutputHelper output) : WorkflowTest(output)
 {
     [Theory]
+    [InlineData("CheckSystem.yaml", "CheckSystem.json")]
     [InlineData("SendActivity.yaml", "SendActivity.json")]
     [InlineData("InvokeAgent.yaml", "InvokeAgent.json")]
     [InlineData("InvokeAgent.yaml", "InvokeAgent.json", true)]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/CheckSystem.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/CheckSystem.json
@@ -1,0 +1,24 @@
+﻿{
+  "description": "Send an activity message.",
+  "setup": {
+    "input": {
+      "type": "String",
+      "value": "Everything good?"
+    }
+  },
+  "validation": {
+    "conversation_count": 1,
+    "min_action_count": 2,
+    "max_action_count": -1,
+    "min_response_count": 0,
+    "actions": {
+      "start": [
+        "check_system"
+      ],
+      "final": [
+        "activity_passed",
+        "check_system_Post"
+      ]
+    }
+  }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Workflows/CheckSystem.yaml
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Workflows/CheckSystem.yaml
@@ -1,0 +1,57 @@
+kind: Workflow
+trigger:
+
+  kind: OnConversationStart
+  id: workflow_test
+  actions:
+
+    - kind: ConditionGroup
+      id: check_system
+      conditions:
+
+        - condition: =IsBlank(System.Conversation)
+          id: conversation_check
+          actions:
+            - kind: EndDialog
+              id: conversation_bad
+
+        - condition: =IsBlank(System.Conversation.Id)
+          id: conversation_id_check1
+          actions:
+            - kind: EndDialog
+              id: conversation_id_bad1
+
+        - condition: =IsBlank(System.ConversationId)
+          id: conversation_id_check2
+          actions:
+            - kind: EndDialog
+              id: conversation_id_bad2
+
+        - condition: =IsBlank(System.LastMessage)
+          id: message_check
+          actions:
+            - kind: EndDialog
+              id: message_bad
+
+        - condition: =IsBlank(System.LastMessage.Id)
+          id: message_id_check1
+          actions:
+            - kind: EndDialog
+              id: message_id_bad1
+
+        - condition: =IsBlank(System.LastMessageId)
+          id: message_id_check2
+          actions:
+            - kind: EndDialog
+              id: message_id_bad2
+
+        - condition: =IsBlank(System.LastMessageText)
+          id: message_text_check
+          actions:
+            - kind: EndDialog
+              id: message_text_bad
+
+      elseActions:
+        - kind: SendActivity
+          id: activity_passed
+          activity: PASSED!


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Capture the message definition returned by the service.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

The input message has null `MessageId`

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.