### PR TITLE
.NET: Fix Concurrency Support for Orchestrations

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/CollectChatMessagesExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/CollectChatMessagesExecutor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Agents.AI.Workflows.Specialized;
 /// Provides an executor that batches received chat messages that it then releases when
 /// receiving a <see cref="TurnToken"/>.
 /// </summary>
-internal sealed class CollectChatMessagesExecutor(string id) : ChatProtocolExecutor(id), IResettableExecutor
+internal sealed class CollectChatMessagesExecutor(string id) : ChatProtocolExecutor(id, declareCrossRunShareable: true), IResettableExecutor
 {
     /// <inheritdoc/>
     protected override ValueTask TakeTurnAsync(List<ChatMessage> messages, IWorkflowContext context, bool? emitEvents, CancellationToken cancellationToken = default)

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/ConcurrentEndExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/ConcurrentEndExecutor.cs
@@ -14,12 +14,14 @@ namespace Microsoft.Agents.AI.Workflows.Specialized;
 /// </summary>
 internal sealed class ConcurrentEndExecutor : Executor, IResettableExecutor
 {
+    public const string ExecutorId = "ConcurrentEnd";
+
     private readonly int _expectedInputs;
     private readonly Func<IList<List<ChatMessage>>, List<ChatMessage>> _aggregator;
     private List<List<ChatMessage>> _allResults;
     private int _remaining;
 
-    public ConcurrentEndExecutor(int expectedInputs, Func<IList<List<ChatMessage>>, List<ChatMessage>> aggregator) : base("ConcurrentEnd")
+    public ConcurrentEndExecutor(int expectedInputs, Func<IList<List<ChatMessage>>, List<ChatMessage>> aggregator) : base(ExecutorId)
     {
         this._expectedInputs = expectedInputs;
         this._aggregator = Throw.IfNull(aggregator);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Agents.AI.Workflows.Specialized;
 /// <summary>Executor used to represent an agent in a handoffs workflow, responding to <see cref="HandoffState"/> events.</summary>
 internal sealed class HandoffAgentExecutor(
     AIAgent agent,
-    string? handoffInstructions) : Executor(agent.GetDescriptiveId()), IResettableExecutor
+    string? handoffInstructions) : Executor(agent.GetDescriptiveId(), declareCrossRunShareable: true), IResettableExecutor
 {
     private static readonly JsonElement s_handoffSchema = AIFunctionFactory.Create(
         ([Description("The reason for the handoff")] string? reasonForHandoff) => { }).JsonSchema;
@@ -70,9 +70,9 @@ internal sealed class HandoffAgentExecutor(
             List<ChatMessage>? roleChanges = allMessages.ChangeAssistantToUserForOtherParticipants(this._agent.DisplayName);
 
             await foreach (var update in this._agent.RunStreamingAsync(allMessages,
-                                                                           options: this._agentOptions,
-                                                                           cancellationToken: cancellationToken)
-                                                        .ConfigureAwait(false))
+                                                                       options: this._agentOptions,
+                                                                       cancellationToken: cancellationToken)
+                                                     .ConfigureAwait(false))
             {
                 await AddUpdateAsync(update, cancellationToken).ConfigureAwait(false);
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffsEndExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffsEndExecutor.cs
@@ -5,8 +5,10 @@ using System.Threading.Tasks;
 namespace Microsoft.Agents.AI.Workflows.Specialized;
 
 /// <summary>Executor used at the end of a handoff workflow to raise a final completed event.</summary>
-internal sealed class HandoffsEndExecutor() : Executor("HandoffEnd"), IResettableExecutor
+internal sealed class HandoffsEndExecutor() : Executor(ExecutorId, declareCrossRunShareable: true), IResettableExecutor
 {
+    public const string ExecutorId = "HandoffEnd";
+
     protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder) =>
         routeBuilder.AddHandler<HandoffState>((handoff, context, cancellationToken) =>
             context.YieldOutputAsync(handoff.Messages, cancellationToken));

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffsStartExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffsStartExecutor.cs
@@ -8,8 +8,10 @@ using Microsoft.Extensions.AI;
 namespace Microsoft.Agents.AI.Workflows.Specialized;
 
 /// <summary>Executor used at the start of a handoffs workflow to accumulate messages and emit them as HandoffState upon receiving a turn token.</summary>
-internal sealed class HandoffsStartExecutor() : ChatProtocolExecutor("HandoffStart", DefaultOptions), IResettableExecutor
+internal sealed class HandoffsStartExecutor() : ChatProtocolExecutor(ExecutorId, DefaultOptions, declareCrossRunShareable: true), IResettableExecutor
 {
+    internal const string ExecutorId = "HandoffStart";
+
     private static ChatProtocolExecutorOptions DefaultOptions => new()
     {
         StringMessageChatRole = ChatRole.User

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/OutputMessagesExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/OutputMessagesExecutor.cs
@@ -13,7 +13,7 @@ public static partial class AgentWorkflowBuilder
     /// Provides an executor that batches received chat messages that it then publishes as the final result
     /// when receiving a <see cref="TurnToken"/>.
     /// </summary>
-    internal sealed class OutputMessagesExecutor() : ChatProtocolExecutor("OutputMessages"), IResettableExecutor
+    internal sealed class OutputMessagesExecutor() : ChatProtocolExecutor("OutputMessages", declareCrossRunShareable: true), IResettableExecutor
     {
         protected override ValueTask TakeTurnAsync(List<ChatMessage> messages, IWorkflowContext context, bool? emitEvents, CancellationToken cancellationToken = default)
             => context.YieldOutputAsync(messages, cancellationToken);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
@@ -86,14 +86,14 @@ public class Workflow
     }
 
     private bool _needsReset;
-    private bool IsResettable => this.Registrations.Values.All(registration => !registration.IsUnresettableSharedInstance);
-
+    private bool HasResettable => this.Registrations.Values.Any(registration => registration.SupportsResetting);
     private async ValueTask<bool> TryResetExecutorRegistrationsAsync()
     {
-        if (this.IsResettable)
+        if (this.HasResettable)
         {
             foreach (ExecutorRegistration registration in this.Registrations.Values)
             {
+                // TryResetAsync returns true if the executor does not need resetting
                 if (!await registration.TryResetAsync().ConfigureAwait(false))
                 {
                     return false;
@@ -158,7 +158,7 @@ public class Workflow
                 });
         }
 
-        this._needsReset = true;
+        this._needsReset = this.HasResettable;
         this._ownedAsSubworkflow = subworkflow;
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
@@ -382,11 +382,12 @@ public class AgentWorkflowBuilderTests
     }
 
     private static async Task<(string UpdateText, List<ChatMessage>? Result)> RunWorkflowAsync(
-        Workflow workflow, List<ChatMessage> input)
+        Workflow workflow, List<ChatMessage> input, ExecutionEnvironment executionEnvironment = ExecutionEnvironment.InProcess_Lockstep)
     {
         StringBuilder sb = new();
 
-        await using StreamingRun run = await InProcessExecution.Lockstep.StreamAsync(workflow, input);
+        IWorkflowExecutionEnvironment environment = executionEnvironment.ToWorkflowExecutionEnvironment();
+        await using StreamingRun run = await environment.StreamAsync(workflow, input);
         await run.TrySendMessageAsync(new TurnToken(emitEvents: true));
 
         WorkflowOutputEvent? output = null;

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/07_GroupChat_Workflow_HostAsAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/07_GroupChat_Workflow_HostAsAgent.cs
@@ -8,7 +8,10 @@ namespace Microsoft.Agents.AI.Workflows.Sample;
 
 internal static class Step7EntryPoint
 {
-    public static async ValueTask RunAsync(TextWriter writer, int maxSteps = 2)
+    public static string EchoAgentId => Step6EntryPoint.EchoAgentId;
+    public static string EchoPrefix => Step6EntryPoint.EchoPrefix;
+
+    public static async ValueTask RunAsync(TextWriter writer, IWorkflowExecutionEnvironment environment, int maxSteps = 2)
     {
         Workflow workflow = Step6EntryPoint.CreateWorkflow(maxSteps);
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/10_Sequential_HostAsAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/10_Sequential_HostAsAgent.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Workflows.UnitTests;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.Sample;
+
+internal static class Step10EntryPoint
+{
+    public static Workflow CreateWorkflow()
+    {
+        TestEchoAgent echoAgent = new("echo", "Echo");
+        return AgentWorkflowBuilder.BuildSequential(echoAgent);
+    }
+    public static Workflow WorkflowInstance => CreateWorkflow();
+
+    public static async ValueTask RunAsync(TextWriter writer, IWorkflowExecutionEnvironment executionEnvironment, IEnumerable<string> inputs)
+    {
+        AIAgent hostAgent = WorkflowInstance.AsAgent("echo-workflow", "EchoW", executionEnvironment: executionEnvironment);
+
+        AgentThread thread = hostAgent.GetNewThread();
+        foreach (string input in inputs)
+        {
+            AgentRunResponse response;
+            object? continuationToken = null;
+            do
+            {
+                response = await hostAgent.RunAsync(input, thread, new AgentRunOptions { ContinuationToken = continuationToken });
+            } while ((continuationToken = response.ContinuationToken) is { });
+
+            foreach (ChatMessage message in response.Messages)
+            {
+                writer.WriteLine($"{message.AuthorName}: {message.Text}");
+            }
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/11_Concurrent_HostAsAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/11_Concurrent_HostAsAgent.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Workflows.UnitTests;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.Sample;
+
+internal static class Step11EntryPoint
+{
+    public const int AgentCount = 2;
+
+    public const string EchoAgentIdPrefix = "echo-";
+    public const string EchoAgentNamePrefix = "Echo";
+
+    public static string ExpectedOutputForInput(string input, int agentNumber)
+        => $"{EchoAgentNamePrefix}{agentNumber}: {input}";
+
+    public static Workflow CreateWorkflow()
+    {
+        TestEchoAgent[] echoAgents = Enumerable.Range(1, AgentCount)
+            .Select(i => new TestEchoAgent($"{EchoAgentIdPrefix}{i}", $"{EchoAgentNamePrefix}{i}"))
+            .ToArray();
+
+        return AgentWorkflowBuilder.BuildConcurrent(echoAgents);
+    }
+    public static Workflow WorkflowInstance => CreateWorkflow();
+
+    public static async ValueTask RunAsync(TextWriter writer, IWorkflowExecutionEnvironment executionEnvironment, IEnumerable<string> inputs)
+    {
+        AIAgent hostAgent = WorkflowInstance.AsAgent("echo-workflow", "EchoW", executionEnvironment: executionEnvironment);
+
+        AgentThread thread = hostAgent.GetNewThread();
+        foreach (string input in inputs)
+        {
+            AgentRunResponse response;
+            object? continuationToken = null;
+            do
+            {
+                response = await hostAgent.RunAsync(input, thread, new AgentRunOptions { ContinuationToken = continuationToken });
+            } while ((continuationToken = response.ContinuationToken) is { });
+
+            foreach (ChatMessage message in response.Messages)
+            {
+                writer.WriteLine($"{message.AuthorName}: {message.Text}");
+            }
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/12_HandOff_HostAsAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/12_HandOff_HostAsAgent.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Workflows.UnitTests;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.Sample;
+
+internal sealed class HandoffTestEchoAgent(string id, string name, string prefix = "")
+    : TestEchoAgent(id, name, prefix)
+{
+    protected override IEnumerable<ChatMessage> GetEpilogueMessages(AgentRunOptions? options = null)
+    {
+        if (options is ChatClientAgentRunOptions chatClientOptions &&
+            chatClientOptions.ChatOptions != null)
+        {
+            IEnumerable<AITool>? handoffs = chatClientOptions.ChatOptions
+                                                             .Tools?
+                                                             .Where(tool => tool.Name?.StartsWith(HandoffsWorkflowBuilder.FunctionPrefix,
+                                                                                                  StringComparison.OrdinalIgnoreCase) is true);
+
+            if (handoffs != null)
+            {
+                AITool? handoff = handoffs.FirstOrDefault();
+                if (handoff != null)
+                {
+                    return [new(ChatRole.Assistant, [new FunctionCallContent(Guid.NewGuid().ToString("N"), handoff.Name)])
+                    {
+                        AuthorName = this.DisplayName,
+                        MessageId = Guid.NewGuid().ToString("N"),
+                        CreatedAt = DateTime.UtcNow
+                    }];
+                }
+            }
+        }
+
+        return base.GetEpilogueMessages(options);
+    }
+}
+
+internal static class Step12EntryPoint
+{
+    public const int AgentCount = 2;
+
+    public const string EchoAgentIdPrefix = "echo-";
+    public const string EchoAgentNamePrefix = "Echo";
+
+    public static string EchoPrefixForAgent(int agentNumber)
+        => $"{agentNumber}:";
+
+    public static Workflow CreateWorkflow()
+    {
+        TestEchoAgent[] echoAgents = Enumerable.Range(1, AgentCount)
+            .Select(i => new HandoffTestEchoAgent($"{EchoAgentIdPrefix}{i}", $"{EchoAgentNamePrefix}{i}", EchoPrefixForAgent(i)))
+            .ToArray();
+
+        return new HandoffsWorkflowBuilder(echoAgents[0])
+                   .WithHandoff(echoAgents[0], echoAgents[1])
+                   .Build();
+    }
+
+    public static Workflow WorkflowInstance => CreateWorkflow();
+
+    public static async ValueTask RunAsync(TextWriter writer, IWorkflowExecutionEnvironment executionEnvironment, IEnumerable<string> inputs)
+    {
+        AIAgent hostAgent = WorkflowInstance.AsAgent("echo-workflow", "EchoW", executionEnvironment: executionEnvironment);
+
+        AgentThread thread = hostAgent.GetNewThread();
+        foreach (string input in inputs)
+        {
+            AgentRunResponse response;
+            object? continuationToken = null;
+            do
+            {
+                response = await hostAgent.RunAsync(input, thread, new AgentRunOptions { ContinuationToken = continuationToken });
+            } while ((continuationToken = response.ContinuationToken) is { });
+
+            foreach (ChatMessage message in response.Messages)
+            {
+                writer.WriteLine(message.Text);
+            }
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestEchoAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestEchoAgent.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+internal class TestEchoAgent(string? id = null, string? name = null, string? prefix = null) : AIAgent
+{
+    public override string Id => id ?? base.Id;
+    public override string? Name => name ?? base.Name;
+
+    public override AgentThread DeserializeThread(JsonElement serializedThread, JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        return JsonSerializer.Deserialize<EchoAgentThread>(serializedThread, jsonSerializerOptions) ?? this.GetNewThread();
+    }
+
+    public override AgentThread GetNewThread()
+    {
+        return new EchoAgentThread();
+    }
+
+    private static ChatMessage UpdateThread(ChatMessage message, InMemoryAgentThread? thread = null)
+    {
+        thread?.MessageStore.Add(message);
+
+        return message;
+    }
+
+    private IEnumerable<ChatMessage> EchoMessages(IEnumerable<ChatMessage> messages, AgentThread? thread = null, AgentRunOptions? options = null)
+    {
+        foreach (ChatMessage message in messages)
+        {
+            UpdateThread(message, thread as InMemoryAgentThread);
+        }
+
+        IEnumerable<ChatMessage> echoMessages
+            = from message in messages
+              where message.Role == ChatRole.User &&
+                    !string.IsNullOrEmpty(message.Text)
+              select
+                    UpdateThread(new ChatMessage(ChatRole.Assistant, $"{prefix}{message.Text}")
+                    {
+                        AuthorName = this.DisplayName,
+                        CreatedAt = DateTimeOffset.Now,
+                        MessageId = Guid.NewGuid().ToString("N")
+                    }, thread as InMemoryAgentThread);
+
+        return echoMessages.Concat(this.GetEpilogueMessages(options).Select(m => UpdateThread(m, thread as InMemoryAgentThread)));
+    }
+
+    protected virtual IEnumerable<ChatMessage> GetEpilogueMessages(AgentRunOptions? options = null)
+    {
+        return Enumerable.Empty<ChatMessage>();
+    }
+
+    public override Task<AgentRunResponse> RunAsync(IEnumerable<ChatMessage> messages, AgentThread? thread = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        AgentRunResponse result =
+            new(this.EchoMessages(messages, thread, options).ToList())
+            {
+                AgentId = this.Id,
+                CreatedAt = DateTimeOffset.Now,
+                ResponseId = Guid.NewGuid().ToString("N"),
+            };
+
+        return Task.FromResult(result);
+    }
+
+    public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(IEnumerable<ChatMessage> messages, AgentThread? thread = null, AgentRunOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        string responseId = Guid.NewGuid().ToString("N");
+
+        foreach (ChatMessage message in this.EchoMessages(messages, thread, options).ToList())
+        {
+            yield return
+                new(message.Role, message.Contents)
+                {
+                    AgentId = this.Id,
+                    AuthorName = message.AuthorName,
+                    ResponseId = responseId,
+                    MessageId = message.MessageId,
+                    CreatedAt = message.CreatedAt
+                };
+        }
+    }
+
+    private sealed class EchoAgentThread : InMemoryAgentThread
+    {
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Concurrent-Shared run support was recently added to workflows, but Orchestrations did not fully update to support it. As well, the logic around resetting was flawed, causing workflows consisting only of Cross-Run Shareable executor registrations to fail to reset properly.

### Description

* Closes #1613 (ported from #1637 to avoid delaying the fix)
* Marks stateless AgentWorkflow specialized executors as Cross-Run Shareable ()
  * CollectChatMessagesExecutor
  * HandoffStartExecutor
  * HandoffAgentExecutor
  * HandoffEndExecutor
  * OutputMessagesExecutor
* Switches ConcurrentEnd executor registration to be factory-based to enable Cross-Run Shareable
* Adds unit tests for missing orchestration patterns

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.