### PR TITLE
Python: removed additional properties from messages sent to OAI responses and chat completions

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1973,6 +1973,7 @@ class ChatMessage(SerializationMixin):
         author_name: The name of the author of the message.
         message_id: The ID of the chat message.
         additional_properties: Any additional properties associated with the chat message.
+            Additional properties are used within Agent Framework, they are not sent to services.
         raw_representation: The raw representation of the chat message from an underlying implementation.
 
     Examples:
@@ -2033,6 +2034,7 @@ class ChatMessage(SerializationMixin):
             author_name: Optional name of the author of the message.
             message_id: Optional ID of the chat message.
             additional_properties: Optional additional properties associated with the chat message.
+                Additional properties are used within Agent Framework, they are not sent to services.
             raw_representation: Optional raw representation of the chat message.
             **kwargs: Additional keyword arguments.
         """
@@ -2059,6 +2061,7 @@ class ChatMessage(SerializationMixin):
             author_name: Optional name of the author of the message.
             message_id: Optional ID of the chat message.
             additional_properties: Optional additional properties associated with the chat message.
+                Additional properties are used within Agent Framework, they are not sent to services.
             raw_representation: Optional raw representation of the chat message.
             **kwargs: Additional keyword arguments.
         """
@@ -2086,6 +2089,7 @@ class ChatMessage(SerializationMixin):
             author_name: Optional name of the author of the message.
             message_id: Optional ID of the chat message.
             additional_properties: Optional additional properties associated with the chat message.
+                Additional properties are used within Agent Framework, they are not sent to services.
             raw_representation: Optional raw representation of the chat message.
             kwargs: will be combined with additional_properties if provided.
         """

--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -369,8 +369,6 @@ class OpenAIBaseChatClient(OpenAIBase, BaseChatClient):
             args: dict[str, Any] = {
                 "role": message.role.value if isinstance(message.role, Role) else message.role,
             }
-            if message.additional_properties:
-                args["metadata"] = message.additional_properties
             match content:
                 case FunctionCallContent():
                     if all_messages and "tool_calls" in all_messages[-1]:

--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -412,8 +412,6 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
         args: dict[str, Any] = {
             "role": message.role.value if isinstance(message.role, Role) else message.role,
         }
-        if message.additional_properties:
-            args["metadata"] = message.additional_properties
         for content in message.contents:
             match content:
                 case TextReasoningContent():


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The Responses API gives an error when additional properties are set on a chat message and some services did not send additional properties while Responses and OpenAI chat did, this removes that. The API docs for both also do not mention any other fields, but apparantely the Chat Completion API did not complain while Responses did.

Also adds a note on this to the docstring of ChatMessage.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.