### PR TITLE
Python: Add `maximum_consecutive_errors_per_request` Parameter for Fail-Fast Exception Handling

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -593,6 +593,7 @@ class ChatAgent(BaseAgent):
         frequency_penalty: float | None = None,
         logit_bias: dict[str | int, float] | None = None,
         max_tokens: int | None = None,
+        maximum_consecutive_errors_per_request: int | None = None,
         metadata: dict[str, Any] | None = None,
         model_id: str | None = None,
         presence_penalty: float | None = None,
@@ -637,6 +638,9 @@ class ChatAgent(BaseAgent):
             frequency_penalty: The frequency penalty to use.
             logit_bias: The logit bias to use.
             max_tokens: The maximum number of tokens to generate.
+            maximum_consecutive_errors_per_request: Maximum number of consecutive tool errors allowed.
+                If set to 0, exceptions from tool calls will be raised immediately instead of
+                being converted to conversational responses. If None, uses framework default (3).
             metadata: Additional metadata to include in the request.
             model_id: The model_id to use for the agent.
             presence_penalty: The presence penalty to use.
@@ -693,6 +697,7 @@ class ChatAgent(BaseAgent):
             instructions=instructions,
             logit_bias=logit_bias,
             max_tokens=max_tokens,
+            maximum_consecutive_errors_per_request=maximum_consecutive_errors_per_request,
             metadata=metadata,
             presence_penalty=presence_penalty,
             response_format=response_format,

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -3019,6 +3019,7 @@ class ChatOptions(SerializationMixin):
         instructions: str | None = None,
         logit_bias: MutableMapping[str | int, float] | None = None,
         max_tokens: int | None = None,
+        maximum_consecutive_errors_per_request: int | None = None,
         metadata: MutableMapping[str, str] | None = None,
         presence_penalty: float | None = None,
         response_format: type[BaseModel] | None = None,
@@ -3047,6 +3048,9 @@ class ChatOptions(SerializationMixin):
             instructions: the instructions, will be turned into a system or equivalent message.
             logit_bias: The logit bias mapping.
             max_tokens: The maximum number of tokens (must be > 0).
+            maximum_consecutive_errors_per_request: Maximum number of consecutive tool errors allowed.
+                If set to 0, exceptions from tool calls will be raised immediately instead of
+                being converted to conversational responses. If None, uses framework default (3).
             metadata: Metadata mapping.
             presence_penalty: The presence penalty (must be between -2.0 and 2.0).
             response_format: Structured output response format schema. Must be a valid Pydantic model.
@@ -3080,6 +3084,8 @@ class ChatOptions(SerializationMixin):
             top_p = float(top_p)
         if max_tokens is not None and max_tokens <= 0:
             raise ValueError("max_tokens must be greater than 0")
+        if maximum_consecutive_errors_per_request is not None and maximum_consecutive_errors_per_request < 0:
+            raise ValueError("maximum_consecutive_errors_per_request must be >= 0")
 
         if additional_properties is None:
             additional_properties = {}
@@ -3094,6 +3100,7 @@ class ChatOptions(SerializationMixin):
         self.instructions = instructions
         self.logit_bias = logit_bias
         self.max_tokens = max_tokens
+        self.maximum_consecutive_errors_per_request = maximum_consecutive_errors_per_request
         self.metadata = metadata
         self.presence_penalty = presence_penalty
         self.response_format = response_format

--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -160,6 +160,7 @@ class OpenAIBaseChatClient(OpenAIBase, BaseChatClient):
             exclude={
                 "type",
                 "instructions",  # included as system message
+                "maximum_consecutive_errors_per_request",  # internal parameter for tool execution
             }
         )
 


### PR DESCRIPTION
### Motivation and Context
Adds a new `maximum_consecutive_errors_per_request` parameter to `ChatAgent` and `ChatOptions` that enables fail-fast exception handling for tool calls. When set to 0, exceptions from tool execution are raised immediately instead of being converted to conversational responses.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.