### PR TITLE
Python: Bug fix: OpenAI Chat Client to consume author name

### DIFF
--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -369,6 +369,11 @@ class OpenAIBaseChatClient(OpenAIBase, BaseChatClient):
             args: dict[str, Any] = {
                 "role": message.role.value if isinstance(message.role, Role) else message.role,
             }
+
+            # Include author name if provided
+            if message.author_name:
+                args["name"] = message.author_name
+
             match content:
                 case FunctionCallContent():
                     if all_messages and "tool_calls" in all_messages[-1]:

--- a/python/packages/core/tests/openai/test_openai_chat_client_base.py
+++ b/python/packages/core/tests/openai/test_openai_chat_client_base.py
@@ -443,3 +443,27 @@ def test_chat_response_update_created_at_uses_utc(openai_unit_test_env: dict[str
     assert response_update.created_at == expected_formatted, (
         f"Expected UTC timestamp {expected_formatted}, got {response_update.created_at}"
     )
+
+
+# endregion
+
+# region Prepare Chat History Tests
+
+
+def test_prepare_chat_history_includes_author_name(openai_unit_test_env: dict[str, str]):
+    """Test that _prepare_chat_history_for_request includes author name when provided."""
+    from agent_framework import Role
+
+    chat_history = [
+        ChatMessage(role=Role.USER, text="Hello", author_name="Alice"),
+        ChatMessage(role=Role.ASSISTANT, text="Hi there!", author_name="Bot"),
+    ]
+
+    client = OpenAIChatClient()
+    prepared_history = client._prepare_chat_history_for_request(chat_history)  # type: ignore
+
+    assert prepared_history[0]["name"] == "Alice", "Author name for user message should be included."
+    assert prepared_history[1]["name"] == "Bot", "Author name for assistant message should be included."
+
+
+# endregion


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
The OpenAI Chat client doesn't consume author names set in messages. This essentially prevents all multi-agent scenarios from working because models won't have context on who has spoken.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
This PR fixes the issue in the OpenAI client. For other clients, we will do a pass separately. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.