### PR TITLE
Python: Bug fix for Redis TypeError

### DIFF
--- a/python/packages/core/agent_framework/_threads.py
+++ b/python/packages/core/agent_framework/_threads.py
@@ -140,6 +140,7 @@ class ChatMessageStoreState(SerializationMixin):
         """
         if not messages:
             self.messages: list[ChatMessage] = []
+            return
         if not isinstance(messages, list):
             raise TypeError("Messages should be a list")
         new_messages: list[ChatMessage] = []

--- a/python/packages/core/tests/core/test_threads.py
+++ b/python/packages/core/tests/core/test_threads.py
@@ -384,6 +384,18 @@ class TestStoreState:
 
         assert len(state.messages) == 0
 
+    def test_init_none(self) -> None:
+        """Test ChatMessageStoreState initialization with None messages."""
+        state = ChatMessageStoreState(messages=None)
+
+        assert len(state.messages) == 0
+
+    def test_init_no_messages_arg(self) -> None:
+        """Test ChatMessageStoreState initialization without messages argument."""
+        state = ChatMessageStoreState()
+
+        assert len(state.messages) == 0
+
 
 class TestThreadState:
     """Test cases for AgentThreadState class."""
@@ -415,3 +427,22 @@ class TestThreadState:
 
         assert state.service_thread_id is None
         assert state.chat_message_store_state is None
+
+    def test_init_with_chat_message_store_state_no_messages(self) -> None:
+        """Test AgentThreadState initialization with chat_message_store_state without messages field.
+
+        This tests the scenario where a custom ChatMessageStore (like RedisChatMessageStore)
+        serializes its state without a 'messages' field, containing only configuration data
+        like thread_id, redis_url, etc.
+        """
+        store_data: dict[str, Any] = {
+            "type": "redis_store_state",
+            "thread_id": "test_thread_123",
+            "redis_url": "redis://localhost:6379",
+            "key_prefix": "chat_messages",
+        }
+        state = AgentThreadState.from_dict({"chat_message_store_state": store_data})
+
+        assert state.service_thread_id is None
+        assert state.chat_message_store_state is not None
+        assert state.chat_message_store_state.messages == []


### PR DESCRIPTION
### Motivation and Context

When using `RedisChatMessageStore` for message storage and calling `thread.serialize()`, the following error occurs:

```
File "/Users/worker/workspace/project/agent-framework-demo/chatagent_redisstore_demo.py", line 93, in chat_demo
    serialized_thread = await thread_1.serialize()
File ".../agent_framework/_threads.py", line 430, in serialize
    state = AgentThreadState(
        service_thread_id=self._service_thread_id, chat_message_store_state=chat_message_store_state
    )
File ".../agent_framework/_threads.py", line 175, in __init__
    self.chat_message_store_state = ChatMessageStoreState.from_dict(chat_message_store_state)
File ".../agent_framework/_serialization.py", line 552, in from_dict
    return cls(**kwargs)
File ".../agent_framework/_threads.py", line 144, in __init__
    raise TypeError("Messages should be a list")
```

The bug is in `ChatMessageStoreState.__init__()` in `_threads` where in the constructor, the line `if not isinstance(messages, list): ` always runs, even if `messages` is `None`. When `RedisChatMessageStore.serialize()` returns a dict without a messages field (containing only thread_id, redis_url, etc.), the messages parameter defaults to None, triggering the `TypeError`.

The fix is to add an early return after handling the empty/None case - no further processing is necessary because the incoming messages are `None`. 

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #1991 
- Adds tests for coverage.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.