### PR TITLE
Python: A2A Workflows Transport Fix

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -127,7 +127,21 @@ class A2AAgent(BaseAgent):
         )
         factory = ClientFactory(config)
         interceptors = [auth_interceptor] if auth_interceptor is not None else None
-        self.client = factory.create(agent_card, interceptors=interceptors)  # type: ignore
+
+        # Attempt transport negotiation with the provided agent card
+        try:
+            self.client = factory.create(agent_card, interceptors=interceptors)  # type: ignore
+        except Exception as transport_error:
+            # Transport negotiation failed - fall back to minimal agent card with JSONRPC
+            fallback_card = minimal_agent_card(agent_card.url, [TransportProtocol.jsonrpc])
+            try:
+                self.client = factory.create(fallback_card, interceptors=interceptors)  # type: ignore
+            except Exception as fallback_error:
+                raise RuntimeError(
+                    f"A2A transport negotiation failed. "
+                    f"Primary error: {transport_error}. "
+                    f"Fallback error: {fallback_error}"
+                ) from transport_error
 
     async def __aenter__(self) -> "A2AAgent":
         """Async context manager entry."""


### PR DESCRIPTION
### Motivation and Context
This PR adds fallback for the "no suitable transport method found" error when using A2A with workflows.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.