### PR TITLE
.NET: sanitize redirectUrl for logs

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DevUI/DevUIMiddleware.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DevUI/DevUIMiddleware.cs
@@ -83,8 +83,7 @@ internal sealed partial class DevUIMiddleware
             context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
             context.Response.Headers.Location = redirectUrl;
 
-            var sanitizedRedirectUrl = NewlineRegex().Replace(redirectUrl, "");
-            this._logger.LogDebug("Redirecting {OriginalPath} to {RedirectUrl}", path, sanitizedRedirectUrl);
+            this._logger.LogDebug("Redirecting {OriginalPath} to {RedirectUrl}", NewlineRegex().Replace(path, ""), NewlineRegex().Replace(redirectUrl, ""));
             return;
         }
 


### PR DESCRIPTION
1) Sanitizing redirect url
2) Using redirect Url from the _basePath to not use input without validation

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.