### PR TITLE
.NET: Fixes issue 1623 - invalid Mermaid/DOT identifiers for fan-in nodes in workflow visualization

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs
@@ -201,7 +201,7 @@ public static class WorkflowVisualizer
                 var target = fanInData.SinkId;
                 var sources = fanInData.SourceIds.ToList();
                 var digest = ComputeFanInDigest(target, sources);
-                var nodeId = $"fan_in::{target}::{digest}";
+                var nodeId = $"fan_in_{target}_{digest}";
 
                 // Avoid duplicates - the same fan-in edge group might appear in multiple source executor lists
                 if (seen.Add(nodeId))


### PR DESCRIPTION
## Motivation and Context
This PR fixes a bug in workflow visualization where fan-in nodes generated invalid identifiers that caused parsing failures in both Mermaid.js and Graphviz DOT renderers.
Why is this change required?
•	Fan-in workflows failed to render in Mermaid-based visualization tools
•	Users could not visualize complex workflows with fan-in patterns
•	Documentation and debugging tools were broken for these scenarios

What problem does it solve?
Fixes issue https://github.com/microsoft/agent-framework/issues/1623
•	Mermaid syntax errors when rendering fan-in nodes with : characters
•	DOT format incompatibility with colon-based identifiers
•	Parser failures preventing workflow visualization

What scenario does it contribute to?
•	Workflow visualization and debugging
•	Documentation generation for complex workflows
•	Visual workflow designers and analysis tools
•	Any scenario using ToMermaidString() or ToDotString() with fan-in patterns

## Description
The Problem
The WorkflowVisualizer.ComputeFanInDescriptors method was generating fan-in node IDs using :: as a separator:
```
var nodeId = $"fan_in::{target}::{digest}";
// Example output: fan_in::ExpertReviewAggregator::42934990
```
This violated identifier naming rules in both target formats:
•	Mermaid: Node IDs cannot contain : characters
•	DOT: Colons require special escaping and complicate parsing
The Solution
Changed the separator from :: to _ (underscore) on line 204 in WorkflowVisualizer.cs:
```
var nodeId = $"fan_in_{target}_{digest}";
// Example output: fan_in_ExpertReviewAggregator_42934990
```

Impact:
•	✅ All fan-in workflows now render correctly in Mermaid
•	✅ DOT exports produce clean, valid syntax
•	✅ Maintains uniqueness through SHA256 digest
•	✅ No breaking changes to workflow semantics or API
•	✅ All existing workflows continue to work without modification

Contribution Checklist
•	[x] The code builds clean without any errors or warnings
•	[x] The PR follows the Contribution Guidelines
•	[x] All unit tests pass, and I have added new tests where possible
•	[ ] Is this a breaking change? No - this only affects internal node ID generation for visualization
