### PR TITLE
.NET: [Feature Branch] Update HTTP API to be consistent across languages

### DIFF
--- a/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
+++ b/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
@@ -65,6 +65,25 @@ The expected `application/json` output will look something like:
 {
   "status": 200,
   "thread_id": "@dafx-joker@your-thread-id",
-  "response": "Why don't pirates ever learn the alphabet? Because they always get stuck at 'C'!"
+  "response": {
+    "Messages": [
+      {
+        "AuthorName": "Joker",
+        "CreatedAt": "2025-11-11T12:00:00.0000000Z",
+        "Role": "assistant",
+        "Contents": [
+          {
+            "Type": "text",
+            "Text": "Why don't pirates ever learn the alphabet? Because they always get stuck at 'C'!"
+          }
+        ]
+      }
+    ],
+    "Usage": {
+      "InputTokenCount": 78,
+      "OutputTokenCount": 36,
+      "TotalTokenCount": 114
+    }
+  }
 }
 ```

--- a/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
+++ b/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
@@ -35,8 +35,36 @@ Invoke-RestMethod -Method Post `
     -Body "Tell me a joke about a pirate."
 ```
 
-The response from the agent will be displayed in the terminal where you ran `func start`. The expected output will look something like:
+You can also send JSON requests:
+
+```bash
+curl -X POST http://localhost:7071/api/agents/Joker/run \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"message": "Tell me a joke about a pirate."}'
+```
+
+To continue a conversation, include the `thread_id` in the query string or JSON body:
+
+```bash
+curl -X POST "http://localhost:7071/api/agents/Joker/run?thread_id=@dafx-joker@your-thread-id" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"message": "Tell me another one."}'
+```
+
+The response from the agent will be displayed in the terminal where you ran `func start`. The expected `text/plain` output will look something like:
 
 ```text
 Why don't pirates ever learn the alphabet? Because they always get stuck at "C"!
+```
+
+The expected `application/json` output will look something like:
+
+```json
+{
+  "status": 200,
+  "thread_id": "@dafx-joker@your-thread-id",
+  "response": "Why don't pirates ever learn the alphabet? Because they always get stuck at 'C'!"
+}
 ```

--- a/dotnet/samples/AzureFunctions/06_LongRunningTools/README.md
+++ b/dotnet/samples/AzureFunctions/06_LongRunningTools/README.md
@@ -29,7 +29,7 @@ curl -i -X POST http://localhost:7071/api/agents/publisher/run \
     -d 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"'
 
 # Save the thread ID to a variable and print it to the terminal
-threadId=$(cat headers.txt | grep "X-Agent-Thread" | cut -d' ' -f2)
+threadId=$(cat headers.txt | grep "x-ms-thread-id" | cut -d' ' -f2)
 echo "Thread ID: $threadId"
 ```
 
@@ -43,7 +43,7 @@ Invoke-RestMethod -Method Post `
     -Body 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"' `
 
 # Save the thread ID to a variable and print it to the console
-$threadId = $ResponseHeaders['X-Agent-Thread']
+$threadId = $ResponseHeaders['x-ms-thread-id']
 Write-Host "Thread ID: $threadId"
 ```
 
@@ -52,12 +52,12 @@ The response will be a text string that looks something like the following, indi
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/plain
-X-Agent-Thread: @publisher@351ec855-7f4d-4527-a60d-498301ced36d
+x-ms-thread-id: @publisher@351ec855-7f4d-4527-a60d-498301ced36d
 
 The content generation workflow for the topic "The Future of Artificial Intelligence" has been successfully started, and the instance ID is **6a04276e8d824d8d941e1dc4142cc254**. If you need any further assistance or updates on the workflow, feel free to ask!
 ```
 
-The `X-Agent-Thread` response header contains the thread ID, which can be used to continue the conversation by passing it as a query parameter to the `run` endpoint. The commands above show how to save the thread ID to a `$threadId` variable for use in subsequent requests.
+The `x-ms-thread-id` response header contains the thread ID, which can be used to continue the conversation by passing it as a query parameter (`thread_id`) to the `run` endpoint. The commands above show how to save the thread ID to a `$threadId` variable for use in subsequent requests.
 
 Behind the scenes, the publisher agent will:
 
@@ -70,12 +70,12 @@ Bash (Linux/macOS/WSL):
 
 ```bash
 # Approve the content
-curl -X POST http://localhost:7071/api/agents/publisher/run?threadId=$threadId \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
     -H "Content-Type: text/plain" \
     -d 'Approve the content'
 
 # Reject the content with feedback
-curl -X POST http://localhost:7071/api/agents/publisher/run?threadId=$threadId \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
     -H "Content-Type: text/plain" \
     -d 'Reject the content with feedback: The article needs more technical depth and better examples.'
 ```
@@ -85,13 +85,13 @@ PowerShell:
 ```powershell
 # Approve the content
 Invoke-RestMethod -Method Post `
-    -Uri http://localhost:7071/api/agents/publisher/run?threadId=$threadId `
+    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
     -ContentType text/plain `
     -Body 'Approve the content'
 
 # Reject the content with feedback
 Invoke-RestMethod -Method Post `
-    -Uri http://localhost:7071/api/agents/publisher/run?threadId=$threadId `
+    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
     -ContentType text/plain `
     -Body 'Reject the content with feedback: The article needs more technical depth and better examples.'
 ```
@@ -101,7 +101,7 @@ Once the workflow has completed, you can get the status by prompting the publish
 Bash (Linux/macOS/WSL):
 
 ```bash
-curl -X POST http://localhost:7071/api/agents/publisher/run?threadId=$threadId \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
     -H "Content-Type: text/plain" \
     -d 'Get the status of the workflow you previously started'
 ```
@@ -110,7 +110,7 @@ PowerShell:
 
 ```powershell
 Invoke-RestMethod -Method Post `
-    -Uri http://localhost:7071/api/agents/publisher/run?threadId=$threadId `
+    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
     -ContentType text/plain `
     -Body 'Get the status of the workflow you previously started'
 ```

--- a/dotnet/samples/AzureFunctions/06_LongRunningTools/demo.http
+++ b/dotnet/samples/AzureFunctions/06_LongRunningTools/demo.http
@@ -9,19 +9,19 @@ Start a content generation workflow for the topic 'The Future of Artificial Inte
 @threadId = <YOUR_THREAD_ID>
 
 ### Check the status of the workflow
-POST http://localhost:7071/api/agents/publisher/run?threadId={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
 Content-Type: text/plain
 
 Check the status of the workflow you previously started
 
 ### Reject content with feedback
-POST http://localhost:7071/api/agents/publisher/run?threadId={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
 Content-Type: text/plain
 
 Reject the content with feedback: The article needs more technical depth and better examples.
 
 ### Approve content
-POST http://localhost:7071/api/agents/publisher/run?threadId={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
 Content-Type: text/plain
 
 Approve the content

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -73,7 +73,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             this._outputHelper.WriteLine($"Agent run response: {responseText}");
 
             // The response headers should include the agent thread ID, which can be used to continue the conversation.
-            string? threadId = response.Headers.GetValues("X-Agent-Thread")?.FirstOrDefault();
+            string? threadId = response.Headers.GetValues("x-ms-thread-id")?.FirstOrDefault();
             Assert.NotNull(threadId);
 
             this._outputHelper.WriteLine($"Agent thread ID: {threadId}");
@@ -286,7 +286,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             this._outputHelper.WriteLine($"Agent response: {startResponseText}");
 
             // The response should be deserializable as an AgentRunResponse object and have a valid thread ID
-            startResponse.Headers.TryGetValues("X-Agent-Thread", out IEnumerable<string>? agentIdValues);
+            startResponse.Headers.TryGetValues("x-ms-thread-id", out IEnumerable<string>? agentIdValues);
             string? threadId = agentIdValues?.FirstOrDefault();
             Assert.NotNull(threadId);
             Assert.StartsWith("@dafx-publisher@", threadId);
@@ -307,7 +307,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
                 timeout: TimeSpan.FromSeconds(60));
 
             // Approve the content
-            Uri approvalUri = new($"{runAgentUri}?threadId={threadId}");
+            Uri approvalUri = new($"{runAgentUri}?thread_id={threadId}");
             using HttpContent approvalContent = new StringContent("Approve the content", Encoding.UTF8, "text/plain");
             using HttpResponseMessage approvalResponse = await s_sharedHttpClient.PostAsync(approvalUri, approvalContent);
             Assert.True(approvalResponse.IsSuccessStatusCode, $"Approve content request failed with status: {approvalResponse.StatusCode}");
@@ -327,7 +327,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
                 timeout: TimeSpan.FromSeconds(60));
 
             // Verify the final orchestration status by asking the agent for the status
-            Uri statusUri = new($"{runAgentUri}?threadId={threadId}");
+            Uri statusUri = new($"{runAgentUri}?thread_id={threadId}");
             await this.WaitForConditionAsync(
                 condition: async () =>
                 {


### PR DESCRIPTION
### Motivation and Context

Azure Functions built-in HTTP APIs between .NET and Python were inconsistent. They need to be made consistent so that documentation can be more easily created explaining how to interact with the HTTP APIs, regardless of what SDK is being used.

### Description

The following changes were made:

- The agent run HTTP API now accepts text or JSON
- The agent run HTTP API returns JSON in a particular format
- The `X-Agent-Thread` response header was renamed to `x-ms-thread-id`
- The `threadId` query string parameter was renamed to `thread_id`

Note that this PR isn't intended to create full parity. Rather, it's meant to address the highest priority gaps. Full parity will be attempted later.

FYI @anthonychu

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.