### PR TITLE
.NET: [Feature Branch] Remove IsPackable=false in preparation for durable extension nuget release

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj
@@ -7,8 +7,6 @@
     <!-- CA2007: This rule should generally be suppressed in Durable Task libraries -->
     <!-- MEAI001: UserInputRequestContent is experimental but used in source-generated code for AgentRunResponse -->
     <NoWarn>$(NoWarn);CA2007;MEAI001</NoWarn>
-    <!-- Disable packing until we are ready to release this as a nuget -->
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj
@@ -6,8 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- CA2007: This rule should generally be suppressed in Durable Task libraries. Also, this is not library code. -->
     <NoWarn>$(NoWarn);CA2007</NoWarn>
-    <!-- Disable packing until we are ready to release this as a nuget -->
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />


### PR DESCRIPTION
### Motivation and Context

During development, we explicitly marked the durable extension projects with `<IsPackable>false</IsPackable>` to ensure we didn't accidentally publish them to nuget.org as part of the normal .NET release process.

### Description

The durable extension code for .NET is now in a state where it's ready for a release anytime, so we've enabling it for packaging by the release process.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.