### PR TITLE
.NET: [BREAKING] fix: Subworkflows do not work well with Chat Protocol and Checkpointing

### DIFF
--- a/dotnet/samples/GettingStarted/Workflows/Checkpoint/CheckpointAndRehydrate/Program.cs
+++ b/dotnet/samples/GettingStarted/Workflows/Checkpoint/CheckpointAndRehydrate/Program.cs
@@ -73,7 +73,7 @@ public static class Program
         CheckpointInfo savedCheckpoint = checkpoints[CheckpointIndex];
 
         await using Checkpointed<StreamingRun> newCheckpointedRun =
-            await InProcessExecution.ResumeStreamAsync(newWorkflow, savedCheckpoint, checkpointManager, checkpointedRun.Run.RunId);
+            await InProcessExecution.ResumeStreamAsync(newWorkflow, savedCheckpoint, checkpointManager);
 
         await foreach (WorkflowEvent evt in newCheckpointedRun.Run.WatchStreamAsync())
         {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ChatProtocol.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ChatProtocol.cs
@@ -20,12 +20,19 @@ public static class ChatProtocolExtensions
     /// Determines whether the specified protocol descriptor represents the Agent Workflow Chat Protocol.
     /// </summary>
     /// <param name="descriptor">The protocol descriptor to evaluate.</param>
+    /// <param name="allowCatchAll">If <see langword="true"/>, will allow protocols handling all inputs to be treated
+    /// as a Chat Protocol</param>
     /// <returns><see langword="true"/> if the protocol descriptor represents a supported chat protocol; otherwise, <see
     /// langword="false"/>.</returns>
-    public static bool IsChatProtocol(this ProtocolDescriptor descriptor)
+    public static bool IsChatProtocol(this ProtocolDescriptor descriptor, bool allowCatchAll = false)
     {
         bool foundListChatMessageInput = false;
         bool foundTurnTokenInput = false;
+
+        if (allowCatchAll && descriptor.AcceptsAll)
+        {
+            return true;
+        }
 
         // We require that the workflow be a ChatProtocol; right now that is defined as accepting at
         // least List<ChatMessage> as input (pending polymorphism/interface-input support), as well as
@@ -50,9 +57,11 @@ public static class ChatProtocolExtensions
     /// Throws an exception if the specified protocol descriptor does not represent a valid chat protocol.
     /// </summary>
     /// <param name="descriptor">The protocol descriptor to validate as a chat protocol. Cannot be null.</param>
-    public static void ThrowIfNotChatProtocol(this ProtocolDescriptor descriptor)
+    /// <param name="allowCatchAll">If <see langword="true"/>, will allow protocols handling all inputs to be treated
+    /// as a Chat Protocol</param>
+    public static void ThrowIfNotChatProtocol(this ProtocolDescriptor descriptor, bool allowCatchAll = false)
     {
-        if (!descriptor.IsChatProtocol())
+        if (!descriptor.IsChatProtocol(allowCatchAll))
         {
             throw new InvalidOperationException("Workflow does not support ChatProtocol: At least List<ChatMessage>" +
                 " and TurnToken must be supported as input.");

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ChatProtocolExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ChatProtocolExecutor.cs
@@ -29,6 +29,12 @@ public abstract class ChatProtocolExecutor : StatefulExecutor<List<ChatMessage>>
     private static readonly Func<List<ChatMessage>> s_initFunction = () => [];
     private readonly ChatRole? _stringMessageChatRole;
 
+    private static readonly StatefulExecutorOptions s_baseExecutorOptions = new()
+    {
+        AutoSendMessageHandlerResultObject = false,
+        AutoYieldOutputHandlerResultObject = false
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ChatProtocolExecutor"/> class.
     /// </summary>
@@ -36,7 +42,7 @@ public abstract class ChatProtocolExecutor : StatefulExecutor<List<ChatMessage>>
     /// <param name="options">Optional configuration settings for the executor. If null, default options are used.</param>
     /// <param name="declareCrossRunShareable">Declare that this executor may be used simultaneously by multiple runs safely.</param>
     protected ChatProtocolExecutor(string id, ChatProtocolExecutorOptions? options = null, bool declareCrossRunShareable = false)
-        : base(id, () => [], declareCrossRunShareable: declareCrossRunShareable)
+        : base(id, () => [], s_baseExecutorOptions, declareCrossRunShareable)
     {
         this._stringMessageChatRole = options?.StringMessageChatRole;
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/ISuperStepJoinContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/ISuperStepJoinContext.cs
@@ -13,6 +13,7 @@ internal interface ISuperStepJoinContext
 
     ValueTask ForwardWorkflowEventAsync(WorkflowEvent workflowEvent, CancellationToken cancellationToken = default);
     ValueTask SendMessageAsync<TMessage>(string senderId, [DisallowNull] TMessage message, CancellationToken cancellationToken = default);
+    ValueTask YieldOutputAsync<TOutput>(string senderId, [DisallowNull] TOutput output, CancellationToken cancellationToken = default);
 
     ValueTask<string> AttachSuperstepAsync(ISuperStepRunner superStepRunner, CancellationToken cancellationToken = default);
     ValueTask<bool> DetachSuperstepAsync(string id);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Executor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Executor.cs
@@ -210,7 +210,7 @@ public abstract class Executor : IIdentified
         // TODO: Once burden of annotating yield/output messages becomes easier for the non-Auto case,
         // we should (1) start checking for validity on output/send side, and (2) add the Yield/Send
         // types to the ProtocolDescriptor.
-        return new(this.InputTypes);
+        return new(this.InputTypes, this.Router.HasCatchAll);
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/IWorkflowExecutionEnvironment.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/IWorkflowExecutionEnvironment.cs
@@ -75,10 +75,9 @@ public interface IWorkflowExecutionEnvironment
     /// <param name="workflow">The workflow to be executed. Must not be <c>null</c>.</param>
     /// <param name="fromCheckpoint">The <see cref="CheckpointInfo"/> corresponding to the checkpoint from which to resume.</param>
     /// <param name="checkpointManager">The <see cref="CheckpointManager"/> to use with this run.</param>
-    /// <param name="runId">An optional unique identifier for the run. If not provided, a new identifier will be generated.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A <see cref="StreamingRun"/> that provides access to the results of the streaming run.</returns>
-    ValueTask<Checkpointed<StreamingRun>> ResumeStreamAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default);
+    ValueTask<Checkpointed<StreamingRun>> ResumeStreamAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Initiates a non-streaming execution of the workflow with the specified input.
@@ -117,9 +116,8 @@ public interface IWorkflowExecutionEnvironment
     /// <param name="workflow">The workflow to be executed. Must not be <c>null</c>.</param>
     /// <param name="fromCheckpoint">The <see cref="CheckpointInfo"/> corresponding to the checkpoint from which to resume.</param>
     /// <param name="checkpointManager">The <see cref="CheckpointManager"/> to use with this run.</param>
-    /// <param name="runId">An optional unique identifier for the run. If not provided, a new identifier will be generated.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A <see cref="ValueTask{Run}"/> that represents the asynchronous operation. The result contains a <see
     /// cref="Run"/> for managing and interacting with the streaming run.</returns>
-    ValueTask<Checkpointed<Run>> ResumeAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default);
+    ValueTask<Checkpointed<Run>> ResumeAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessExecutionEnvironment.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessExecutionEnvironment.cs
@@ -30,9 +30,9 @@ public sealed class InProcessExecutionEnvironment : IWorkflowExecutionEnvironmen
         return runner.BeginStreamAsync(this.ExecutionMode, cancellationToken);
     }
 
-    internal ValueTask<AsyncRunHandle> ResumeRunAsync(Workflow workflow, ICheckpointManager? checkpointManager, string? runId, CheckpointInfo fromCheckpoint, IEnumerable<Type> knownValidInputTypes, CancellationToken cancellationToken)
+    internal ValueTask<AsyncRunHandle> ResumeRunAsync(Workflow workflow, ICheckpointManager? checkpointManager, CheckpointInfo fromCheckpoint, IEnumerable<Type> knownValidInputTypes, CancellationToken cancellationToken)
     {
-        InProcessRunner runner = InProcessRunner.CreateTopLevelRunner(workflow, checkpointManager, runId, this.EnableConcurrentRuns, knownValidInputTypes);
+        InProcessRunner runner = InProcessRunner.CreateTopLevelRunner(workflow, checkpointManager, fromCheckpoint.RunId, this.EnableConcurrentRuns, knownValidInputTypes);
         return runner.ResumeStreamAsync(this.ExecutionMode, fromCheckpoint, cancellationToken);
     }
 
@@ -95,10 +95,9 @@ public sealed class InProcessExecutionEnvironment : IWorkflowExecutionEnvironmen
         Workflow workflow,
         CheckpointInfo fromCheckpoint,
         CheckpointManager checkpointManager,
-        string? runId = null,
         CancellationToken cancellationToken = default)
     {
-        AsyncRunHandle runHandle = await this.ResumeRunAsync(workflow, checkpointManager, runId: runId, fromCheckpoint, [], cancellationToken)
+        AsyncRunHandle runHandle = await this.ResumeRunAsync(workflow, checkpointManager, fromCheckpoint, [], cancellationToken)
                                              .ConfigureAwait(false);
 
         return await runHandle.WithCheckpointingAsync<StreamingRun>(() => new(new StreamingRun(runHandle)))
@@ -172,10 +171,9 @@ public sealed class InProcessExecutionEnvironment : IWorkflowExecutionEnvironmen
         Workflow workflow,
         CheckpointInfo fromCheckpoint,
         CheckpointManager checkpointManager,
-        string? runId = null,
         CancellationToken cancellationToken = default)
     {
-        AsyncRunHandle runHandle = await this.ResumeRunAsync(workflow, checkpointManager, runId: runId, fromCheckpoint, [], cancellationToken)
+        AsyncRunHandle runHandle = await this.ResumeRunAsync(workflow, checkpointManager, fromCheckpoint, [], cancellationToken)
                                              .ConfigureAwait(false);
 
         return await runHandle.WithCheckpointingAsync<Run>(() => new(new Run(runHandle)))

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProcessExecution.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProcessExecution.cs
@@ -57,9 +57,9 @@ public static class InProcessExecution
     public static ValueTask<Checkpointed<StreamingRun>> StreamAsync<TInput>(Workflow workflow, TInput input, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default) where TInput : notnull
         => Default.StreamAsync(workflow, input, checkpointManager, runId, cancellationToken);
 
-    /// <inheritdoc cref="IWorkflowExecutionEnvironment.ResumeStreamAsync(Workflow, CheckpointInfo, CheckpointManager, string?, CancellationToken)"/>
-    public static ValueTask<Checkpointed<StreamingRun>> ResumeStreamAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default)
-        => Default.ResumeStreamAsync(workflow, fromCheckpoint, checkpointManager, runId, cancellationToken);
+    /// <inheritdoc cref="IWorkflowExecutionEnvironment.ResumeStreamAsync(Workflow, CheckpointInfo, CheckpointManager, CancellationToken)"/>
+    public static ValueTask<Checkpointed<StreamingRun>> ResumeStreamAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, CancellationToken cancellationToken = default)
+        => Default.ResumeStreamAsync(workflow, fromCheckpoint, checkpointManager, cancellationToken);
 
     /// <inheritdoc cref="IWorkflowExecutionEnvironment.RunAsync{TInput}(Workflow, TInput, string?, CancellationToken)"/>
     public static ValueTask<Run> RunAsync<TInput>(Workflow workflow, TInput input, string? runId = null, CancellationToken cancellationToken = default) where TInput : notnull
@@ -69,7 +69,7 @@ public static class InProcessExecution
     public static ValueTask<Checkpointed<Run>> RunAsync<TInput>(Workflow workflow, TInput input, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default) where TInput : notnull
         => Default.RunAsync(workflow, input, checkpointManager, runId, cancellationToken);
 
-    /// <inheritdoc cref="IWorkflowExecutionEnvironment.ResumeAsync(Workflow, CheckpointInfo, CheckpointManager, string?, CancellationToken)"/>
-    public static ValueTask<Checkpointed<Run>> ResumeAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, string? runId = null, CancellationToken cancellationToken = default)
-        => Default.ResumeAsync(workflow, fromCheckpoint, checkpointManager, runId, cancellationToken);
+    /// <inheritdoc cref="IWorkflowExecutionEnvironment.ResumeAsync(Workflow, CheckpointInfo, CheckpointManager, CancellationToken)"/>
+    public static ValueTask<Checkpointed<Run>> ResumeAsync(Workflow workflow, CheckpointInfo fromCheckpoint, CheckpointManager checkpointManager, CancellationToken cancellationToken = default)
+        => Default.ResumeAsync(workflow, fromCheckpoint, checkpointManager, cancellationToken);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ProtocolDescriptor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ProtocolDescriptor.cs
@@ -12,12 +12,18 @@ namespace Microsoft.Agents.AI.Workflows;
 public class ProtocolDescriptor
 {
     /// <summary>
-    /// Get the collection of types accepted by the <see cref="Workflow"/> or <see cref="Executor"/>.
+    /// Get the collection of types explicitly accepted by the <see cref="Workflow"/> or <see cref="Executor"/>.
     /// </summary>
     public IEnumerable<Type> Accepts { get; }
 
-    internal ProtocolDescriptor(IEnumerable<Type> acceptedTypes)
+    /// <summary>
+    /// Gets a value indicating whether the <see cref="Workflow"/> or <see cref="Executor"/> has a "catch-all" handler.
+    /// </summary>
+    public bool AcceptsAll { get; set; }
+
+    internal ProtocolDescriptor(IEnumerable<Type> acceptedTypes, bool acceptsAll)
     {
         this.Accepts = acceptedTypes.ToArray();
+        this.AcceptsAll = acceptsAll;
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/OutputMessagesExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/OutputMessagesExecutor.cs
@@ -7,17 +7,16 @@ using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.Workflows;
 
-public static partial class AgentWorkflowBuilder
+/// <summary>
+/// Provides an executor that batches received chat messages that it then publishes as the final result
+/// when receiving a <see cref="TurnToken"/>.
+/// </summary>
+internal sealed class OutputMessagesExecutor(ChatProtocolExecutorOptions? options = null) : ChatProtocolExecutor(ExecutorId, options, declareCrossRunShareable: true), IResettableExecutor
 {
-    /// <summary>
-    /// Provides an executor that batches received chat messages that it then publishes as the final result
-    /// when receiving a <see cref="TurnToken"/>.
-    /// </summary>
-    internal sealed class OutputMessagesExecutor() : ChatProtocolExecutor("OutputMessages", declareCrossRunShareable: true), IResettableExecutor
-    {
-        protected override ValueTask TakeTurnAsync(List<ChatMessage> messages, IWorkflowContext context, bool? emitEvents, CancellationToken cancellationToken = default)
-            => context.YieldOutputAsync(messages, cancellationToken);
+    public const string ExecutorId = "OutputMessages";
 
-        ValueTask IResettableExecutor.ResetAsync() => default;
-    }
+    protected override ValueTask TakeTurnAsync(List<ChatMessage> messages, IWorkflowContext context, bool? emitEvents, CancellationToken cancellationToken = default)
+        => context.YieldOutputAsync(messages, cancellationToken);
+
+    ValueTask IResettableExecutor.ResetAsync() => default;
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/SubworkflowBinding.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/SubworkflowBinding.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Agents.AI.Workflows;
 /// <param name="ExecutorOptions"></param>
 public record SubworkflowBinding(Workflow WorkflowInstance, string Id, ExecutorOptions? ExecutorOptions = null)
     : ExecutorBinding(Throw.IfNull(Id),
-                           CreateWorkflowExecutorFactory(WorkflowInstance, Id, ExecutorOptions),
-                           typeof(WorkflowHostExecutor),
-                           WorkflowInstance)
+                      CreateWorkflowExecutorFactory(WorkflowInstance, Id, ExecutorOptions),
+                      typeof(WorkflowHostExecutor),
+                      WorkflowInstance)
 {
     private static Func<string, ValueTask<Executor>> CreateWorkflowExecutorFactory(Workflow workflow, string id, ExecutorOptions? options)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
@@ -166,9 +166,9 @@ public class Workflow
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1513:Use ObjectDisposedException throw helper",
             Justification = "Does not exist in NetFx 4.7.2")]
-    internal async ValueTask ReleaseOwnershipAsync(object ownerToken)
+    internal async ValueTask ReleaseOwnershipAsync(object ownerToken, object? targetOwnerToken)
     {
-        object? originalToken = Interlocked.CompareExchange(ref this._ownerToken, null, ownerToken) ??
+        object? originalToken = Interlocked.CompareExchange(ref this._ownerToken, targetOwnerToken, ownerToken) ??
             throw new InvalidOperationException("Attempting to release ownership of a Workflow that is not owned.");
 
         if (!ReferenceEquals(originalToken, ownerToken))

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
@@ -23,6 +23,8 @@ public static class WorkflowHostingExtensions
     /// <see cref="InProcessExecution.Lockstep"/> for the in-process environments.</param>
     /// <param name="includeExceptionDetails">If <see langword="true"/>, will include <see cref="System.Exception.Message"/>
     /// in the <see cref="ErrorContent"/> representing the workflow error.</param>
+    /// <param name="includeWorkflowOutputsInResponse">If <see langword="true"/>, will transform outgoing workflow outputs
+    /// into into content in <see cref="AgentResponseUpdate"/>s or the <see cref="AgentResponse"/> as appropriate.</param>
     /// <returns></returns>
     public static AIAgent AsAgent(
         this Workflow workflow,
@@ -31,9 +33,10 @@ public static class WorkflowHostingExtensions
         string? description = null,
         CheckpointManager? checkpointManager = null,
         IWorkflowExecutionEnvironment? executionEnvironment = null,
-        bool includeExceptionDetails = false)
+        bool includeExceptionDetails = false,
+        bool includeWorkflowOutputsInResponse = false)
     {
-        return new WorkflowHostAgent(workflow, id, name, description, checkpointManager, executionEnvironment, includeExceptionDetails);
+        return new WorkflowHostAgent(workflow, id, name, description, checkpointManager, executionEnvironment, includeExceptionDetails, includeWorkflowOutputsInResponse);
     }
 
     internal static FunctionCallContent ToFunctionCall(this ExternalRequest request)

--- a/dotnet/src/Shared/Workflows/Execution/WorkflowRunner.cs
+++ b/dotnet/src/Shared/Workflows/Execution/WorkflowRunner.cs
@@ -95,7 +95,7 @@ internal sealed class WorkflowRunner
                 Debug.WriteLine($"RESTORE #{this.LastCheckpoint.CheckpointId}");
                 Notify("WORKFLOW: Restore", ConsoleColor.DarkYellow);
 
-                run = await InProcessExecution.ResumeStreamAsync(workflow, this.LastCheckpoint, checkpointManager, run.Run.RunId).ConfigureAwait(false);
+                run = await InProcessExecution.ResumeStreamAsync(workflow, this.LastCheckpoint, checkpointManager).ConfigureAwait(false);
             }
             else
             {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Framework/WorkflowHarness.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Framework/WorkflowHarness.cs
@@ -55,7 +55,7 @@ internal sealed class WorkflowHarness(Workflow workflow, string runId)
     {
         Console.WriteLine("\nRESUMING WORKFLOW...");
         Assert.NotNull(this._lastCheckpoint);
-        Checkpointed<StreamingRun> run = await InProcessExecution.ResumeStreamAsync(workflow, this._lastCheckpoint, this.GetCheckpointManager(), runId);
+        Checkpointed<StreamingRun> run = await InProcessExecution.ResumeStreamAsync(workflow, this._lastCheckpoint, this.GetCheckpointManager());
         IReadOnlyList<WorkflowEvent> workflowEvents = await MonitorAndDisposeWorkflowRunAsync(run, response).ToArrayAsync();
         return new WorkflowEvents(workflowEvents);
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/05_Simple_Workflow_Checkpointing.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/05_Simple_Workflow_Checkpointing.cs
@@ -42,7 +42,7 @@ internal static class Step5EntryPoint
         {
             await handle.DisposeAsync().ConfigureAwait(false);
 
-            checkpointed = await environment.ResumeStreamAsync(workflow, targetCheckpoint, checkpointManager, runId: handle.RunId, cancellationToken: CancellationToken.None)
+            checkpointed = await environment.ResumeStreamAsync(workflow, targetCheckpoint, checkpointManager, cancellationToken: CancellationToken.None)
                                             .ConfigureAwait(false);
             handle = checkpointed.Run;
         }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/13_Subworkflow_Checkpointing.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/Sample/13_Subworkflow_Checkpointing.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.Sample;
+
+internal static class Step13EntryPoint
+{
+    public static Workflow SubworkflowInstance
+    {
+        get
+        {
+            OutputMessagesExecutor output = new(new ChatProtocolExecutorOptions() { StringMessageChatRole = ChatRole.User });
+            return new WorkflowBuilder(output).WithOutputFrom(output).Build();
+        }
+    }
+
+    public static Workflow WorkflowInstance
+    {
+        get
+        {
+            ExecutorBinding subworkflow = SubworkflowInstance.BindAsExecutor("EchoSubworkflow");
+            return new WorkflowBuilder(subworkflow).WithOutputFrom(subworkflow).Build();
+        }
+    }
+
+    public static async ValueTask<AgentThread> RunAsAgentAsync(TextWriter writer, string input, IWorkflowExecutionEnvironment environment, AgentThread? thread)
+    {
+        AIAgent hostAgent = WorkflowInstance.AsAgent("echo-workflow", "EchoW", executionEnvironment: environment, includeWorkflowOutputsInResponse: true);
+
+        thread ??= await hostAgent.GetNewThreadAsync();
+        AgentResponse response;
+        ResponseContinuationToken? continuationToken = null;
+        do
+        {
+            response = await hostAgent.RunAsync(input, thread, new AgentRunOptions { ContinuationToken = continuationToken });
+        } while ((continuationToken = response.ContinuationToken) is { });
+
+        foreach (ChatMessage message in response.Messages)
+        {
+            writer.WriteLine($"{message.AuthorName}: {message.Text}");
+        }
+
+        return thread;
+    }
+
+    public static async ValueTask<CheckpointInfo> RunAsync(TextWriter writer, string input, IWorkflowExecutionEnvironment environment, CheckpointManager checkpointManager, CheckpointInfo? resumeFrom)
+    {
+        await using Checkpointed<StreamingRun> checkpointed = await BeginAsync();
+        StreamingRun run = checkpointed.Run;
+
+        await run.TrySendMessageAsync(new TurnToken());
+
+        CheckpointInfo? lastCheckpoint = null;
+        await foreach (WorkflowEvent evt in run.WatchStreamAsync())
+        {
+            if (evt is WorkflowOutputEvent output)
+            {
+                if (output.Data is List<ChatMessage> messages)
+                {
+                    foreach (ChatMessage message in messages)
+                    {
+                        writer.WriteLine($"{output.SourceId}: {message.Text}");
+                    }
+                }
+                else
+                {
+                    Debug.Fail($"Unexpected output type: {(output.Data == null ? "null" : output.Data?.GetType().Name)}");
+                }
+            }
+            else if (evt is SuperStepCompletedEvent stepCompleted)
+            {
+                lastCheckpoint = stepCompleted.CompletionInfo?.Checkpoint;
+            }
+        }
+
+        return lastCheckpoint!;
+
+        async ValueTask<Checkpointed<StreamingRun>> BeginAsync()
+        {
+            if (resumeFrom == null)
+            {
+                return await environment.StreamAsync(WorkflowInstance, input, checkpointManager);
+            }
+
+            Checkpointed<StreamingRun> checkpointed = await environment.ResumeStreamAsync(WorkflowInstance, resumeFrom, checkpointManager);
+            await checkpointed.Run.TrySendMessageAsync(input);
+            return checkpointed;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Subworkflows run into issues with Checkpointing and the Chat Protocol:

- The concurrency rework made subtle changes in behaviour that introduced a hang when using subworkflows with `ChatProtocol` and streaming execution.
- The `ResetAsync()` implementation in `WorkflowHostExecutor` was improperly resetting the `joinContext` - this was happening on restore checkpoint _after_ the join context was attached when the executor is instantiated
- Subworkflows cannot be used as the start node when hosted `AsAgent()` due to inability to treat Catch-All as a Chat Protocol
- Subworkflow ownership issue when used in non-concurrent mode after finishing a run

Also fixes:
* When `ChatMessages` are output by executors that are not agents, there is no corresponding `AgentResponseUpdate`/`AgentResponse` event

Breaking Changes
* [BREAKING CHANGE] It is possible to provide the wrong `runId` when resuming from `CheckpointInfo` (even though the data already exists on `CheckpointInfo`), which could lead to odd error like "unable to find checkpoint with ID=..."

### Description

Multiple fixes targeting related capabilities around Subworkflows and Checkpointing both AsAgent and directly:
- Fixes #2585
- Fixes #2140 

Also fixes:
* Subworkflow outputs do not get output through the parent workflow (fixes #2163)
* When ChatMessages are output by executors that are not agents, there is no corresponding AgentRunUpdate/AgentRunResponse event

Likely relevant to #2419, will validate / add test in separate PR.

Breaking Changes
* [BREAKING CHANGE] Removes the `runId` argument from `ResumeAsync()` and `ResumeStreamAsync()`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.