### PR TITLE
.NET: feat: Add Cancellation API on StreamingRun

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/StreamingRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/StreamingRun.cs
@@ -79,11 +79,14 @@ public sealed class StreamingRun : IAsyncDisposable
         CancellationToken cancellationToken = default)
         => this._runHandle.TakeEventStreamAsync(blockOnPendingRequest, cancellationToken);
 
+    /// <summary>
+    /// Attempt to cancel the streaming run.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous send operation.</returns>
+    public ValueTask CancelRunAsync() => this._runHandle.CancelRunAsync();
+
     /// <inheritdoc/>
-    public ValueTask DisposeAsync()
-    {
-        return this._runHandle.DisposeAsync();
-    }
+    public ValueTask DisposeAsync() => this._runHandle.DisposeAsync();
 }
 
 /// <summary>


### PR DESCRIPTION
### Description

In non-Lockstep execution modes, cancelling the watching of events out of a workflow does not terminate its execution. Though it gets stopped on disposal, this is not a very intuitive and discoverable affordance.

The `StreamingRun.CancelRunAsync()` provides an affordance for this.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] ~~**Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.~~