### PR TITLE
.NET: Re-enable the "retrieve object" check in StateManager

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/StateManager.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/StateManager.cs
@@ -106,8 +106,7 @@ internal sealed class StateManager
         if (typeof(T) == typeof(object))
         {
             // Reading as object will break across serialize/deserialize boundaries, e.g. checkpointing, distributed runtime, etc.
-            // Disabled pending upstream updates for this change; see https://github.com/microsoft/agent-framework/issues/1369
-            //throw new NotSupportedException("Reading state as 'object' is not supported. Use 'PortableValue' instead for variants.");
+            throw new NotSupportedException("Reading state as 'object' is not supported. Use 'PortableValue' instead for variants.");
         }
 
         Throw.IfNullOrEmpty(key);


### PR DESCRIPTION
### Motivation and Context

As we implemented more of Checkpointing and proper support for polymorphic values behind `PortableValue`, there was a brief period where the Declarative layer needed to gradually switch from the old way of using the APIs to `PortableValue`. To make this integration easier, we temporarily disabled the check that users are not trying to read `object` from the state store.

### Description

This change restores the check.

Closes #1369

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] ~~**Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.~~