### PR TITLE
Python: Fix: Use HTTP exporter for http/protobuf protocol

### DIFF
--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -321,7 +321,7 @@ def _create_otlp_exporters(
     if not actual_logs_endpoint and not actual_traces_endpoint and not actual_metrics_endpoint:
         return exporters
 
-    if protocol in ("grpc", "http/protobuf"):
+    if protocol == "grpc":
         # Import all gRPC exporters
         try:
             from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter as GRPCLogExporter
@@ -357,7 +357,7 @@ def _create_otlp_exporters(
                 )
             )
 
-    elif protocol == "http":
+    elif protocol in ("http/protobuf", "http"):
         # Import all HTTP exporters
         try:
             from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter as HTTPLogExporter


### PR DESCRIPTION
## Summary

Fixes #3056

This PR fixes an issue where the `http/protobuf` protocol was incorrectly using gRPC exporters instead of HTTP exporters.

### Changes
- Changed `if protocol in ("grpc", "http/protobuf"):` to `if protocol == "grpc":` 
- Changed `elif protocol == "http":` to `elif protocol in ("http/protobuf", "http"):`

### Background

According to the [OpenTelemetry SDK specification](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/), OTLP supports three protocol options:
- `grpc` - Uses gRPC exporters (`opentelemetry-exporter-otlp-proto-grpc`)
- `http/protobuf` - Uses HTTP exporters (`opentelemetry-exporter-otlp-proto-http`)
- `http/json` - Uses HTTP exporters

The official OpenTelemetry Python SDK also maps these protocols correctly:
```python
_EXPORTER_BY_OTLP_PROTOCOL = {
    "grpc": _EXPORTER_OTLP_PROTO_GRPC,
    "http/protobuf": _EXPORTER_OTLP_PROTO_HTTP,
}
```

This fix aligns the Agent Framework with the OpenTelemetry specification.