### PR TITLE
.NET: [BREAKING] Don't stamp unknown author name on output messages.

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -353,9 +353,9 @@ public sealed partial class ChatClientAgent : AIAgent
 
         chatClient = ApplyRunOptionsTransformations(options, chatClient);
 
-        var agentName = this.GetLoggingAgentName();
+        var loggingAgentName = this.GetLoggingAgentName();
 
-        this._logger.LogAgentChatClientInvokingAgent(nameof(RunAsync), this.Id, agentName, this._chatClientType);
+        this._logger.LogAgentChatClientInvokingAgent(nameof(RunAsync), this.Id, loggingAgentName, this._chatClientType);
 
         // Call the IChatClient and notify the AIContextProvider of any failures.
         TChatClientResponse chatResponse;
@@ -369,7 +369,7 @@ public sealed partial class ChatClientAgent : AIAgent
             throw;
         }
 
-        this._logger.LogAgentChatClientInvokedAgent(nameof(RunAsync), this.Id, agentName, this._chatClientType, inputMessages.Count);
+        this._logger.LogAgentChatClientInvokedAgent(nameof(RunAsync), this.Id, loggingAgentName, this._chatClientType, inputMessages.Count);
 
         // We can derive the type of supported thread from whether we have a conversation id,
         // so let's update it and set the conversation id for the service thread case.
@@ -378,7 +378,7 @@ public sealed partial class ChatClientAgent : AIAgent
         // Ensure that the author name is set for each message in the response.
         foreach (ChatMessage chatResponseMessage in chatResponse.Messages)
         {
-            chatResponseMessage.AuthorName ??= agentName;
+            chatResponseMessage.AuthorName ??= this.Name;
         }
 
         // Only notify the thread of new messages if the chatResponse was successful to avoid inconsistent message state in the thread.

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentTests.cs
@@ -194,8 +194,10 @@ public partial class ChatClientAgentTests
     /// <summary>
     /// Verify that RunAsync sets AuthorName on all response messages.
     /// </summary>
-    [Fact]
-    public async Task RunAsyncSetsAuthorNameOnAllResponseMessagesAsync()
+    [Theory]
+    [InlineData("TestAgent")]
+    [InlineData(null)]
+    public async Task RunAsyncSetsAuthorNameOnAllResponseMessagesAsync(string? authorName)
     {
         // Arrange
         Mock<IChatClient> mockService = new();
@@ -210,13 +212,13 @@ public partial class ChatClientAgentTests
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new ChatResponse(responseMessages));
 
-        ChatClientAgent agent = new(mockService.Object, options: new() { Instructions = "test instructions", Name = "TestAgent" });
+        ChatClientAgent agent = new(mockService.Object, options: new() { Instructions = "test instructions", Name = authorName });
 
         // Act
         var result = await agent.RunAsync([new(ChatRole.User, "test")]);
 
         // Assert
-        Assert.All(result.Messages, msg => Assert.Equal("TestAgent", msg.AuthorName));
+        Assert.All(result.Messages, msg => Assert.Equal(authorName, msg.AuthorName));
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

We log "Unknown Agent" when an agent has no name, but we were also setting that as the author name on output messages when the Agent had no name, which is incorrect.

### Description

- Don't set "Unknown Agent" for logging on output messages.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.