### PR TITLE
.NET: Shorten TextSearchSearchResult to TextSearchResult

### DIFF
--- a/dotnet/samples/GettingStarted/Agents/Agent_Step18_TextSearchRag/Program.cs
+++ b/dotnet/samples/GettingStarted/Agents/Agent_Step18_TextSearchRag/Program.cs
@@ -42,11 +42,11 @@ Console.WriteLine(await agent.RunAsync("How long does standard shipping usually 
 Console.WriteLine("\n>> Asking about product care\n");
 Console.WriteLine(await agent.RunAsync("What is the best way to maintain the TrailRunner tent fabric?", thread));
 
-static Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> MockSearchAsync(string query, CancellationToken cancellationToken)
+static Task<IEnumerable<TextSearchProvider.TextSearchResult>> MockSearchAsync(string query, CancellationToken cancellationToken)
 {
     // The mock search inspects the user's question and returns pre-defined snippets
     // that resemble documents stored in an external knowledge source.
-    List<TextSearchProvider.TextSearchSearchResult> results = new();
+    List<TextSearchProvider.TextSearchResult> results = new();
 
     if (query.Contains("return", StringComparison.OrdinalIgnoreCase) || query.Contains("refund", StringComparison.OrdinalIgnoreCase))
     {
@@ -78,5 +78,5 @@ static Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> MockSearchAs
         });
     }
 
-    return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>(results);
+    return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>(results);
 }

--- a/dotnet/src/Microsoft.Agents.AI/Data/TextSearchProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Data/TextSearchProviderOptions.cs
@@ -45,7 +45,7 @@ public sealed class TextSearchProviderOptions
     /// <remarks>
     /// If provided, <see cref="ContextPrompt"/> and <see cref="CitationsPrompt"/> are ignored.
     /// </remarks>
-    public Func<IList<TextSearchProvider.TextSearchSearchResult>, string>? ContextFormatter { get; set; }
+    public Func<IList<TextSearchProvider.TextSearchResult>, string>? ContextFormatter { get; set; }
 
     /// <summary>
     /// Gets or sets the number of recent conversation messages (both user and assistant) to keep in memory

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Data/TextSearchProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Data/TextSearchProviderTests.cs
@@ -39,17 +39,17 @@ public sealed class TextSearchProviderTests
     public async Task InvokingAsync_ShouldInjectFormattedResultsAsync(string? overrideContextPrompt, string? overrideCitationsPrompt, bool withLogging)
     {
         // Arrange
-        List<TextSearchProvider.TextSearchSearchResult> results =
+        List<TextSearchProvider.TextSearchResult> results =
         [
             new() { Name = "Doc1", Link = "http://example.com/doc1", Value = "Content of Doc1" },
             new() { Name = "Doc2", Link = "http://example.com/doc2", Value = "Content of Doc2" }
         ];
 
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>(results);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>(results);
         }
 
         var options = new TextSearchProviderOptions
@@ -156,15 +156,15 @@ public sealed class TextSearchProviderTests
     public async Task SearchAsync_ShouldReturnFormattedResultsAsync(string? overrideContextPrompt, string? overrideCitationsPrompt)
     {
         // Arrange
-        List<TextSearchProvider.TextSearchSearchResult> results =
+        List<TextSearchProvider.TextSearchResult> results =
         [
             new() { Name = "Doc1", Link = "http://example.com/doc1", Value = "Content of Doc1" },
             new() { Name = "Doc2", Link = "http://example.com/doc2", Value = "Content of Doc2" }
         ];
 
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>(results);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>(results);
         }
 
         var options = new TextSearchProviderOptions
@@ -208,15 +208,15 @@ public sealed class TextSearchProviderTests
     public async Task InvokingAsync_ShouldUseContextFormatterWhenProvidedAsync()
     {
         // Arrange
-        List<TextSearchProvider.TextSearchSearchResult> results =
+        List<TextSearchProvider.TextSearchResult> results =
         [
             new() { Name = "Doc1", Link = "http://example.com/doc1", Value = "Content of Doc1" },
             new() { Name = "Doc2", Link = "http://example.com/doc2", Value = "Content of Doc2" }
         ];
 
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>(results);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>(results);
         }
 
         var options = new TextSearchProviderOptions
@@ -242,15 +242,15 @@ public sealed class TextSearchProviderTests
         // Arrange
         var payload1 = new RawPayload { Id = "R1" };
         var payload2 = new RawPayload { Id = "R2" };
-        List<TextSearchProvider.TextSearchSearchResult> results =
+        List<TextSearchProvider.TextSearchResult> results =
         [
             new() { Name = "Doc1", Value = "Content 1", RawRepresentation = payload1 },
             new() { Name = "Doc2", Value = "Content 2", RawRepresentation = payload2 }
         ];
 
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>(results);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>(results);
         }
 
         var options = new TextSearchProviderOptions
@@ -299,10 +299,10 @@ public sealed class TextSearchProviderTests
             RecentMessageMemoryLimit = 3
         };
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]); // No results needed.
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]); // No results needed.
         }
         var provider = new TextSearchProvider(SearchDelegateAsync, options);
 
@@ -338,10 +338,10 @@ public sealed class TextSearchProviderTests
             RecentMessageMemoryLimit = 5
         };
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegateAsync(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]);
         }
         var provider = new TextSearchProvider(SearchDelegateAsync, options);
 
@@ -443,10 +443,10 @@ public sealed class TextSearchProviderTests
         // Act
         var state = provider.Serialize();
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]);
         }
         var roundTrippedProvider = new TextSearchProvider(SearchDelegate2Async, state, options: new TextSearchProviderOptions
         {
@@ -482,10 +482,10 @@ public sealed class TextSearchProviderTests
         var state = initialProvider.Serialize();
 
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]);
         }
 
         // Act
@@ -508,10 +508,10 @@ public sealed class TextSearchProviderTests
         var emptyState = JsonSerializer.Deserialize("{}", TestJsonSerializerContext.Default.JsonElement);
 
         string? capturedInput = null;
-        Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
+        Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchDelegate2Async(string input, CancellationToken ct)
         {
             capturedInput = input;
-            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]);
+            return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]);
         }
 
         // Act
@@ -530,9 +530,9 @@ public sealed class TextSearchProviderTests
 
     #endregion
 
-    private Task<IEnumerable<TextSearchProvider.TextSearchSearchResult>> NoResultSearchAsync(string input, CancellationToken ct)
+    private Task<IEnumerable<TextSearchProvider.TextSearchResult>> NoResultSearchAsync(string input, CancellationToken ct)
     {
-        return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchSearchResult>>([]);
+        return Task.FromResult<IEnumerable<TextSearchProvider.TextSearchResult>>([]);
     }
 
     private sealed class RawPayload


### PR DESCRIPTION
### Motivation and Context

#1594

### Description

- After renaming from 'Rag' to 'Search', this type was oddly named, so renaming from TextSearchSearchResult to TextSearchResult.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.