### PR TITLE
Python: fix(devui): serialize nested ChatMessage objects in workflow events

### DIFF
--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -814,10 +814,10 @@ class MessageMapper:
                 return [trace_event]
 
             # For unknown/legacy events, still emit as workflow event for backward compatibility
-            # Get event data and deep serialize it to handle nested SerializationMixin objects
+            # Get event data and recursively serialize it to handle nested SerializationMixin objects
             raw_event_data = getattr(event, "data", None)
             serialized_event_data: dict[str, Any] | str | list[Any] | None = (
-                self._deep_serialize(raw_event_data) if raw_event_data is not None else None
+                _serialize_content_recursive(raw_event_data) if raw_event_data is not None else None
             )
 
             # Create structured workflow event (keeping for backward compatibility)
@@ -841,61 +841,6 @@ class MessageMapper:
         except Exception as e:
             logger.warning(f"Error converting workflow event: {e}")
             return [await self._create_error_event(str(e), context)]
-
-    def _deep_serialize(self, obj: Any) -> Any:
-        """Recursively serialize objects to JSON-compatible types.
-        
-        This method handles nested structures containing SerializationMixin objects
-        (like ChatMessage) that need to be converted to dictionaries before JSON
-        serialization. It supports arbitrary nesting depth and multiple object types.
-        
-        Args:
-            obj: Object to serialize. Can be a primitive type, list, dict, 
-                 SerializationMixin object, Pydantic model, or nested combination.
-            
-        Returns:
-            JSON-serializable version of the object (dict, list, str, int, float, bool, or None).
-        """
-        # Base case: None
-        if obj is None:
-            return None
-            
-        # Base case: JSON primitives - return as-is
-        if isinstance(obj, (str, int, float, bool)):
-            return obj
-            
-        # Recursive case: Lists and tuples
-        if isinstance(obj, (list, tuple)):
-            return [self._deep_serialize(item) for item in obj]
-            
-        # Recursive case: Dictionaries
-        if isinstance(obj, dict):
-            return {key: self._deep_serialize(value) for key, value in obj.items()}
-            
-        # Recursive case: SerializationMixin objects (ChatMessage, Role, etc.)
-        # These objects have a to_dict() method that returns a dictionary representation
-        if hasattr(obj, "to_dict") and callable(getattr(obj, "to_dict", None)):
-            try:
-                # Call to_dict() and recursively serialize the result
-                # This handles nested SerializationMixin objects within the dictionary
-                return self._deep_serialize(obj.to_dict())
-            except Exception as e:
-                logger.debug(f"Failed to serialize object with to_dict(): {e}")
-                return str(obj)
-                
-        # Recursive case: Pydantic models
-        # These have a model_dump() method (Pydantic v2) for serialization
-        if hasattr(obj, "model_dump") and callable(getattr(obj, "model_dump", None)):
-            try:
-                return self._deep_serialize(obj.model_dump())
-            except Exception as e:
-                logger.debug(f"Failed to serialize Pydantic model: {e}")
-                return str(obj)
-                
-        # Fallback: Convert to string representation
-        # This ensures we always return something serializable, even for unknown types
-        logger.debug(f"Unknown type {type(obj).__name__}, converting to string")
-        return str(obj)
 
     # Content type mappers - implementing our comprehensive mapping plan
 


### PR DESCRIPTION
Resolve #1920 

Add _deep_serialize() method to handle recursive serialization of SerializationMixin objects in nested structures (e.g., list[ChatMessage]). Fixes serialization errors when Handoff Workflows yield conversation outputs.

### Motivation and Context
When using Handoff Workflows that yield list[ChatMessage] as output, DevUI throws a serialization error:
`[2025-11-05 09:43:19 - agent_framework_devui/_server.py:544 - ERROR] Error in streaming execution: Unable to serialize unknown type: <class 'agent_framework._types.ChatMessage'>`
The error occurs because `WorkflowOutputEvent.data` contains a list of `ChatMessage` objects. The mapper's serialization logic in `_convert_workflow_event()` only checks if the event data itself has a `to_dict()` method. When the data is a `list[ChatMessage]`, the list object doesn't have this method, so the `ChatMessage` objects inside remain unserialized, causing JSON serialization to fail.
This change fixes the serialization issue for Handoff Workflows and any future workflows that yield nested SerializationMixin objects.
### Description
Added a `_deep_serialize()` method that recursively serializes all nested structures:
- Lists/tuples containing serializable objects
- Dicts with serializable values
- Nested combinations (e.g., list[dict[str, ChatMessage]])
- SerializationMixin objects
- Pydantic models
This ensures any workflow output containing nested SerializationMixin objects can be properly serialized to JSON.
Changes:
Added `_deep_serialize()` method to `MessageMappe`r class in `agent_framework_devui/_mapper.py`
Updated `_convert_workflow_event()` to use`_deep_serialize()` for event data
### Files Changed:
python/packages/devui/agent_framework_devui/_mapper.py

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ X ] The code builds clean without any errors or warnings
- [ X ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ X ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.