### PR TITLE
.NET Foundry Agents - Tool Initialization Fix

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AzureAI/AgentsClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AzureAI/AgentsClientExtensions.cs
@@ -598,7 +598,7 @@ public static class AgentsClientExtensions
                     throw new ArgumentException("The agent definition in-process tools must be provided in the extension method tools parameter.");
                 }
 
-                // Agregate all missing tools for a single error message.
+                // Aggregate all missing tools for a single error message.
                 List<string>? missingTools = null;
 
                 // Check function tools


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Unblock _Declarative Workflows_ usage of `AzureAIAgentChatClient`

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Turns out: for `FunctionTool`, `ResponseTool.AsAITool()` creates a unique type that isn't an `AIFunction` or `AIFunctionDeclaration`.

Rather, it creates a special purpose (useless) `AITool` subclass `ResponseToolAITool`: 

https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIResponsesChatClient.cs#L1277C27-L1277C45

If we pass in `requireInvocableTools: false`, let's align the behavior to match what's implied by the name and _not require these function tools_.

For Declarative Workflows, I'm still passing in  `ResponseToolAITool` so that I can pass the validation here:

https://github.com/microsoft/agent-framework/blob/feature-foundry-agents/dotnet/src/Microsoft.Agents.AI.AzureAI/AgentsClientExtensions.cs#L691

(since this doesn't respect the `requireInvocableTools` parameter)


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.