### PR TITLE
.NET Workflows - Use async SDK method for `CreateMessage`

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/AzureAgentProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/AzureAgentProvider.cs
@@ -48,21 +48,18 @@ public sealed class AzureAgentProvider(string projectEndpoint, TokenCredential p
     }
 
     /// <inheritdoc/>
-    public override Task<ChatMessage> CreateMessageAsync(string conversationId, ChatMessage conversationMessage, CancellationToken cancellationToken = default)
+    public override async Task<ChatMessage> CreateMessageAsync(string conversationId, ChatMessage conversationMessage, CancellationToken cancellationToken = default)
     {
-        // TODO: Switch to asynchronous "CreateMessageAsync", when fix properly applied:
-        //  BUG: https://github.com/Azure/azure-sdk-for-net/issues/52571
-        //   PR: https://github.com/Azure/azure-sdk-for-net/pull/52653
         PersistentThreadMessage newMessage =
-            this.GetAgentsClient().Messages.CreateMessage(
+            await this.GetAgentsClient().Messages.CreateMessageAsync(
                 conversationId,
                 role: s_roleMap[conversationMessage.Role.Value.ToUpperInvariant()],
                 contentBlocks: GetContent(),
                 attachments: null,
                 metadata: GetMetadata(),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
-        return Task.FromResult(ToChatMessage(newMessage));
+        return ToChatMessage(newMessage);
 
         Dictionary<string, string>? GetMetadata()
         {


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Use proper async method now that SDK fix is published to nuget package.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Was calling `CreateMessage` as a work-around to `CreateMessageAsync` until serialization bug could be fix.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.