### PR TITLE
Update to latest dotnet devcontainer and add docker in docker.

### DIFF
--- a/.devcontainer/dotnet/devcontainer.json
+++ b/.devcontainer/dotnet/devcontainer.json
@@ -1,10 +1,11 @@
 {
   "name": "C# (.NET)",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2.4.0": {},
     "ghcr.io/devcontainers/features/powershell:1.5.1": {},
-    "ghcr.io/devcontainers/features/azure-cli:1.2.8": {}
+    "ghcr.io/devcontainers/features/azure-cli:1.2.8": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2.12.4": {}
   },
   "workspaceFolder": "/workspaces/agent-framework/dotnet/",
   "customizations": {


### PR DESCRIPTION
### Motivation and Context

The project has been updated to use the .net 10 SDK, but the dev container is using an image that uses the .net 9 SDK, so we have to update to the latest.
Even the latest image is only using the .net 10 rc SDK, but it should hopefully be updated soon to point to the GA version, in which case the container would start working correctly.

### Description

- Updating to the latest dev container.
- Adding support for docker in docker for cases where we need to run a docker container.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.