### PR TITLE
Python: Small fix in OpenAI Responses client

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -391,6 +391,9 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
             args["metadata"] = message.additional_properties
         for content in message.contents:
             match content:
+                case TextReasoningContent():
+                    # Don't send reasoning content back to model
+                    continue
                 case FunctionResultContent():
                     new_args: dict[str, Any] = {}
                     new_args.update(self._openai_content_parser(message.role, content, call_id_to_id))
@@ -485,6 +488,7 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
                     "type": "function_call",
                     "name": content.name,
                     "arguments": content.arguments,
+                    "status": None,
                 }
             case FunctionResultContent():
                 # call_id for the result needs to be the same as the call_id for the function call


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Resolves: https://github.com/microsoft/agent-framework/issues/1423

1. Skip `TextReasoningContent` when sending requests to Responses API. (`TextContent` can be used instead)
2. Added `status=None` value to `FunctionCallContent` to make it compatible with `gpt-oss` models.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.