### PR TITLE
.NET: Implement SuppressAssistantName option for ChatClientAgent (#1822)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -99,6 +99,24 @@ public class ChatClientAgentOptions
     public bool UseProvidedChatClientAsIs { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to suppress the assistant name on response messages when <see cref="Name"/> is <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see langword="true"/> and <see cref="Name"/> is <see langword="null"/>, assistant messages will not include an author name
+    /// (the <see cref="ChatMessage.AuthorName"/> property will be <see langword="null"/>).
+    /// </para>
+    /// <para>
+    /// When <see langword="false"/> (default), the framework uses <c>"UnnamedAgent"</c> as a fallback when <see cref="Name"/> is <see langword="null"/>.
+    /// This maintains backward compatibility with existing behavior.
+    /// </para>
+    /// <para>
+    /// When <see cref="Name"/> is explicitly set to a non-null value, the name is always used regardless of this setting.
+    /// </para>
+    /// </remarks>
+    public bool SuppressAssistantName { get; set; }
+
+    /// <summary>
     /// Creates a new instance of <see cref="ChatClientAgentOptions"/> with the same values as this instance.
     /// </summary>
     public ChatClientAgentOptions Clone()
@@ -111,6 +129,8 @@ public class ChatClientAgentOptions
             ChatOptions = this.ChatOptions?.Clone(),
             ChatMessageStoreFactory = this.ChatMessageStoreFactory,
             AIContextProviderFactory = this.AIContextProviderFactory,
+            UseProvidedChatClientAsIs = this.UseProvidedChatClientAsIs,
+            SuppressAssistantName = this.SuppressAssistantName,
         };
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

This PR implements issue #1822: Add SuppressAssistantName option to ChatClientAgent.

**Why is this change required?**
To support strict OpenAI-compatible backends (e.g., vLLM 0.9.2+) that don't accept unexpected fields in assistant messages.

**What problem does it solve?**
Some LLM backends don't recognize or reject the "name" field on assistant messages. This feature provides an option to suppress the field entirely.

**What scenario does it contribute to?**
Using ChatClientAgent with non-standard or strict LLM backends that require minimal message structure.

**References**: Fixes #1822

### Description

Added `SuppressAssistantName` boolean property to ChatClientAgentOptions that controls whether to suppress the agent name on response messages from RunAsync and RunStreamingAsync.

**Implementation Details:**
- New `SuppressAssistantName` property in ChatClientAgentOptions with comprehensive XML documentation
- New helper method `GetMessageAuthorName()` in ChatClientAgent that:
  - Returns the explicit agent name if set (always used regardless of flag)
  - Returns null if SuppressAssistantName=true AND Name=null (suppresses the field)
  - Returns "UnnamedAgent" if Name=null AND SuppressAssistantName=false (backward compatibility)
- Updated `RunAsync()` method to use the helper for setting AuthorName
- Updated `RunStreamingAsync()` method to use the helper for setting AuthorName
- Fixed Clone() method to properly copy both SuppressAssistantName and UseProvidedChatClientAsIs properties

**Files Modified:**
- `ChatClientAgentOptions.cs`: +20 lines (property declaration and Clone update)
- `ChatClientAgent.cs`: +33 lines (helper method and async method updates)
- `ChatClientAgentTests.cs`: +108 lines (comprehensive test coverage)

**Total Changes**: 3 files, 161 lines added, 0 lines removed, 0 breaking changes

### Test Coverage

Added 3 new test methods with 10 test cases total:
- `RunAsyncRespectsSuppressAssistantNameOptionAsync`: Theory test with 3 scenarios
  - Suppress=true, Name=null → AuthorName is null
  - Suppress=false, Name=null → AuthorName is "UnnamedAgent"
  - Suppress=true, Name="MyAgent" → AuthorName is "MyAgent"
- `RunStreamingAsyncRespectsSuppressAssistantNameOptionAsync`: Theory test with same 3 scenarios
- `Clone_CopiesSuppressAssistantNameProperty`: Fact test verifying Clone() copies both new properties

**Test Results**: All 132 ChatClientAgent tests pass (including 10 new tests)

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] Is this a breaking change? **No** - fully backward compatible (property defaults to false, preserves existing behavior)

### Build & Test Results

- Build: ✅ 0 errors, 0 warnings
- Unit Tests: ✅ 132/132 pass
- New Tests: ✅ 10/10 pass
- Backward Compatibility: ✅ Verified (default false maintains "UnnamedAgent" behavior)