### PR TITLE
update to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 8 * * 4,0" # Every Thursday(4) and Sunday(0) at 8:00 UTC
-    experimental:
-      nuget-native-updater: false
-      enable-cooldown-metrics-collection: false
     ignore:
       # For all System.* and Microsoft.Extensions/Bcl.* packages, ignore all major version updates
       - dependency-name: "System.*"
@@ -28,6 +25,14 @@ updates:
       - "dependencies"
 
   # Maintain dependencies for python
+  - package-ecosystem: "pip"
+    directory: "python/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "python"
+      - "dependencies"
   - package-ecosystem: "uv"
     directory: "python/"
     schedule:


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The python dependabot was not configured correctly, needs both uv and pip in order to properly work (pip updates pyproject, while uv updates uv.lock if needed, should be in a single PR, explained here: https://github.com/dependabot/dependabot-core/issues/12609#issuecomment-3407284321)

Removed experimental from nuget since both flags were removed:
- nuget-native-updater: https://github.com/dependabot/dependabot-core/issues/12686
- cooldown: https://github.com/dependabot/dependabot-core/pull/13046

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.