### PR TITLE
.NET: Add SuppressAssistantName option to ChatClientAgentOptions

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -99,6 +99,18 @@ public class ChatClientAgentOptions
     public bool UseProvidedChatClientAsIs { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to suppress the name field on assistant messages when the agent name is not set.
+    /// </summary>
+    /// <remarks>
+    /// When set to <see langword="true"/>, assistant messages will not include a name field in the serialized payload
+    /// if the agent's <see cref="Name"/> property is <see langword="null"/>. This is useful for compatibility with
+    /// strict OpenAI-compatible backends that reject assistant messages with a name field.
+    /// When set to <see langword="false"/> (the default), the framework will use "UnnamedAgent" as a fallback name
+    /// when the agent name is not set, maintaining backward compatibility.
+    /// </remarks>
+    public bool SuppressAssistantName { get; set; }
+
+    /// <summary>
     /// Creates a new instance of <see cref="ChatClientAgentOptions"/> with the same values as this instance.
     /// </summary>
     public ChatClientAgentOptions Clone()
@@ -111,6 +123,8 @@ public class ChatClientAgentOptions
             ChatOptions = this.ChatOptions?.Clone(),
             ChatMessageStoreFactory = this.ChatMessageStoreFactory,
             AIContextProviderFactory = this.AIContextProviderFactory,
+            UseProvidedChatClientAsIs = this.UseProvidedChatClientAsIs,
+            SuppressAssistantName = this.SuppressAssistantName,
         };
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -106,7 +106,7 @@ public class ChatClientAgentOptions
     /// if the agent's <see cref="Name"/> property is <see langword="null"/>. This is useful for compatibility with
     /// strict OpenAI-compatible backends that reject assistant messages with a name field.
     /// When set to <see langword="false"/> (the default), the framework will use "UnnamedAgent" as a fallback name
-    /// when the agent name is not set, maintaining backward compatibility.
+    /// when the agent name is not set.
     /// </remarks>
     public bool SuppressAssistantName { get; set; }
 

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -123,7 +123,6 @@ public class ChatClientAgentOptions
             ChatOptions = this.ChatOptions?.Clone(),
             ChatMessageStoreFactory = this.ChatMessageStoreFactory,
             AIContextProviderFactory = this.AIContextProviderFactory,
-            UseProvidedChatClientAsIs = this.UseProvidedChatClientAsIs,
             SuppressAssistantName = this.SuppressAssistantName,
         };
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentOptionsTests.cs
@@ -221,4 +221,24 @@ public class ChatClientAgentOptionsTests
         Assert.Null(clone.ChatMessageStoreFactory);
         Assert.Null(clone.AIContextProviderFactory);
     }
+
+    [Fact]
+    public void Clone_CopiesSuppressAssistantNameProperty()
+    {
+        // Arrange
+        var original = new ChatClientAgentOptions
+        {
+            Name = "Test Agent",
+            SuppressAssistantName = true,
+            UseProvidedChatClientAsIs = true
+        };
+
+        // Act
+        var clone = original.Clone();
+
+        // Assert
+        Assert.NotSame(original, clone);
+        Assert.Equal(original.SuppressAssistantName, clone.SuppressAssistantName);
+        Assert.Equal(original.UseProvidedChatClientAsIs, clone.UseProvidedChatClientAsIs);
+    }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
@@ -255,6 +255,46 @@ public partial class ChatClientAgentTests
     }
 
     /// <summary>
+    /// Verify that RunStreamingAsync respects SuppressAssistantName option when setting AuthorName.
+    /// </summary>
+    [Theory]
+    [InlineData(true, null, null)]  // SuppressAssistantName=true, Name=null -> AuthorName=null
+    [InlineData(false, null, "UnnamedAgent")]  // SuppressAssistantName=false, Name=null -> AuthorName="UnnamedAgent"
+    [InlineData(true, "MyAgent", "MyAgent")]  // SuppressAssistantName=true, Name="MyAgent" -> AuthorName="MyAgent"
+    public async Task RunStreamingAsyncRespectsSuppressAssistantNameOptionAsync(bool suppressAssistantName, string? agentName, string? expectedAuthorName)
+    {
+        // Arrange
+        Mock<IChatClient> mockService = new();
+        var responseUpdates = new[]
+        {
+            new ChatResponseUpdate(role: ChatRole.Assistant, content: "response")
+        };
+        mockService.Setup(
+            s => s.GetStreamingResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>())).Returns(ToAsyncEnumerableAsync(responseUpdates));
+
+        ChatClientAgent agent = new(mockService.Object, options: new()
+        {
+            Instructions = "test instructions",
+            Name = agentName,
+            SuppressAssistantName = suppressAssistantName
+        });
+
+        // Act
+        var updates = agent.RunStreamingAsync([new(ChatRole.User, "test")]);
+        List<AgentRunResponseUpdate> result = [];
+        await foreach (var update in updates)
+        {
+            result.Add(update);
+        }
+
+        // Assert
+        Assert.All(result, update => Assert.Equal(expectedAuthorName, update.AuthorName));
+    }
+
+    /// <summary>
     /// Verify that RunAsync works with existing thread and can retreive messages if the thread has a MessageStore.
     /// </summary>
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
@@ -220,6 +220,41 @@ public partial class ChatClientAgentTests
     }
 
     /// <summary>
+    /// Verify that RunAsync respects SuppressAssistantName option when setting AuthorName.
+    /// </summary>
+    [Theory]
+    [InlineData(true, null, null)]  // SuppressAssistantName=true, Name=null -> AuthorName=null
+    [InlineData(false, null, "UnnamedAgent")]  // SuppressAssistantName=false, Name=null -> AuthorName="UnnamedAgent"
+    [InlineData(true, "MyAgent", "MyAgent")]  // SuppressAssistantName=true, Name="MyAgent" -> AuthorName="MyAgent"
+    public async Task RunAsyncRespectsSuppressAssistantNameOptionAsync(bool suppressAssistantName, string? agentName, string? expectedAuthorName)
+    {
+        // Arrange
+        Mock<IChatClient> mockService = new();
+        var responseMessages = new[]
+        {
+            new ChatMessage(ChatRole.Assistant, "response")
+        };
+        mockService.Setup(
+            s => s.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new ChatResponse(responseMessages));
+
+        ChatClientAgent agent = new(mockService.Object, options: new()
+        {
+            Instructions = "test instructions",
+            Name = agentName,
+            SuppressAssistantName = suppressAssistantName
+        });
+
+        // Act
+        var result = await agent.RunAsync([new(ChatRole.User, "test")]);
+
+        // Assert
+        Assert.All(result.Messages, msg => Assert.Equal(expectedAuthorName, msg.AuthorName));
+    }
+
+    /// <summary>
     /// Verify that RunAsync works with existing thread and can retreive messages if the thread has a MessageStore.
     /// </summary>
     [Fact]


### PR DESCRIPTION
## Allow disabling name field on assistant messages

### Description

Fixes #1807

Adds support for suppressing the `name` field on assistant messages when the agent name is not set, enabling compatibility with strict OpenAI-compatible backends (e.g., vLLM's 0.9.2+ OpenAI-Compatible server) that reject assistant messages containing a `name` field.

### Problem

When using `ChatClientAgent` with an OpenAI-compatible backend that strictly validates the schema, requests fail with `400 Bad Request` because the framework automatically emits `"name": "UnnamedAgent"` on assistant messages even when the agent's `Name` property is `null`. Some backends only accept `name` for legacy `role:"function"` messages and forbid extra properties on `assistant`/`user`/`system` messages.

### Solution

Added a new `SuppressAssistantName` boolean property to `ChatClientAgentOptions` that controls whether the name field is included on assistant messages:

- When `SuppressAssistantName = true` and `Name = null`: Assistant messages will not include a `name` field (returns `null` for `AuthorName`)
- When `SuppressAssistantName = false` (default) and `Name = null`: Framework uses `"UnnamedAgent"` as fallback (maintains backward compatibility)
- When `Name` is explicitly set: The name is always used regardless of the `SuppressAssistantName` flag

### Changes

- Added `SuppressAssistantName` property to `ChatClientAgentOptions`
- Updated `ChatClientAgent` to respect the flag in both `RunAsync` and `RunStreamingAsync` methods
- Added `GetMessageAuthorName()` helper method to centralize the logic
- Updated `Clone()` method to include the new property
- Added unit tests

### Backward Compatibility

- The new property defaults to `false`, preserving existing behavior where `"UnnamedAgent"` is used as a fallback name.

### Testing

- Added `RunAsyncRespectsSuppressAssistantNameOptionAsync` theory test covering 3 scenarios:
  - `SuppressAssistantName=true, Name=null` → `AuthorName=null`
  - `SuppressAssistantName=false, Name=null` → `AuthorName="UnnamedAgent"` (backward compatibility)
  - `SuppressAssistantName=true, Name="MyAgent"` → `AuthorName="MyAgent"` (respects explicit name)
- Added RunStreamingAsyncRespectsSuppressAssistantNameOptionAsync theory test covering the same 3 scenarios for the streaming code path
- Added `Clone_CopiesSuppressAssistantNameProperty` test to verify cloning behavior

### Usage Example

```csharp
var agent = new ChatClientAgent(
    chatClient,
    options: new ChatClientAgentOptions
    {
        SuppressAssistantName = true  // Suppress name field when Name is null
    }
);
```