### PR TITLE
Python: [BREAKING] Renamed create_agent to as_agent

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
@@ -4,18 +4,21 @@ import ast
 import json
 import re
 import sys
-from collections.abc import AsyncIterable, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import AsyncIterable, Callable, Mapping, MutableMapping, MutableSequence, Sequence
 from typing import Any, ClassVar, Generic, TypedDict
 
 from agent_framework import (
     AGENT_FRAMEWORK_USER_AGENT,
     BaseChatClient,
+    ChatAgent,
     ChatMessage,
+    ChatMessageStoreProtocol,
     ChatOptions,
     ChatResponse,
     ChatResponseUpdate,
     CitationAnnotation,
     Contents,
+    ContextProvider,
     DataContent,
     FunctionApprovalRequestContent,
     FunctionApprovalResponseContent,
@@ -23,6 +26,7 @@ from agent_framework import (
     FunctionResultContent,
     HostedFileContent,
     HostedMCPTool,
+    Middleware,
     Role,
     TextContent,
     TextSpanRegion,
@@ -1162,3 +1166,58 @@ class AzureAIAgentClient(BaseChatClient[TAzureAIAgentOptions], Generic[TAzureAIA
             The service URL for the chat client, or None if not set.
         """
         return self.agents_client._config.endpoint  # type: ignore
+
+    def as_agent(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        instructions: str | None = None,
+        tools: ToolProtocol
+        | Callable[..., Any]
+        | MutableMapping[str, Any]
+        | Sequence[ToolProtocol | Callable[..., Any] | MutableMapping[str, Any]]
+        | None = None,
+        default_options: TAzureAIAgentOptions | None = None,
+        chat_message_store_factory: Callable[[], ChatMessageStoreProtocol] | None = None,
+        context_provider: ContextProvider | None = None,
+        middleware: Sequence[Middleware] | None = None,
+        **kwargs: Any,
+    ) -> ChatAgent[TAzureAIAgentOptions]:
+        """Convert this chat client to a ChatAgent.
+
+        This method creates a ChatAgent instance with this client pre-configured.
+        It does NOT create an agent on the Azure AI service - the actual agent
+        will be created on the server during the first invocation (run).
+
+        For creating and managing persistent agents on the server, use
+        :class:`~agent_framework_azure_ai.AzureAIAgentsProvider` instead.
+
+        Keyword Args:
+            id: The unique identifier for the agent. Will be created automatically if not provided.
+            name: The name of the agent.
+            description: A brief description of the agent's purpose.
+            instructions: Optional instructions for the agent.
+            tools: The tools to use for the request.
+            default_options: A TypedDict containing chat options.
+            chat_message_store_factory: Factory function to create an instance of ChatMessageStoreProtocol.
+            context_provider: Context providers to include during agent invocation.
+            middleware: List of middleware to intercept agent and function invocations.
+            kwargs: Any additional keyword arguments.
+
+        Returns:
+            A ChatAgent instance configured with this chat client.
+        """
+        return super().as_agent(
+            id=id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            tools=tools,
+            default_options=default_options,
+            chat_message_store_factory=chat_message_store_factory,
+            context_provider=context_provider,
+            middleware=middleware,
+            **kwargs,
+        )

--- a/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
@@ -1167,6 +1167,7 @@ class AzureAIAgentClient(BaseChatClient[TAzureAIAgentOptions], Generic[TAzureAIA
         """
         return self.agents_client._config.endpoint  # type: ignore
 
+    @override
     def as_agent(
         self,
         *,

--- a/python/packages/azure-ai/agent_framework_azure_ai/_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_client.py
@@ -517,6 +517,7 @@ class AzureAIClient(OpenAIBaseResponsesClient[TAzureAIClientOptions], Generic[TA
 
         return mcp
 
+    @override
     def as_agent(
         self,
         *,

--- a/python/packages/azure-ai/agent_framework_azure_ai/_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_client.py
@@ -1,14 +1,19 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import sys
-from collections.abc import Mapping, MutableSequence
+from collections.abc import Callable, Mapping, MutableMapping, MutableSequence, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypedDict, TypeVar, cast
 
 from agent_framework import (
     AGENT_FRAMEWORK_USER_AGENT,
+    ChatAgent,
     ChatMessage,
+    ChatMessageStoreProtocol,
+    ContextProvider,
     HostedMCPTool,
+    Middleware,
     TextContent,
+    ToolProtocol,
     get_logger,
     use_chat_middleware,
     use_function_invocation,
@@ -511,3 +516,58 @@ class AzureAIClient(OpenAIBaseResponsesClient[TAzureAIClientOptions], Generic[TA
                         mcp["require_approval"] = {"never": {"tool_names": list(never_require_approvals)}}
 
         return mcp
+
+    def as_agent(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        instructions: str | None = None,
+        tools: ToolProtocol
+        | Callable[..., Any]
+        | MutableMapping[str, Any]
+        | Sequence[ToolProtocol | Callable[..., Any] | MutableMapping[str, Any]]
+        | None = None,
+        default_options: TAzureAIClientOptions | None = None,
+        chat_message_store_factory: Callable[[], ChatMessageStoreProtocol] | None = None,
+        context_provider: ContextProvider | None = None,
+        middleware: Sequence[Middleware] | None = None,
+        **kwargs: Any,
+    ) -> ChatAgent[TAzureAIClientOptions]:
+        """Convert this chat client to a ChatAgent.
+
+        This method creates a ChatAgent instance with this client pre-configured.
+        It does NOT create an agent on the Azure AI service - the actual agent
+        will be created on the server during the first invocation (run).
+
+        For creating and managing persistent agents on the server, use
+        :class:`~agent_framework_azure_ai.AzureAIProjectAgentProvider` instead.
+
+        Keyword Args:
+            id: The unique identifier for the agent. Will be created automatically if not provided.
+            name: The name of the agent.
+            description: A brief description of the agent's purpose.
+            instructions: Optional instructions for the agent.
+            tools: The tools to use for the request.
+            default_options: A TypedDict containing chat options.
+            chat_message_store_factory: Factory function to create an instance of ChatMessageStoreProtocol.
+            context_provider: Context providers to include during agent invocation.
+            middleware: List of middleware to intercept agent and function invocations.
+            kwargs: Any additional keyword arguments.
+
+        Returns:
+            A ChatAgent instance configured with this chat client.
+        """
+        return super().as_agent(
+            id=id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            tools=tools,
+            default_options=default_options,
+            chat_message_store_factory=chat_message_store_factory,
+            context_provider=context_provider,
+            middleware=middleware,
+            **kwargs,
+        )

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -104,13 +104,13 @@ class AgentFunctionApp(DFAppBase):
         from agent_framework.azure import AgentFunctionApp, AzureOpenAIChatClient
 
         # Create agents with unique names
-        weather_agent = AzureOpenAIChatClient(...).create_agent(
+        weather_agent = AzureOpenAIChatClient(...).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather agent.",
             tools=[get_weather],
         )
 
-        math_agent = AzureOpenAIChatClient(...).create_agent(
+        math_agent = AzureOpenAIChatClient(...).as_agent(
             name="MathAgent",
             instructions="You are a helpful math assistant.",
             tools=[calculate],

--- a/python/packages/core/agent_framework/_clients.py
+++ b/python/packages/core/agent_framework/_clients.py
@@ -377,7 +377,7 @@ class BaseChatClient(SerializationMixin, ABC, Generic[TOptions_co]):
         """
         return "Unknown"
 
-    def create_agent(
+    def as_agent(
         self,
         *,
         id: str | None = None,
@@ -428,7 +428,7 @@ class BaseChatClient(SerializationMixin, ABC, Generic[TOptions_co]):
                 client = OpenAIChatClient(model_id="gpt-4")
 
                 # Create an agent using the convenience method
-                agent = client.create_agent(
+                agent = client.as_agent(
                     name="assistant",
                     instructions="You are a helpful assistant.",
                     default_options={"temperature": 0.7, "max_tokens": 500},

--- a/python/packages/core/agent_framework/_workflows/_handoff.py
+++ b/python/packages/core/agent_framework/_workflows/_handoff.py
@@ -710,9 +710,9 @@ class HandoffBuilder:
             from agent_framework.openai import OpenAIChatClient
 
             client = OpenAIChatClient()
-            triage = client.create_agent(instructions="...", name="triage_agent")
-            refund = client.create_agent(instructions="...", name="refund_agent")
-            billing = client.create_agent(instructions="...", name="billing_agent")
+            triage = client.as_agent(instructions="...", name="triage_agent")
+            refund = client.as_agent(instructions="...", name="refund_agent")
+            billing = client.as_agent(instructions="...", name="billing_agent")
 
             builder = HandoffBuilder().participants([triage, refund, billing])
             builder.with_start_agent(triage)

--- a/python/packages/core/agent_framework/openai/_assistants_client.py
+++ b/python/packages/core/agent_framework/openai/_assistants_client.py
@@ -769,6 +769,7 @@ class OpenAIAssistantsClient(
         if description and not self.assistant_description:
             self.assistant_description = description
 
+    @override
     def as_agent(
         self,
         *,

--- a/python/packages/core/agent_framework/openai/_assistants_client.py
+++ b/python/packages/core/agent_framework/openai/_assistants_client.py
@@ -9,8 +9,12 @@ from collections.abc import (
     Mapping,
     MutableMapping,
     MutableSequence,
+    Sequence,
 )
-from typing import Any, Generic, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypedDict, cast
+
+if TYPE_CHECKING:
+    from .._agents import ChatAgent
 
 from openai import AsyncOpenAI
 from openai.types.beta.threads import (
@@ -28,11 +32,14 @@ from openai.types.beta.threads.runs import RunStep
 from pydantic import ValidationError
 
 from .._clients import BaseChatClient
-from .._middleware import use_chat_middleware
+from .._memory import ContextProvider
+from .._middleware import Middleware, use_chat_middleware
+from .._threads import ChatMessageStoreProtocol
 from .._tools import (
     AIFunction,
     HostedCodeInterpreterTool,
     HostedFileSearchTool,
+    ToolProtocol,
     use_function_invocation,
 )
 from .._types import (
@@ -761,3 +768,58 @@ class OpenAIAssistantsClient(
             self.assistant_name = agent_name
         if description and not self.assistant_description:
             self.assistant_description = description
+
+    def as_agent(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        instructions: str | None = None,
+        tools: ToolProtocol
+        | Callable[..., Any]
+        | MutableMapping[str, Any]
+        | Sequence[ToolProtocol | Callable[..., Any] | MutableMapping[str, Any]]
+        | None = None,
+        default_options: TOpenAIAssistantsOptions | None = None,
+        chat_message_store_factory: Callable[[], ChatMessageStoreProtocol] | None = None,
+        context_provider: ContextProvider | None = None,
+        middleware: Sequence[Middleware] | None = None,
+        **kwargs: Any,
+    ) -> "ChatAgent[TOpenAIAssistantsOptions]":
+        """Convert this chat client to a ChatAgent.
+
+        This method creates a ChatAgent instance with this client pre-configured.
+        It does NOT create an assistant on the OpenAI service - the actual assistant
+        will be created on the server during the first invocation (run).
+
+        For creating and managing persistent assistants on the server, use
+        :class:`~agent_framework.openai.OpenAIAssistantProvider` instead.
+
+        Keyword Args:
+            id: The unique identifier for the agent. Will be created automatically if not provided.
+            name: The name of the agent.
+            description: A brief description of the agent's purpose.
+            instructions: Optional instructions for the agent.
+            tools: The tools to use for the request.
+            default_options: A TypedDict containing chat options.
+            chat_message_store_factory: Factory function to create an instance of ChatMessageStoreProtocol.
+            context_provider: Context providers to include during agent invocation.
+            middleware: List of middleware to intercept agent and function invocations.
+            kwargs: Any additional keyword arguments.
+
+        Returns:
+            A ChatAgent instance configured with this chat client.
+        """
+        return super().as_agent(
+            id=id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            tools=tools,
+            default_options=default_options,
+            chat_message_store_factory=chat_message_store_factory,
+            context_provider=context_provider,
+            middleware=middleware,
+            **kwargs,
+        )

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
@@ -72,7 +72,7 @@ class WorkflowFactory:
 
             # Pre-register agents for InvokeAzureAgent actions
             chat_client = AzureOpenAIChatClient()
-            agent = chat_client.create_agent(name="MyAgent", instructions="You are helpful.")
+            agent = chat_client.as_agent(name="MyAgent", instructions="You are helpful.")
 
             factory = WorkflowFactory(agents={"MyAgent": agent})
             workflow = factory.create_workflow_from_yaml_path("workflow.yaml")
@@ -115,8 +115,8 @@ class WorkflowFactory:
                 # With pre-registered agents
                 client = AzureOpenAIChatClient()
                 agents = {
-                    "WriterAgent": client.create_agent(name="Writer", instructions="Write content."),
-                    "ReviewerAgent": client.create_agent(name="Reviewer", instructions="Review content."),
+                    "WriterAgent": client.as_agent(name="Writer", instructions="Write content."),
+                    "ReviewerAgent": client.as_agent(name="Reviewer", instructions="Review content."),
                 }
                 factory = WorkflowFactory(agents=agents)
 
@@ -533,14 +533,14 @@ class WorkflowFactory:
                     WorkflowFactory()
                     .register_agent(
                         "Writer",
-                        client.create_agent(
+                        client.as_agent(
                             name="Writer",
                             instructions="Write content.",
                         ),
                     )
                     .register_agent(
                         "Reviewer",
-                        client.create_agent(
+                        client.as_agent(
                             name="Reviewer",
                             instructions="Review content.",
                         ),

--- a/python/packages/foundry_local/agent_framework_foundry_local/_foundry_local_client.py
+++ b/python/packages/foundry_local/agent_framework_foundry_local/_foundry_local_client.py
@@ -169,7 +169,7 @@ class FoundryLocalClient(OpenAIBaseChatClient[TFoundryLocalChatOptions], Generic
 
                 client = FoundryLocalClient(model_id="phi-4-mini")
 
-                agent = client.create_agent(
+                agent = client.as_agent(
                     name="LocalAgent",
                     instructions="You are a helpful agent.",
                     tools=get_weather,

--- a/python/packages/foundry_local/samples/foundry_local_agent.py
+++ b/python/packages/foundry_local/samples/foundry_local_agent.py
@@ -65,7 +65,7 @@ async def main() -> None:
             print(
                 f"- {model.alias} for {model.task} - id={model.id} - {(model.file_size_mb / 1000):.2f} GB - {model.license}"
             )
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="LocalAgent",
         instructions="You are a helpful agent.",
         tools=get_weather,

--- a/python/packages/lab/gaia/samples/azure_ai_agent.py
+++ b/python/packages/lab/gaia/samples/azure_ai_agent.py
@@ -49,7 +49,7 @@ async def create_gaia_agent() -> AsyncIterator[ChatAgent]:
     """
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="GaiaAgent",
             instructions="Solve tasks to your best ability. Use Bing Search to find "
             "information and Code Interpreter to perform calculations and data analysis.",

--- a/python/packages/lab/gaia/samples/openai_agent.py
+++ b/python/packages/lab/gaia/samples/openai_agent.py
@@ -49,7 +49,7 @@ async def create_gaia_agent() -> AsyncIterator[ChatAgent]:
     """
     chat_client = OpenAIResponsesClient()
 
-    async with chat_client.create_agent(
+    async with chat_client.as_agent(
         name="GaiaAgent",
         instructions="Solve tasks to your best ability. Use Web Search to find "
         "information and Code Interpreter to perform calculations and data analysis.",

--- a/python/samples/autogen-migration/orchestrations/01_round_robin_group_chat.py
+++ b/python/samples/autogen-migration/orchestrations/01_round_robin_group_chat.py
@@ -59,17 +59,17 @@ async def run_agent_framework() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create specialized agents
-    researcher = client.create_agent(
+    researcher = client.as_agent(
         name="researcher",
         instructions="You are a researcher. Provide facts and data about the topic.",
     )
 
-    writer = client.create_agent(
+    writer = client.as_agent(
         name="writer",
         instructions="You are a writer. Turn research into engaging content.",
     )
 
-    editor = client.create_agent(
+    editor = client.as_agent(
         name="editor",
         instructions="You are an editor. Review and finalize the content.",
     )
@@ -109,17 +109,17 @@ async def run_agent_framework_with_cycle() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create specialized agents
-    researcher = client.create_agent(
+    researcher = client.as_agent(
         name="researcher",
         instructions="You are a researcher. Provide facts and data about the topic.",
     )
 
-    writer = client.create_agent(
+    writer = client.as_agent(
         name="writer",
         instructions="You are a writer. Turn research into engaging content.",
     )
 
-    editor = client.create_agent(
+    editor = client.as_agent(
         name="editor",
         instructions="You are an editor. Review and finalize the content. End with APPROVED if satisfied.",
     )

--- a/python/samples/autogen-migration/orchestrations/02_selector_group_chat.py
+++ b/python/samples/autogen-migration/orchestrations/02_selector_group_chat.py
@@ -65,19 +65,19 @@ async def run_agent_framework() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create specialized agents
-    python_expert = client.create_agent(
+    python_expert = client.as_agent(
         name="python_expert",
         instructions="You are a Python programming expert. Answer Python-related questions.",
         description="Expert in Python programming",
     )
 
-    javascript_expert = client.create_agent(
+    javascript_expert = client.as_agent(
         name="javascript_expert",
         instructions="You are a JavaScript programming expert. Answer JavaScript-related questions.",
         description="Expert in JavaScript programming",
     )
 
-    database_expert = client.create_agent(
+    database_expert = client.as_agent(
         name="database_expert",
         instructions="You are a database expert. Answer SQL and database-related questions.",
         description="Expert in databases and SQL",
@@ -87,7 +87,7 @@ async def run_agent_framework() -> None:
         GroupChatBuilder()
         .participants([python_expert, javascript_expert, database_expert])
         .set_manager(
-            manager=client.create_agent(
+            manager=client.as_agent(
                 name="selector_manager",
                 instructions="Based on the conversation, select the most appropriate expert to respond next.",
             ),

--- a/python/samples/autogen-migration/orchestrations/03_swarm.py
+++ b/python/samples/autogen-migration/orchestrations/03_swarm.py
@@ -108,7 +108,7 @@ async def run_agent_framework() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create triage agent
-    triage_agent = client.create_agent(
+    triage_agent = client.as_agent(
         name="triage",
         instructions=(
             "You are a triage agent. Analyze the user's request and route to the appropriate specialist:\n"
@@ -119,14 +119,14 @@ async def run_agent_framework() -> None:
     )
 
     # Create billing specialist
-    billing_agent = client.create_agent(
+    billing_agent = client.as_agent(
         name="billing_agent",
         instructions="You are a billing specialist. Help with payment and billing questions. Provide clear assistance.",
         description="Handles billing and payment questions",
     )
 
     # Create technical support specialist
-    tech_support = client.create_agent(
+    tech_support = client.as_agent(
         name="technical_support",
         instructions="You are technical support. Help with technical issues. Provide clear assistance.",
         description="Handles technical support questions",

--- a/python/samples/autogen-migration/orchestrations/04_magentic_one.py
+++ b/python/samples/autogen-migration/orchestrations/04_magentic_one.py
@@ -69,19 +69,19 @@ async def run_agent_framework() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create specialized agents
-    researcher = client.create_agent(
+    researcher = client.as_agent(
         name="researcher",
         instructions="You are a research analyst. Gather and analyze information.",
         description="Research analyst for data gathering",
     )
 
-    coder = client.create_agent(
+    coder = client.as_agent(
         name="coder",
         instructions="You are a programmer. Write code based on requirements.",
         description="Software developer for implementation",
     )
 
-    reviewer = client.create_agent(
+    reviewer = client.as_agent(
         name="reviewer",
         instructions="You are a code reviewer. Review code for quality and correctness.",
         description="Code reviewer for quality assurance",

--- a/python/samples/autogen-migration/single_agent/01_basic_assistant_agent.py
+++ b/python/samples/autogen-migration/single_agent/01_basic_assistant_agent.py
@@ -33,7 +33,7 @@ async def run_agent_framework() -> None:
 
     # AF constructs a lightweight ChatAgent backed by OpenAIChatClient
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="assistant",
         instructions="You are a helpful assistant. Answer in one sentence.",
     )

--- a/python/samples/autogen-migration/single_agent/02_assistant_agent_with_tool.py
+++ b/python/samples/autogen-migration/single_agent/02_assistant_agent_with_tool.py
@@ -65,7 +65,7 @@ async def run_agent_framework() -> None:
 
     # Create agent with tool
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="assistant",
         instructions="You are a helpful assistant. Use available tools to answer questions.",
         tools=[get_weather],

--- a/python/samples/autogen-migration/single_agent/03_assistant_agent_thread_and_stream.py
+++ b/python/samples/autogen-migration/single_agent/03_assistant_agent_thread_and_stream.py
@@ -40,7 +40,7 @@ async def run_agent_framework() -> None:
     from agent_framework.openai import OpenAIChatClient
 
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="assistant",
         instructions="You are a helpful math tutor.",
     )

--- a/python/samples/autogen-migration/single_agent/04_agent_as_tool.py
+++ b/python/samples/autogen-migration/single_agent/04_agent_as_tool.py
@@ -54,7 +54,7 @@ async def run_agent_framework() -> None:
     client = OpenAIChatClient(model_id="gpt-4.1-mini")
 
     # Create specialized writer agent
-    writer = client.create_agent(
+    writer = client.as_agent(
         name="writer",
         instructions="You are a creative writer. Write short, engaging content.",
     )
@@ -68,7 +68,7 @@ async def run_agent_framework() -> None:
     )
 
     # Create coordinator agent with writer tool
-    coordinator = client.create_agent(
+    coordinator = client.as_agent(
         name="coordinator",
         instructions="You coordinate with specialized agents. Delegate writing tasks to the writer agent.",
         tools=[writer_tool],

--- a/python/samples/demos/hosted_agents/agent_with_hosted_mcp/main.py
+++ b/python/samples/demos/hosted_agents/agent_with_hosted_mcp/main.py
@@ -8,7 +8,7 @@ from azure.identity import DefaultAzureCredential
 
 def main():
     # Create an Agent using the Azure OpenAI Chat Client with a MCP Tool that connects to Microsoft Learn MCP
-    agent = AzureOpenAIChatClient(credential=DefaultAzureCredential()).create_agent(
+    agent = AzureOpenAIChatClient(credential=DefaultAzureCredential()).as_agent(
         name="DocsAgent",
         instructions="You are a helpful assistant that can help with microsoft documentation questions.",
         tools=HostedMCPTool(

--- a/python/samples/demos/hosted_agents/agent_with_text_search_rag/main.py
+++ b/python/samples/demos/hosted_agents/agent_with_text_search_rag/main.py
@@ -93,7 +93,7 @@ class TextSearchContextProvider(ContextProvider):
 
 def main():
     # Create an Agent using the Azure OpenAI Chat Client
-    agent = AzureOpenAIChatClient(credential=DefaultAzureCredential()).create_agent(
+    agent = AzureOpenAIChatClient(credential=DefaultAzureCredential()).as_agent(
         name="SupportSpecialist",
         instructions=(
             "You are a helpful support specialist for Contoso Outdoors. "

--- a/python/samples/demos/hosted_agents/agents_in_workflow/main.py
+++ b/python/samples/demos/hosted_agents/agents_in_workflow/main.py
@@ -8,21 +8,21 @@ from azure.identity import DefaultAzureCredential  # pyright: ignore[reportUnkno
 
 def main():
     # Create agents
-    researcher = AzureOpenAIChatClient(credential=DefaultAzureCredential()).create_agent(
+    researcher = AzureOpenAIChatClient(credential=DefaultAzureCredential()).as_agent(
         instructions=(
             "You're an expert market and product researcher. "
             "Given a prompt, provide concise, factual insights, opportunities, and risks."
         ),
         name="researcher",
     )
-    marketer = AzureOpenAIChatClient(credential=DefaultAzureCredential()).create_agent(
+    marketer = AzureOpenAIChatClient(credential=DefaultAzureCredential()).as_agent(
         instructions=(
             "You're a creative marketing strategist. "
             "Craft compelling value propositions and target messaging aligned to the prompt."
         ),
         name="marketer",
     )
-    legal = AzureOpenAIChatClient(credential=DefaultAzureCredential()).create_agent(
+    legal = AzureOpenAIChatClient(credential=DefaultAzureCredential()).as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. "
             "Highlight constraints, disclaimers, and policy concerns based on the prompt."

--- a/python/samples/demos/m365-agent/m365_agent_demo/app.py
+++ b/python/samples/demos/m365-agent/m365_agent_demo/app.py
@@ -93,7 +93,7 @@ def get_weather(
 
 def build_agent() -> ChatAgent:
     """Create and return the chat agent instance with weather tool registered."""
-    return OpenAIChatClient().create_agent(
+    return OpenAIChatClient().as_agent(
         name="WeatherAgent", instructions="You are a helpful weather agent.", tools=get_weather
     )
 

--- a/python/samples/demos/workflow_evaluation/create_workflow.py
+++ b/python/samples/demos/workflow_evaluation/create_workflow.py
@@ -78,7 +78,7 @@ class ResearchLead(Executor):
 
     def __init__(self, chat_client: AzureAIClient, id: str = "travel-planning-coordinator"):
         # store=True to preserve conversation history for evaluation
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             id="travel-planning-coordinator",
             instructions=(
                 "You are the final coordinator. You will receive responses from multiple agents: "
@@ -220,7 +220,7 @@ async def _create_workflow(project_client, credential):
     travel_request_handler_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="travel-request-handler"
     )
-    travel_request_handler = travel_request_handler_client.create_agent(
+    travel_request_handler = travel_request_handler_client.as_agent(
         id="travel-request-handler",
         instructions=(
             "You receive user travel queries and relay them to specialized agents. Extract key information: destination, dates, budget, and preferences. Pass this information forward clearly to the next agents."
@@ -233,7 +233,7 @@ async def _create_workflow(project_client, credential):
     hotel_search_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="hotel-search-agent"
     )
-    hotel_search_agent = hotel_search_client.create_agent(
+    hotel_search_agent = hotel_search_client.as_agent(
         id="hotel-search-agent",
         instructions=(
             "You are a hotel search specialist. Your task is ONLY to search for and provide hotel information. Use search_hotels to find options, get_hotel_details for specifics, and check_availability to verify rooms. Output format: List hotel names, prices per night, total cost for the stay, locations, ratings, amenities, and addresses. IMPORTANT: Only provide hotel information without additional commentary."
@@ -247,7 +247,7 @@ async def _create_workflow(project_client, credential):
     flight_search_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="flight-search-agent"
     )
-    flight_search_agent = flight_search_client.create_agent(
+    flight_search_agent = flight_search_client.as_agent(
         id="flight-search-agent",
         instructions=(
             "You are a flight search specialist. Your task is ONLY to search for and provide flight information. Use search_flights to find options, get_flight_details for specifics, and check_availability for seats. Output format: List flight numbers, airlines, departure/arrival times, prices, durations, and cabin class. IMPORTANT: Only provide flight information without additional commentary."
@@ -261,7 +261,7 @@ async def _create_workflow(project_client, credential):
     activity_search_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="activity-search-agent"
     )
-    activity_search_agent = activity_search_client.create_agent(
+    activity_search_agent = activity_search_client.as_agent(
         id="activity-search-agent",
         instructions=(
             "You are an activities specialist. Your task is ONLY to search for and provide activity information. Use search_activities to find options for activities. Output format: List activity names, descriptions, prices, durations, ratings, and categories. IMPORTANT: Only provide activity information without additional commentary."
@@ -275,7 +275,7 @@ async def _create_workflow(project_client, credential):
     booking_confirmation_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="booking-confirmation-agent"
     )
-    booking_confirmation_agent = booking_confirmation_client.create_agent(
+    booking_confirmation_agent = booking_confirmation_client.as_agent(
         id="booking-confirmation-agent",
         instructions=(
             "You confirm bookings. Use check_hotel_availability and check_flight_availability to verify slots, then confirm_booking to finalize. Provide ONLY: confirmation numbers, booking references, and confirmation status."
@@ -289,7 +289,7 @@ async def _create_workflow(project_client, credential):
     booking_payment_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="booking-payment-agent"
     )
-    booking_payment_agent = booking_payment_client.create_agent(
+    booking_payment_agent = booking_payment_client.as_agent(
         id="booking-payment-agent",
         instructions=(
             "You process payments. Use validate_payment_method to verify payment, then process_payment to complete transactions. Provide ONLY: payment confirmation status, transaction IDs, and payment amounts."
@@ -303,7 +303,7 @@ async def _create_workflow(project_client, credential):
     booking_info_client = AzureAIClient(
         project_client=project_client, credential=credential, agent_name="booking-info-aggregation-agent"
     )
-    booking_info_aggregation_agent = booking_info_client.create_agent(
+    booking_info_aggregation_agent = booking_info_client.as_agent(
         id="booking-info-aggregation-agent",
         instructions=(
             "You aggregate hotel and flight search results. Receive options from search agents and organize them. Provide: top 2-3 hotel options with prices and top 2-3 flight options with prices in a structured format."

--- a/python/samples/getting_started/agents/anthropic/anthropic_advanced.py
+++ b/python/samples/getting_started/agents/anthropic/anthropic_advanced.py
@@ -17,7 +17,7 @@ This sample demonstrates using Anthropic with:
 
 async def main() -> None:
     """Example of streaming response (get results as they are generated)."""
-    agent = AnthropicClient[AnthropicChatOptions]().create_agent(
+    agent = AnthropicClient[AnthropicChatOptions]().as_agent(
         name="DocsAgent",
         instructions="You are a helpful agent for both Microsoft docs questions and general questions.",
         tools=[

--- a/python/samples/getting_started/agents/anthropic/anthropic_basic.py
+++ b/python/samples/getting_started/agents/anthropic/anthropic_basic.py
@@ -26,7 +26,7 @@ async def non_streaming_example() -> None:
     print("=== Non-streaming Response Example ===")
 
     agent = AnthropicClient(
-    ).create_agent(
+    ).as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,
@@ -43,7 +43,7 @@ async def streaming_example() -> None:
     print("=== Streaming Response Example ===")
 
     agent = AnthropicClient(
-    ).create_agent(
+    ).as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,

--- a/python/samples/getting_started/agents/anthropic/anthropic_foundry.py
+++ b/python/samples/getting_started/agents/anthropic/anthropic_foundry.py
@@ -28,7 +28,7 @@ To use the Foundry integration ensure you have the following environment variabl
 
 async def main() -> None:
     """Example of streaming response (get results as they are generated)."""
-    agent = AnthropicClient(anthropic_client=AsyncAnthropicFoundry()).create_agent(
+    agent = AnthropicClient(anthropic_client=AsyncAnthropicFoundry()).as_agent(
         name="DocsAgent",
         instructions="You are a helpful agent for both Microsoft docs questions and general questions.",
         tools=[

--- a/python/samples/getting_started/agents/anthropic/anthropic_skills.py
+++ b/python/samples/getting_started/agents/anthropic/anthropic_skills.py
@@ -31,7 +31,7 @@ async def main() -> None:
 
     # Create a agent with the pptx skill enabled
     # Skills also need the code interpreter tool to function
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="DocsAgent",
         instructions="You are a helpful agent for creating powerpoint presentations.",
         tools=HostedCodeInterpreterTool(),

--- a/python/samples/getting_started/agents/azure_ai/azure_ai_provider_methods.py
+++ b/python/samples/getting_started/agents/azure_ai/azure_ai_provider_methods.py
@@ -145,49 +145,6 @@ async def get_agent_by_reference_example() -> None:
             )
 
 
-async def get_agent_by_details_example() -> None:
-    """Example of using provider.get_agent(details=...) with pre-fetched AgentDetails.
-
-    This method uses pre-fetched AgentDetails to get the latest version.
-    Use this when you already have AgentDetails from a previous API call.
-    """
-    print("=== provider.get_agent(details=...) Example ===")
-
-    async with (
-        AzureCliCredential() as credential,
-        AIProjectClient(endpoint=os.environ["AZURE_AI_PROJECT_ENDPOINT"], credential=credential) as project_client,
-    ):
-        # First, create an agent using the SDK directly
-        created_agent = await project_client.agents.create_version(
-            agent_name="TestAgentByDetails",
-            description="Test agent for get_agent by details example.",
-            definition=PromptAgentDefinition(
-                model=os.environ["AZURE_AI_MODEL_DEPLOYMENT_NAME"],
-                instructions="You are a helpful assistant. Always include an emoji in your response.",
-            ),
-        )
-
-        try:
-            # Fetch AgentDetails separately (simulating a previous API call)
-            agent_details = await project_client.agents.get(agent_name=created_agent.name)
-
-            # Get the agent using the pre-fetched details (sync - no HTTP call)
-            provider = AzureAIProjectAgentProvider(project_client=project_client)
-            agent = provider.as_agent(agent_details.versions.latest)
-
-            print(f"Retrieved agent: {agent.name} (from pre-fetched details)")
-
-            query = "How are you today?"
-            print(f"User: {query}")
-            result = await agent.run(query)
-            print(f"Agent: {result}\n")
-        finally:
-            # Clean up the agent
-            await project_client.agents.delete_version(
-                agent_name=created_agent.name, agent_version=created_agent.version
-            )
-
-
 async def multiple_agents_example() -> None:
     """Example of using a single provider to spawn multiple agents.
 
@@ -284,7 +241,6 @@ async def main() -> None:
     await create_agent_example()
     await get_agent_by_name_example()
     await get_agent_by_reference_example()
-    await get_agent_by_details_example()
     await as_agent_example()
     await multiple_agents_example()
 

--- a/python/samples/getting_started/agents/azure_openai/azure_assistants_basic.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_assistants_basic.py
@@ -32,7 +32,7 @@ async def non_streaming_example() -> None:
     # and deleted after getting a response
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    async with AzureOpenAIAssistantsClient(credential=AzureCliCredential()).create_agent(
+    async with AzureOpenAIAssistantsClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     ) as agent:
@@ -48,7 +48,7 @@ async def streaming_example() -> None:
 
     # Since no assistant ID is provided, the assistant will be automatically created
     # and deleted after getting a response
-    async with AzureOpenAIAssistantsClient(credential=AzureCliCredential()).create_agent(
+    async with AzureOpenAIAssistantsClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     ) as agent:

--- a/python/samples/getting_started/agents/azure_openai/azure_assistants_with_explicit_settings.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_assistants_with_explicit_settings.py
@@ -34,7 +34,7 @@ async def main() -> None:
         endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         deployment_name=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         credential=AzureCliCredential(),
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     ) as agent:

--- a/python/samples/getting_started/agents/azure_openai/azure_chat_client_basic.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_chat_client_basic.py
@@ -31,7 +31,7 @@ async def non_streaming_example() -> None:
     # Create agent with Azure Chat Client
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )
@@ -49,7 +49,7 @@ async def streaming_example() -> None:
     # Create agent with Azure Chat Client
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/azure_openai/azure_chat_client_with_explicit_settings.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_chat_client_with_explicit_settings.py
@@ -34,7 +34,7 @@ async def main() -> None:
         deployment_name=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"],
         endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         credential=AzureCliCredential(),
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/azure_openai/azure_responses_client_basic.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_responses_client_basic.py
@@ -30,7 +30,7 @@ async def non_streaming_example() -> None:
 
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )
@@ -47,7 +47,7 @@ async def streaming_example() -> None:
 
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/azure_openai/azure_responses_client_image_analysis.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_responses_client_image_analysis.py
@@ -18,7 +18,7 @@ async def main():
     print("=== Azure Responses Agent with Image Analysis ===")
 
     # 1. Create an Azure Responses agent with vision capabilities
-    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIResponsesClient(credential=AzureCliCredential()).as_agent(
         name="VisionAgent",
         instructions="You are a helpful agent that can analyze images.",
     )

--- a/python/samples/getting_started/agents/azure_openai/azure_responses_client_with_explicit_settings.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_responses_client_with_explicit_settings.py
@@ -34,7 +34,7 @@ async def main() -> None:
         deployment_name=os.environ["AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME"],
         endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         credential=AzureCliCredential(),
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/azure_openai/azure_responses_client_with_local_mcp.py
+++ b/python/samples/getting_started/agents/azure_openai/azure_responses_client_with_local_mcp.py
@@ -37,7 +37,7 @@ async def main():
         credential=credential,
     )
 
-    agent: ChatAgent = responses_client.create_agent(
+    agent: ChatAgent = responses_client.as_agent(
         name="DocsAgent",
         instructions=("You are a helpful assistant that can help with Microsoft documentation questions."),
     )

--- a/python/samples/getting_started/agents/custom/custom_chat_client.py
+++ b/python/samples/getting_started/agents/custom/custom_chat_client.py
@@ -125,7 +125,7 @@ async def main() -> None:
     print(f"Direct response: {direct_response.messages[0].text}")
 
     # Create an agent using the custom chat client
-    echo_agent = echo_client.create_agent(
+    echo_agent = echo_client.as_agent(
         name="EchoAgent",
         instructions="You are a helpful assistant that echoes back what users say.",
     )

--- a/python/samples/getting_started/agents/ollama/ollama_agent_basic.py
+++ b/python/samples/getting_started/agents/ollama/ollama_agent_basic.py
@@ -27,7 +27,7 @@ async def non_streaming_example() -> None:
     """Example of non-streaming response (get the complete result at once)."""
     print("=== Non-streaming Response Example ===")
 
-    agent = OllamaChatClient().create_agent(
+    agent = OllamaChatClient().as_agent(
         name="TimeAgent",
         instructions="You are a helpful time agent answer in one sentence.",
         tools=get_time,
@@ -43,7 +43,7 @@ async def streaming_example() -> None:
     """Example of streaming response (get results as they are generated)."""
     print("=== Streaming Response Example ===")
 
-    agent = OllamaChatClient().create_agent(
+    agent = OllamaChatClient().as_agent(
         name="TimeAgent",
         instructions="You are a helpful time agent answer in one sentence.",
         tools=get_time,

--- a/python/samples/getting_started/agents/ollama/ollama_agent_reasoning.py
+++ b/python/samples/getting_started/agents/ollama/ollama_agent_reasoning.py
@@ -21,7 +21,7 @@ https://ollama.com/
 async def reasoning_example() -> None:
     print("=== Response Reasoning Example ===")
 
-    agent = OllamaChatClient().create_agent(
+    agent = OllamaChatClient().as_agent(
         name="TimeAgent",
         instructions="You are a helpful agent answer in one sentence.",
         default_options={"think": True},  # Enable Reasoning on agent level

--- a/python/samples/getting_started/agents/ollama/ollama_with_openai_chat_client.py
+++ b/python/samples/getting_started/agents/ollama/ollama_with_openai_chat_client.py
@@ -36,7 +36,7 @@ async def non_streaming_example() -> None:
         api_key="ollama",  # Just a placeholder, Ollama doesn't require API key
         base_url=os.getenv("OLLAMA_ENDPOINT"),
         model_id=os.getenv("OLLAMA_MODEL"),
-    ).create_agent(
+    ).as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,
@@ -56,7 +56,7 @@ async def streaming_example() -> None:
         api_key="ollama",  # Just a placeholder, Ollama doesn't require API key
         base_url=os.getenv("OLLAMA_ENDPOINT"),
         model_id=os.getenv("OLLAMA_MODEL"),
-    ).create_agent(
+    ).as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,

--- a/python/samples/getting_started/agents/openai/openai_chat_client_basic.py
+++ b/python/samples/getting_started/agents/openai/openai_chat_client_basic.py
@@ -26,7 +26,7 @@ async def non_streaming_example() -> None:
     """Example of non-streaming response (get the complete result at once)."""
     print("=== Non-streaming Response Example ===")
 
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,
@@ -42,7 +42,7 @@ async def streaming_example() -> None:
     """Example of streaming response (get results as they are generated)."""
     print("=== Streaming Response Example ===")
 
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather agent.",
         tools=get_weather,

--- a/python/samples/getting_started/agents/openai/openai_chat_client_with_explicit_settings.py
+++ b/python/samples/getting_started/agents/openai/openai_chat_client_with_explicit_settings.py
@@ -30,7 +30,7 @@ async def main() -> None:
     agent = OpenAIChatClient(
         model_id=os.environ["OPENAI_CHAT_MODEL_ID"],
         api_key=os.environ["OPENAI_API_KEY"],
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/openai/openai_chat_client_with_local_mcp.py
+++ b/python/samples/getting_started/agents/openai/openai_chat_client_with_local_mcp.py
@@ -55,7 +55,7 @@ async def mcp_tools_on_agent_level() -> None:
     # Tools are provided when creating the agent
     # The agent can use these tools for any query during its lifetime
     # The agent will connect to the MCP server through its context manager.
-    async with OpenAIChatClient().create_agent(
+    async with OpenAIChatClient().as_agent(
         name="DocsAgent",
         instructions="You are a helpful assistant that can help with microsoft documentation questions.",
         tools=MCPStreamableHTTPTool(  # Tools defined at agent creation

--- a/python/samples/getting_started/agents/openai/openai_chat_client_with_runtime_json_schema.py
+++ b/python/samples/getting_started/agents/openai/openai_chat_client_with_runtime_json_schema.py
@@ -32,7 +32,7 @@ runtime_schema = {
 async def non_streaming_example() -> None:
     print("=== Non-streaming runtime JSON schema example ===")
 
-    agent = OpenAIChatClient[OpenAIChatOptions]().create_agent(
+    agent = OpenAIChatClient[OpenAIChatOptions]().as_agent(
         name="RuntimeSchemaAgent",
         instructions="Return only JSON that matches the provided schema. Do not add commentary.",
     )
@@ -65,7 +65,7 @@ async def non_streaming_example() -> None:
 async def streaming_example() -> None:
     print("=== Streaming runtime JSON schema example ===")
 
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="RuntimeSchemaAgent",
         instructions="Return only JSON that matches the provided schema. Do not add commentary.",
     )

--- a/python/samples/getting_started/agents/openai/openai_responses_client_image_analysis.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_image_analysis.py
@@ -17,7 +17,7 @@ async def main():
     print("=== OpenAI Responses Agent with Image Analysis ===")
 
     # 1. Create an OpenAI Responses agent with vision capabilities
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="VisionAgent",
         instructions="You are a helpful agent that can analyze images.",
     )

--- a/python/samples/getting_started/agents/openai/openai_responses_client_image_generation.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_image_generation.py
@@ -48,7 +48,7 @@ async def main() -> None:
     print("=== OpenAI Responses Image Generation Agent Example ===")
 
     # Create an agent with customized image generation options
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         instructions="You are a helpful AI that can generate images.",
         tools=[
             HostedImageGenerationTool(

--- a/python/samples/getting_started/agents/openai/openai_responses_client_reasoning.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_reasoning.py
@@ -19,7 +19,7 @@ In this case they are here: https://platform.openai.com/docs/api-reference/respo
 """
 
 
-agent = OpenAIResponsesClient[OpenAIResponsesOptions](model_id="gpt-5").create_agent(
+agent = OpenAIResponsesClient[OpenAIResponsesOptions](model_id="gpt-5").as_agent(
     name="MathHelper",
     instructions="You are a personal math tutor. When asked a math question, "
     "reason over how best to approach the problem and share your thought process.",

--- a/python/samples/getting_started/agents/openai/openai_responses_client_streaming_image_generation.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_streaming_image_generation.py
@@ -42,7 +42,7 @@ async def main():
     print("=== OpenAI Streaming Image Generation Example ===\n")
 
     # Create agent with streaming image generation enabled
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         instructions="You are a helpful agent that can generate images.",
         tools=[
             HostedImageGenerationTool(

--- a/python/samples/getting_started/agents/openai/openai_responses_client_with_explicit_settings.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_with_explicit_settings.py
@@ -30,7 +30,7 @@ async def main() -> None:
     agent = OpenAIResponsesClient(
         model_id=os.environ["OPENAI_RESPONSES_MODEL_ID"],
         api_key=os.environ["OPENAI_API_KEY"],
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful weather agent.",
         tools=get_weather,
     )

--- a/python/samples/getting_started/agents/openai/openai_responses_client_with_runtime_json_schema.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_with_runtime_json_schema.py
@@ -32,7 +32,7 @@ runtime_schema = {
 async def non_streaming_example() -> None:
     print("=== Non-streaming runtime JSON schema example ===")
 
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="RuntimeSchemaAgent",
         instructions="Return only JSON that matches the provided schema. Do not add commentary.",
     )
@@ -65,7 +65,7 @@ async def non_streaming_example() -> None:
 async def streaming_example() -> None:
     print("=== Streaming runtime JSON schema example ===")
 
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="RuntimeSchemaAgent",
         instructions="Return only JSON that matches the provided schema. Do not add commentary.",
     )

--- a/python/samples/getting_started/agents/openai/openai_responses_client_with_structured_output.py
+++ b/python/samples/getting_started/agents/openai/openai_responses_client_with_structured_output.py
@@ -25,7 +25,7 @@ async def non_streaming_example() -> None:
     print("=== Non-streaming example ===")
 
     # Create an OpenAI Responses agent
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="CityAgent",
         instructions="You are a helpful agent that describes cities in a structured format.",
     )
@@ -51,7 +51,7 @@ async def streaming_example() -> None:
     print("=== Streaming example ===")
 
     # Create an OpenAI Responses agent
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="CityAgent",
         instructions="You are a helpful agent that describes cities in a structured format.",
     )

--- a/python/samples/getting_started/azure_functions/01_single_agent/function_app.py
+++ b/python/samples/getting_started/azure_functions/01_single_agent/function_app.py
@@ -16,7 +16,7 @@ from azure.identity import AzureCliCredential
 def _create_agent() -> Any:
     """Create the Joker agent."""
 
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="Joker",
         instructions="You are good at telling jokes.",
     )

--- a/python/samples/getting_started/azure_functions/02_multi_agent/function_app.py
+++ b/python/samples/getting_started/azure_functions/02_multi_agent/function_app.py
@@ -52,13 +52,13 @@ def calculate_tip(bill_amount: float, tip_percentage: float = 15.0) -> dict[str,
 # 1. Create multiple agents, each with its own instruction set and tools.
 chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-weather_agent = chat_client.create_agent(
+weather_agent = chat_client.as_agent(
     name="WeatherAgent",
     instructions="You are a helpful weather assistant. Provide current weather information.",
     tools=[get_weather],
 )
 
-math_agent = chat_client.create_agent(
+math_agent = chat_client.as_agent(
     name="MathAgent",
     instructions="You are a helpful math assistant. Help users with calculations like tip calculations.",
     tools=[calculate_tip],

--- a/python/samples/getting_started/azure_functions/03_reliable_streaming/function_app.py
+++ b/python/samples/getting_started/azure_functions/03_reliable_streaming/function_app.py
@@ -151,7 +151,7 @@ redis_callback = RedisStreamCallback()
 # Create the travel planner agent
 def create_travel_agent():
     """Create the TravelPlanner agent with tools."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="TravelPlanner",
         instructions="""You are an expert travel planner who creates detailed, personalized travel itineraries.
 When asked to plan a trip, you should:

--- a/python/samples/getting_started/azure_functions/04_single_agent_orchestration_chaining/function_app.py
+++ b/python/samples/getting_started/azure_functions/04_single_agent_orchestration_chaining/function_app.py
@@ -32,7 +32,7 @@ def _create_writer_agent() -> Any:
         "when given an improved sentence you polish it further."
     )
 
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name=WRITER_AGENT_NAME,
         instructions=instructions,
     )

--- a/python/samples/getting_started/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
+++ b/python/samples/getting_started/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
@@ -29,12 +29,12 @@ CHEMIST_AGENT_NAME = "ChemistAgent"
 def _create_agents() -> list[Any]:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    physicist = chat_client.create_agent(
+    physicist = chat_client.as_agent(
         name=PHYSICIST_AGENT_NAME,
         instructions="You are an expert in physics. You answer questions from a physics perspective.",
     )
 
-    chemist = chat_client.create_agent(
+    chemist = chat_client.as_agent(
         name=CHEMIST_AGENT_NAME,
         instructions="You are an expert in chemistry. You answer questions from a chemistry perspective.",
     )

--- a/python/samples/getting_started/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
+++ b/python/samples/getting_started/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
@@ -45,12 +45,12 @@ class EmailPayload(BaseModel):
 def _create_agents() -> list[Any]:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    spam_agent = chat_client.create_agent(
+    spam_agent = chat_client.as_agent(
         name=SPAM_AGENT_NAME,
         instructions="You are a spam detection assistant that identifies spam emails.",
     )
 
-    email_agent = chat_client.create_agent(
+    email_agent = chat_client.as_agent(
         name=EMAIL_AGENT_NAME,
         instructions="You are an email assistant that helps users draft responses to emails with professionalism.",
     )

--- a/python/samples/getting_started/azure_functions/07_single_agent_orchestration_hitl/function_app.py
+++ b/python/samples/getting_started/azure_functions/07_single_agent_orchestration_hitl/function_app.py
@@ -51,7 +51,7 @@ def _create_writer_agent() -> Any:
         "Return your response as JSON with 'title' and 'content' fields."
     )
 
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name=WRITER_AGENT_NAME,
         instructions=instructions,
     )

--- a/python/samples/getting_started/azure_functions/08_mcp_server/README.md
+++ b/python/samples/getting_started/azure_functions/08_mcp_server/README.md
@@ -145,17 +145,17 @@ from agent_framework.azure import AgentFunctionApp, AzureOpenAIChatClient
 chat_client = AzureOpenAIChatClient()
 
 # Define agents with different roles
-joker_agent = chat_client.create_agent(
+joker_agent = chat_client.as_agent(
     name="Joker",
     instructions="You are good at telling jokes.",
 )
 
-stock_agent = chat_client.create_agent(
+stock_agent = chat_client.as_agent(
     name="StockAdvisor",
     instructions="Check stock prices.",
 )
 
-plant_agent = chat_client.create_agent(
+plant_agent = chat_client.as_agent(
     name="PlantAdvisor",
     instructions="Recommend plants.",
     description="Get plant recommendations.",

--- a/python/samples/getting_started/azure_functions/08_mcp_server/function_app.py
+++ b/python/samples/getting_started/azure_functions/08_mcp_server/function_app.py
@@ -30,19 +30,19 @@ chat_client = AzureOpenAIChatClient()
 
 # Define three AI agents with different roles
 # Agent 1: Joker - HTTP trigger only (default)
-agent1 = chat_client.create_agent(
+agent1 = chat_client.as_agent(
     name="Joker",
     instructions="You are good at telling jokes.",
 )
 
 # Agent 2: StockAdvisor - MCP tool trigger only
-agent2 = chat_client.create_agent(
+agent2 = chat_client.as_agent(
     name="StockAdvisor",
     instructions="Check stock prices.",
 )
 
 # Agent 3: PlantAdvisor - Both HTTP and MCP tool triggers
-agent3 = chat_client.create_agent(
+agent3 = chat_client.as_agent(
     name="PlantAdvisor",
     instructions="Recommend plants.",
     description="Get plant recommendations.",

--- a/python/samples/getting_started/context_providers/mem0/mem0_basic.py
+++ b/python/samples/getting_started/context_providers/mem0/mem0_basic.py
@@ -32,7 +32,7 @@ async def main() -> None:
     # For Mem0 authentication, set Mem0 API key via "api_key" parameter or MEM0_API_KEY environment variable.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="FriendlyAssistant",
             instructions="You are a friendly assistant.",
             tools=retrieve_company_report,

--- a/python/samples/getting_started/context_providers/mem0/mem0_oss.py
+++ b/python/samples/getting_started/context_providers/mem0/mem0_oss.py
@@ -35,7 +35,7 @@ async def main() -> None:
     local_mem0_client = AsyncMemory()
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="FriendlyAssistant",
             instructions="You are a friendly assistant.",
             tools=retrieve_company_report,

--- a/python/samples/getting_started/context_providers/mem0/mem0_threads.py
+++ b/python/samples/getting_started/context_providers/mem0/mem0_threads.py
@@ -27,7 +27,7 @@ async def example_global_thread_scope() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="GlobalMemoryAssistant",
             instructions="You are an assistant that remembers user preferences across conversations.",
             tools=get_user_preferences,
@@ -65,7 +65,7 @@ async def example_per_operation_thread_scope() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="ScopedMemoryAssistant",
             instructions="You are an assistant with thread-scoped memory.",
             tools=get_user_preferences,
@@ -113,14 +113,14 @@ async def example_multiple_agents() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="PersonalAssistant",
             instructions="You are a personal assistant that helps with personal tasks.",
             context_provider=Mem0Provider(
                 agent_id=agent_id_1,
             ),
         ) as personal_agent,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WorkAssistant",
             instructions="You are a work assistant that helps with professional tasks.",
             context_provider=Mem0Provider(

--- a/python/samples/getting_started/context_providers/redis/azure_redis_conversation.py
+++ b/python/samples/getting_started/context_providers/redis/azure_redis_conversation.py
@@ -77,7 +77,7 @@ async def main() -> None:
     client = OpenAIChatClient()
 
     # Create agent with Azure Redis store
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="AzureRedisAssistant",
         instructions="You are a helpful assistant.",
         chat_message_store_factory=chat_message_store_factory,

--- a/python/samples/getting_started/context_providers/redis/redis_basics.py
+++ b/python/samples/getting_started/context_providers/redis/redis_basics.py
@@ -178,7 +178,7 @@ async def main() -> None:
     client = OpenAIChatClient(model_id=os.getenv("OPENAI_CHAT_MODEL_ID"), api_key=os.getenv("OPENAI_API_KEY"))
     # Create agent wired to the Redis context provider. The provider automatically
     # persists conversational details and surfaces relevant context on each turn.
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="MemoryEnhancedAssistant",
         instructions=(
             "You are a helpful assistant. Personalize replies using provided context. "
@@ -220,7 +220,7 @@ async def main() -> None:
     # Create agent exposing the flight search tool. Tool outputs are captured by the
     # provider and become retrievable context for later turns.
     client = OpenAIChatClient(model_id=os.getenv("OPENAI_CHAT_MODEL_ID"), api_key=os.getenv("OPENAI_API_KEY"))
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="MemoryEnhancedAssistant",
         instructions=(
             "You are a helpful assistant. Personalize replies using provided context. "

--- a/python/samples/getting_started/context_providers/redis/redis_conversation.py
+++ b/python/samples/getting_started/context_providers/redis/redis_conversation.py
@@ -63,7 +63,7 @@ async def main() -> None:
     client = OpenAIChatClient(model_id=os.getenv("OPENAI_CHAT_MODEL_ID"), api_key=os.getenv("OPENAI_API_KEY"))
     # Create agent wired to the Redis context provider. The provider automatically
     # persists conversational details and surfaces relevant context on each turn.
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="MemoryEnhancedAssistant",
         instructions=(
             "You are a helpful assistant. Personalize replies using provided context. "

--- a/python/samples/getting_started/context_providers/redis/redis_threads.py
+++ b/python/samples/getting_started/context_providers/redis/redis_threads.py
@@ -63,7 +63,7 @@ async def example_global_thread_scope() -> None:
         scope_to_per_operation_thread_id=False,  # Share memories across all threads
     )
 
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="GlobalMemoryAssistant",
         instructions=(
             "You are a helpful assistant. Personalize replies using provided context. "
@@ -125,7 +125,7 @@ async def example_per_operation_thread_scope() -> None:
         vector_distance_metric="cosine",
     )
 
-    agent = client.create_agent(
+    agent = client.as_agent(
         name="ScopedMemoryAssistant",
         instructions="You are an assistant with thread-scoped memory.",
         context_provider=provider,
@@ -190,7 +190,7 @@ async def example_multiple_agents() -> None:
         vector_distance_metric="cosine",
     )
 
-    personal_agent = client.create_agent(
+    personal_agent = client.as_agent(
         name="PersonalAssistant",
         instructions="You are a personal assistant that helps with personal tasks.",
         context_provider=personal_provider,
@@ -208,7 +208,7 @@ async def example_multiple_agents() -> None:
         vector_distance_metric="cosine",
     )
 
-    work_agent = client.create_agent(
+    work_agent = client.as_agent(
         name="WorkAssistant",
         instructions="You are a work assistant that helps with professional tasks.",
         context_provider=work_provider,

--- a/python/samples/getting_started/devui/workflow_agents/workflow.py
+++ b/python/samples/getting_started/devui/workflow_agents/workflow.py
@@ -62,7 +62,7 @@ def is_approved(message: Any) -> bool:
 chat_client = AzureOpenAIChatClient(api_key=os.environ.get("AZURE_OPENAI_API_KEY", ""))
 
 # Create Writer agent - generates content
-writer = chat_client.create_agent(
+writer = chat_client.as_agent(
     name="Writer",
     instructions=(
         "You are an excellent content writer. "
@@ -72,7 +72,7 @@ writer = chat_client.create_agent(
 )
 
 # Create Reviewer agent - evaluates and provides structured feedback
-reviewer = chat_client.create_agent(
+reviewer = chat_client.as_agent(
     name="Reviewer",
     instructions=(
         "You are an expert content reviewer. "
@@ -90,7 +90,7 @@ reviewer = chat_client.create_agent(
 )
 
 # Create Editor agent - improves content based on feedback
-editor = chat_client.create_agent(
+editor = chat_client.as_agent(
     name="Editor",
     instructions=(
         "You are a skilled editor. "
@@ -101,7 +101,7 @@ editor = chat_client.create_agent(
 )
 
 # Create Publisher agent - formats content for publication
-publisher = chat_client.create_agent(
+publisher = chat_client.as_agent(
     name="Publisher",
     instructions=(
         "You are a publishing agent. "
@@ -111,7 +111,7 @@ publisher = chat_client.create_agent(
 )
 
 # Create Summarizer agent - creates final publication report
-summarizer = chat_client.create_agent(
+summarizer = chat_client.as_agent(
     name="Summarizer",
     instructions=(
         "You are a summarizer agent. "

--- a/python/samples/getting_started/evaluation/red_teaming/README.md
+++ b/python/samples/getting_started/evaluation/red_teaming/README.md
@@ -113,7 +113,7 @@ async def main() -> None:
     credential = AzureCliCredential()
 
     # 2. Create agent inline
-    agent = AzureOpenAIChatClient(credential=credential).create_agent(
+    agent = AzureOpenAIChatClient(credential=credential).as_agent(
         model="gpt-4o",
         instructions="You are a helpful financial advisor..."
     )

--- a/python/samples/getting_started/evaluation/red_teaming/red_team_agent_sample.py
+++ b/python/samples/getting_started/evaluation/red_teaming/red_team_agent_sample.py
@@ -41,7 +41,7 @@ async def main() -> None:
     # Create the agent
     # Constructor automatically reads from environment variables:
     # AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT_NAME, AZURE_OPENAI_API_KEY
-    agent = AzureOpenAIChatClient(credential=credential).create_agent(
+    agent = AzureOpenAIChatClient(credential=credential).as_agent(
         name="FinancialAdvisor",
         instructions="""You are a professional financial advisor assistant.
 

--- a/python/samples/getting_started/evaluation/self_reflection/self_reflection.py
+++ b/python/samples/getting_started/evaluation/self_reflection/self_reflection.py
@@ -275,7 +275,7 @@ async def run_self_reflection_batch(
     agent = AzureOpenAIChatClient(
         credential=AzureCliCredential(),
         deployment_name=agent_model,
-    ).create_agent(
+    ).as_agent(
         instructions="You are a helpful agent.",
     )
 

--- a/python/samples/getting_started/mcp/agent_as_mcp_server.py
+++ b/python/samples/getting_started/mcp/agent_as_mcp_server.py
@@ -48,7 +48,7 @@ def get_item_price(
 async def run() -> None:
     # Define an agent
     # Agent's name and description provide better context for AI model
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="RestaurantAgent",
         description="Answer questions about the menu.",
         tools=[get_specials, get_item_price],

--- a/python/samples/getting_started/middleware/agent_and_run_level_middleware.py
+++ b/python/samples/getting_started/middleware/agent_and_run_level_middleware.py
@@ -166,7 +166,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/chat_middleware.py
+++ b/python/samples/getting_started/middleware/chat_middleware.py
@@ -142,7 +142,7 @@ async def class_based_chat_middleware() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="EnhancedChatAgent",
             instructions="You are a helpful AI assistant.",
             # Register class-based middleware at agent level (applies to all runs)
@@ -164,7 +164,7 @@ async def function_based_chat_middleware() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="FunctionMiddlewareAgent",
             instructions="You are a helpful AI assistant.",
             # Register function-based middleware at agent level
@@ -194,7 +194,7 @@ async def run_level_middleware() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="RunLevelAgent",
             instructions="You are a helpful AI assistant.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/class_based_middleware.py
+++ b/python/samples/getting_started/middleware/class_based_middleware.py
@@ -99,7 +99,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/decorator_middleware.py
+++ b/python/samples/getting_started/middleware/decorator_middleware.py
@@ -70,7 +70,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="TimeAgent",
             instructions="You are a helpful time assistant. Call get_current_time when asked about time.",
             tools=get_current_time,

--- a/python/samples/getting_started/middleware/exception_handling_with_middleware.py
+++ b/python/samples/getting_started/middleware/exception_handling_with_middleware.py
@@ -58,7 +58,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="DataAgent",
             instructions="You are a helpful data assistant. Use the data service tool to fetch information for users.",
             tools=unstable_data_service,

--- a/python/samples/getting_started/middleware/function_based_middleware.py
+++ b/python/samples/getting_started/middleware/function_based_middleware.py
@@ -83,7 +83,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/middleware_termination.py
+++ b/python/samples/getting_started/middleware/middleware_termination.py
@@ -110,7 +110,7 @@ async def pre_termination_middleware() -> None:
     print("\n--- Example 1: Pre-termination Middleware ---")
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant.",
             tools=get_weather,
@@ -137,7 +137,7 @@ async def post_termination_middleware() -> None:
     print("\n--- Example 2: Post-termination Middleware ---")
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/override_result_with_middleware.py
+++ b/python/samples/getting_started/middleware/override_result_with_middleware.py
@@ -83,7 +83,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="WeatherAgent",
             instructions="You are a helpful weather assistant. Use the weather tool to get current conditions.",
             tools=get_weather,

--- a/python/samples/getting_started/middleware/runtime_context_delegation.py
+++ b/python/samples/getting_started/middleware/runtime_context_delegation.py
@@ -147,7 +147,7 @@ async def pattern_1_single_agent_with_closure() -> None:
     client = OpenAIChatClient(model_id="gpt-4o-mini")
 
     # Create agent with both tools and shared context via middleware
-    communication_agent = client.create_agent(
+    communication_agent = client.as_agent(
         name="communication_agent",
         instructions=(
             "You are a communication assistant that can send emails and notifications. "
@@ -294,14 +294,14 @@ async def pattern_2_hierarchical_with_kwargs_propagation() -> None:
     client = OpenAIChatClient(model_id="gpt-4o-mini")
 
     # Create specialized sub-agents
-    email_agent = client.create_agent(
+    email_agent = client.as_agent(
         name="email_agent",
         instructions="You send emails using the send_email_v2 tool.",
         tools=[send_email_v2],
         middleware=[email_kwargs_tracker],
     )
 
-    sms_agent = client.create_agent(
+    sms_agent = client.as_agent(
         name="sms_agent",
         instructions="You send SMS messages using the send_sms tool.",
         tools=[send_sms],
@@ -309,7 +309,7 @@ async def pattern_2_hierarchical_with_kwargs_propagation() -> None:
     )
 
     # Create coordinator that delegates to sub-agents
-    coordinator = client.create_agent(
+    coordinator = client.as_agent(
         name="coordinator",
         instructions=(
             "You coordinate communication tasks. "
@@ -396,7 +396,7 @@ async def pattern_3_hierarchical_with_middleware() -> None:
     client = OpenAIChatClient(model_id="gpt-4o-mini")
 
     # Sub-agent with validation middleware
-    protected_agent = client.create_agent(
+    protected_agent = client.as_agent(
         name="protected_agent",
         instructions="You perform protected operations that require authentication.",
         tools=[protected_operation],
@@ -404,7 +404,7 @@ async def pattern_3_hierarchical_with_middleware() -> None:
     )
 
     # Coordinator delegates to protected agent
-    coordinator = client.create_agent(
+    coordinator = client.as_agent(
         name="coordinator",
         instructions="You coordinate protected operations. Delegate to protected_executor.",
         tools=[

--- a/python/samples/getting_started/middleware/shared_state_middleware.py
+++ b/python/samples/getting_started/middleware/shared_state_middleware.py
@@ -93,7 +93,7 @@ async def main() -> None:
     # authentication option.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="UtilityAgent",
             instructions="You are a helpful assistant that can provide weather information and current time.",
             tools=[get_weather, get_time],

--- a/python/samples/getting_started/middleware/thread_behavior_middleware.py
+++ b/python/samples/getting_started/middleware/thread_behavior_middleware.py
@@ -70,7 +70,7 @@ async def main() -> None:
 
     # For authentication, run `az login` command in terminal or replace AzureCliCredential with preferred
     # authentication option.
-    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    agent = AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather assistant.",
         tools=get_weather,

--- a/python/samples/getting_started/minimal_sample.py
+++ b/python/samples/getting_started/minimal_sample.py
@@ -15,7 +15,7 @@ def get_weather(
     return f"The weather in {location} is {conditions[randint(0, 3)]} with a high of {randint(10, 30)}°C."
 
 
-agent = OpenAIChatClient().create_agent(
+agent = OpenAIChatClient().as_agent(
     name="WeatherAgent", instructions="You are a helpful weather agent.", tools=get_weather
 )
 print(asyncio.run(agent.run("What's the weather like in Seattle?")))

--- a/python/samples/getting_started/threads/custom_chat_message_store_thread.py
+++ b/python/samples/getting_started/threads/custom_chat_message_store_thread.py
@@ -58,7 +58,7 @@ async def main() -> None:
 
     # OpenAI Chat Client is used as an example here,
     # other chat clients can be used as well.
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="CustomBot",
         instructions="You are a helpful assistant that remembers our conversation.",
         # Use custom chat message store.

--- a/python/samples/getting_started/threads/redis_chat_message_store_thread.py
+++ b/python/samples/getting_started/threads/redis_chat_message_store_thread.py
@@ -33,7 +33,7 @@ async def example_manual_memory_store() -> None:
     thread = AgentThread(message_store=redis_store)
 
     # Create agent
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="RedisBot",
         instructions="You are a helpful assistant that remembers our conversation using Redis.",
     )
@@ -76,7 +76,7 @@ async def example_user_session_management() -> None:
         )
 
     # Create agent with factory pattern
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="SessionBot",
         instructions="You are a helpful assistant. Keep track of user preferences.",
         chat_message_store_factory=create_user_session_store,
@@ -129,7 +129,7 @@ async def example_conversation_persistence() -> None:
     )
 
     thread1 = AgentThread(message_store=store1)
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="PersistentBot",
         instructions="You are a helpful assistant. Remember our conversation history.",
     )
@@ -189,7 +189,7 @@ async def example_thread_serialization() -> None:
 
     original_thread = AgentThread(message_store=original_store)
 
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="SerializationBot",
         instructions="You are a helpful assistant.",
     )
@@ -241,7 +241,7 @@ async def example_message_limits() -> None:
     )
 
     thread = AgentThread(message_store=store)
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="LimitBot",
         instructions="You are a helpful assistant with limited memory.",
     )

--- a/python/samples/getting_started/threads/suspend_resume_thread.py
+++ b/python/samples/getting_started/threads/suspend_resume_thread.py
@@ -22,7 +22,7 @@ async def suspend_resume_service_managed_thread() -> None:
     # AzureAIAgentClient supports service-managed threads.
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="MemoryBot", instructions="You are a helpful assistant that remembers our conversation."
         ) as agent,
     ):
@@ -55,7 +55,7 @@ async def suspend_resume_in_memory_thread() -> None:
 
     # OpenAI Chat Client is used as an example here,
     # other chat clients can be used as well.
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="MemoryBot", instructions="You are a helpful assistant that remembers our conversation."
     )
 

--- a/python/samples/getting_started/tools/README.md
+++ b/python/samples/getting_started/tools/README.md
@@ -80,7 +80,7 @@ class MyTools:
 
 # Create instance and use methods as tools
 tools = MyTools(mode="safe")
-agent = client.create_agent(tools=tools.process)
+agent = client.as_agent(tools=tools.process)
 
 # Change behavior dynamically
 tools.mode = "normal"

--- a/python/samples/getting_started/tools/ai_function_declaration_only.py
+++ b/python/samples/getting_started/tools/ai_function_declaration_only.py
@@ -19,7 +19,7 @@ async def main():
         description="Get the current time in ISO 8601 format.",
     )
 
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="DeclarationOnlyToolAgent",
         instructions="You are a helpful agent that uses tools.",
         tools=function_declaration,

--- a/python/samples/getting_started/tools/ai_function_from_dict_with_dependency_injection.py
+++ b/python/samples/getting_started/tools/ai_function_from_dict_with_dependency_injection.py
@@ -57,7 +57,7 @@ async def main() -> None:
     # - "func": the parameter name that will receive the injected function
     tool = AIFunction.from_dict(definition, dependencies={"ai_function": {"name:add_numbers": {"func": func}}})
 
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="FunctionToolAgent", instructions="You are a helpful assistant.", tools=tool
     )
     response = await agent.run("What is 5 + 3?")

--- a/python/samples/getting_started/tools/ai_function_recover_from_failures.py
+++ b/python/samples/getting_started/tools/ai_function_recover_from_failures.py
@@ -36,7 +36,7 @@ def safe_divide(
 
 async def main():
     # tools = Tools()
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="ToolAgent",
         instructions="Use the provided tools.",
         tools=[greet, safe_divide],

--- a/python/samples/getting_started/tools/ai_function_with_kwargs.py
+++ b/python/samples/getting_started/tools/ai_function_with_kwargs.py
@@ -36,7 +36,7 @@ def get_weather(
 
 
 async def main() -> None:
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="WeatherAgent",
         instructions="You are a helpful weather assistant.",
         tools=[get_weather],

--- a/python/samples/getting_started/tools/ai_function_with_max_exceptions.py
+++ b/python/samples/getting_started/tools/ai_function_with_max_exceptions.py
@@ -31,7 +31,7 @@ def safe_divide(
 
 async def main():
     # tools = Tools()
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="ToolAgent",
         instructions="Use the provided tools.",
         tools=[safe_divide],

--- a/python/samples/getting_started/tools/ai_function_with_max_invocations.py
+++ b/python/samples/getting_started/tools/ai_function_with_max_invocations.py
@@ -20,7 +20,7 @@ def unicorn_function(times: Annotated[int, "The number of unicorns to return."])
 
 async def main():
     # tools = Tools()
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="ToolAgent",
         instructions="Use the provided tools.",
         tools=[unicorn_function],

--- a/python/samples/getting_started/tools/ai_function_with_thread_injection.py
+++ b/python/samples/getting_started/tools/ai_function_with_thread_injection.py
@@ -35,7 +35,7 @@ async def get_weather(
 
 
 async def main() -> None:
-    agent = OpenAIChatClient().create_agent(
+    agent = OpenAIChatClient().as_agent(
         name="WeatherAgent", instructions="You are a helpful weather assistant.", tools=[get_weather]
     )
 

--- a/python/samples/getting_started/tools/ai_functions_in_class.py
+++ b/python/samples/getting_started/tools/ai_functions_in_class.py
@@ -45,7 +45,7 @@ async def main():
     # Applying the ai_function decorator to one of the methods of the class
     add_function = ai_function(description="Add two numbers.")(tools.add)
 
-    agent = OpenAIResponsesClient().create_agent(
+    agent = OpenAIResponsesClient().as_agent(
         name="ToolAgent",
         instructions="Use the provided tools.",
     )

--- a/python/samples/getting_started/tools/function_invocation_configuration.py
+++ b/python/samples/getting_started/tools/function_invocation_configuration.py
@@ -27,7 +27,7 @@ async def main():
         client.function_invocation_configuration.max_iterations = 40
         print(f"Function invocation configured as: \n{client.function_invocation_configuration.to_json(indent=2)}")
 
-    agent = client.create_agent(name="ToolAgent", instructions="Use the provided tools.", tools=add)
+    agent = client.as_agent(name="ToolAgent", instructions="Use the provided tools.", tools=add)
 
     print("=" * 60)
     print("Call add(239847293, 29834)")

--- a/python/samples/getting_started/workflows/_start-here/step2_agents_in_a_workflow.py
+++ b/python/samples/getting_started/workflows/_start-here/step2_agents_in_a_workflow.py
@@ -28,14 +28,14 @@ async def main():
     """Build and run a simple two node agent workflow: Writer then Reviewer."""
     # Create the Azure chat client. AzureCliCredential uses your current az login.
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
-    writer_agent = chat_client.create_agent(
+    writer_agent = chat_client.as_agent(
         instructions=(
             "You are an excellent content writer. You create new content and edit contents based on the feedback."
         ),
         name="writer",
     )
 
-    reviewer_agent = chat_client.create_agent(
+    reviewer_agent = chat_client.as_agent(
         instructions=(
             "You are an excellent content reviewer."
             "Provide actionable feedback to the writer about the provided content."

--- a/python/samples/getting_started/workflows/_start-here/step3_streaming.py
+++ b/python/samples/getting_started/workflows/_start-here/step3_streaming.py
@@ -52,7 +52,7 @@ class Writer(Executor):
 
     def __init__(self, chat_client: AzureOpenAIChatClient, id: str = "writer"):
         # Create a domain specific agent using your configured AzureOpenAIChatClient.
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             instructions=(
                 "You are an excellent content writer. You create new content and edit contents based on the feedback."
             ),
@@ -89,7 +89,7 @@ class Reviewer(Executor):
 
     def __init__(self, chat_client: AzureOpenAIChatClient, id: str = "reviewer"):
         # Create a domain specific agent that evaluates and refines content.
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             instructions=(
                 "You are an excellent content reviewer. You review the content and provide feedback to the writer."
             ),

--- a/python/samples/getting_started/workflows/_start-here/step4_using_factories.py
+++ b/python/samples/getting_started/workflows/_start-here/step4_using_factories.py
@@ -59,7 +59,7 @@ async def reverse_text(text: str, ctx: WorkflowContext[str]) -> None:
 
 def create_agent() -> ChatAgent:
     """Factory function to create a Writer agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=("You decode messages. Try to reconstruct the original message."),
         name="decoder",
     )

--- a/python/samples/getting_started/workflows/agents/azure_ai_agents_streaming.py
+++ b/python/samples/getting_started/workflows/agents/azure_ai_agents_streaming.py
@@ -27,7 +27,7 @@ Prerequisites:
 
 
 def create_writer_agent(client: AzureAIAgentClient) -> ChatAgent:
-    return client.create_agent(
+    return client.as_agent(
         name="Writer",
         instructions=(
             "You are an excellent content writer. You create new content and edit contents based on the feedback."
@@ -36,7 +36,7 @@ def create_writer_agent(client: AzureAIAgentClient) -> ChatAgent:
 
 
 def create_reviewer_agent(client: AzureAIAgentClient) -> ChatAgent:
-    return client.create_agent(
+    return client.as_agent(
         name="Reviewer",
         instructions=(
             "You are an excellent content reviewer. "

--- a/python/samples/getting_started/workflows/agents/azure_chat_agents_function_bridge.py
+++ b/python/samples/getting_started/workflows/agents/azure_chat_agents_function_bridge.py
@@ -87,7 +87,7 @@ async def enrich_with_references(
 
 
 def create_research_agent():
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="research_agent",
         instructions=(
             "Produce a short, bullet-style briefing with two actionable ideas. Label the section as 'Initial Draft'."
@@ -96,7 +96,7 @@ def create_research_agent():
 
 
 def create_final_editor_agent():
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="final_editor_agent",
         instructions=(
             "Use all conversation context (including external notes) to produce the final answer. "

--- a/python/samples/getting_started/workflows/agents/azure_chat_agents_streaming.py
+++ b/python/samples/getting_started/workflows/agents/azure_chat_agents_streaming.py
@@ -27,7 +27,7 @@ Prerequisites:
 
 
 def create_writer_agent():
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are an excellent content writer. You create new content and edit contents based on the feedback."
         ),
@@ -36,7 +36,7 @@ def create_writer_agent():
 
 
 def create_reviewer_agent():
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are an excellent content reviewer."
             "Provide actionable feedback to the writer about the provided content."

--- a/python/samples/getting_started/workflows/agents/azure_chat_agents_tool_calls_with_feedback.py
+++ b/python/samples/getting_started/workflows/agents/azure_chat_agents_tool_calls_with_feedback.py
@@ -168,7 +168,7 @@ class Coordinator(Executor):
 
 def create_writer_agent() -> ChatAgent:
     """Creates a writer agent with tools."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="writer_agent",
         instructions=(
             "You are a marketing writer. Call the available tools before drafting copy so you are precise. "
@@ -182,7 +182,7 @@ def create_writer_agent() -> ChatAgent:
 
 def create_final_editor_agent() -> ChatAgent:
     """Creates a final editor agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="final_editor_agent",
         instructions=(
             "You are an editor who polishes marketing copy after human approval. "

--- a/python/samples/getting_started/workflows/agents/concurrent_workflow_as_agent.py
+++ b/python/samples/getting_started/workflows/agents/concurrent_workflow_as_agent.py
@@ -28,7 +28,7 @@ async def main() -> None:
     # 1) Create three domain agents using AzureOpenAIChatClient
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    researcher = chat_client.create_agent(
+    researcher = chat_client.as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
@@ -36,7 +36,7 @@ async def main() -> None:
         name="researcher",
     )
 
-    marketer = chat_client.create_agent(
+    marketer = chat_client.as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
@@ -44,7 +44,7 @@ async def main() -> None:
         name="marketer",
     )
 
-    legal = chat_client.create_agent(
+    legal = chat_client.as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/getting_started/workflows/agents/custom_agent_executors.py
+++ b/python/samples/getting_started/workflows/agents/custom_agent_executors.py
@@ -43,7 +43,7 @@ class Writer(Executor):
 
     def __init__(self, id: str = "writer"):
         # Create a domain specific agent using your configured AzureOpenAIChatClient.
-        self.agent = AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+        self.agent = AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
             instructions=(
                 "You are an excellent content writer. You create new content and edit contents based on the feedback."
             ),
@@ -85,7 +85,7 @@ class Reviewer(Executor):
 
     def __init__(self, id: str = "reviewer"):
         # Create a domain specific agent that evaluates and refines content.
-        self.agent = AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+        self.agent = AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
             instructions=(
                 "You are an excellent content reviewer. You review the content and provide feedback to the writer."
             ),

--- a/python/samples/getting_started/workflows/agents/group_chat_workflow_as_agent.py
+++ b/python/samples/getting_started/workflows/agents/group_chat_workflow_as_agent.py
@@ -35,7 +35,7 @@ async def main() -> None:
     workflow = (
         GroupChatBuilder()
         .with_agent_orchestrator(
-            OpenAIChatClient().create_agent(
+            OpenAIChatClient().as_agent(
                 name="Orchestrator",
                 instructions="You coordinate a team conversation to solve the user's task.",
             )

--- a/python/samples/getting_started/workflows/agents/handoff_workflow_as_agent.py
+++ b/python/samples/getting_started/workflows/agents/handoff_workflow_as_agent.py
@@ -66,7 +66,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
         Tuple of (triage_agent, refund_agent, order_agent, return_agent)
     """
     # Triage agent: Acts as the frontline dispatcher
-    triage_agent = chat_client.create_agent(
+    triage_agent = chat_client.as_agent(
         instructions=(
             "You are frontline support triage. Route customer issues to the appropriate specialist agents "
             "based on the problem described."
@@ -75,7 +75,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Refund specialist: Handles refund requests
-    refund_agent = chat_client.create_agent(
+    refund_agent = chat_client.as_agent(
         instructions="You process refund requests.",
         name="refund_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -83,7 +83,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Order/shipping specialist: Resolves delivery issues
-    order_agent = chat_client.create_agent(
+    order_agent = chat_client.as_agent(
         instructions="You handle order and shipping inquiries.",
         name="order_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -91,7 +91,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Return specialist: Handles return requests
-    return_agent = chat_client.create_agent(
+    return_agent = chat_client.as_agent(
         instructions="You manage product return requests.",
         name="return_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple

--- a/python/samples/getting_started/workflows/agents/mixed_agents_and_executors.py
+++ b/python/samples/getting_started/workflows/agents/mixed_agents_and_executors.py
@@ -82,7 +82,7 @@ def create_coding_agent(client: AzureAIAgentClient) -> ChatAgent:
     Returns:
         A ChatAgent configured with coding instructions and tools
     """
-    return client.create_agent(
+    return client.as_agent(
         name="CodingAgent",
         instructions=("You are a helpful assistant that can write and execute Python code to solve problems."),
         tools=HostedCodeInterpreterTool(),

--- a/python/samples/getting_started/workflows/agents/sequential_workflow_as_agent.py
+++ b/python/samples/getting_started/workflows/agents/sequential_workflow_as_agent.py
@@ -29,12 +29,12 @@ async def main() -> None:
     # 1) Create agents
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    writer = chat_client.create_agent(
+    writer = chat_client.as_agent(
         instructions=("You are a concise copywriter. Provide a single, punchy marketing sentence based on the prompt."),
         name="writer",
     )
 
-    reviewer = chat_client.create_agent(
+    reviewer = chat_client.as_agent(
         instructions=("You are a thoughtful reviewer. Give brief feedback on the previous assistant message."),
         name="reviewer",
     )

--- a/python/samples/getting_started/workflows/agents/workflow_as_agent_kwargs.py
+++ b/python/samples/getting_started/workflows/agents/workflow_as_agent_kwargs.py
@@ -79,7 +79,7 @@ async def main() -> None:
     chat_client = OpenAIChatClient()
 
     # Create agent with tools that use kwargs
-    agent = chat_client.create_agent(
+    agent = chat_client.as_agent(
         name="assistant",
         instructions=(
             "You are a helpful assistant. Use the available tools to help users. "

--- a/python/samples/getting_started/workflows/agents/workflow_as_agent_with_thread.py
+++ b/python/samples/getting_started/workflows/agents/workflow_as_agent_with_thread.py
@@ -40,7 +40,7 @@ async def main() -> None:
 
     # Define factory functions for workflow participants
     def create_assistant() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="assistant",
             instructions=(
                 "You are a helpful assistant. Answer questions based on the conversation "
@@ -49,7 +49,7 @@ async def main() -> None:
         )
 
     def create_summarizer() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="summarizer",
             instructions=(
                 "You are a summarizer. After the assistant responds, provide a brief "
@@ -124,7 +124,7 @@ async def demonstrate_thread_serialization() -> None:
     chat_client = OpenAIChatClient()
 
     def create_assistant() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="memory_assistant",
             instructions="You are a helpful assistant with good memory. Remember details from our conversation.",
         )

--- a/python/samples/getting_started/workflows/checkpoint/checkpoint_with_human_in_the_loop.py
+++ b/python/samples/getting_started/workflows/checkpoint/checkpoint_with_human_in_the_loop.py
@@ -178,7 +178,7 @@ def create_workflow(checkpoint_storage: FileCheckpointStorage) -> Workflow:
     workflow_builder = (
         WorkflowBuilder(max_iterations=6)
         .register_agent(
-            lambda: AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+            lambda: AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
                 instructions="Write concise, warm release notes that sound human and helpful.",
                 # The agent name is stable across runs which keeps checkpoints deterministic.
                 name="writer",

--- a/python/samples/getting_started/workflows/checkpoint/handoff_with_tool_approval_checkpoint_resume.py
+++ b/python/samples/getting_started/workflows/checkpoint/handoff_with_tool_approval_checkpoint_resume.py
@@ -60,7 +60,7 @@ def submit_refund(refund_description: str, amount: str, order_id: str) -> str:
 def create_agents(client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAgent, ChatAgent]:
     """Create a simple handoff scenario: triage, refund, and order specialists."""
 
-    triage = client.create_agent(
+    triage = client.as_agent(
         name="triage_agent",
         instructions=(
             "You are a customer service triage agent. Listen to customer issues and determine "
@@ -69,7 +69,7 @@ def create_agents(client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAgent, 
         ),
     )
 
-    refund = client.create_agent(
+    refund = client.as_agent(
         name="refund_agent",
         instructions=(
             "You are a refund specialist. Help customers with refund requests. "
@@ -80,7 +80,7 @@ def create_agents(client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAgent, 
         tools=[submit_refund],
     )
 
-    order = client.create_agent(
+    order = client.as_agent(
         name="order_agent",
         instructions=(
             "You are an order tracking specialist. Help customers track their orders. "

--- a/python/samples/getting_started/workflows/checkpoint/workflow_as_agent_checkpoint.py
+++ b/python/samples/getting_started/workflows/checkpoint/workflow_as_agent_checkpoint.py
@@ -44,13 +44,13 @@ async def basic_checkpointing() -> None:
     chat_client = OpenAIChatClient()
 
     def create_assistant() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="assistant",
             instructions="You are a helpful assistant. Keep responses brief.",
         )
 
     def create_reviewer() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="reviewer",
             instructions="You are a reviewer. Provide a one-sentence summary of the assistant's response.",
         )
@@ -88,7 +88,7 @@ async def checkpointing_with_thread() -> None:
     chat_client = OpenAIChatClient()
 
     def create_assistant() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="memory_assistant",
             instructions="You are a helpful assistant with good memory. Reference previous conversation when relevant.",
         )
@@ -132,7 +132,7 @@ async def streaming_with_checkpoints() -> None:
     chat_client = OpenAIChatClient()
 
     def create_assistant() -> ChatAgent:
-        return chat_client.create_agent(
+        return chat_client.as_agent(
             name="streaming_assistant",
             instructions="You are a helpful assistant.",
         )

--- a/python/samples/getting_started/workflows/composition/sub_workflow_kwargs.py
+++ b/python/samples/getting_started/workflows/composition/sub_workflow_kwargs.py
@@ -75,7 +75,7 @@ async def main() -> None:
     chat_client = OpenAIChatClient()
 
     # Create an agent with tools that use kwargs
-    inner_agent = chat_client.create_agent(
+    inner_agent = chat_client.as_agent(
         name="data_agent",
         instructions=(
             "You are a data access agent. Use the available tools to help users. "

--- a/python/samples/getting_started/workflows/control-flow/edge_condition.py
+++ b/python/samples/getting_started/workflows/control-flow/edge_condition.py
@@ -131,7 +131,7 @@ async def to_email_assistant_request(
 def create_spam_detector_agent() -> ChatAgent:
     """Helper to create a spam detection agent."""
     # AzureCliCredential uses your current az login. This avoids embedding secrets in code.
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are a spam detection assistant that identifies spam emails. "
             "Always return JSON with fields is_spam (bool), reason (string), and email_content (string). "
@@ -145,7 +145,7 @@ def create_spam_detector_agent() -> ChatAgent:
 def create_email_assistant_agent() -> ChatAgent:
     """Helper to create an email assistant agent."""
     # AzureCliCredential uses your current az login. This avoids embedding secrets in code.
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are an email assistant that helps users draft professional responses to emails. "
             "Your input may be a JSON object that includes 'email_content'; base your reply on that content. "

--- a/python/samples/getting_started/workflows/control-flow/multi_selection_edge_group.py
+++ b/python/samples/getting_started/workflows/control-flow/multi_selection_edge_group.py
@@ -183,7 +183,7 @@ async def database_access(analysis: AnalysisResult, ctx: WorkflowContext[Never, 
 
 def create_email_analysis_agent() -> ChatAgent:
     """Creates the email analysis agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are a spam detection assistant that identifies spam emails. "
             "Always return JSON with fields 'spam_decision' (one of NotSpam, Spam, Uncertain) "
@@ -196,7 +196,7 @@ def create_email_analysis_agent() -> ChatAgent:
 
 def create_email_assistant_agent() -> ChatAgent:
     """Creates the email assistant agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=("You are an email assistant that helps users draft responses to emails with professionalism."),
         name="email_assistant_agent",
         default_options={"response_format": EmailResponse},
@@ -205,7 +205,7 @@ def create_email_assistant_agent() -> ChatAgent:
 
 def create_email_summary_agent() -> ChatAgent:
     """Creates the email summary agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=("You are an assistant that helps users summarize emails."),
         name="email_summary_agent",
         default_options={"response_format": EmailSummaryModel},

--- a/python/samples/getting_started/workflows/control-flow/simple_loop.py
+++ b/python/samples/getting_started/workflows/control-flow/simple_loop.py
@@ -117,7 +117,7 @@ class ParseJudgeResponse(Executor):
 
 def create_judge_agent() -> ChatAgent:
     """Create a judge agent that evaluates guesses."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=("You strictly respond with one of: MATCHED, ABOVE, BELOW based on the given target and guess."),
         name="judge_agent",
     )

--- a/python/samples/getting_started/workflows/control-flow/switch_case_edge_group.py
+++ b/python/samples/getting_started/workflows/control-flow/switch_case_edge_group.py
@@ -154,7 +154,7 @@ async def handle_uncertain(detection: DetectionResult, ctx: WorkflowContext[Neve
 
 def create_spam_detection_agent() -> ChatAgent:
     """Create and return the spam detection agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are a spam detection assistant that identifies spam emails. "
             "Be less confident in your assessments. "
@@ -168,7 +168,7 @@ def create_spam_detection_agent() -> ChatAgent:
 
 def create_email_assistant_agent() -> ChatAgent:
     """Create and return the email assistant agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=("You are an email assistant that helps users draft responses to emails with professionalism."),
         name="email_assistant_agent",
         default_options={"response_format": EmailResponse},

--- a/python/samples/getting_started/workflows/declarative/customer_support/main.py
+++ b/python/samples/getting_started/workflows/declarative/customer_support/main.py
@@ -168,40 +168,40 @@ async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create agents with structured outputs
-    self_service_agent = chat_client.create_agent(
+    self_service_agent = chat_client.as_agent(
         name="SelfServiceAgent",
         instructions=SELF_SERVICE_INSTRUCTIONS,
         default_options={"response_format": SelfServiceResponse},
     )
 
-    ticketing_agent = chat_client.create_agent(
+    ticketing_agent = chat_client.as_agent(
         name="TicketingAgent",
         instructions=TICKETING_INSTRUCTIONS,
         tools=plugin.get_functions(),
         default_options={"response_format": TicketingResponse},
     )
 
-    routing_agent = chat_client.create_agent(
+    routing_agent = chat_client.as_agent(
         name="TicketRoutingAgent",
         instructions=TICKET_ROUTING_INSTRUCTIONS,
         tools=[plugin.get_ticket],
         default_options={"response_format": RoutingResponse},
     )
 
-    windows_support_agent = chat_client.create_agent(
+    windows_support_agent = chat_client.as_agent(
         name="WindowsSupportAgent",
         instructions=WINDOWS_SUPPORT_INSTRUCTIONS,
         tools=[plugin.get_ticket],
         default_options={"response_format": SupportResponse},
     )
 
-    resolution_agent = chat_client.create_agent(
+    resolution_agent = chat_client.as_agent(
         name="TicketResolutionAgent",
         instructions=RESOLUTION_INSTRUCTIONS,
         tools=[plugin.resolve_ticket],
     )
 
-    escalation_agent = chat_client.create_agent(
+    escalation_agent = chat_client.as_agent(
         name="TicketEscalationAgent",
         instructions=ESCALATION_INSTRUCTIONS,
         tools=[plugin.get_ticket, plugin.send_notification],

--- a/python/samples/getting_started/workflows/declarative/deep_research/main.py
+++ b/python/samples/getting_started/workflows/declarative/deep_research/main.py
@@ -126,38 +126,38 @@ async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create agents
-    research_agent = chat_client.create_agent(
+    research_agent = chat_client.as_agent(
         name="ResearchAgent",
         instructions=RESEARCH_INSTRUCTIONS,
     )
 
-    planner_agent = chat_client.create_agent(
+    planner_agent = chat_client.as_agent(
         name="PlannerAgent",
         instructions=PLANNER_INSTRUCTIONS,
     )
 
-    manager_agent = chat_client.create_agent(
+    manager_agent = chat_client.as_agent(
         name="ManagerAgent",
         instructions=MANAGER_INSTRUCTIONS,
         default_options={"response_format": ManagerResponse},
     )
 
-    summary_agent = chat_client.create_agent(
+    summary_agent = chat_client.as_agent(
         name="SummaryAgent",
         instructions=SUMMARY_INSTRUCTIONS,
     )
 
-    knowledge_agent = chat_client.create_agent(
+    knowledge_agent = chat_client.as_agent(
         name="KnowledgeAgent",
         instructions=KNOWLEDGE_INSTRUCTIONS,
     )
 
-    coder_agent = chat_client.create_agent(
+    coder_agent = chat_client.as_agent(
         name="CoderAgent",
         instructions=CODER_INSTRUCTIONS,
     )
 
-    weather_agent = chat_client.create_agent(
+    weather_agent = chat_client.as_agent(
         name="WeatherAgent",
         instructions=WEATHER_INSTRUCTIONS,
     )

--- a/python/samples/getting_started/workflows/declarative/function_tools/README.md
+++ b/python/samples/getting_started/workflows/declarative/function_tools/README.md
@@ -73,7 +73,7 @@ Session Complete
 ```python
 # Create the agent with tools
 chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
-menu_agent = chat_client.create_agent(
+menu_agent = chat_client.as_agent(
     name="MenuAgent",
     instructions="You are a helpful restaurant menu assistant...",
     tools=[get_menu, get_specials, get_item_price],

--- a/python/samples/getting_started/workflows/declarative/function_tools/main.py
+++ b/python/samples/getting_started/workflows/declarative/function_tools/main.py
@@ -59,7 +59,7 @@ def get_item_price(name: Annotated[str, Field(description="Menu item name")]) ->
 async def main():
     # Create agent with tools
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
-    menu_agent = chat_client.create_agent(
+    menu_agent = chat_client.as_agent(
         name="MenuAgent",
         instructions="Answer questions about menu items, specials, and prices.",
         tools=[get_menu, get_specials, get_item_price],

--- a/python/samples/getting_started/workflows/declarative/marketing/main.py
+++ b/python/samples/getting_started/workflows/declarative/marketing/main.py
@@ -52,15 +52,15 @@ async def main() -> None:
     """Run the marketing workflow with real Azure AI agents."""
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    analyst_agent = chat_client.create_agent(
+    analyst_agent = chat_client.as_agent(
         name="AnalystAgent",
         instructions=ANALYST_INSTRUCTIONS,
     )
-    writer_agent = chat_client.create_agent(
+    writer_agent = chat_client.as_agent(
         name="WriterAgent",
         instructions=WRITER_INSTRUCTIONS,
     )
-    editor_agent = chat_client.create_agent(
+    editor_agent = chat_client.as_agent(
         name="EditorAgent",
         instructions=EDITOR_INSTRUCTIONS,
     )

--- a/python/samples/getting_started/workflows/declarative/student_teacher/main.py
+++ b/python/samples/getting_started/workflows/declarative/student_teacher/main.py
@@ -55,12 +55,12 @@ async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create student and teacher agents
-    student_agent = chat_client.create_agent(
+    student_agent = chat_client.as_agent(
         name="StudentAgent",
         instructions=STUDENT_INSTRUCTIONS,
     )
 
-    teacher_agent = chat_client.create_agent(
+    teacher_agent = chat_client.as_agent(
         name="TeacherAgent",
         instructions=TEACHER_INSTRUCTIONS,
     )

--- a/python/samples/getting_started/workflows/human-in-the-loop/agents_with_approval_requests.py
+++ b/python/samples/getting_started/workflows/human-in-the-loop/agents_with_approval_requests.py
@@ -213,7 +213,7 @@ async def conclude_workflow(
 
 def create_email_writer_agent() -> ChatAgent:
     """Create the Email Writer agent with tools that require approval."""
-    return OpenAIChatClient().create_agent(
+    return OpenAIChatClient().as_agent(
         name="Email Writer",
         instructions=("You are an excellent email assistant. You respond to incoming emails."),
         # tools with `approval_mode="always_require"` will trigger approval requests

--- a/python/samples/getting_started/workflows/human-in-the-loop/concurrent_request_info.py
+++ b/python/samples/getting_started/workflows/human-in-the-loop/concurrent_request_info.py
@@ -99,7 +99,7 @@ async def main() -> None:
     _chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create agents that analyze from different perspectives
-    technical_analyst = _chat_client.create_agent(
+    technical_analyst = _chat_client.as_agent(
         name="technical_analyst",
         instructions=(
             "You are a technical analyst. When given a topic, provide a technical "
@@ -108,7 +108,7 @@ async def main() -> None:
         ),
     )
 
-    business_analyst = _chat_client.create_agent(
+    business_analyst = _chat_client.as_agent(
         name="business_analyst",
         instructions=(
             "You are a business analyst. When given a topic, provide a business "
@@ -117,7 +117,7 @@ async def main() -> None:
         ),
     )
 
-    user_experience_analyst = _chat_client.create_agent(
+    user_experience_analyst = _chat_client.as_agent(
         name="ux_analyst",
         instructions=(
             "You are a UX analyst. When given a topic, provide a user experience "

--- a/python/samples/getting_started/workflows/human-in-the-loop/group_chat_request_info.py
+++ b/python/samples/getting_started/workflows/human-in-the-loop/group_chat_request_info.py
@@ -44,7 +44,7 @@ async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create agents for a group discussion
-    optimist = chat_client.create_agent(
+    optimist = chat_client.as_agent(
         name="optimist",
         instructions=(
             "You are an optimistic team member. You see opportunities and potential "
@@ -53,7 +53,7 @@ async def main() -> None:
         ),
     )
 
-    pragmatist = chat_client.create_agent(
+    pragmatist = chat_client.as_agent(
         name="pragmatist",
         instructions=(
             "You are a pragmatic team member. You focus on practical implementation "
@@ -62,7 +62,7 @@ async def main() -> None:
         ),
     )
 
-    creative = chat_client.create_agent(
+    creative = chat_client.as_agent(
         name="creative",
         instructions=(
             "You are a creative team member. You propose innovative solutions and "
@@ -72,7 +72,7 @@ async def main() -> None:
     )
 
     # Orchestrator coordinates the discussion
-    orchestrator = chat_client.create_agent(
+    orchestrator = chat_client.as_agent(
         name="orchestrator",
         instructions=(
             "You are a discussion manager coordinating a team conversation between participants. "

--- a/python/samples/getting_started/workflows/human-in-the-loop/guessing_game_with_human_input.py
+++ b/python/samples/getting_started/workflows/human-in-the-loop/guessing_game_with_human_input.py
@@ -145,7 +145,7 @@ class TurnManager(Executor):
 
 def create_guessing_agent() -> ChatAgent:
     """Create the guessing agent with instructions to guess a number between 1 and 10."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         name="GuessingAgent",
         instructions=(
             "You guess a number between 1 and 10. "

--- a/python/samples/getting_started/workflows/human-in-the-loop/sequential_request_info.py
+++ b/python/samples/getting_started/workflows/human-in-the-loop/sequential_request_info.py
@@ -41,12 +41,12 @@ async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
     # Create agents for a sequential document review workflow
-    drafter = chat_client.create_agent(
+    drafter = chat_client.as_agent(
         name="drafter",
         instructions=("You are a document drafter. When given a topic, create a brief draft (2-3 sentences)."),
     )
 
-    editor = chat_client.create_agent(
+    editor = chat_client.as_agent(
         name="editor",
         instructions=(
             "You are an editor. Review the draft and make improvements. "
@@ -54,7 +54,7 @@ async def main() -> None:
         ),
     )
 
-    finalizer = chat_client.create_agent(
+    finalizer = chat_client.as_agent(
         name="finalizer",
         instructions=(
             "You are a finalizer. Take the edited content and create a polished final version. "

--- a/python/samples/getting_started/workflows/orchestration/concurrent_agents.py
+++ b/python/samples/getting_started/workflows/orchestration/concurrent_agents.py
@@ -30,7 +30,7 @@ async def main() -> None:
     # 1) Create three domain agents using AzureOpenAIChatClient
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    researcher = chat_client.create_agent(
+    researcher = chat_client.as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
@@ -38,7 +38,7 @@ async def main() -> None:
         name="researcher",
     )
 
-    marketer = chat_client.create_agent(
+    marketer = chat_client.as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
@@ -46,7 +46,7 @@ async def main() -> None:
         name="marketer",
     )
 
-    legal = chat_client.create_agent(
+    legal = chat_client.as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/getting_started/workflows/orchestration/concurrent_custom_agent_executors.py
+++ b/python/samples/getting_started/workflows/orchestration/concurrent_custom_agent_executors.py
@@ -40,7 +40,7 @@ class ResearcherExec(Executor):
     agent: ChatAgent
 
     def __init__(self, chat_client: AzureOpenAIChatClient, id: str = "researcher"):
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             instructions=(
                 "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
                 " opportunities, and risks."
@@ -60,7 +60,7 @@ class MarketerExec(Executor):
     agent: ChatAgent
 
     def __init__(self, chat_client: AzureOpenAIChatClient, id: str = "marketer"):
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             instructions=(
                 "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
                 " aligned to the prompt."
@@ -80,7 +80,7 @@ class LegalExec(Executor):
     agent: ChatAgent
 
     def __init__(self, chat_client: AzureOpenAIChatClient, id: str = "legal"):
-        self.agent = chat_client.create_agent(
+        self.agent = chat_client.as_agent(
             instructions=(
                 "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
                 " based on the prompt."

--- a/python/samples/getting_started/workflows/orchestration/concurrent_custom_aggregator.py
+++ b/python/samples/getting_started/workflows/orchestration/concurrent_custom_aggregator.py
@@ -30,21 +30,21 @@ Prerequisites:
 async def main() -> None:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    researcher = chat_client.create_agent(
+    researcher = chat_client.as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
         ),
         name="researcher",
     )
-    marketer = chat_client.create_agent(
+    marketer = chat_client.as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
         ),
         name="marketer",
     )
-    legal = chat_client.create_agent(
+    legal = chat_client.as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/getting_started/workflows/orchestration/concurrent_participant_factory.py
+++ b/python/samples/getting_started/workflows/orchestration/concurrent_participant_factory.py
@@ -46,7 +46,7 @@ Prerequisites:
 
 def create_researcher() -> ChatAgent:
     """Factory function to create a researcher agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
@@ -57,7 +57,7 @@ def create_researcher() -> ChatAgent:
 
 def create_marketer() -> ChatAgent:
     """Factory function to create a marketer agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
@@ -68,7 +68,7 @@ def create_marketer() -> ChatAgent:
 
 def create_legal() -> ChatAgent:
     """Factory function to create a legal/compliance agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/getting_started/workflows/orchestration/handoff_autonomous.py
+++ b/python/samples/getting_started/workflows/orchestration/handoff_autonomous.py
@@ -44,7 +44,7 @@ def create_agents(
     chat_client: AzureOpenAIChatClient,
 ) -> tuple[ChatAgent, ChatAgent, ChatAgent]:
     """Create coordinator and specialists for autonomous iteration."""
-    coordinator = chat_client.create_agent(
+    coordinator = chat_client.as_agent(
         instructions=(
             "You are a coordinator. You break down a user query into a research task and a summary task. "
             "Assign the two tasks to the appropriate specialists, one after the other."
@@ -52,7 +52,7 @@ def create_agents(
         name="coordinator",
     )
 
-    research_agent = chat_client.create_agent(
+    research_agent = chat_client.as_agent(
         instructions=(
             "You are a research specialist that explores topics thoroughly using web search. "
             "When given a research task, break it down into multiple aspects and explore each one. "
@@ -65,7 +65,7 @@ def create_agents(
         tools=[HostedWebSearchTool()],
     )
 
-    summary_agent = chat_client.create_agent(
+    summary_agent = chat_client.as_agent(
         instructions=(
             "You summarize research findings. Provide a concise, well-organized summary. When done, return "
             "control to the coordinator."

--- a/python/samples/getting_started/workflows/orchestration/handoff_participant_factory.py
+++ b/python/samples/getting_started/workflows/orchestration/handoff_participant_factory.py
@@ -67,7 +67,7 @@ def process_return(order_number: Annotated[str, "Order number to process return 
 
 def create_triage_agent() -> ChatAgent:
     """Factory function to create a triage agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are frontline support triage. Route customer issues to the appropriate specialist agents "
             "based on the problem described."
@@ -78,7 +78,7 @@ def create_triage_agent() -> ChatAgent:
 
 def create_refund_agent() -> ChatAgent:
     """Factory function to create a refund agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="You process refund requests.",
         name="refund_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -88,7 +88,7 @@ def create_refund_agent() -> ChatAgent:
 
 def create_order_status_agent() -> ChatAgent:
     """Factory function to create an order status agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="You handle order and shipping inquiries.",
         name="order_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -98,7 +98,7 @@ def create_order_status_agent() -> ChatAgent:
 
 def create_return_agent() -> ChatAgent:
     """Factory function to create a return agent instance."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="You manage product return requests.",
         name="return_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple

--- a/python/samples/getting_started/workflows/orchestration/handoff_simple.py
+++ b/python/samples/getting_started/workflows/orchestration/handoff_simple.py
@@ -66,7 +66,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
         Tuple of (triage_agent, refund_agent, order_agent, return_agent)
     """
     # Triage agent: Acts as the frontline dispatcher
-    triage_agent = chat_client.create_agent(
+    triage_agent = chat_client.as_agent(
         instructions=(
             "You are frontline support triage. Route customer issues to the appropriate specialist agents "
             "based on the problem described."
@@ -75,7 +75,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Refund specialist: Handles refund requests
-    refund_agent = chat_client.create_agent(
+    refund_agent = chat_client.as_agent(
         instructions="You process refund requests.",
         name="refund_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -83,7 +83,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Order/shipping specialist: Resolves delivery issues
-    order_agent = chat_client.create_agent(
+    order_agent = chat_client.as_agent(
         instructions="You handle order and shipping inquiries.",
         name="order_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple
@@ -91,7 +91,7 @@ def create_agents(chat_client: AzureOpenAIChatClient) -> tuple[ChatAgent, ChatAg
     )
 
     # Return specialist: Handles return requests
-    return_agent = chat_client.create_agent(
+    return_agent = chat_client.as_agent(
         instructions="You manage product return requests.",
         name="return_agent",
         # In a real application, an agent can have multiple tools; here we keep it simple

--- a/python/samples/getting_started/workflows/orchestration/handoff_with_code_interpreter_file.py
+++ b/python/samples/getting_started/workflows/orchestration/handoff_with_code_interpreter_file.py
@@ -90,7 +90,7 @@ async def create_agents_v1(credential: AzureCliCredential) -> AsyncIterator[tupl
     from agent_framework.azure import AzureAIAgentClient
 
     async with AzureAIAgentClient(credential=credential) as client:
-        triage = client.create_agent(
+        triage = client.as_agent(
             name="triage_agent",
             instructions=(
                 "You are a triage agent. Route code-related requests to the code_specialist. "
@@ -99,7 +99,7 @@ async def create_agents_v1(credential: AzureCliCredential) -> AsyncIterator[tupl
             ),
         )
 
-        code_specialist = client.create_agent(
+        code_specialist = client.as_agent(
             name="code_specialist",
             instructions=(
                 "You are a Python code specialist. Use the code interpreter to execute Python code "
@@ -124,12 +124,12 @@ async def create_agents_v2(credential: AzureCliCredential) -> AsyncIterator[tupl
         AzureAIClient(credential=credential) as triage_client,
         AzureAIClient(credential=credential) as code_client,
     ):
-        triage = triage_client.create_agent(
+        triage = triage_client.as_agent(
             name="TriageAgent",
             instructions="You are a triage agent. Your ONLY job is to route requests to the appropriate specialist.",
         )
 
-        code_specialist = code_client.create_agent(
+        code_specialist = code_client.as_agent(
             name="CodeSpecialist",
             instructions=(
                 "You are a Python code specialist. You have access to a code interpreter tool. "

--- a/python/samples/getting_started/workflows/orchestration/sequential_agents.py
+++ b/python/samples/getting_started/workflows/orchestration/sequential_agents.py
@@ -31,12 +31,12 @@ async def main() -> None:
     # 1) Create agents
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    writer = chat_client.create_agent(
+    writer = chat_client.as_agent(
         instructions=("You are a concise copywriter. Provide a single, punchy marketing sentence based on the prompt."),
         name="writer",
     )
 
-    reviewer = chat_client.create_agent(
+    reviewer = chat_client.as_agent(
         instructions=("You are a thoughtful reviewer. Give brief feedback on the previous assistant message."),
         name="reviewer",
     )

--- a/python/samples/getting_started/workflows/orchestration/sequential_custom_executors.py
+++ b/python/samples/getting_started/workflows/orchestration/sequential_custom_executors.py
@@ -60,7 +60,7 @@ class Summarizer(Executor):
 async def main() -> None:
     # 1) Create a content agent
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
-    content = chat_client.create_agent(
+    content = chat_client.as_agent(
         instructions="Produce a concise paragraph answering the user's request.",
         name="content",
     )

--- a/python/samples/getting_started/workflows/orchestration/sequential_participant_factory.py
+++ b/python/samples/getting_started/workflows/orchestration/sequential_participant_factory.py
@@ -50,7 +50,7 @@ class Accumulate(Executor):
 
 
 def create_agent() -> ChatAgent:
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions="Produce a concise paragraph answering the user's request.",
         name="ContentProducer",
     )

--- a/python/samples/getting_started/workflows/parallelism/fan_out_fan_in_edges.py
+++ b/python/samples/getting_started/workflows/parallelism/fan_out_fan_in_edges.py
@@ -94,7 +94,7 @@ class AggregateInsights(Executor):
 
 def create_researcher_agent() -> ChatAgent:
     """Creates a research domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
@@ -105,7 +105,7 @@ def create_researcher_agent() -> ChatAgent:
 
 def create_marketer_agent() -> ChatAgent:
     """Creates a marketing domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
@@ -116,7 +116,7 @@ def create_marketer_agent() -> ChatAgent:
 
 def create_legal_agent() -> ChatAgent:
     """Creates a legal/compliance domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/getting_started/workflows/state-management/shared_states_with_agents.py
+++ b/python/samples/getting_started/workflows/state-management/shared_states_with_agents.py
@@ -157,7 +157,7 @@ async def handle_spam(detection: DetectionResult, ctx: WorkflowContext[Never, st
 
 def create_spam_detection_agent() -> ChatAgent:
     """Creates a spam detection agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are a spam detection assistant that identifies spam emails. "
             "Always return JSON with fields is_spam (bool) and reason (string)."
@@ -170,7 +170,7 @@ def create_spam_detection_agent() -> ChatAgent:
 
 def create_email_assistant_agent() -> ChatAgent:
     """Creates an email assistant agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You are an email assistant that helps users draft responses to emails with professionalism. "
             "Return JSON with a single field 'response' containing the drafted reply."

--- a/python/samples/getting_started/workflows/state-management/workflow_kwargs.py
+++ b/python/samples/getting_started/workflows/state-management/workflow_kwargs.py
@@ -73,7 +73,7 @@ async def main() -> None:
     chat_client = OpenAIChatClient()
 
     # Create agent with tools that use kwargs
-    agent = chat_client.create_agent(
+    agent = chat_client.as_agent(
         name="assistant",
         instructions=(
             "You are a helpful assistant. Use the available tools to help users. "

--- a/python/samples/getting_started/workflows/tool-approval/concurrent_builder_tool_approval.py
+++ b/python/samples/getting_started/workflows/tool-approval/concurrent_builder_tool_approval.py
@@ -104,7 +104,7 @@ async def main() -> None:
     # 3. Create two agents focused on different stocks but with the same tool sets
     chat_client = OpenAIChatClient()
 
-    microsoft_agent = chat_client.create_agent(
+    microsoft_agent = chat_client.as_agent(
         name="MicrosoftAgent",
         instructions=(
             "You are a personal trading assistant focused on Microsoft (MSFT). "
@@ -113,7 +113,7 @@ async def main() -> None:
         tools=[get_stock_price, get_market_sentiment, get_portfolio_balance, execute_trade],
     )
 
-    google_agent = chat_client.create_agent(
+    google_agent = chat_client.as_agent(
         name="GoogleAgent",
         instructions=(
             "You are a personal trading assistant focused on Google (GOOGL). "

--- a/python/samples/getting_started/workflows/tool-approval/group_chat_builder_tool_approval.py
+++ b/python/samples/getting_started/workflows/tool-approval/group_chat_builder_tool_approval.py
@@ -96,7 +96,7 @@ async def main() -> None:
     # 3. Create specialized agents
     chat_client = OpenAIChatClient()
 
-    qa_engineer = chat_client.create_agent(
+    qa_engineer = chat_client.as_agent(
         name="QAEngineer",
         instructions=(
             "You are a QA engineer responsible for running tests before deployment. "
@@ -105,7 +105,7 @@ async def main() -> None:
         tools=[run_tests],
     )
 
-    devops_engineer = chat_client.create_agent(
+    devops_engineer = chat_client.as_agent(
         name="DevOpsEngineer",
         instructions=(
             "You are a DevOps engineer responsible for deployments. First check staging "

--- a/python/samples/getting_started/workflows/tool-approval/sequential_builder_tool_approval.py
+++ b/python/samples/getting_started/workflows/tool-approval/sequential_builder_tool_approval.py
@@ -67,7 +67,7 @@ def get_database_schema() -> str:
 async def main() -> None:
     # 2. Create the agent with tools (approval mode is set per-tool via decorator)
     chat_client = OpenAIChatClient()
-    database_agent = chat_client.create_agent(
+    database_agent = chat_client.as_agent(
         name="DatabaseAgent",
         instructions=(
             "You are a database assistant. You can view the database schema and execute "

--- a/python/samples/getting_started/workflows/visualization/concurrent_with_visualization.py
+++ b/python/samples/getting_started/workflows/visualization/concurrent_with_visualization.py
@@ -88,7 +88,7 @@ class AggregateInsights(Executor):
 
 def create_researcher_agent() -> ChatAgent:
     """Creates a research domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're an expert market and product researcher. Given a prompt, provide concise, factual insights,"
             " opportunities, and risks."
@@ -99,7 +99,7 @@ def create_researcher_agent() -> ChatAgent:
 
 def create_marketer_agent() -> ChatAgent:
     """Creates a marketing domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a creative marketing strategist. Craft compelling value propositions and target messaging"
             " aligned to the prompt."
@@ -110,7 +110,7 @@ def create_marketer_agent() -> ChatAgent:
 
 def create_legal_agent() -> ChatAgent:
     """Creates a legal domain expert agent."""
-    return AzureOpenAIChatClient(credential=AzureCliCredential()).create_agent(
+    return AzureOpenAIChatClient(credential=AzureCliCredential()).as_agent(
         instructions=(
             "You're a cautious legal/compliance reviewer. Highlight constraints, disclaimers, and policy concerns"
             " based on the prompt."

--- a/python/samples/semantic-kernel-migration/azure_ai_agent/01_basic_azure_ai_agent.py
+++ b/python/samples/semantic-kernel-migration/azure_ai_agent/01_basic_azure_ai_agent.py
@@ -16,7 +16,7 @@ async def run_semantic_kernel() -> None:
     async with AzureCliCredential() as credential, AzureAIAgent.create_client(credential=credential) as client:
         settings = AzureAIAgentSettings()  # Reads env vars for region/deployment.
         # SK builds the remote agent definition then wraps it with AzureAIAgent.
-        definition = await client.agents.create_agent(
+        definition = await client.agents.as_agent(
             model=settings.model_deployment_name,
             name="Support",
             instructions="Answer customer questions in one paragraph.",
@@ -32,7 +32,7 @@ async def run_agent_framework() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="Support",
             instructions="Answer customer questions in one paragraph.",
         ) as agent,

--- a/python/samples/semantic-kernel-migration/azure_ai_agent/02_azure_ai_agent_with_code_interpreter.py
+++ b/python/samples/semantic-kernel-migration/azure_ai_agent/02_azure_ai_agent_with_code_interpreter.py
@@ -16,7 +16,7 @@ async def run_semantic_kernel() -> None:
     async with AzureCliCredential() as credential, AzureAIAgent.create_client(credential=credential) as client:
         settings = AzureAIAgentSettings()
         # Register the hosted code interpreter tool with the remote agent.
-        definition = await client.agents.create_agent(
+        definition = await client.agents.as_agent(
             model=settings.model_deployment_name,
             name="Analyst",
             instructions="Use the code interpreter for numeric work.",
@@ -35,7 +35,7 @@ async def run_agent_framework() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="Analyst",
             instructions="Use the code interpreter for numeric work.",
             tools=[HostedCodeInterpreterTool()],

--- a/python/samples/semantic-kernel-migration/azure_ai_agent/03_azure_ai_agent_threads_and_followups.py
+++ b/python/samples/semantic-kernel-migration/azure_ai_agent/03_azure_ai_agent_threads_and_followups.py
@@ -10,7 +10,7 @@ async def run_semantic_kernel() -> None:
 
     async with AzureCliCredential() as credential, AzureAIAgent.create_client(credential=credential) as client:
         settings = AzureAIAgentSettings()
-        definition = await client.agents.create_agent(
+        definition = await client.agents.as_agent(
             model=settings.model_deployment_name,
             name="Planner",
             instructions="Track follow-up questions within the same thread.",
@@ -38,7 +38,7 @@ async def run_agent_framework() -> None:
 
     async with (
         AzureCliCredential() as credential,
-        AzureAIAgentClient(credential=credential).create_agent(
+        AzureAIAgentClient(credential=credential).as_agent(
             name="Planner",
             instructions="Track follow-up questions within the same thread.",
         ) as agent,

--- a/python/samples/semantic-kernel-migration/chat_completion/01_basic_chat_completion.py
+++ b/python/samples/semantic-kernel-migration/chat_completion/01_basic_chat_completion.py
@@ -29,7 +29,7 @@ async def run_agent_framework() -> None:
     from agent_framework.openai import OpenAIChatClient
 
     # AF constructs a lightweight ChatAgent backed by OpenAIChatClient.
-    chat_agent = OpenAIChatClient().create_agent(
+    chat_agent = OpenAIChatClient().as_agent(
         name="Support",
         instructions="Answer in one sentence.",
     )

--- a/python/samples/semantic-kernel-migration/chat_completion/02_chat_completion_with_tool.py
+++ b/python/samples/semantic-kernel-migration/chat_completion/02_chat_completion_with_tool.py
@@ -42,7 +42,7 @@ async def run_agent_framework() -> None:
         return "Clam chowder, Cobb salad, Chai tea"
 
     # AF tools are provided as callables on each agent instance.
-    chat_agent = OpenAIChatClient().create_agent(
+    chat_agent = OpenAIChatClient().as_agent(
         name="Host",
         instructions="Answer menu questions accurately.",
         tools=[specials],

--- a/python/samples/semantic-kernel-migration/chat_completion/03_chat_completion_thread_and_stream.py
+++ b/python/samples/semantic-kernel-migration/chat_completion/03_chat_completion_thread_and_stream.py
@@ -40,7 +40,7 @@ async def run_agent_framework() -> None:
     from agent_framework.openai import OpenAIChatClient
 
     # AF thread objects are requested explicitly from the agent.
-    chat_agent = OpenAIChatClient().create_agent(
+    chat_agent = OpenAIChatClient().as_agent(
         name="Writer",
         instructions="Keep answers short and friendly.",
     )

--- a/python/samples/semantic-kernel-migration/openai_assistant/01_basic_openai_assistant.py
+++ b/python/samples/semantic-kernel-migration/openai_assistant/01_basic_openai_assistant.py
@@ -32,7 +32,7 @@ async def run_agent_framework() -> None:
 
     assistants_client = OpenAIAssistantsClient()
     # AF wraps the assistant lifecycle with an async context manager.
-    async with assistants_client.create_agent(
+    async with assistants_client.as_agent(
         name="Helper",
         instructions="Answer questions in one concise paragraph.",
         model=ASSISTANT_MODEL,

--- a/python/samples/semantic-kernel-migration/openai_assistant/02_openai_assistant_with_code_interpreter.py
+++ b/python/samples/semantic-kernel-migration/openai_assistant/02_openai_assistant_with_code_interpreter.py
@@ -33,7 +33,7 @@ async def run_agent_framework() -> None:
 
     assistants_client = OpenAIAssistantsClient()
     # AF exposes the same tool configuration via create_agent.
-    async with assistants_client.create_agent(
+    async with assistants_client.as_agent(
         name="CodeRunner",
         instructions="Use the code interpreter when calculations are required.",
         model="gpt-4.1",

--- a/python/samples/semantic-kernel-migration/openai_assistant/03_openai_assistant_function_tool.py
+++ b/python/samples/semantic-kernel-migration/openai_assistant/03_openai_assistant_function_tool.py
@@ -67,7 +67,7 @@ async def run_agent_framework() -> None:
 
     assistants_client = OpenAIAssistantsClient()
     # AF converts the decorated function into an assistant-compatible tool.
-    async with assistants_client.create_agent(
+    async with assistants_client.as_agent(
         name="WeatherHelper",
         instructions="Call get_forecast to fetch weather details.",
         model=ASSISTANT_MODEL,

--- a/python/samples/semantic-kernel-migration/orchestrations/concurrent_basic.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/concurrent_basic.py
@@ -77,12 +77,12 @@ def _print_semantic_kernel_outputs(outputs: Sequence[ChatMessageContent]) -> Non
 async def run_agent_framework_example(prompt: str) -> Sequence[list[ChatMessage]]:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    physics = chat_client.create_agent(
+    physics = chat_client.as_agent(
         instructions=("You are an expert in physics. Answer questions from a physics perspective."),
         name="physics",
     )
 
-    chemistry = chat_client.create_agent(
+    chemistry = chat_client.as_agent(
         instructions=("You are an expert in chemistry. Answer questions from a chemistry perspective."),
         name="chemistry",
     )

--- a/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
@@ -234,7 +234,7 @@ async def run_agent_framework_example(task: str) -> str:
     workflow = (
         GroupChatBuilder()
         .set_manager(
-            manager=AzureOpenAIChatClient(credential=credential).create_agent(),
+            manager=AzureOpenAIChatClient(credential=credential).as_agent(),
             display_name="Coordinator",
         )
         .participants(researcher=researcher, planner=planner)

--- a/python/samples/semantic-kernel-migration/orchestrations/handoff.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/handoff.py
@@ -180,7 +180,7 @@ async def run_semantic_kernel_example(initial_task: str, scripted_responses: Seq
 
 
 def _create_af_agents(client: AzureOpenAIChatClient):
-    triage = client.create_agent(
+    triage = client.as_agent(
         name="triage_agent",
         instructions=(
             "You are a customer support triage agent. Route requests:\n"
@@ -189,19 +189,19 @@ def _create_af_agents(client: AzureOpenAIChatClient):
             "- handoff_to_order_return_agent for returns"
         ),
     )
-    refund = client.create_agent(
+    refund = client.as_agent(
         name="refund_agent",
         instructions=(
             "Handle refunds. Ask for order id and reason. If shipping info is needed, hand off to order_status_agent."
         ),
     )
-    status = client.create_agent(
+    status = client.as_agent(
         name="order_status_agent",
         instructions=(
             "Provide order status, tracking, and timelines. If billing questions appear, hand off to refund_agent."
         ),
     )
-    returns = client.create_agent(
+    returns = client.as_agent(
         name="order_return_agent",
         instructions=(
             "Coordinate returns, confirm addresses, and summarize next steps. Hand off to triage_agent if unsure."

--- a/python/samples/semantic-kernel-migration/orchestrations/sequential.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/sequential.py
@@ -63,12 +63,12 @@ async def sk_agent_response_callback(
 async def run_agent_framework_example(prompt: str) -> list[ChatMessage]:
     chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
 
-    writer = chat_client.create_agent(
+    writer = chat_client.as_agent(
         instructions=("You are a concise copywriter. Provide a single, punchy marketing sentence based on the prompt."),
         name="writer",
     )
 
-    reviewer = chat_client.create_agent(
+    reviewer = chat_client.as_agent(
         instructions=("You are a thoughtful reviewer. Give brief feedback on the previous assistant message."),
         name="reviewer",
     )


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Related ADR: https://github.com/microsoft/agent-framework/blob/main/docs/decisions/0011-create-get-agent-api.md

This PR renames `BaseChatClient` method that creates local wrapper agents from `create_agent` to `as_agent`, following naming convention where `as_*` indicates a lightweight conversion/wrapping operation without side effects.

```python
# Before
agent = chat_client.create_agent(...)

# After
agent = chat_client.as_agent(...)
```

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.