### PR TITLE
Python: Update fan in fan out sample to show concurrency

### DIFF
--- a/python/samples/getting_started/workflows/parallelism/fan_out_fan_in_edges.py
+++ b/python/samples/getting_started/workflows/parallelism/fan_out_fan_in_edges.py
@@ -143,7 +143,7 @@ async def main() -> None:
     # 3) Run with a single prompt and print progress plus the final consolidated output
     async for event in workflow.run_stream("We are launching a new budget-friendly electric bike for urban commuters."):
         if isinstance(event, ExecutorInvokedEvent):
-            # Show which agent ran and what step completed for lightweight observability.
+            # Show when executors are invoked and completed for lightweight observability.
             print(f"{event.executor_id} invoked")
         elif isinstance(event, ExecutorCompletedEvent):
             print(f"{event.executor_id} completed")


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
`AgentRunEvent` is not emitted by the workflow when it's run in streaming mode. The sample `python/samples/getting_started/workflows/parallelism/fan_out_fan_in_edges.py` shows the wrong event.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This PR replaces the `AgentRunEvent` with the expected events from executors when they are invoked and complete.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.