### PR TITLE
.NET Workflows - Fix to ensure declarative workflows fire event when message added to workflow conversation

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConversationMessages.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConversationMessages.json
@@ -10,7 +10,7 @@
     "conversation_count": 2,
     "min_action_count": 8,
     "min_message_count": 1,
-    "min_response_count": 0,
+    "min_response_count": 1,
     "actions": {
       "start": [
         "conversation_create1",


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Ensure `AddConversationMessage` and `CopyConversationMessages` raise `AgentRunResponseEvent` when adding messages to the workflow/external conversation.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Integration tests: https://github.com/microsoft/agent-framework/actions/runs/19340511303

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.