### PR TITLE
.NET Workflows - Fix portable value conversion case for empty array

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/PortableValueExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/PortableValueExtensions.cs
@@ -40,6 +40,12 @@ internal static class PortableValueExtensions
     private static TableValue ToTable(this PortableValue[] values)
     {
         FormulaValue[] formulaValues = values.Select(value => value.ToFormula()).ToArray();
+
+        if (formulaValues.Length == 0)
+        {
+            return FormulaValue.NewTable(RecordType.Empty());
+        }
+
         if (formulaValues[0] is RecordValue recordValue)
         {
             return FormulaValue.NewTable(ParseRecordType(recordValue), formulaValues.OfType<RecordValue>());

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Extensions/PortableValueExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Extensions/PortableValueExtensionsTests.cs
@@ -54,6 +54,13 @@ public sealed class PortableValueExtensionsTests
     public void ChatMessageType() => TestValidType(new ChatMessage(ChatRole.User, "input"), RecordType.Empty());
 
     [Fact]
+    public void ListEmptyType()
+    {
+        TableValue convertedValue = (TableValue)TestValidType(Array.Empty<int>(), TableType.Empty());
+        Assert.Equal(0, convertedValue.Count());
+    }
+
+    [Fact]
     public void ListSimpleType()
     {
         TableValue convertedValue = (TableValue)TestValidType(new List<int> { 1, 2, 3 }, TableType.Empty());


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Conversion logic fails with empty array.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Indexing `formulaValues[0]` for empty array throws `IndexOutOfRangeException`

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.