### PR TITLE
Python: Prefer runtime `kwargs` for `conversation_id` in OpenAI Responses client

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -605,7 +605,11 @@ class OpenAIBaseResponsesClient(
             options["model"] = self.model_id
 
     def _get_current_conversation_id(self, options: dict[str, Any], **kwargs: Any) -> str | None:
-        """Get the current conversation ID from options dict or kwargs."""
+        """Get the current conversation ID, preferring kwargs over options.
+
+        This ensures runtime-updated conversation IDs (for example, from tool execution
+        loops) take precedence over the initial configuration provided in options.
+        """
         return kwargs.get("conversation_id") or options.get("conversation_id")
 
     def _prepare_messages_for_openai(self, chat_messages: Sequence[ChatMessage]) -> list[dict[str, Any]]:

--- a/python/packages/core/tests/openai/test_openai_responses_client.py
+++ b/python/packages/core/tests/openai/test_openai_responses_client.py
@@ -1682,6 +1682,20 @@ async def test_prepare_options_store_parameter_handling() -> None:
     assert "previous_response_id" not in options
 
 
+async def test_conversation_id_precedence_kwargs_over_options() -> None:
+    """When both kwargs and options contain conversation_id, kwargs wins."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+    messages = [ChatMessage(role="user", text="Hello")]
+
+    # options has a stale response id, kwargs carries the freshest one
+    opts = {"conversation_id": "resp_old_123"}
+    run_opts = await client._prepare_options(messages, opts, conversation_id="resp_new_456")  # type: ignore
+
+    # Verify kwargs takes precedence and maps to previous_response_id for resp_* IDs
+    assert run_opts.get("previous_response_id") == "resp_new_456"
+    assert "conversation" not in run_opts
+
+
 def test_with_callable_api_key() -> None:
     """Test OpenAIResponsesClient initialization with callable API key."""
 


### PR DESCRIPTION
### Motivation and Context
Fixes stale tool-call routing by preferring the freshest `conversation_id` propagated via runtime `kwargs`

Resolves #3304 
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.