### PR TITLE
Python: Fix: Default handoff tool registration in HandoffBuilder

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_handoff.py
+++ b/python/packages/core/agent_framework/_workflows/_handoff.py
@@ -1274,12 +1274,12 @@ class HandoffBuilder:
                         updated_executor, tool_targets = self._prepare_agent_with_handoffs(executor, targets_map)
                         self._executors[source_exec_id] = updated_executor
                         handoff_tool_targets.update(tool_targets)
-        else:
-            # Default behavior: only coordinator gets handoff tools to all specialists
-            if isinstance(starting_executor, AgentExecutor) and specialists:
-                starting_executor, tool_targets = self._prepare_agent_with_handoffs(starting_executor, specialists)
-                self._executors[self._starting_agent_id] = starting_executor
-                handoff_tool_targets.update(tool_targets)  # Update references after potential agent modifications
+            else:
+                # Default behavior: only coordinator gets handoff tools to all specialists
+                if isinstance(starting_executor, AgentExecutor) and specialists:
+                    starting_executor, tool_targets = self._prepare_agent_with_handoffs(starting_executor, specialists)
+                    self._executors[self._starting_agent_id] = starting_executor
+                    handoff_tool_targets.update(tool_targets)  # Update references after potential agent modifications
         starting_executor = self._executors[self._starting_agent_id]
         specialists = {
             exec_id: executor for exec_id, executor in self._executors.items() if exec_id != self._starting_agent_id


### PR DESCRIPTION
### Motivation and Context

This change fixes the default handoff behavior in the Python SDK.

When using the `HandoffBuilder` without explicitly calling `.add_handoff()`, the handoff mechanism does not register the coordinator’s handoff tools correctly, causing the workflow to stop after printing the tool name (e.g. `[handoff_to_refund_agent]`) instead of routing control to the target specialist agent.

The fix ensures that the default “coordinator → all specialists” handoff registration logic is correctly applied during workflow construction, restoring expected multi-agent orchestration behavior.

Fixes #1851

---

### Description

- Corrected the conditional logic and indentation inside the `HandoffBuilder.build()` method.  
- Ensured that, when `.add_handoff()` is not used, the builder still registers default handoff tools for the coordinator agent to all other participants.  
- Verified the fix using the sample `python/samples/getting_started/workflows/orchestration/handoff_simple.py`, confirming that specialist agents (`refund_agent`, `support_agent`, etc.) now receive and respond to delegated conversations as expected.

---

### Contribution Checklist

- [x] The code builds clean without any errors or warnings  
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)  
- [x] All unit tests pass, and I have added new tests where possible  
- [ ] **Is this a breaking change?** No  
