### PR TITLE
Python: Preserve MCP array items schema in Pydantic field generation

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -278,7 +278,7 @@ def _get_input_model_from_mcp_tool(tool: types.Tool) -> type[BaseModel]:
         python_type = resolve_type(prop_details)
         description = prop_details.get("description", "")
 
-        # Handle array types
+        # Build field kwargs (description, array items schema, etc.)
         field_kwargs: dict[str, Any] = {}
         if description:
             field_kwargs["description"] = description

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -484,7 +484,7 @@ def test_get_input_model_from_mcp_tool_with_ref_schema():
 
 
 def test_get_input_model_from_mcp_tool_with_simple_array():
-    """Test array without complex items schema (should not add json_schema_extra)."""
+    """Test array with simple items schema (items schema should be preserved in json_schema_extra)."""
     tool = types.Tool(
         name="simple_array_tool",
         description="Tool with simple array",


### PR DESCRIPTION
### Motivation and Context
Fixes an issue where MCP tools with complex array parameters (like `browser_fill_form` from Playwright MCP) were losing their array items schema during the MCP → Pydantic → JSON Schema conversion pipeline, causing LLMs to receive incomplete parameter information.

When converting MCP tool schemas to Pydantic models, array parameters with complex `items` schemas were being converted to simple `list` types without preserving the detailed structure of array items. This resulted in LLMs receiving incomplete schemas and making wrong function calls.

**Before Fix:**
```json
{
  "type": "function",
  "function": {
    "name": "browser_fill_form",
    "description": "Fill multiple form fields",
    "parameters": {
      "properties": {
        "fields": {
          "description": "Fields to fill in",
          "items": {},
          "title": "Fields",
          "type": "array"
        }
      },
      "required": [
        "fields"
      ],
      "title": "browser_fill_form_input",
      "type": "object"
    }
  }
}
```

**After Fix:**
```json
{
  "type": "function",
  "function": {
    "name": "browser_fill_form",
    "description": "Fill multiple form fields",
    "parameters": {
      "properties": {
        "fields": {
          "description": "Fields to fill in",
          "items": {
            "additionalProperties": false,
            "properties": {
              "name": {
                "description": "Human-readable field name",
                "type": "string"
              },
              "type": {
                "description": "Type of the field",
                "enum": [
                  "textbox",
                  "checkbox",
                  "radio",
                  "combobox",
                  "slider"
                ],
                "type": "string"
              },
              "ref": {
                "description": "Exact target field reference from the page snapshot",
                "type": "string"
              },
              "value": {
                "description": "Value to fill in the field. If the field is a checkbox, the value should be `true` or `false`. If the field is a combobox, the value should be the text of the option.",  
                "type": "string"
              }
            },
            "required": [
              "name",
              "type",
              "ref",
              "value"
            ],
            "type": "object"
          },
          "title": "Fields",
          "type": "array"
        }
      },
      "required": [
        "fields"
      ],
      "title": "browser_fill_form_input",
      "type": "object"
    }
  }
}
```
Resolves #1869 
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.