### PR TITLE
Python: fix(core): Honor tool_choice parameter passed to agent.run() and chat client methods

### DIFF
--- a/python/packages/core/agent_framework/_clients.py
+++ b/python/packages/core/agent_framework/_clients.py
@@ -101,7 +101,7 @@ class ChatClientProtocol(Protocol):
         stop: str | Sequence[str] | None = None,
         store: bool | None = None,
         temperature: float | None = None,
-        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = "auto",
+        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         tools: ToolProtocol
         | Callable[..., Any]
         | MutableMapping[str, Any]
@@ -160,7 +160,7 @@ class ChatClientProtocol(Protocol):
         stop: str | Sequence[str] | None = None,
         store: bool | None = None,
         temperature: float | None = None,
-        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = "auto",
+        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         tools: ToolProtocol
         | Callable[..., Any]
         | MutableMapping[str, Any]
@@ -501,7 +501,7 @@ class BaseChatClient(SerializationMixin, ABC):
         stop: str | Sequence[str] | None = None,
         store: bool | None = None,
         temperature: float | None = None,
-        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = "auto",
+        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         tools: ToolProtocol
         | Callable[..., Any]
         | MutableMapping[str, Any]
@@ -596,7 +596,7 @@ class BaseChatClient(SerializationMixin, ABC):
         stop: str | Sequence[str] | None = None,
         store: bool | None = None,
         temperature: float | None = None,
-        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = "auto",
+        tool_choice: ToolMode | Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         tools: ToolProtocol
         | Callable[..., Any]
         | MutableMapping[str, Any]
@@ -688,12 +688,18 @@ class BaseChatClient(SerializationMixin, ABC):
             chat_options: The chat options to prepare.
         """
         chat_tool_mode = chat_options.tool_choice
-        if chat_tool_mode is None or chat_tool_mode == ToolMode.NONE or chat_tool_mode == "none":
+        # Explicitly disabled: clear tools and set to NONE
+        if chat_tool_mode == ToolMode.NONE or chat_tool_mode == "none":
             chat_options.tools = None
             chat_options.tool_choice = ToolMode.NONE
             return
+        # No tools available: set to NONE regardless of requested mode
         if not chat_options.tools:
             chat_options.tool_choice = ToolMode.NONE
+        # Tools available but no explicit mode: default to AUTO
+        elif chat_tool_mode is None:
+            chat_options.tool_choice = ToolMode.AUTO
+        # Tools available with explicit mode: preserve the mode
         else:
             chat_options.tool_choice = chat_tool_mode
 

--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -205,8 +205,8 @@ class OpenAIBaseChatClient(OpenAIBase, BaseChatClient):
             run_options.pop("tools", None)
             run_options.pop("parallel_tool_calls", None)
             run_options.pop("tool_choice", None)
-        # tool choice when `tool_choice` is a dict with single key `mode`, extract the mode value
-        if (tool_choice := run_options.get("tool_choice")) and len(tool_choice.keys()) == 1:
+        # tool_choice: ToolMode serializes to {"type": "tool_mode", "mode": "..."}, extract mode
+        if (tool_choice := run_options.get("tool_choice")) and isinstance(tool_choice, dict) and "mode" in tool_choice:
             run_options["tool_choice"] = tool_choice["mode"]
 
         # response format

--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -435,8 +435,8 @@ class OpenAIBaseResponsesClient(OpenAIBase, BaseChatClient):
         else:
             run_options.pop("parallel_tool_calls", None)
             run_options.pop("tool_choice", None)
-        # tool choice when `tool_choice` is a dict with single key `mode`, extract the mode value
-        if (tool_choice := run_options.get("tool_choice")) and len(tool_choice.keys()) == 1:
+        # tool_choice: ToolMode serializes to {"type": "tool_mode", "mode": "..."}, extract mode
+        if (tool_choice := run_options.get("tool_choice")) and isinstance(tool_choice, dict) and "mode" in tool_choice:
             run_options["tool_choice"] = tool_choice["mode"]
 
         # additional properties

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -632,3 +632,93 @@ async def test_agent_tool_receives_thread_in_kwargs(chat_client_base: Any) -> No
     assert result.text == "done"
     assert captured.get("has_thread") is True
     assert captured.get("has_message_store") is True
+
+
+async def test_chat_agent_tool_choice_run_level_overrides_agent_level(
+    chat_client_base: Any, ai_function_tool: Any
+) -> None:
+    """Verify that tool_choice passed to run() overrides agent-level tool_choice."""
+    from agent_framework import ChatOptions, ToolMode
+
+    captured_options: list[ChatOptions] = []
+
+    # Store the original inner method
+    original_inner = chat_client_base._inner_get_response
+
+    async def capturing_inner(
+        *, messages: MutableSequence[ChatMessage], chat_options: ChatOptions, **kwargs: Any
+    ) -> ChatResponse:
+        captured_options.append(chat_options)
+        return await original_inner(messages=messages, chat_options=chat_options, **kwargs)
+
+    chat_client_base._inner_get_response = capturing_inner
+
+    # Create agent with agent-level tool_choice="auto" and a tool (tools required for tool_choice to be meaningful)
+    agent = ChatAgent(chat_client=chat_client_base, tool_choice="auto", tools=[ai_function_tool])
+
+    # Run with run-level tool_choice="required"
+    await agent.run("Hello", tool_choice="required")
+
+    # Verify the client received tool_choice="required", not "auto"
+    assert len(captured_options) >= 1
+    assert captured_options[0].tool_choice == "required"
+    assert captured_options[0].tool_choice == ToolMode.REQUIRED_ANY
+
+
+async def test_chat_agent_tool_choice_agent_level_used_when_run_level_not_specified(
+    chat_client_base: Any, ai_function_tool: Any
+) -> None:
+    """Verify that agent-level tool_choice is used when run() doesn't specify one."""
+    from agent_framework import ChatOptions, ToolMode
+
+    captured_options: list[ChatOptions] = []
+
+    original_inner = chat_client_base._inner_get_response
+
+    async def capturing_inner(
+        *, messages: MutableSequence[ChatMessage], chat_options: ChatOptions, **kwargs: Any
+    ) -> ChatResponse:
+        captured_options.append(chat_options)
+        return await original_inner(messages=messages, chat_options=chat_options, **kwargs)
+
+    chat_client_base._inner_get_response = capturing_inner
+
+    # Create agent with agent-level tool_choice="required" and a tool
+    agent = ChatAgent(chat_client=chat_client_base, tool_choice="required", tools=[ai_function_tool])
+
+    # Run without specifying tool_choice
+    await agent.run("Hello")
+
+    # Verify the client received tool_choice="required" from agent-level
+    assert len(captured_options) >= 1
+    assert captured_options[0].tool_choice == "required"
+    assert captured_options[0].tool_choice == ToolMode.REQUIRED_ANY
+
+
+async def test_chat_agent_tool_choice_none_at_run_preserves_agent_level(
+    chat_client_base: Any, ai_function_tool: Any
+) -> None:
+    """Verify that tool_choice=None at run() uses agent-level default."""
+    from agent_framework import ChatOptions
+
+    captured_options: list[ChatOptions] = []
+
+    original_inner = chat_client_base._inner_get_response
+
+    async def capturing_inner(
+        *, messages: MutableSequence[ChatMessage], chat_options: ChatOptions, **kwargs: Any
+    ) -> ChatResponse:
+        captured_options.append(chat_options)
+        return await original_inner(messages=messages, chat_options=chat_options, **kwargs)
+
+    chat_client_base._inner_get_response = capturing_inner
+
+    # Create agent with agent-level tool_choice="auto" and a tool
+    agent = ChatAgent(chat_client=chat_client_base, tool_choice="auto", tools=[ai_function_tool])
+
+    # Run with explicitly passing None (same as not specifying)
+    await agent.run("Hello", tool_choice=None)
+
+    # Verify the client received tool_choice="auto" from agent-level
+    assert len(captured_options) >= 1
+    assert captured_options[0].tool_choice == "auto"


### PR DESCRIPTION
### Motivation and Context

When passing `tool_choice="required"` to `agent.run()` or directly to chat client methods, the value was being silently reverted to `"auto"` or `"none"` before reaching the model. This prevented users from controlling tool invocation behavior at runtime.

Three issues were identified:

1. OpenAI client dict extraction - The condition `len(tool_choice.keys()) == 1` failed because `ToolMode.to_dict()` returns `{"type": "tool_mode", "mode": "required"}` (2 keys), causing the mode extraction to fail.

2. Default parameter override - `BaseChatClient.get_response()` and `get_streaming_response()` had `tool_choice="auto"` as the default parameter. When merged with `chat_options`, this default overrode user-specified values.

3. None treated as disable - `_prepare_tool_choice()` treated `tool_choice=None` the same as `"none"`, clearing tools and disabling tool use even when tools were provided.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Changed OpenAI client tool_choice extraction to check for `"mode"` key presence instead of dict key count.
- Changed default `tool_choice` parameter from `"auto"` to `None` in ChatClientProtocol / BaseChatClient
- Updated `_prepare_tool_choice()` logic
- Added new tests for coverage

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.