### PR TITLE
.NET: Fix gen_ai.operation.name to be invoke_agent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
@@ -114,7 +114,8 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
 
         // Override information set by OpenTelemetryChatClient to make it specific to invoke_agent.
 
-        activity.DisplayName = $"invoke_agent {this.DisplayName}";
+        activity.DisplayName = $"{OpenTelemetryConsts.GenAI.InvokeAgent} {this.DisplayName}";
+        activity.SetTag(OpenTelemetryConsts.GenAI.Operation.Name, OpenTelemetryConsts.GenAI.InvokeAgent);
 
         if (!string.IsNullOrWhiteSpace(this._providerName))
         {

--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryConsts.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryConsts.cs
@@ -18,6 +18,11 @@ internal static class OpenTelemetryConsts
             public const string Description = "gen_ai.agent.description";
         }
 
+        public static class Operation
+        {
+            public const string Name = "gen_ai.operation.name";
+        }
+
         public static class Provider
         {
             public const string Name = "gen_ai.provider.name";

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
@@ -171,6 +171,7 @@ public class OpenTelemetryAgentTests
         Assert.Equal(12345, (int)activity.GetTagItem("server.port")!);
 
         Assert.Equal("invoke_agent TestAgent", activity.DisplayName);
+        Assert.Equal("invoke_agent", activity.GetTagItem("gen_ai.operation.name"));
         Assert.Equal("TestAgentProviderFromAIAgentMetadata", activity.GetTagItem("gen_ai.provider.name"));
         Assert.Equal(innerAgent.Name, activity.GetTagItem("gen_ai.agent.name"));
         Assert.Equal(innerAgent.Id, activity.GetTagItem("gen_ai.agent.id"));
@@ -431,6 +432,7 @@ public class OpenTelemetryAgentTests
         Assert.Equal(12345, (int)activity.GetTagItem("server.port")!);
 
         Assert.Equal($"invoke_agent {innerAgent.DisplayName}", activity.DisplayName);
+        Assert.Equal("invoke_agent", activity.GetTagItem("gen_ai.operation.name"));
         Assert.Equal("TestAgentProviderFromAIAgentMetadata", activity.GetTagItem("gen_ai.provider.name"));
         Assert.Equal(innerAgent.Name, activity.GetTagItem("gen_ai.agent.name"));
         Assert.Equal(innerAgent.Id, activity.GetTagItem("gen_ai.agent.id"));


### PR DESCRIPTION
Fixes https://github.com/microsoft/agent-framework/issues/1728