### PR TITLE
Python: switch from flit to uv build for package building

### DIFF
--- a/python/shared_tasks.toml
+++ b/python/shared_tasks.toml
@@ -5,6 +5,6 @@ lint = "ruff check"
 pyright = "pyright"
 publish = "uv publish"
 clean-dist = "rm -rf dist"
-build-package = "python -m flit build"
+build-package = "uv build"
 move-dist = "sh -c 'mkdir -p ../../dist && mv dist/* ../../dist/ 2>/dev/null || true'"
 build = ["build-package", "move-dist"]


### PR DESCRIPTION
### Motivation and Context

Standardize package building across the Python monorepo by using `uv build` instead of directly invoking `python -m flit build`.

Purely relying on `flit build` for the `ag-ui` package, that has multiple modules, doesn't build properly. 

All other packages were inspected after building with `uv build` and contain the same modules as before.

### Description

- Updated `shared_tasks.toml` to use `uv build` for the `build-package` task
- `uv build` respects the underlying build backend configuration in `pyproject.toml` (flit-core, hatchling, setuptools, etc.)
- Provides a consistent build interface across all packages while still honoring each package's specific build configuration

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.