### PR TITLE
.NET: Fix issue #2181 - Sample type mismatch

### DIFF
--- a/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
@@ -229,14 +229,16 @@ internal sealed class StringToChatMessageExecutor(string id) : Executor<string>(
 /// Executor that synchronizes agent output and prepares it for the next stage.
 /// This demonstrates how executors can process agent outputs and forward to the next agent.
 /// </summary>
+/// Disable RCS1168 to allow different naming from base class
+#pragma warning disable RCS1168
 internal sealed class JailbreakSyncExecutor() : Executor<List<ChatMessage>>("JailbreakSync")
 {
     public override async ValueTask HandleAsync(
-        List<ChatMessage> message,
+        List<ChatMessage> messages,
         IWorkflowContext context,
         CancellationToken cancellationToken = default)
     {
-        ChatMessage agentReply = message.LastOrDefault(m => m.Role == ChatRole.Assistant)
+        ChatMessage agentReply = messages.LastOrDefault(m => m.Role == ChatRole.Assistant)
             ?? throw new InvalidOperationException("Detector returned no assistant message.");
 
         Console.WriteLine(); // New line after agent streaming
@@ -285,12 +287,12 @@ internal sealed class JailbreakSyncExecutor() : Executor<List<ChatMessage>>("Jai
 /// </summary>
 internal sealed class FinalOutputExecutor() : Executor<List<ChatMessage>, string>("FinalOutput")
 {
-    public override ValueTask<string> HandleAsync(List<ChatMessage> message, IWorkflowContext context, CancellationToken cancellationToken = default)
+    public override ValueTask<string> HandleAsync(List<ChatMessage> messages, IWorkflowContext context, CancellationToken cancellationToken = default)
     {
         Console.WriteLine(); // New line after agent streaming
         Console.ForegroundColor = ConsoleColor.Green;
 
-        var assistantOutput = message.LastOrDefault(m => m.Role == ChatRole.Assistant)
+        var assistantOutput = messages.LastOrDefault(m => m.Role == ChatRole.Assistant)
             ?? throw new InvalidOperationException("Response agent returned no assistant message.");
 
         Console.WriteLine($"\n[{this.Id}] Final Response:");
@@ -301,3 +303,4 @@ internal sealed class FinalOutputExecutor() : Executor<List<ChatMessage>, string
         return ValueTask.FromResult(assistantOutput.Text ?? string.Empty);
     }
 }
+#pragma warning restore RCS116

--- a/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
@@ -303,4 +303,4 @@ internal sealed class FinalOutputExecutor() : Executor<List<ChatMessage>, string
         return ValueTask.FromResult(assistantOutput.Text ?? string.Empty);
     }
 }
-#pragma warning restore RCS116
+#pragma warning restore RCS1168

--- a/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
@@ -283,17 +283,21 @@ internal sealed class JailbreakSyncExecutor() : Executor<List<ChatMessage>>("Jai
 /// <summary>
 /// Executor that outputs the final result and marks the end of the workflow.
 /// </summary>
-internal sealed class FinalOutputExecutor() : Executor<ChatMessage, string>("FinalOutput")
+internal sealed class FinalOutputExecutor() : Executor<List<ChatMessage>, string>("FinalOutput")
 {
-    public override ValueTask<string> HandleAsync(ChatMessage message, IWorkflowContext context, CancellationToken cancellationToken = default)
+    public override ValueTask<string> HandleAsync(List<ChatMessage> message, IWorkflowContext context, CancellationToken cancellationToken = default)
     {
         Console.WriteLine(); // New line after agent streaming
         Console.ForegroundColor = ConsoleColor.Green;
+
+        var assistantOutput = message.LastOrDefault(m => m.Role == ChatRole.Assistant)
+            ?? throw new InvalidOperationException("Response agent returned no assistant message.");
+
         Console.WriteLine($"\n[{this.Id}] Final Response:");
-        Console.WriteLine($"{message.Text}");
+        Console.WriteLine($"{assistantOutput.Text}");
         Console.WriteLine("\n[End of Workflow]");
         Console.ResetColor();
 
-        return ValueTask.FromResult(message.Text ?? string.Empty);
+        return ValueTask.FromResult(assistantOutput.Text ?? string.Empty);
     }
 }

--- a/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
@@ -5,9 +5,6 @@ using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-
 namespace MixedWorkflowWithAgentsAndExecutors;
 
 /// <summary>


### PR DESCRIPTION

### Motivation and Context

This change fixes the workflow break in **07_MixedWorkflowAgentsAndExecutors**, where the edge from `JailbreakDetector` to `JailbreakSync` was consistently dropped due to a payload type mismatch.

The sample defines `JailbreakSyncExecutor` as `Executor<ChatMessage>`, but the agent host emits a collection of messages (`List<ChatMessage>`). Because the executor declared a narrower input type, edge delivery failed with `delivery_status: dropped type mismatch`, preventing all downstream components (`JailbreakSync`, `ResponseAgent`, `FinalOutput`) from running.

Updating the executor to accept `List<ChatMessage>` restores compatibility with the emitted payload, allowing the workflow to execute end-to-end as intended.

Fixes: #2181 
### Description
- Updated the `JailbreakSyncExecutor` constructor from:
  ```csharp
  Executor<ChatMessage>("JailbreakSync")
  ```
  to:
  ```csharp
  Executor<List<ChatMessage>>("JailbreakSync")
  ```
- Ensures that the executor’s declared input type matches the message collection emitted by the agent host.
- Restores proper delivery of the edge `JailbreakDetector → JailbreakSync`.
- Verified the fix by running the full sample:
  - `StringToChat`, `JailbreakDetector`, `JailbreakSync`, `ResponseAgent`, and `FinalOutputExecutor` all execute correctly.
  - Console output now includes the JailbreakSync formatted message and the final agent response.
- Confirmed via OpenTelemetry that:
  - `edge_group.delivered = true` for all affected edges.
  - No further type-mismatch drops occur.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?**