### PR TITLE
Fix GH008 - Re-Upload missing favicons via LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Auto-detect text files, ensure they use LF.
 * text=auto eol=lf working-tree-encoding=UTF-8
-
 # Bash scripts
 *.sh  text eol=lf
 *.cmd text eol=crlf
+python/docs/agent-framework/_static/images/logo/favicon-*.png filter=lfs diff=lfs merge=lfs -text

--- a/python/docs/agent-framework/_static/images/logo/favicon-16x16.png
+++ b/python/docs/agent-framework/_static/images/logo/favicon-16x16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a649cf9cca62edf0f4f6e4acf76981fb9b27399b4d598b22b189c92424f4ea
+size 434

--- a/python/docs/agent-framework/_static/images/logo/favicon-32x32.png
+++ b/python/docs/agent-framework/_static/images/logo/favicon-32x32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a272fc4c4a508fd936c130a727728da6c773de710a5ae600d06fac06329e0f6d
+size 998

--- a/python/docs/agent-framework/_static/images/logo/favicon-512x512.png
+++ b/python/docs/agent-framework/_static/images/logo/favicon-512x512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1f90048923bdaa4e2eeb6ab70f3cc059dc706d43e7208f336102702fc231b81
+size 45618


### PR DESCRIPTION
### Motivation and Context

Attempt to address the error.

```
remote: error: GH008: Your push referenced at least 3 unknown Git LFS objects:
remote:     b4a649cf9cca62edf0f4f6e4acf76981fb9b27399b4d598b22b189c92424f4ea
remote:     a272fc4c4a508fd936c130a727728da6c773de710a5ae600d06fac06329e0f6d
remote:     c1f90048923bdaa4e2eeb6ab70f3cc059dc706d43e7208f336102702fc231b81
```

> [!NOTE]
> To be able to fix the error above I need to create the missing references again to remove them permanently.
> The original images were sent at a time there was no Agent Framework logo and were the Autogen, this will be cleaned up in a subsequent PR.
