### PR TITLE
Modify VisionAgent to fetch and send image bytes

### DIFF
--- a/dotnet/samples/GettingStarted/Agents/Agent_Step11_UsingImages/Program.cs
+++ b/dotnet/samples/GettingStarted/Agents/Agent_Step11_UsingImages/Program.cs
@@ -17,9 +17,14 @@ var agent = new AzureOpenAIClient(new Uri(endpoint), new AzureCliCredential())
         name: "VisionAgent",
         instructions: "You are a helpful agent that can analyze images");
 
+
+using HttpClient httpClient = new();
+httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+byte[] imageBytes = await httpClient.GetByteArrayAsync("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg");
+
 ChatMessage message = new(ChatRole.User, [
     new TextContent("What do you see in this image?"),
-    new UriContent("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg", "image/jpeg")
+    new DataContent(imageBytes, "image/jpeg")
 ]);
 
 var thread = agent.GetNewThread();


### PR DESCRIPTION
Updated image handling in VisionAgent to use byte array.

System.Net.Http.HttpRequestException: 'Response status code does not indicate success: 403 (Forbidden).'

### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.