### PR TITLE
Python: Support A2A connections without target URL for Foundry `A2ATool`

### DIFF
--- a/python/samples/getting_started/agents/azure_ai/azure_ai_with_agent_to_agent.py
+++ b/python/samples/getting_started/agents/azure_ai/azure_ai_with_agent_to_agent.py
@@ -14,11 +14,23 @@ to enable communication with other agents using the A2A protocol.
 Prerequisites:
 1. Set AZURE_AI_PROJECT_ENDPOINT and AZURE_AI_MODEL_DEPLOYMENT_NAME environment variables.
 2. Ensure you have an A2A connection configured in your Azure AI project
-    and set A2A_PROJECT_CONNECTION_ID environment variable.
+   and set A2A_PROJECT_CONNECTION_ID environment variable.
+3. (Optional) A2A_ENDPOINT - If the connection is missing target (e.g., "Custom keys" type),
+   set the A2A endpoint URL directly.
 """
 
 
 async def main() -> None:
+    # Configure A2A tool with connection ID
+    a2a_tool = {
+        "type": "a2a_preview",
+        "project_connection_id": os.environ["A2A_PROJECT_CONNECTION_ID"],
+    }
+    
+    # If the connection is missing a target, we need to set the A2A endpoint URL
+    if os.environ.get("A2A_ENDPOINT"):
+        a2a_tool["base_url"] = os.environ["A2A_ENDPOINT"]
+    
     async with (
         AzureCliCredential() as credential,
         AzureAIClient(credential=credential).create_agent(
@@ -26,10 +38,7 @@ async def main() -> None:
             instructions="""You are a helpful assistant that can communicate with other agents.
             Use the A2A tool when you need to interact with other agents to complete tasks
             or gather information from specialized agents.""",
-            tools={
-                "type": "a2a_preview",
-                "project_connection_id": os.environ["A2A_PROJECT_CONNECTION_ID"],
-            },
+            tools=a2a_tool,
         ) as agent,
     ):
         query = "What can the secondary agent do?"


### PR DESCRIPTION
### Motivation and Context
This change aligns with Azure SDK's pattern for handling A2A connections that may not have a target URL configured (e.g., Custom Keys connection type).
Their `RemoteA2A` connection type is not available to GA and hence, we need to use Custom keys

Changes:
- Add conditional base_url support when A2A_ENDPOINT env var is set
- Always use project_connection_id for connection management
- Update documentation to explain optional A2A_ENDPOINT usage
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.