### PR TITLE
Python: Use executor_id and edge_group_id as span names for meaningful observability traces

### DIFF
--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1626,7 +1626,7 @@ def create_processing_span(
                         links.append(trace.Link(span_context))
 
     return workflow_tracer().start_as_current_span(
-        executor_id,
+        f"{OtelAttr.EXECUTOR_PROCESS_SPAN} {executor_id}",
         kind=trace.SpanKind.INTERNAL,
         attributes={
             OtelAttr.EXECUTOR_ID: executor_id,
@@ -1698,9 +1698,8 @@ def create_edge_group_processing_span(
                 # If linking fails, continue without link (graceful degradation)
                 pass
 
-    span_name = edge_group_id if edge_group_id else edge_group_type
     return workflow_tracer().start_as_current_span(
-        span_name,
+        f"{OtelAttr.EDGE_GROUP_PROCESS_SPAN} {edge_group_type}",
         kind=trace.SpanKind.INTERNAL,
         attributes=attributes,
         links=links,

--- a/python/packages/core/tests/workflow/test_edge.py
+++ b/python/packages/core/tests/workflow/test_edge.py
@@ -327,7 +327,7 @@ async def test_single_edge_group_tracing_success(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process SingleEdgeGroup"
     assert span.attributes.get("edge_group.type") == "SingleEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is True
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DELIVERED.value
@@ -372,7 +372,7 @@ async def test_single_edge_group_tracing_condition_failure(span_exporter) -> Non
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process SingleEdgeGroup"
     assert span.attributes.get("edge_group.type") == "SingleEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is False
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DROPPED_CONDITION_FALSE.value
@@ -407,7 +407,7 @@ async def test_single_edge_group_tracing_type_mismatch(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process SingleEdgeGroup"
     assert span.attributes.get("edge_group.type") == "SingleEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is False
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DROPPED_TYPE_MISMATCH.value
@@ -441,7 +441,7 @@ async def test_single_edge_group_tracing_target_mismatch(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process SingleEdgeGroup"
     assert span.attributes.get("edge_group.type") == "SingleEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is False
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DROPPED_TARGET_MISMATCH.value
@@ -800,7 +800,7 @@ async def test_fan_out_edge_group_tracing_success(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process FanOutEdgeGroup"
     assert span.attributes.get("edge_group.type") == "FanOutEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is True
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DELIVERED.value
@@ -856,7 +856,7 @@ async def test_fan_out_edge_group_tracing_with_target(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process FanOutEdgeGroup"
     assert span.attributes.get("edge_group.type") == "FanOutEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is True
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DELIVERED.value
@@ -1024,7 +1024,7 @@ async def test_fan_in_edge_group_tracing_buffered(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process FanInEdgeGroup"
     assert span.attributes.get("edge_group.type") == "FanInEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is True
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.BUFFERED.value
@@ -1056,7 +1056,7 @@ async def test_fan_in_edge_group_tracing_buffered(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process FanInEdgeGroup"
     assert span.attributes.get("edge_group.type") == "FanInEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is True
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DELIVERED.value
@@ -1102,7 +1102,7 @@ async def test_fan_in_edge_group_tracing_type_mismatch(span_exporter) -> None:
 
     span = edge_group_spans[0]
     assert span.attributes is not None
-    assert span.name == span.attributes.get("edge_group.id")
+    assert span.name == "edge_group.process FanInEdgeGroup"
     assert span.attributes.get("edge_group.type") == "FanInEdgeGroup"
     assert span.attributes.get("edge_group.delivered") is False
     assert span.attributes.get("edge_group.delivery_status") == EdgeGroupDeliveryStatus.DROPPED_TYPE_MISMATCH.value

--- a/python/packages/core/tests/workflow/test_workflow_observability.py
+++ b/python/packages/core/tests/workflow/test_workflow_observability.py
@@ -151,8 +151,8 @@ async def test_span_creation_and_attributes(span_exporter: InMemorySpanExporter)
     event_names = [event.name for event in workflow_span.events]
     assert "workflow.started" in event_names
 
-    # Check processing span - span name is now the executor_id
-    processing_span = next(s for s in spans if s.name == "executor-456")
+    # Check processing span - span name uses format "executor.process {executor_id}"
+    processing_span = next(s for s in spans if s.name == "executor.process executor-456")
     assert processing_span.kind == trace.SpanKind.INTERNAL
     assert processing_span.attributes is not None
     assert processing_span.attributes.get("executor.id") == "executor-456"
@@ -219,7 +219,9 @@ async def test_trace_context_handling(span_exporter: InMemorySpanExporter) -> No
 
     # Verify processing span attributes
     processing_span = processing_spans[0]
-    assert processing_span.name == "test-executor"  # Span name is now executor_id
+    assert (
+        processing_span.name == "executor.process test-executor"
+    )  # Span name uses format "executor.process {executor_id}"
     assert processing_span.attributes is not None
     assert processing_span.attributes.get("executor.id") == "test-executor"
     assert processing_span.attributes.get("executor.type") == "MockExecutor"


### PR DESCRIPTION
### Motivation and Context

Changes span names from hardcoded constants (`executor.process`, `edge_group.process`) to use meaningful identifiers (`executor_id`, `edge_group_id`), making observability traces readable when multiple executors/edge groups are present in a workflow.

## Changes

- `create_processing_span`: Uses `executor_id` as span name instead of `OtelAttr.EXECUTOR_PROCESS_SPAN`
- `create_edge_group_processing_span`: Uses `edge_group_id` (or `edge_group_type` as fallback) as span name instead of `OtelAttr.EDGE_GROUP_PROCESS_SPAN`
- Updated tests to filter spans by attributes rather than hardcoded names

**Not a breaking change.** Span names are not part of the public API contract. All span attributes (`executor.id`, `executor.type`, `edge_group.type`, etc.) remain unchanged, so existing trace consumers continue to work correctly with more meaningful span names.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Fixes #2467
- Adjust tests based on new behavior

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.