### PR TITLE
Python: fix(python): add __str__ to ChatMessage to prevent repr in display output

### DIFF
--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -556,6 +556,43 @@ def test_chat_message_with_chatrole_instance():
     assert m.text == "hi"
 
 
+# region ChatMessage __str__ and __repr__
+
+
+def test_chat_message_str_with_text():
+    """Test __str__ returns text when TextContent is present."""
+    msg = ChatMessage(role=Role.ASSISTANT, text="Hello world")
+    assert str(msg) == "Hello world"
+
+
+def test_chat_message_str_with_tool_call_only():
+    """Test __str__ returns meaningful output for tool-call-only messages, not repr."""
+    msg = ChatMessage(
+        role=Role.ASSISTANT,
+        contents=[FunctionCallContent(call_id="call_123", name="search_database", arguments='{"query": "test"}')],
+    )
+    result = str(msg)
+    assert "object at" not in result
+    assert "search_database" in result
+
+
+def test_chat_message_str_empty():
+    """Test __str__ returns empty string for empty message."""
+    msg = ChatMessage(role=Role.ASSISTANT, contents=[])
+    assert str(msg) == ""
+
+
+def test_chat_message_repr():
+    """Test __repr__ returns debug-friendly representation."""
+    msg = ChatMessage(role=Role.ASSISTANT, text="Hello")
+    result = repr(msg)
+    assert "ChatMessage(" in result
+    assert "Hello" in result
+
+
+# endregion ChatMessage __str__ and __repr__
+
+
 # region ChatResponse
 
 


### PR DESCRIPTION
## Summary

When a `ChatMessage` contains only tool calls (no text), `str(message)` returns Python's default repr (`<agent_framework._types.ChatMessage object at 0x...>`) instead of meaningful content.

This PR adds `__str__` and `__repr__` methods to `ChatMessage`:
- `__str__` returns text content when present, or a formatted summary of tool calls
- `__repr__` returns debug-friendly output with role, text preview, and content count

## The Bug

In `MagenticAgentExecutor._invoke_agent()` line 1730:
```python
text = last.text or str(last)
```

When the message has only `FunctionCallContent` (no `TextContent`), `.text` returns empty string, triggering the `str(last)` fallback—which produced the repr garbage.

## The Fix

By adding `__str__` to `ChatMessage`, the existing code works correctly without modification. This also future-proofs any other code that calls `str()` on a `ChatMessage`.

## Test Plan

- Added 4 focused tests covering text, tool-call-only, empty, and repr cases
- All existing tests pass (1145 passed)
- fmt, lint, pyright, mypy all clean

Fixes #2562