### PR TITLE
Python: fix all to include the latest and made that single source of truth

### DIFF
--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -45,6 +45,8 @@ all = [
     "agent-framework-ag-ui",
     "agent-framework-anthropic",
     "agent-framework-azure-ai",
+    "agent-framework-azurefunctions",
+    "agent-framework-chatkit",
     "agent-framework-copilotstudio",
     "agent-framework-devui",
     "agent-framework-mem0",

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -49,6 +49,7 @@ all = [
     "agent-framework-chatkit",
     "agent-framework-copilotstudio",
     "agent-framework-devui",
+    "agent-framework-lab",
     "agent-framework-mem0",
     "agent-framework-purview",
     "agent-framework-redis",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,19 +23,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core",
-    "agent-framework-a2a",
-    "agent-framework-ag-ui",
-    "agent-framework-anthropic",
-    "agent-framework-azure-ai",
-    "agent-framework-azurefunctions",
-    "agent-framework-chatkit",
-    "agent-framework-copilotstudio",
-    "agent-framework-devui",
+    "agent-framework-core[all]",
     "agent-framework-lab",
-    "agent-framework-mem0",
-    "agent-framework-purview",
-    "agent-framework-redis",
 ]
 
 [dependency-groups]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core[all]",
-    "agent-framework-lab",
 ]
 
 [dependency-groups]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -86,7 +86,6 @@ version = "1.0.0b251114"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-lab", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -118,10 +117,7 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "agent-framework-core", extras = ["all"], editable = "packages/core" },
-    { name = "agent-framework-lab", editable = "packages/lab" },
-]
+requires-dist = [{ name = "agent-framework-core", extras = ["all"], editable = "packages/core" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -305,6 +301,7 @@ all = [
     { name = "agent-framework-chatkit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-copilotstudio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-devui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-lab", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-mem0", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-purview", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -320,6 +317,7 @@ requires-dist = [
     { name = "agent-framework-chatkit", marker = "extra == 'all'", editable = "packages/chatkit" },
     { name = "agent-framework-copilotstudio", marker = "extra == 'all'", editable = "packages/copilotstudio" },
     { name = "agent-framework-devui", marker = "extra == 'all'", editable = "packages/devui" },
+    { name = "agent-framework-lab", marker = "extra == 'all'", editable = "packages/lab" },
     { name = "agent-framework-mem0", marker = "extra == 'all'", editable = "packages/mem0" },
     { name = "agent-framework-purview", marker = "extra == 'all'", editable = "packages/purview" },
     { name = "agent-framework-redis", marker = "extra == 'all'", editable = "packages/redis" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -85,19 +85,8 @@ name = "agent-framework"
 version = "1.0.0b251114"
 source = { virtual = "." }
 dependencies = [
-    { name = "agent-framework-a2a", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-ag-ui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-azure-ai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-azurefunctions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-chatkit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-copilotstudio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-devui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-lab", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-mem0", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-purview", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "agent-framework-redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -130,19 +119,8 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework-a2a", editable = "packages/a2a" },
-    { name = "agent-framework-ag-ui", editable = "packages/ag-ui" },
-    { name = "agent-framework-anthropic", editable = "packages/anthropic" },
-    { name = "agent-framework-azure-ai", editable = "packages/azure-ai" },
-    { name = "agent-framework-azurefunctions", editable = "packages/azurefunctions" },
-    { name = "agent-framework-chatkit", editable = "packages/chatkit" },
-    { name = "agent-framework-copilotstudio", editable = "packages/copilotstudio" },
-    { name = "agent-framework-core", editable = "packages/core" },
-    { name = "agent-framework-devui", editable = "packages/devui" },
+    { name = "agent-framework-core", extras = ["all"], editable = "packages/core" },
     { name = "agent-framework-lab", editable = "packages/lab" },
-    { name = "agent-framework-mem0", editable = "packages/mem0" },
-    { name = "agent-framework-purview", editable = "packages/purview" },
-    { name = "agent-framework-redis", editable = "packages/redis" },
 ]
 
 [package.metadata.requires-dev]
@@ -190,7 +168,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-ag-ui"
-version = "1.0.0b251114"
+version = "1.0.0b251117"
 source = { editable = "packages/ag-ui" }
 dependencies = [
     { name = "ag-ui-protocol", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -323,6 +301,8 @@ all = [
     { name = "agent-framework-ag-ui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-azure-ai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-azurefunctions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-chatkit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-copilotstudio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-devui", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-mem0", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -336,6 +316,8 @@ requires-dist = [
     { name = "agent-framework-ag-ui", marker = "extra == 'all'", editable = "packages/ag-ui" },
     { name = "agent-framework-anthropic", marker = "extra == 'all'", editable = "packages/anthropic" },
     { name = "agent-framework-azure-ai", marker = "extra == 'all'", editable = "packages/azure-ai" },
+    { name = "agent-framework-azurefunctions", marker = "extra == 'all'", editable = "packages/azurefunctions" },
+    { name = "agent-framework-chatkit", marker = "extra == 'all'", editable = "packages/chatkit" },
     { name = "agent-framework-copilotstudio", marker = "extra == 'all'", editable = "packages/copilotstudio" },
     { name = "agent-framework-devui", marker = "extra == 'all'", editable = "packages/devui" },
     { name = "agent-framework-mem0", marker = "extra == 'all'", editable = "packages/mem0" },


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We need to ensure we keep `all` of the core package in sync with the packages installed by `agent-framework`, this does that by making `agent-framework` depend on `agent-framework-core[all]`

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.