### PR TITLE
.NET: Fix InMemoryChatMessageStore serialization bug.

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/InMemoryChatMessageStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/InMemoryChatMessageStore.cs
@@ -97,8 +97,9 @@ public sealed class InMemoryChatMessageStore : ChatMessageStore, IList<ChatMessa
 
         if (serializedStoreState.ValueKind is JsonValueKind.Object)
         {
+            var jso = jsonSerializerOptions ?? AgentAbstractionsJsonUtilities.DefaultOptions;
             var state = serializedStoreState.Deserialize(
-                AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(StoreState))) as StoreState;
+                jso.GetTypeInfo(typeof(StoreState))) as StoreState;
             if (state?.Messages is { } messages)
             {
                 this._messages = messages;
@@ -164,7 +165,8 @@ public sealed class InMemoryChatMessageStore : ChatMessageStore, IList<ChatMessa
             Messages = this._messages,
         };
 
-        return JsonSerializer.SerializeToElement(state, AgentAbstractionsJsonUtilities.DefaultOptions.GetTypeInfo(typeof(StoreState)));
+        var jso = jsonSerializerOptions ?? AgentAbstractionsJsonUtilities.DefaultOptions;
+        return JsonSerializer.SerializeToElement(state, jso.GetTypeInfo(typeof(StoreState)));
     }
 
     /// <inheritdoc />

--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/TestJsonSerializerContext.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/TestJsonSerializerContext.cs
@@ -22,4 +22,5 @@ namespace Microsoft.Agents.AI.Abstractions.UnitTests;
 [JsonSerializable(typeof(InMemoryAgentThread.InMemoryAgentThreadState))]
 [JsonSerializable(typeof(ServiceIdAgentThread.ServiceIdAgentThreadState))]
 [JsonSerializable(typeof(ServiceIdAgentThreadTests.EmptyObject))]
+[JsonSerializable(typeof(InMemoryChatMessageStoreTests.TestAIContent))]
 internal sealed partial class TestJsonSerializerContext : JsonSerializerContext;


### PR DESCRIPTION
### Motivation and Context

There are cases where consumers may want to create and use their own AIContent types.
The InMemoryChatMessageStore wasn't using the provided JSO object, so consumers didn't have a way of
providing their own JSO that supports serializing their own AIContent types.

### Description

- Update InMemoryChatMessageStore to use the provided JSO for serialization and deserialization.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.