### PR TITLE
Rename nightly build GitHub source in FAQS.md to be consistent

### DIFF
--- a/docs/FAQS.md
+++ b/docs/FAQS.md
@@ -23,23 +23,23 @@ To download nightly builds follow the following steps:
     <configuration>
       <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-        <add key="github" value="https://nuget.pkg.github.com/microsoft/index.json" />
+        <add key="GitHubMicrosoft" value="https://nuget.pkg.github.com/microsoft/index.json" />
       </packageSources>
     
       <packageSourceMapping>
         <packageSource key="nuget.org">
           <package pattern="*" />
         </packageSource>
-        <packageSource key="github">
+        <packageSource key="GitHubMicrosoft">
           <package pattern="*nightly"/>
         </packageSource>
       </packageSourceMapping>
     
       <packageSourceCredentials>
-        <github>
-            <add key="Username" value="<Your GitHub Id>" />
-            <add key="ClearTextPassword" value="<Your Personal Access Token>" />
-          </github>
+        <GitHubMicrosoft>
+          <add key="Username" value="<Your GitHub Id>" />
+          <add key="ClearTextPassword" value="<Your Personal Access Token>" />
+        </GitHubMicrosoft>
       </packageSourceCredentials>
     </configuration>
     ```


### PR DESCRIPTION
### Motivation and Context

While configuring my machine to get nightly builds, I noticed an inconsistency in the FAQ for configuring the GitHub package source.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Updates the NuGet.config illustrated to use the same package source name referenced in the powershell statement.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.