### PR TITLE
Python: [Feature Branch] Removed optional ID from FunctionResultContent

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -510,7 +510,6 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
                 # call_id for the result needs to be the same as the call_id for the function call
                 args: dict[str, Any] = {
                     "call_id": content.call_id,
-                    "id": call_id_to_id.get(content.call_id),
                     "type": "function_call_output",
                 }
                 if content.result:


### PR DESCRIPTION
This property doesn't allow to send FunctionResultContent as input to the model when `store=True`. Based on [OpenAI API documentation ](https://platform.openai.com/docs/api-reference/responses/create#responses_create-input-input_item_list-item-function_tool_call-id), this property is optional, and it's not configured on .NET side.

This PR removes it to unblock multi-agent scenarios.