### PR TITLE
Python: Fix Pydantic error when using Literal type for tool params

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -886,6 +886,8 @@ def _parse_annotation(annotation: Any) -> Any:
     If the second annotation (after the type) is a string, then we convert that to a Pydantic Field description.
     The rest are returned as-is, allowing for multiple annotations.
 
+    Literal types are returned as-is to preserve their enum-like values.
+
     Args:
         annotation: The type annotation to parse.
 
@@ -894,6 +896,12 @@ def _parse_annotation(annotation: Any) -> Any:
     """
     origin = get_origin(annotation)
     if origin is not None:
+        # Literal types should be returned as-is - their args are the allowed values,
+        # not type annotations to be parsed. For example, Literal["Data", "Security"]
+        # has args ("Data", "Security") which are the valid string values.
+        if origin is Literal:
+            return annotation
+
         args = get_args(annotation)
         # For other generics, return the origin type (e.g., list for List[int])
         if len(args) > 1 and isinstance(args[1], str):


### PR DESCRIPTION
### Motivation and Context

When using `Literal` type annotations for tool parameters in `@ai_function` decorated methods, Pydantic throws:

```
PydanticUserError: search_flows_input is not fully defined; you should define Data, then call search_flows_input.model_rebuild().
```

The `_parse_annotation` function incorrectly processed `Literal` types. For `Literal["Data", "Security"]`, the args are `("Data", "Security")`. The code checked if `args[1]` is a string (which `"Security"` is), then mistakenly created `Annotated[ForwardRef('Data'), Field(description='Security')]`, treating literal values as type references.

The fix: added early return in `_parse_annotation` when `get_origin(annotation) is Literal` to preserve Literal types unchanged.

Testing:

Added 9 tests covering:
- Literal string/int/bool types in standalone functions and class methods
- Literal combined with `Annotated` and `Field`
- Unit tests for `_parse_annotation` function

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Fixes #2891

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.