### PR TITLE
Python: Fix ExecutorInvokedEvent and ExecutorCompletedEvent observability data

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -277,9 +277,11 @@ class Executor(RequestInfoMixin, DictConvertible):
                 await context.add_event(failure_event)
                 raise
             with _framework_event_origin():
-                # Include sent messages as the completion data
+                # Include sent messages and yielded outputs as the completion data
                 sent_messages = context.get_sent_messages()
-                completed_event = ExecutorCompletedEvent(self.id, sent_messages if sent_messages else None)
+                yielded_outputs = context.get_yielded_outputs()
+                completion_data = sent_messages + yielded_outputs
+                completed_event = ExecutorCompletedEvent(self.id, completion_data if completion_data else None)
             await context.add_event(completed_event)
 
     def _create_context_for_handler(

--- a/python/packages/core/tests/workflow/test_executor.py
+++ b/python/packages/core/tests/workflow/test_executor.py
@@ -184,8 +184,8 @@ async def test_executor_completed_event_contains_sent_messages():
         assert collector_completed.data is None
 
 
-async def test_executor_completed_event_none_when_no_messages_sent():
-    """Test that ExecutorCompletedEvent.data is None when no messages are sent."""
+async def test_executor_completed_event_includes_yielded_outputs():
+    """Test that ExecutorCompletedEvent.data includes yielded outputs."""
     from typing_extensions import Never
 
     from agent_framework import WorkflowOutputEvent
@@ -203,9 +203,10 @@ async def test_executor_completed_event_none_when_no_messages_sent():
 
     assert len(completed_events) == 1
     assert completed_events[0].executor_id == "yielder"
-    assert completed_events[0].data is None
+    # Yielded outputs are now included in ExecutorCompletedEvent.data
+    assert completed_events[0].data == ["TEST"]
 
-    # Verify the output was still yielded correctly
+    # Verify the output was also yielded as WorkflowOutputEvent
     output_events = [e for e in events if isinstance(e, WorkflowOutputEvent)]
     assert len(output_events) == 1
     assert output_events[0].data == "TEST"

--- a/python/samples/getting_started/workflows/observability/executor_io_observation.py
+++ b/python/samples/getting_started/workflows/observability/executor_io_observation.py
@@ -119,6 +119,7 @@ async def main() -> None:
         Input: str: 'HELLO WORLD'
     [WORKFLOW OUTPUT] str: 'DLROW OLLEH'
     [COMPLETED] reverse_text
+        Output: list: [str: 'DLROW OLLEH']
     """
 
 


### PR DESCRIPTION
### Motivation & Context

1. When an executor handler mutates its input (appending to a list), `ExecutorInvokedEvent.data` incorrectly reflects the mutated state instead of the original input at invocation time.

2. For workflow observability, `ExecutorCompletedEvent.data` only contained messages sent via `send_message()`, not outputs from `yield_output()`. This made it impossible to observe the output of terminal executors that only yield workflow outputs.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Closes #2929
- Closes #3080
- Use `copy.deepcopy()` when creating `ExecutorInvokedEvent` to preserve original input state
- Include yielded outputs in `ExecutorCompletedEvent.data` alongside sent messages
- Add `get_yielded_outputs()` method to `WorkflowContext`
- Update tests and sample expected output

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.