### PR TITLE
.NET: Don't add OpenAIResponses as part of Dev UI

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DevUI/DevUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DevUI/DevUIExtensions.cs
@@ -16,7 +16,6 @@ public static class DevUIExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddOpenAIConversations();
-        builder.Services.AddOpenAIResponses();
 
         return builder;
     }
@@ -34,7 +33,6 @@ public static class DevUIExtensions
         group.MapDevUI(pattern: "/devui");
         group.MapEntities();
         group.MapOpenAIConversations();
-        group.MapOpenAIResponses();
         return group;
     }
 


### PR DESCRIPTION
You should be able to add and remove Dev UI without impacting your other production endpoints. This is the pattern used by Swagger UI, where you need to separate set up the OpenAPI endpoint that the Swagger UI depends on.

