### PR TITLE
[Feature Branch] GitHub actions gets stuck waiting for DTS emulator to start up

### DIFF
--- a/.github/actions/azure-functions-integration-setup/action.yml
+++ b/.github/actions/azure-functions-integration-setup/action.yml
@@ -8,19 +8,29 @@ runs:
         shell: bash
         run: |
           if [ "$(docker ps -aq -f name=dts-emulator)" ]; then
+            echo "Stopping and removing existing Durable Task Scheduler Emulator"
             docker rm -f dts-emulator
           fi
+          echo "Starting Durable Task Scheduler Emulator"
           docker run -d --name dts-emulator -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
-          timeout 30 bash -c 'until curl --silent --fail http://localhost:8080/healthz; do sleep 1; done'
+          echo "Waiting for Durable Task Scheduler Emulator to be ready"
+          timeout 30 bash -c 'until curl --silent http://localhost:8080/healthz; do sleep 1; done'
+          echo "Durable Task Scheduler Emulator is ready"
       - name: Start Azurite (Azure Storage emulator)
         shell: bash
         run: |
           if [ "$(docker ps -aq -f name=azurite)" ]; then
+            echo "Stopping and removing existing Azurite (Azure Storage emulator)"
             docker rm -f azurite
           fi
+          echo "Starting Azurite (Azure Storage emulator)"
           docker run -d --name azurite -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
+          echo "Waiting for Azurite (Azure Storage emulator) to be ready"
+          timeout 30 bash -c 'until curl --silent http://localhost:10000/devstoreaccount1; do sleep 1; done'
+          echo "Azurite (Azure Storage emulator) is ready"
       - name: Install Azure Functions Core Tools
         shell: bash
         run: |
+          echo "Installing Azure Functions Core Tools"
           npm install -g azure-functions-core-tools@4 --unsafe-perm true
           func --version


### PR DESCRIPTION
### Motivation and Context

The DTS emulator step doesn't complete because of the `--fail` parameter that was applied to the `curl` command which checks for status. This is because the emulator returns HTTP 400 for curl commands. But this isn't actually a problem - we just need to check whether that port is responding to know that it's safe to move on.

### Description

Removed the `--fail` parameter from the `curl` command, and added more logging.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.