### PR TITLE
.NET: Fix JailbreakSyncExecutor and FinalOutputExecutor to use List<C…

### DIFF
--- a/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/_Foundational/07_MixedWorkflowAgentsAndExecutors/Program.cs
@@ -287,10 +287,13 @@ internal sealed class FinalOutputExecutor() : Executor<List<ChatMessage>, string
         Console.WriteLine(); // New line after agent streaming
         Console.ForegroundColor = ConsoleColor.Green;
         Console.WriteLine($"\n[{this.Id}] Final Response:");
-        Console.WriteLine($"{lastMessage.Text}");
+        // Safely print the assistant text - normalize null to empty string before printing and returning.
+        string assistantText = lastMessage.Text ?? string.Empty;
+        Console.WriteLine(assistantText);
         Console.WriteLine("\n[End of Workflow]");
         Console.ResetColor();
 
-        return ValueTask.FromResult(lastMessage.Text ?? string.Empty);
+        // Ensure we never return null
+        return ValueTask.FromResult(assistantText);
     }
 }


### PR DESCRIPTION
### Motivation and Context


This change is required because previously JailbreakSyncExecutor and FinalOutputExecutor only accepted a single ChatMessage. That limitation caused the sample workflow described in issue #2696 to break — after the AI agent step, subsequent executors were skipped. With this update, those executors now accept List<ChatMessage> (one of the officially supported input types), which restores correct workflow chaining and prevents silent failures.

### Description

- Updated input type for JailbreakSyncExecutor and FinalOutputExecutor from ChatMessage to List<ChatMessage>.

- Adjusted sample usage and test cases to pass lists instead of single messages.

- No other functional changes were made to executor logic.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.