### PR TITLE
.NET: [BREAKING] Durable agents - change thread_id from entity ID to GUID

### DIFF
--- a/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
+++ b/dotnet/samples/AzureFunctions/01_SingleAgent/README.md
@@ -47,7 +47,7 @@ curl -X POST http://localhost:7071/api/agents/Joker/run \
 To continue a conversation, include the `thread_id` in the query string or JSON body:
 
 ```bash
-curl -X POST "http://localhost:7071/api/agents/Joker/run?thread_id=@dafx-joker@your-thread-id" \
+curl -X POST "http://localhost:7071/api/agents/Joker/run?thread_id=your-thread-id" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
     -d '{"message": "Tell me another one."}'
@@ -64,7 +64,7 @@ The expected `application/json` output will look something like:
 ```json
 {
   "status": 200,
-  "thread_id": "@dafx-joker@your-thread-id",
+  "thread_id": "ee6e47a0-f24b-40b1-ade8-16fcebb9eb40",
   "response": {
     "Messages": [
       {

--- a/dotnet/samples/AzureFunctions/06_LongRunningTools/README.md
+++ b/dotnet/samples/AzureFunctions/06_LongRunningTools/README.md
@@ -52,7 +52,7 @@ The response will be a text string that looks something like the following, indi
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/plain
-x-ms-thread-id: @publisher@351ec855-7f4d-4527-a60d-498301ced36d
+x-ms-thread-id: 351ec855-7f4d-4527-a60d-498301ced36d
 
 The content generation workflow for the topic "The Future of Artificial Intelligence" has been successfully started, and the instance ID is **6a04276e8d824d8d941e1dc4142cc254**. If you need any further assistance or updates on the workflow, feel free to ask!
 ```

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -75,9 +75,9 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             // The response headers should include the agent thread ID, which can be used to continue the conversation.
             string? threadId = response.Headers.GetValues("x-ms-thread-id")?.FirstOrDefault();
             Assert.NotNull(threadId);
+            Assert.NotEmpty(threadId);
 
             this._outputHelper.WriteLine($"Agent thread ID: {threadId}");
-            Assert.StartsWith("@dafx-joker@", threadId);
 
             // Wait for up to 30 seconds to see if the agent response is available in the logs
             await this.WaitForConditionAsync(
@@ -289,7 +289,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             startResponse.Headers.TryGetValues("x-ms-thread-id", out IEnumerable<string>? agentIdValues);
             string? threadId = agentIdValues?.FirstOrDefault();
             Assert.NotNull(threadId);
-            Assert.StartsWith("@dafx-publisher@", threadId);
+            Assert.NotEmpty(threadId);
 
             // Wait for the orchestration to report that it's waiting for human approval
             await this.WaitForConditionAsync(

--- a/python/samples/getting_started/azure_functions/01_single_agent/README.md
+++ b/python/samples/getting_started/azure_functions/01_single_agent/README.md
@@ -18,20 +18,40 @@ Follow the common setup steps in `../README.md` to install tooling, configure Az
 
 Send a prompt to the Joker agent:
 
+Bash (Linux/macOS/WSL):
+
 ```bash
-curl -X POST http://localhost:7071/api/agents/Joker/run \
-     -H "Content-Type: text/plain" \
+curl -i -X POST http://localhost:7071/api/agents/Joker/run \
      -d "Tell me a short joke about cloud computing."
+```
+
+PowerShell:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:7071/api/agents/Joker/run `
+    -Body "Tell me a short joke about cloud computing."
 ```
 
 The agent responds with a JSON payload that includes the generated joke.
 
-> **Note:** To return immediately with an HTTP 202 response instead of waiting for the agent output, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body. The default behavior waits for the response.
+> [!TIP]
+> To return immediately with an HTTP 202 response instead of waiting for the agent output, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body. The default behavior waits for the response.
 
 ## Expected Output
 
-When you send a POST request with plain-text input, the Functions host responds with an HTTP 202 and queues the request for the durable agent entity. A typical response body looks like the following:
-Expected HTTP 202 payload:
+The default plain-text response looks like the following:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+x-ms-thread-id: 4f205157170244bfbd80209df383757e
+
+Why did the cloud break up with the server?
+
+Because it found someone more "uplifting"!
+```
+
+When you specify the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body, the Functions host responds with an HTTP 202 and queues the request to run in the background. A typical response body looks like the following:
 
 ```json
 {


### PR DESCRIPTION
### Motivation and Context

Fixes #2236 

### Description

In order to make .NET and Python implementations consistent, we're changing the format and interpretation of thread_id values for the built-in HTTP triggers for durable agents.

This is a breaking change for clients that attempt to construct their own thread IDs. However, the expected common case is server-generated thread IDs.

This change also fixes some errors in the single-agent Python sample for Azure Functions.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.