### PR TITLE
.NET: Make “Start Chat” button clearly visible

### DIFF
--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -606,14 +606,6 @@
         box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
     }
 
-    .start-chat-btn.start-chat-btn-disabled {
-        background: #e5e7eb;
-        color: #9ca3af;
-        cursor: not-allowed;
-        box-shadow: none;
-        transform: none;
-    }
-
     .conversations-section {
         margin-bottom: 1.5rem;
     }
@@ -912,8 +904,6 @@
 	private bool isDiscoveringCard = false;
 	private string? discoveredAgentCardJson = null;
 	private string? discoveryError = null;
-
-    private bool IsStartChatDisabled => string.IsNullOrEmpty(selectedAgentName) || currentConversation is not null || isStreaming;
 
 	private enum Protocol
 	{

--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -605,12 +605,12 @@
         box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
     }
 
-    .start-chat-btn-disabled {
-        background: #e5e7eb !important;
-        color: #9ca3af !important;
-        cursor: not-allowed !important;
-        box-shadow: none !important;
-        transform: none !important;
+    .start-chat-btn.start-chat-btn-disabled {
+        background: #e5e7eb;
+        color: #9ca3af;
+        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
     }
 
     .conversations-section {

--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -1012,7 +1012,7 @@
 
 	private void StartNewConversation()
 	{
-		if (string.IsNullOrEmpty(selectedAgentName))
+        if (IsStartChatDisabled || string.IsNullOrEmpty(selectedAgentName))
 			return;
 
 		var newConversation = new Conversation

--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -36,15 +36,16 @@
                     <option value="@agent.Name">@GetAgentDisplayName(agent.Name!) - @agent.Description</option>
                 }
             </select>
-                <button class="start-chat-btn @(IsStartChatDisabled ? "start-chat-btn-disabled" : string.Empty)"
-                    @onclick="StartNewConversation"
-                    disabled="@IsStartChatDisabled">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="12" y1="5" x2="12" y2="19"></line>
-                    <line x1="5" y1="12" x2="19" y2="12"></line>
-                </svg>
-                Start Chat
-            </button>
+            @if (!string.IsNullOrEmpty(selectedAgentName))
+            {
+                <button class="start-chat-btn" @onclick="StartNewConversation">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="12" y1="5" x2="12" y2="19"></line>
+                        <line x1="5" y1="12" x2="19" y2="12"></line>
+                    </svg>
+                    Start Chat
+                </button>
+            }
         </div>
     </div>
 
@@ -1012,7 +1013,7 @@
 
 	private void StartNewConversation()
 	{
-        if (IsStartChatDisabled || string.IsNullOrEmpty(selectedAgentName))
+		if (string.IsNullOrEmpty(selectedAgentName))
 			return;
 
 		var newConversation = new Conversation

--- a/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
+++ b/dotnet/samples/AgentWebChat/AgentWebChat.Web/Components/Pages/Home.razor
@@ -36,16 +36,15 @@
                     <option value="@agent.Name">@GetAgentDisplayName(agent.Name!) - @agent.Description</option>
                 }
             </select>
-            @if (!string.IsNullOrEmpty(selectedAgentName) && currentConversation is null)
-            {
-                <button class="start-chat-btn" @onclick="StartNewConversation">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <line x1="12" y1="5" x2="12" y2="19"></line>
-                        <line x1="5" y1="12" x2="19" y2="12"></line>
-                    </svg>
-                    Start Chat
-                </button>
-            }
+                <button class="start-chat-btn @(IsStartChatDisabled ? "start-chat-btn-disabled" : string.Empty)"
+                    @onclick="StartNewConversation"
+                    disabled="@IsStartChatDisabled">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19"></line>
+                    <line x1="5" y1="12" x2="19" y2="12"></line>
+                </svg>
+                Start Chat
+            </button>
         </div>
     </div>
 
@@ -606,6 +605,14 @@
         box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
     }
 
+    .start-chat-btn-disabled {
+        background: #e5e7eb !important;
+        color: #9ca3af !important;
+        cursor: not-allowed !important;
+        box-shadow: none !important;
+        transform: none !important;
+    }
+
     .conversations-section {
         margin-bottom: 1.5rem;
     }
@@ -904,6 +911,8 @@
 	private bool isDiscoveringCard = false;
 	private string? discoveredAgentCardJson = null;
 	private string? discoveryError = null;
+
+    private bool IsStartChatDisabled => string.IsNullOrEmpty(selectedAgentName) || currentConversation is not null || isStreaming;
 
 	private enum Protocol
 	{


### PR DESCRIPTION
### Motivation and Context

Previously, the “Start Chat” button sometimes disappeared after a conversation began, so users couldn’t reliably find the primary action. Disabling it also caused confusion because it looked clickable yet did nothing. The goal is to keep the button consistently visible (and not disabled) while ensuring clicks are safely ignored when a new chat shouldn’t start.

### Description

- Always render the “Start Chat” button so the primary action remains discoverable.
- Keep the button enabled and rely on a guard inside StartNewConversation to no-op when starting a new chat isn’t allowed (e.g., no agent selected, conversation active, or streaming in progress), preventing unwanted invocations without hiding or disabling the control.
- Maintain the aligned visual state via the dedicated start-chat-btn-disabled styling without !important, using a more specific selector to show a muted look when appropriate.
- Leave the rest of the chat flow unchanged: conversations start as before, and the button remains available once conditions permit starting a new session.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.