### PR TITLE
Python: fix: always include output in function call result message

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -518,9 +518,8 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
                 args: dict[str, Any] = {
                     "call_id": content.call_id,
                     "type": "function_call_output",
+                    "output": prepare_function_call_results(content.result),
                 }
-                if content.result:
-                    args["output"] = prepare_function_call_results(content.result)
                 return args
             case FunctionApprovalRequestContent():
                 return {


### PR DESCRIPTION
### Motivation and Context

Previously the "output" field was only appended to function call result message in `AzureOpenAIResponsesClient` only if it was a 'truthy' value.

This meant that if the result of the tool call was an empty list (treated as 'falsy' value by python), the message was missing an output field, which was resulting in a following `BadRequest` error coming from OpenAI api:
`ServiceResponseException: <class 'agent_framework.azure._responses_client.AzureOpenAIResponsesClient'> service failed to complete the prompt: Error code: 400 - {'error': {'message': "Missing required parameter: 'input[3].output'.", 'type': 'invalid_request_error', 'param': 'input[3].output', 'code': 'missing_required_parameter'}}`. 

Screenshot below showcases the error (I added a simple log to prints `content.result`.

<img width="2854" height="600" alt="image" src="https://github.com/user-attachments/assets/d65b0933-24fb-4de9-8e84-4c7bf8685ec5" />


The error comes from the fact that to according OpenAI Responses api schema, the "output" field is required as part of Function call tool output input message [(link to schema)](https://platform.openai.com/docs/api-reference/responses/create)

<img width="629" height="420" alt="image" src="https://github.com/user-attachments/assets/cb2798e2-299d-4fc0-88d8-5caf867b292c" />

The error can be simply reproduced by using a dummy tool that always returns empty list or None.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

This pull request simply always appends an "output" field to the function call output message, regardless whether the result of function call is truthy or not. I also made the mock tool and tested that the serialization function `prepare_function_call_results`  is able to deal with None value as well as other falsy values.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.