### PR TITLE
Python: Fix Anthropic streaming response bugs

### DIFF
--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -536,9 +536,7 @@ class AnthropicClient(BaseChatClient):
                 usage = self._parse_usage_from_anthropic(event.usage)
                 return ChatResponseUpdate(
                     contents=[UsageContent(details=usage, raw_representation=event.usage)] if usage else [],
-                    finish_reason=FINISH_REASON_MAP.get(event.delta.stop_reason)
-                    if event.delta.stop_reason
-                    else None,
+                    finish_reason=FINISH_REASON_MAP.get(event.delta.stop_reason) if event.delta.stop_reason else None,
                     raw_representation=event,
                 )
             case "message_stop":


### PR DESCRIPTION
### Motivation and Context

Fixes two bugs in the Anthropic chat client streaming implementation:

### Description

1. Use `raw_representation` instead of `raw_response` parameter (which was silently ignored)
2. Extract `finish_reason` from `event.delta.stop_reason` in `message_delta` events

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.