### PR TITLE
Python: Fix the example of multi-tier handoff workflow with specialist-to-specialist routing

### DIFF
--- a/python/samples/getting_started/workflows/orchestration/handoff_specialist_to_specialist.py
+++ b/python/samples/getting_started/workflows/orchestration/handoff_specialist_to_specialist.py
@@ -192,7 +192,7 @@ async def main() -> None:
     print("=" * 80 + "\n")
 
     # Start workflow with initial message
-    print("[User]: I need help with order 12345. I want a replacement and need to know when it will arrive.\n")
+    print(f"[User]: {scripted_responses[0]}\n")
     events = await _drain(workflow.run_stream(scripted_responses[0]))
     pending_requests = _handle_events(events)
 


### PR DESCRIPTION
### Motivation and Context

In [the example of multi-tier handoff workflow with specialist-to-specialist routing](https://github.com/microsoft/agent-framework/blob/main/python/samples/getting_started/workflows/orchestration/handoff_specialist_to_specialist.py), the same user inputs are being sent twice. This leads to redundant processing and may cause slight confusion for users. Additionally, the behavior does not align with the comment in the code. 

At line 184, the comment states:
[`"Thank you!",  # Final response to trigger termination after billing agent answers`
](https://github.com/microsoft/agent-framework/blob/92df9e14bf5b81165829325cd699d5cf0973d77c/python/samples/getting_started/workflows/orchestration/handoff_specialist_to_specialist.py#L184)
However, the actual workflow terminates one step earlier than described.

### Description

Send the same user input once, fix the comment and the expected output, and the number of times to terminate the workflow.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.