### PR TITLE
Python: Use the last entry in the task history to avoid empty responses

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -391,15 +391,14 @@ class A2AAgent(BaseAgent):
         elif task.history is not None and len(task.history) > 0:
             # Include the last history item as the agent response
             history_item = task.history[-1]
-            if isinstance(history_item, Message):
-                contents = self._a2a_parts_to_contents(history_item.parts)
-                messages.append(
-                    ChatMessage(
-                        role=Role.ASSISTANT if history_item.role == A2ARole.agent else Role.USER,
-                        contents=contents,
-                        raw_representation=history_item,
-                    )
+            contents = self._a2a_parts_to_contents(history_item.parts)
+            messages.append(
+                ChatMessage(
+                    role=Role.ASSISTANT if history_item.role == A2ARole.agent else Role.USER,
+                    contents=contents,
+                    raw_representation=history_item,
                 )
+            )
 
         return messages
 


### PR DESCRIPTION
### Motivation and Context

When testing with this sample https://github.com/a2aproject/a2a-samples/tree/main/samples/python/agents/azureaifoundry_sdk I'm seeing empty responses from the agent. The actual response is in the last message of the history and not in the artifacts.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.