### PR TITLE
.NET Workflows - Expose `SendMessage` override to all platforms

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/IWorkflowContextExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/IWorkflowContextExtensions.cs
@@ -30,7 +30,7 @@ internal static class IWorkflowContextExtensions
         context.SendResultMessageAsync(id, result: null, cancellationToken);
 
     public static ValueTask SendResultMessageAsync(this IWorkflowContext context, string id, object? result, CancellationToken cancellationToken = default) =>
-        context.SendMessageAsync(new ActionExecutorResult(id, result), targetId: null, cancellationToken);
+        context.SendMessageAsync(new ActionExecutorResult(id, result), cancellationToken);
 
     public static ValueTask QueueStateResetAsync(this IWorkflowContext context, PropertyPath variablePath, CancellationToken cancellationToken = default) =>
         context.QueueStateUpdateAsync(Throw.IfNull(variablePath.VariableName), UnassignedValue.Instance, Throw.IfNull(variablePath.NamespaceAlias), cancellationToken);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/DeclarativeWorkflowContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/DeclarativeWorkflowContext.cs
@@ -77,7 +77,7 @@ internal sealed class DeclarativeWorkflowContext : IWorkflowContext
         this.State.Bind();
     }
 
-    private bool IsManagedScope(string? scopeName) => scopeName is not null && VariableScopeNames.IsValidName(scopeName);
+    private static bool IsManagedScope(string? scopeName) => scopeName is not null && VariableScopeNames.IsValidName(scopeName);
 
     /// <inheritdoc/>
     public async ValueTask<TValue?> ReadStateAsync<TValue>(string key, string? scopeName = null, CancellationToken cancellationToken = default)
@@ -86,7 +86,7 @@ internal sealed class DeclarativeWorkflowContext : IWorkflowContext
         {
             // Not a managed scope, just pass through.  This is valid when a declarative
             // workflow has been ejected to code (where DeclarativeWorkflowContext is also utilized).
-            _ when !this.IsManagedScope(scopeName) => await this.Source.ReadStateAsync<TValue>(key, scopeName, cancellationToken).ConfigureAwait(false),
+            _ when !IsManagedScope(scopeName) => await this.Source.ReadStateAsync<TValue>(key, scopeName, cancellationToken).ConfigureAwait(false),
             // Retrieve formula values directly from the managed state to avoid conversion.
             _ when typeof(TValue) == typeof(FormulaValue) => (TValue?)(object?)this.State.Get(key, scopeName),
             // Retrieve native types from the source context to avoid conversion.
@@ -100,7 +100,7 @@ internal sealed class DeclarativeWorkflowContext : IWorkflowContext
         {
             // Not a managed scope, just pass through.  This is valid when a declarative
             // workflow has been ejected to code (where DeclarativeWorkflowContext is also utilized).
-            _ when !this.IsManagedScope(scopeName) => await this.Source.ReadOrInitStateAsync(key, initialStateFactory, scopeName, cancellationToken).ConfigureAwait(false),
+            _ when !IsManagedScope(scopeName) => await this.Source.ReadOrInitStateAsync(key, initialStateFactory, scopeName, cancellationToken).ConfigureAwait(false),
             // Retrieve formula values directly from the managed state to avoid conversion.
             _ when typeof(TValue) == typeof(FormulaValue) => await EnsureFormulaValueAsync().ConfigureAwait(false),
             // Retrieve native types from the source context to avoid conversion.
@@ -134,8 +134,12 @@ internal sealed class DeclarativeWorkflowContext : IWorkflowContext
         => this.Source.ReadStateKeysAsync(scopeName, cancellationToken);
 
     /// <inheritdoc/>
-    public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
+    public ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default)
         => this.Source.SendMessageAsync(message, targetId, cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken = default)
+        => this.Source.SendMessageAsync(message, cancellationToken);
 
     public ValueTask UpdateStateAsync<T>(string key, T? value, string? scopeName, bool allowSystem, CancellationToken cancellationToken = default)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeAzureAgentExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeAzureAgentExecutor.cs
@@ -73,7 +73,7 @@ internal sealed class InvokeAzureAgentExecutor(InvokeAzureAgent model, WorkflowA
             {
                 isComplete = false;
                 UserInputRequest approvalRequest = new(agentName, inputRequests.OfType<AIContent>().ToArray());
-                await context.SendMessageAsync(approvalRequest, targetId: null, cancellationToken).ConfigureAwait(false);
+                await context.SendMessageAsync(approvalRequest, cancellationToken).ConfigureAwait(false);
             }
 
             // Identify function calls that have no associated result.
@@ -82,7 +82,7 @@ internal sealed class InvokeAzureAgentExecutor(InvokeAzureAgent model, WorkflowA
             {
                 isComplete = false;
                 AgentFunctionToolRequest toolRequest = new(agentName, functionCalls);
-                await context.SendMessageAsync(toolRequest, targetId: null, cancellationToken).ConfigureAwait(false);
+                await context.SendMessageAsync(toolRequest, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
@@ -76,7 +76,7 @@ internal sealed class QuestionExecutor(Question model, WorkflowAgentProvider age
     {
         int count = await this._promptCount.ReadAsync(context).ConfigureAwait(false);
         AnswerRequest inputRequest = new(this.FormatPrompt(this.Model.Prompt));
-        await context.SendMessageAsync(inputRequest, targetId: null, cancellationToken).ConfigureAwait(false);
+        await context.SendMessageAsync(inputRequest, cancellationToken).ConfigureAwait(false);
         await this._promptCount.WriteAsync(context, count + 1).ConfigureAwait(false);
     }
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/IWorkflowContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/IWorkflowContext.cs
@@ -86,19 +86,15 @@ public interface IWorkflowContext
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.
     /// The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default);
+    ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default);
 
-#if NET // What's the right way to do this so we do not make life a misery for netstandard2.0 targets?
-    // What's the value if they have to still write `cancellationToken: cancellationToken` to skip the targetId parameter?
-    // TODO: Remove this? (Maybe not: NET will eventually be the only target framework, right?)
     /// <summary>
     /// Queues a message to be sent to connected executors. The message will be sent during the next SuperStep.
     /// </summary>
     /// <param name="message">The message to be sent.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    ValueTask SendMessageAsync(object message, CancellationToken cancellationToken) => this.SendMessageAsync(message, null, cancellationToken);
-#endif
+    ValueTask SendMessageAsync(object message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds an output value to the workflow's output queue. These outputs will be bubbled out of the workflow using the

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
@@ -246,10 +246,11 @@ internal sealed class InProcessRunnerContext : IRunnerContext
     {
         public ValueTask AddEventAsync(WorkflowEvent workflowEvent, CancellationToken cancellationToken = default) => RunnerContext.AddEventAsync(workflowEvent, cancellationToken);
 
-        public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
-        {
-            return RunnerContext.SendMessageAsync(ExecutorId, message, targetId, cancellationToken);
-        }
+        public ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default) =>
+            RunnerContext.SendMessageAsync(ExecutorId, message, targetId, cancellationToken);
+
+        public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken) =>
+            this.SendMessageAsync(message, targetId: null, cancellationToken);
 
         public async ValueTask YieldOutputAsync(object output, CancellationToken cancellationToken = default)
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
@@ -143,7 +143,7 @@ public class SpecializedExecutorSmokeTests
 
         public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken) => this.SendMessageAsync(message, targetId: null, cancellationToken);
 
-        public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
+        public ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default)
         {
             if (message is List<ChatMessage> messages)
             {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
@@ -141,6 +141,8 @@ public class SpecializedExecutorSmokeTests
         public ValueTask<HashSet<string>> ReadStateKeysAsync(string? scopeName = null, CancellationToken cancellationToken = default)
             => this._stateManager.ReadKeysAsync(new ScopeId(executorId, scopeName));
 
+        public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken) => this.SendMessageAsync(message, targetId: null, cancellationToken);
+
         public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
         {
             if (message is List<ChatMessage> messages)

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestRunContext.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestRunContext.cs
@@ -36,8 +36,11 @@ public class TestRunContext : IRunnerContext
         public ValueTask<HashSet<string>> ReadStateKeysAsync(string? scopeName = null, CancellationToken cancellationToken = default)
             => new([]);
 
-        public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
+        public ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default)
             => runnerContext.SendMessageAsync(executorId, message, targetId, cancellationToken);
+
+        public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken = default)
+            => runnerContext.SendMessageAsync(executorId, message, targetId: null, cancellationToken);
 
         public ValueTask<T> ReadOrInitStateAsync<T>(string key, Func<T> initialStateFactory, string? scopeName = null, CancellationToken cancellationToken = default)
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestWorkflowContext.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestWorkflowContext.cs
@@ -71,5 +71,8 @@ internal sealed class TestWorkflowContext : IWorkflowContext
         return default;
     }
 
+    public ValueTask SendMessageAsync(object message, CancellationToken cancellationToken) =>
+        this.SendMessageAsync(message, targetId: null, cancellationToken);
+
     public IReadOnlyDictionary<string, string>? TraceContext => null;
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestWorkflowContext.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TestWorkflowContext.cs
@@ -65,7 +65,7 @@ internal sealed class TestWorkflowContext : IWorkflowContext
     public ValueTask<HashSet<string>> ReadStateKeysAsync(string? scopeName = null, CancellationToken cancellationToken = default)
         => this.StateManager.ReadKeysAsync(new ScopeId(this._executorId, scopeName));
 
-    public ValueTask SendMessageAsync(object message, string? targetId = null, CancellationToken cancellationToken = default)
+    public ValueTask SendMessageAsync(object message, string? targetId, CancellationToken cancellationToken = default)
     {
         this.SentMessages.Enqueue(message);
         return default;


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Remove default interface implementation and build directive for `SendMessage(object, CancellationToken)`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Based on PR feedback from Ben.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.