### PR TITLE
.NET: MapAGUI supports per-request agent selection

### DIFF
--- a/dotnet/samples/AGUIClientServer/AGUIDojoServer/Program.cs
+++ b/dotnet/samples/AGUIClientServer/AGUIDojoServer/Program.cs
@@ -40,6 +40,21 @@ app.MapAGUI("/agentic_generative_ui", ChatClientAgentFactory.CreateAgenticUI());
 var jsonOptions = app.Services.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
 app.MapAGUI("/shared_state", ChatClientAgentFactory.CreateSharedState(jsonOptions.Value.SerializerOptions));
 
+app.MapAGUI("/agents/{agentId}", async (context) =>
+{
+    var agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
+    return agentId switch
+    {
+        "agentic_chat" => ChatClientAgentFactory.CreateAgenticChat(),
+        "backend_tool_rendering" => ChatClientAgentFactory.CreateBackendToolRendering(),
+        "human_in_the_loop" => ChatClientAgentFactory.CreateHumanInTheLoop(),
+        "tool_based_generative_ui" => ChatClientAgentFactory.CreateToolBasedGenerativeUI(),
+        "agentic_generative_ui" => ChatClientAgentFactory.CreateAgenticUI(),
+        "shared_state" => ChatClientAgentFactory.CreateSharedState(jsonOptions.Value.SerializerOptions),
+        _ => throw new ArgumentException($"Unknown agent ID: {agentId}"),
+    };
+});
+
 await app.RunAsync();
 
 public partial class Program { }

--- a/dotnet/samples/AGUIClientServer/AGUIDojoServer/Program.cs
+++ b/dotnet/samples/AGUIClientServer/AGUIDojoServer/Program.cs
@@ -40,10 +40,11 @@ app.MapAGUI("/agentic_generative_ui", ChatClientAgentFactory.CreateAgenticUI());
 var jsonOptions = app.Services.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
 app.MapAGUI("/shared_state", ChatClientAgentFactory.CreateSharedState(jsonOptions.Value.SerializerOptions));
 
-app.MapAGUI("/agents/{agentId}", async (context) =>
+// Map an AG-UI agent endpoint with per-request agent selection based on route parameter
+app.MapAGUI("/agents/{agentId}", (context) =>
 {
-    var agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
-    return agentId switch
+    string agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
+    return ValueTask.FromResult(agentId switch
     {
         "agentic_chat" => ChatClientAgentFactory.CreateAgenticChat(),
         "backend_tool_rendering" => ChatClientAgentFactory.CreateBackendToolRendering(),
@@ -52,7 +53,7 @@ app.MapAGUI("/agents/{agentId}", async (context) =>
         "agentic_generative_ui" => ChatClientAgentFactory.CreateAgenticUI(),
         "shared_state" => ChatClientAgentFactory.CreateSharedState(jsonOptions.Value.SerializerOptions),
         _ => throw new ArgumentException($"Unknown agent ID: {agentId}"),
-    };
+    });
 });
 
 await app.RunAsync();

--- a/dotnet/samples/AGUIClientServer/AGUIServer/Program.cs
+++ b/dotnet/samples/AGUIClientServer/AGUIServer/Program.cs
@@ -48,4 +48,14 @@ var agent = new AzureOpenAIClient(
 // Map the AG-UI agent endpoint
 app.MapAGUI("/", agent);
 
+app.MapAGUI("/agents/{agentId}", async (context) =>
+{
+    var agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
+    return agentId switch
+    {
+        "0" => agent,
+        _ => throw new ArgumentException($"Unknown agent ID: {agentId}"),
+    };
+});
+
 await app.RunAsync();

--- a/dotnet/samples/AGUIClientServer/AGUIServer/Program.cs
+++ b/dotnet/samples/AGUIClientServer/AGUIServer/Program.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using AGUIServer;
 using Azure.AI.OpenAI;
 using Azure.Identity;
+using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Extensions.AI;
 using OpenAI;
@@ -48,14 +49,16 @@ var agent = new AzureOpenAIClient(
 // Map the AG-UI agent endpoint
 app.MapAGUI("/", agent);
 
-app.MapAGUI("/agents/{agentId}", async (context) =>
+// Map an AG-UI agent endpoint with per-request agent selection based on route parameter
+app.MapAGUI("/agents/{agentId}", (context) =>
 {
-    var agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
-    return agentId switch
+    string agentId = context.Request.RouteValues["agentId"]?.ToString() ?? string.Empty;
+    AIAgent selectedAgent = agentId switch
     {
         "0" => agent,
         _ => throw new ArgumentException($"Unknown agent ID: {agentId}"),
     };
+    return ValueTask.FromResult(selectedAgent);
 });
 
 await app.RunAsync();

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -82,6 +82,10 @@ public static class AGUIEndpointRouteBuilderExtensions
 
             // Determine the agent to use
             var aiAgent = await aiAgentSelector(context).ConfigureAwait(false);
+            if (aiAgent is null)
+            {
+                return Results.BadRequest("Agent could not be determined.");
+            }
 
             // Run the agent and convert to AG-UI events
             var events = aiAgent.RunStreamingAsync(

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.Shared;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -32,6 +34,21 @@ public static class AGUIEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         [StringSyntax("route")] string pattern,
         AIAgent aiAgent)
+    {
+        return endpoints.MapAGUI(pattern, _ => ValueTask.FromResult(aiAgent));
+    }
+
+    /// <summary>
+    /// Maps an AG-UI agent endpoint.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="pattern">The URL pattern for the endpoint.</param>
+    /// <param name="aiAgentSelector">A function to select the agent instance based on the HTTP context.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder"/> for the mapped endpoint.</returns>
+    public static IEndpointConventionBuilder MapAGUI(
+        this IEndpointRouteBuilder endpoints,
+        [StringSyntax("route")] string pattern,
+        Func<HttpContext, ValueTask<AIAgent>> aiAgentSelector)
     {
         return endpoints.MapPost(pattern, async ([FromBody] RunAgentInput? input, HttpContext context, CancellationToken cancellationToken) =>
         {
@@ -62,6 +79,9 @@ public static class AGUIEndpointRouteBuilderExtensions
                     }
                 }
             };
+
+            // Determine the agent to use
+            var aiAgent = await aiAgentSelector(context).ConfigureAwait(false);
 
             // Run the agent and convert to AG-UI events
             var events = aiAgent.RunStreamingAsync(

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
@@ -45,6 +45,26 @@ public sealed class AGUIEndpointRouteBuilderExtensionsTests
     }
 
     [Fact]
+    public void MapAGUIAgent_MapsEndpoint_WithOnDemandAgentSelection()
+    {
+        // Arrange
+        Mock<IEndpointRouteBuilder> endpointsMock = new();
+        Mock<IServiceProvider> serviceProviderMock = new();
+
+        endpointsMock.Setup(e => e.ServiceProvider).Returns(serviceProviderMock.Object);
+        endpointsMock.Setup(e => e.DataSources).Returns([]);
+
+        const string Pattern = "/api/agent";
+        AIAgent agent = new TestAgent();
+
+        // Act
+        IEndpointConventionBuilder? result = AGUIEndpointRouteBuilderExtensions.MapAGUI(endpointsMock.Object, Pattern, (httpContext) => ValueTask.FromResult(agent));
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
     public async Task MapAGUIAgent_WithNullOrInvalidInput_Returns400BadRequestAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The current AGUI agent mapping binds one agent to an endpoint route. There is currently no way to bind an agent dynamically to an endpoint route with route parameters.

With this change we can select an `AIAgent` per-request based on route parameters or anything from `HttpContext`.

This also addresses https://github.com/microsoft/agent-framework/issues/2179.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Additionally to providing an `AIAgent` instance directly during route building, we can now also provide a `Func<HttpContext, AIAgent>` to determine the `AIAgent` per-request on-demand based on route parameters or anything from `HttpContext`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.