### PR TITLE
Python: test: add unit tests for OpenAIResponsesClient store parameter handling with proper usage mock

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -366,8 +366,12 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
             for key, value in additional_properties.items():
                 if value is not None:
                     run_options[key] = value
-        if "store" not in run_options:
-            run_options["store"] = False
+        if "store" in run_options:
+            # keep store param as it is
+            pass
+        else:
+            # do not add store parameter
+            run_options.pop("store", None)
         if (tool_choice := run_options.get("tool_choice")) and len(tool_choice.keys()) == 1:
             run_options["tool_choice"] = tool_choice["mode"]
         return run_options

--- a/python/packages/core/tests/openai/test_openai_responses.py
+++ b/python/packages/core/tests/openai/test_openai_responses.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_framework._types import ChatMessage, Role, TextContent
+from agent_framework.openai._responses_client import OpenAIResponsesClient
+
+
+def create_chat_message(text: str) -> ChatMessage:
+    content = TextContent(text=text)
+    return ChatMessage(role=Role.USER, contents=[content])
+
+
+@pytest.mark.asyncio
+async def test_store_parameter_not_sent_by_default():
+    client = OpenAIResponsesClient(api_key="test-key", model_id="gpt-4o")
+    with patch.object(client.client.responses, "create", new_callable=AsyncMock) as mock_create:
+        # Create a properly structured mock response
+        mock_response = MagicMock()
+        mock_response.usage.input_tokens_details.cached_tokens = 10
+        mock_response.usage.output_tokens_details.reasoning_tokens = 20
+        mock_response.usage.input_tokens_details = mock_response.usage.input_tokens_details
+        mock_response.usage.output_tokens_details = mock_response.usage.output_tokens_details
+        mock_response.usage = mock_response.usage
+        mock_create.return_value = mock_response
+
+        message = create_chat_message("test")
+        await client.get_response(messages=[message])
+
+        args, kwargs = mock_create.call_args
+        assert "store" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_store_parameter_explicit_false():
+    client = OpenAIResponsesClient(api_key="test-key", model_id="gpt-4o")
+    with patch.object(client.client.responses, "create", new_callable=AsyncMock) as mock_create:
+        mock_response = MagicMock()
+        mock_response.usage.input_tokens_details.cached_tokens = 15
+        mock_response.usage.output_tokens_details.reasoning_tokens = 25
+        mock_response.usage.input_tokens_details = mock_response.usage.input_tokens_details
+        mock_response.usage.output_tokens_details = mock_response.usage.output_tokens_details
+        mock_response.usage = mock_response.usage
+        mock_create.return_value = mock_response
+
+        message = create_chat_message("test")
+        await client.get_response(messages=[message], store=False)
+
+        args, kwargs = mock_create.call_args
+        assert kwargs.get("store") is False
+
+
+@pytest.mark.asyncio
+async def test_store_parameter_explicit_true():
+    client = OpenAIResponsesClient(api_key="test-key", model_id="gpt-4o")
+    with patch.object(client.client.responses, "create", new_callable=AsyncMock) as mock_create:
+        mock_response = MagicMock()
+        mock_response.usage.input_tokens_details.cached_tokens = 30
+        mock_response.usage.output_tokens_details.reasoning_tokens = 40
+        mock_response.usage.input_tokens_details = mock_response.usage.input_tokens_details
+        mock_response.usage.output_tokens_details = mock_response.usage.output_tokens_details
+        mock_response.usage = mock_response.usage
+        mock_create.return_value = mock_response
+
+        message = create_chat_message("test")
+        await client.get_response(messages=[message], store=True)
+
+        args, kwargs = mock_create.call_args
+        assert kwargs.get("store") is True


### PR DESCRIPTION
This pull request adds new unit tests to the OpenAIResponsesClient to verify the correct handling of the store parameter when making API calls.

Changes made:
Added tests to ensure the store parameter is only sent when explicitly configured.

Mocked OpenAI usage token counts correctly as integers to avoid runtime errors during tests.
Improved test reliability by patching the exact API call method used internally.

Why:
These tests validate the fix for issue #2389 where the client incorrectly defaulted store to False, causing unintended behavior in response storage.