### PR TITLE
Python: Fix MangenticAgentExecutor producing repr str for tool call content

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_magentic.py
+++ b/python/packages/core/agent_framework/_workflows/_magentic.py
@@ -1727,7 +1727,7 @@ class MagenticAgentExecutor(Executor):
             last: ChatMessage = messages[-1]
             author = last.author_name or self._agent_id
             role: Role = last.role if last.role else Role.ASSISTANT
-            text = last.text or str(last)
+            text = last.text or ""
             msg = ChatMessage(role=role, text=text, author_name=author)
             await self._emit_agent_message_event(ctx, msg)
             return msg

--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -1274,7 +1274,7 @@ class MessageMapper:
                             "trace_type": "magentic_orchestrator",
                             "orchestrator_id": orchestrator_id,
                             "kind": kind,
-                            "text": text or str(message),
+                            "text": text or "",
                             "timestamp": datetime.now().isoformat(),
                         },
                         span_id=f"magentic_orch_{uuid4().hex[:8]}",


### PR DESCRIPTION
### Motivation and Context

When an agent's response contains only `FunctionCallContent` (tool calls) without text content, `ChatMessage.text` returns an empty string. The code `text = last.text or str(last)` evaluated the fallback `str(last)`, which produced garbage repr output like `<agent_framework._types.ChatMessage object at 0x...>`.

Changed to `text = last.text or ""` to match the existing pattern used elsewhere in the SDK. The `contents` list still contains the `FunctionCallContent` items for consumers who need them.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Fixes #2562

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.