### PR TITLE
.NET: fix: AIAgent - DebuggerDisplay using a non-existing Property

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Agents.AI;
 /// and process user requests. An agent instance may participate in multiple concurrent conversations, and each conversation
 /// may involve multiple agents working together.
 /// </remarks>
-[DebuggerDisplay("{DisplayName,nq}")]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public abstract class AIAgent
 {
     /// <summary>
@@ -71,6 +71,9 @@ public abstract class AIAgent
     /// which is particularly useful in multi-agent systems.
     /// </remarks>
     public virtual string? Description { get; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => string.IsNullOrWhiteSpace(this.Name) ? $"Id = {this.Id}" : $"Name = {this.Name} ({this.Id})";
 
     /// <summary>Asks the <see cref="AIAgent"/> for an object of the specified type <paramref name="serviceType"/>.</summary>
     /// <param name="serviceType">The type of object being requested.</param>


### PR DESCRIPTION
### Motivation and Context

In a recent update, the property `DisplayName` was removed from AIAgent.cs, but the property is still used in the class DebuggerDisplay attribute.

Because of this, when debugging, you see this when hovering the mouse over the agent:

<img width="1115" height="62" alt="image" src="https://github.com/user-attachments/assets/24acc429-32cb-48ef-bd7b-6d06a9d4ba8d" />

### Description

This PR fixes this by introducing a private DebuggerDisplay (like many other classes in AF do) that either shows Name + Id (if name is provided)

<img width="973" height="81" alt="image" src="https://github.com/user-attachments/assets/b1e71518-0deb-446f-97ae-14145e9d3451" />

or just the Id if the Agent does not have a name

<img width="805" height="71" alt="image" src="https://github.com/user-attachments/assets/66942656-9dab-4f6e-bdd1-666053709efb" />

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.