### PR TITLE
.NET: reformat event sequence in OpenAI Responses hosting

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponsesProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponsesProcessor.cs
@@ -169,6 +169,13 @@ internal sealed class AIAgentResponsesProcessor
                             Part = null!
                         };
                         yield return new(responseContentPartAdded, responseContentPartAdded.Type);
+
+                        var responseOutputItemAddedResponse = new StreamingOutputItemAddedResponse(sequenceNumber++)
+                        {
+                            OutputIndex = index++,
+                            Item = openAIResponseItem
+                        };
+                        yield return new(responseOutputItemAddedResponse, responseOutputItemAddedResponse.Type);
                     }
 
                     lastResponseItem = openAIResponseItem;
@@ -190,7 +197,7 @@ internal sealed class AIAgentResponsesProcessor
                 // here goes a sequence of completions for earlier started events:
 
                 // "response.output_text.delta" should be completed with "response.output_text.done"
-                var index = messageIdOutputIndexes[lastResponseItem.Id];
+                var index = messageIdOutputIndexes[lastResponseItem.Id ?? "<null>"];
                 var responseOutputTextDeltaResponse = new StreamingOutputTextDoneResponse(sequenceNumber++)
                 {
                     ItemId = lastResponseItem.Id,

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Model/ResponseStreamEvent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Model/ResponseStreamEvent.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses.Model;
 [JsonDerivedType(typeof(StreamingInProgressResponse), StreamingInProgressResponse.EventType)]
 [JsonDerivedType(typeof(StreamingOutputTextDeltaResponse), StreamingOutputTextDeltaResponse.EventType)]
 [JsonDerivedType(typeof(StreamingOutputTextDoneResponse), StreamingOutputTextDoneResponse.EventType)]
-[JsonDerivedType(typeof(StreamingInProgressResponse), StreamingInProgressResponse.EventType)]
 [JsonDerivedType(typeof(StreamingContentPartAddedResponse), StreamingContentPartAddedResponse.EventType)]
 [JsonDerivedType(typeof(StreamingContentPartDoneResponse), StreamingContentPartDoneResponse.EventType)]
 [JsonDerivedType(typeof(StreamingCreatedResponse), StreamingCreatedResponse.EventType)]
@@ -61,7 +60,7 @@ internal sealed class StreamingContentPartAddedResponse : StreamingResponseEvent
     public required int ContentIndex { get; set; }
 
     [JsonPropertyName("item_id")]
-    public required string? ItemId { get; set; }
+    public string? ItemId { get; set; }
 
     [JsonPropertyName("output_index")]
     public required int OutputIndex { get; set; }
@@ -82,7 +81,7 @@ internal sealed class StreamingContentPartDoneResponse : StreamingResponseEventB
     public required int ContentIndex { get; set; }
 
     [JsonPropertyName("item_id")]
-    public required string ItemId { get; set; }
+    public string? ItemId { get; set; }
 
     [JsonPropertyName("output_index")]
     public required int OutputIndex { get; set; }
@@ -140,7 +139,7 @@ internal sealed class StreamingOutputTextDoneResponse : StreamingResponseEventBa
     public required int ContentIndex { get; set; }
 
     [JsonPropertyName("item_id")]
-    public required string ItemId { get; set; }
+    public string? ItemId { get; set; }
 
     [JsonPropertyName("output_index")]
     public int OutputIndex { get; set; }


### PR DESCRIPTION
Reformatted event sequence in streaming responses as per spec example: https://platform.openai.com/docs/api-reference/responses/create

<img width="847" height="1456" alt="image" src="https://github.com/user-attachments/assets/94b4ba5d-e1a2-4d2f-a688-6c4b4c9ad108" />
