### PR TITLE
.NET: AgentHostExecutor should use agent DisplayName as Executor ID

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/AIAgentBinding.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/AIAgentBinding.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Agents.AI.Workflows;
 /// <param name="Agent">The AI agent.</param>
 /// <param name="EmitEvents">Specifies whether the agent should emit events. If null, the default behavior is applied.</param>
 public record AIAgentBinding(AIAgent Agent, bool EmitEvents = false)
-    : ExecutorBinding(Throw.IfNull(Agent).Name ?? Throw.IfNull(Agent.Id),
+    : ExecutorBinding(Throw.IfNull(Agent).GetDescriptiveId(),
                            (_) => new(new AIAgentHostExecutor(Agent, EmitEvents)),
                            typeof(AIAgentHostExecutor),
                            Agent)

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/AIAgentHostExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/AIAgentHostExecutor.cs
@@ -14,7 +14,7 @@ internal sealed class AIAgentHostExecutor : ChatProtocolExecutor
     private readonly AIAgent _agent;
     private AgentThread? _thread;
 
-    public AIAgentHostExecutor(AIAgent agent, bool emitEvents = false) : base(id: agent.DisplayName)
+    public AIAgentHostExecutor(AIAgent agent, bool emitEvents = false) : base(id: agent.GetDescriptiveId())
     {
         this._agent = agent;
         this._emitEvents = emitEvents;

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SpecializedExecutorSmokeTests.cs
@@ -211,8 +211,10 @@ public class SpecializedExecutorSmokeTests
         // Verify that the agent host executor registration IDs in the workflow definition
         // match the agent names when agent names are provided.
         // The property DisplayName falls back to using the agent ID when Name is not set.
-        definition.Executors[agentA.DisplayName].ExecutorId.Should().Be(AgentAName);
-        definition.Executors[agentB.DisplayName].ExecutorId.Should().Be(AgentBName);
+        agentA.GetDescriptiveId().Should().Contain(AgentAName);
+        agentB.GetDescriptiveId().Should().Contain(AgentBName);
+        definition.Executors[agentA.GetDescriptiveId()].ExecutorId.Should().Be(agentA.GetDescriptiveId());
+        definition.Executors[agentB.GetDescriptiveId()].ExecutorId.Should().Be(agentB.GetDescriptiveId());
 
         // This will create an instance of the start agent and verify that the ID
         // of the executor instance matches the ID of the registration.
@@ -231,8 +233,10 @@ public class SpecializedExecutorSmokeTests
         // Verify that the agent host executor registration IDs in the workflow definition
         // match the agent IDs when agent names are not provided.
         // The property DisplayName falls back to using the agent ID when Name is not set.
-        definition.Executors[agentA.DisplayName].ExecutorId.Should().Be(agentA.Id);
-        definition.Executors[agentB.DisplayName].ExecutorId.Should().Be(agentB.Id);
+        agentA.GetDescriptiveId().Should().Contain(agentA.Id);
+        agentB.GetDescriptiveId().Should().Contain(agentB.Id);
+        definition.Executors[agentA.GetDescriptiveId()].ExecutorId.Should().Be(agentA.GetDescriptiveId());
+        definition.Executors[agentB.GetDescriptiveId()].ExecutorId.Should().Be(agentB.GetDescriptiveId());
 
         // This will create an instance of the start agent and verify that the ID
         // of the executor instance matches the ID of the registration.


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
Addresses: https://github.com/microsoft/agent-framework/issues/1743

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
1. Use agent `DisplayName` as Executor ID
2. Add unit tests


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.