### PR TITLE
.NET: [Feature Branch] Introduce Azure OpenAI config for .NET pipeline

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -150,10 +150,14 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+        # This setup action is required for both Durable Task and Azure Functions integration tests.
+        # We only run it on Ubuntu since the Durable Task and Azure Functions features are not available
+        # on .NET Framework (net472) which is what we use the Windows runner for.
       - name: Set up Durable Task and Azure Functions Integration Test Emulators
-        if: github.event_name != 'pull_request' && matrix.integration-tests
+        if: github.event_name != 'pull_request' && matrix.integration-tests && matrix.os == 'ubuntu-latest'
         uses: ./.github/actions/azure-functions-integration-setup
         id: azure-functions-setup
+
       - name: Run Integration Tests
         shell: bash
         if: github.event_name != 'pull_request' && matrix.integration-tests
@@ -175,6 +179,9 @@ jobs:
           OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
           OpenAI__ChatModelId: ${{ vars.OPENAI__CHATMODELID }}
           OpenAI__ChatReasoningModelId: ${{ vars.OPENAI__CHATREASONINGMODELID }}
+          # Azure OpenAI Models
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: ${{ vars.AZUREOPENAI__CHATDEPLOYMENTNAME }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZUREOPENAI__ENDPOINT }}
           # Azure AI Foundry
           AzureAI__Endpoint: ${{ secrets.AZUREAI__ENDPOINT }}
           AzureAI__DeploymentName: ${{ vars.AZUREAI__DEPLOYMENTNAME }}

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TestHelper.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TestHelper.cs
@@ -116,17 +116,14 @@ internal sealed class TestHelper : IDisposable
 
     internal static ChatClient GetAzureOpenAIChatClient(IConfiguration configuration)
     {
-        string azureOpenAiEndpoint =
-            configuration["AZUREAI:ENDPOINT"] ?? // Defined in dotnet-build-and-test.yml (as AZUREAI__ENDPOINT)
-            configuration["AZURE_OPENAI_ENDPOINT"] ?? // Legacy
-            throw new InvalidOperationException("The required AZUREAI__ENDPOINT or AZURE_OPENAI_ENDPOINT env variable is not set.");
-        string azureOpenAiDeploymentName =
-            configuration["AZUREAI:DEPLOYMENTNAME"] ?? // Defined in dotnet-build-and-test.yml (as AZUREAI__DEPLOYMENTNAME)
-            configuration["AZURE_OPENAI_DEPLOYMENT"] ?? // Legacy
-            throw new InvalidOperationException("The required AZUREAI__DEPLOYMENTNAME or AZURE_OPENAI_DEPLOYMENT env variable is not set.");
+        string azureOpenAiEndpoint = configuration["AZURE_OPENAI_ENDPOINT"] ??
+            throw new InvalidOperationException("The required AZURE_OPENAI_ENDPOINT env variable is not set.");
+        string azureOpenAiDeploymentName = configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"] ??
+            throw new InvalidOperationException("The required AZURE_OPENAI_CHAT_DEPLOYMENT_NAME env variable is not set.");
 
-        // Check if AZURE_OPENAI_KEY is provided for token-based authentication
-        string? azureOpenAiKey = configuration["AZURE_OPENAI_KEY"];
+        // Check if AZURE_OPENAI_API_KEY is provided for key-based authentication.
+        // NOTE: This is not used for automated tests, but can be useful for local development.
+        string? azureOpenAiKey = configuration["AZURE_OPENAI_API_KEY"];
 
         AzureOpenAIClient client = !string.IsNullOrEmpty(azureOpenAiKey)
             ? new AzureOpenAIClient(new Uri(azureOpenAiEndpoint), new AzureKeyCredential(azureOpenAiKey))

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TestHelper.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TestHelper.cs
@@ -121,9 +121,9 @@ internal sealed class TestHelper : IDisposable
         string azureOpenAiDeploymentName = configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"] ??
             throw new InvalidOperationException("The required AZURE_OPENAI_CHAT_DEPLOYMENT_NAME env variable is not set.");
 
-        // Check if AZURE_OPENAI_API_KEY is provided for key-based authentication.
+        // Check if AZURE_OPENAI_KEY is provided for key-based authentication.
         // NOTE: This is not used for automated tests, but can be useful for local development.
-        string? azureOpenAiKey = configuration["AZURE_OPENAI_API_KEY"];
+        string? azureOpenAiKey = configuration["AZURE_OPENAI_KEY"];
 
         AzureOpenAIClient client = !string.IsNullOrEmpty(azureOpenAiKey)
             ? new AzureOpenAIClient(new Uri(azureOpenAiEndpoint), new AzureKeyCredential(azureOpenAiKey))

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -635,14 +635,10 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             RedirectStandardError = true,
         };
 
-        string openAiEndpoint =
-            s_configuration["AZUREAI:ENDPOINT"] ?? // Defined in dotnet-build-and-test.yml (as AZUREAI__ENDPOINT)
-            s_configuration["AZURE_OPENAI_ENDPOINT"] ?? // Legacy
-            throw new InvalidOperationException("The required AZUREAI__ENDPOINT or AZURE_OPENAI_ENDPOINT env variable is not set.");
-        string openAiDeployment =
-            s_configuration["AZUREAI:DEPLOYMENTNAME"] ?? // Defined in dotnet-build-and-test.yml (as AZUREAI__DEPLOYMENTNAME)
-            s_configuration["AZURE_OPENAI_DEPLOYMENT"] ?? // Legacy
-            throw new InvalidOperationException("The required AZUREAI__DEPLOYMENTNAME or AZURE_OPENAI_DEPLOYMENT env variable is not set.");
+        string openAiEndpoint = s_configuration["AZURE_OPENAI_ENDPOINT"] ??
+            throw new InvalidOperationException("The required AZURE_OPENAI_ENDPOINT env variable is not set.");
+        string openAiDeployment = s_configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"] ??
+            throw new InvalidOperationException("The required AZURE_OPENAI_CHAT_DEPLOYMENT_NAME env variable is not set.");
 
         // Set required environment variables for the function app (see local.settings.json for required settings)
         startInfo.EnvironmentVariables["AZURE_OPENAI_ENDPOINT"] = openAiEndpoint;


### PR DESCRIPTION
### Motivation and Context

The Durable Task / Azure Functions integration tests are designed to use Azure OpenAI with token-based credentials. However, none of the .NET tests use this configuration! The integration tests for .NET instead assume using public OpenAI or Foundry for persistent agents, so there's no compatible configuration that can be reused for our integration tests.

### Description

I'm introducing the existing `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` environment variables into the .NET pipeline. I verified that these environment variables are already being used by several of the Python tests (with Azure CLI credentials), so I have reasonably high confidence that these configuration values will work properly in the .NET context as well.

I'm also fixing the prerequisite setup to only run when targeting Ubuntu since Windows pipelines don't support docker. Conveniently, our integration tests don't run on Windows since Windows is only used to validate `net472` targets, and we aren't supporting `net472`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.