### PR TITLE
.NET: Fix workflow lookup with AddAsAIAgent(name) when name differs from workflow name

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
@@ -26,8 +26,10 @@ public static class HostedWorkflowBuilderExtensions
     /// <returns>An <see cref="IHostedAgentBuilder"/> that can be used to further configure the agent.</returns>
     public static IHostedAgentBuilder AddAsAIAgent(this IHostedWorkflowBuilder builder, string? name)
     {
-        var agentName = name ?? builder.Name;
-        return builder.HostApplicationBuilder.AddAIAgent(agentName, (sp, key) => sp.GetRequiredKeyedService<Workflow>(key)
-                                                                                   .AsAgent(name: key));
+        var workflowName = builder.Name;
+        var agentName = name ?? workflowName;
+
+        return builder.HostApplicationBuilder.AddAIAgent(agentName, (sp, key) =>
+            sp.GetRequiredKeyedService<Workflow>(workflowName).AsAgent(name: key));
     }
 }


### PR DESCRIPTION
Fixes #1924 

### Description

The call to `GetRequiredKeyedService<Workflow>` was using the specified agent name rather than the workflow name.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
  - Copilot added comprehensive tests for `AddAsAIAgent` and the new `AddAsAIAgent_WithDifferentName_RetrievesWorkflowCorrectly` failed before the fix was applied
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.