### PR TITLE
Python: Fix azurefunctions MCP tool invocation to use correct agent 

### DIFF
--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -608,12 +608,14 @@ class AgentFunctionApp(DFAppBase):
 
         # Create or parse session ID
         if thread_id and isinstance(thread_id, str) and thread_id.strip():
-            # If thread_id is in @name@key format, extract only the key portion
-            if thread_id.startswith("@") and "@" in thread_id[1:]:
-                key = thread_id[1:].split("@", 1)[1]
-                session_id = AgentSessionId(name=agent_name, key=key)
-            else:
-                # Use thread_id as-is for the key
+            try:
+                session_id = AgentSessionId.parse(thread_id, agent_name=agent_name)
+            except ValueError as e:
+                logger.warning(
+                    "Failed to parse AgentSessionId from thread_id '%s': %s. Falling back to new session ID.",
+                    thread_id,
+                    e,
+                )
                 session_id = AgentSessionId(name=agent_name, key=thread_id)
         else:
             # Generate new session ID

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_models.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_models.py
@@ -109,26 +109,34 @@ class AgentSessionId:
         return f"AgentSessionId(name='{self.name}', key='{self.key}')"
 
     @staticmethod
-    def parse(session_id_string: str) -> AgentSessionId:
+    def parse(session_id_string: str, agent_name: str | None = None) -> AgentSessionId:
         """Parses a string representation of an agent session ID.
 
         Args:
-            session_id_string: A string in the form @name@key
+            session_id_string: A string in the form @name@key, or a plain key string
+                when agent_name is provided.
+            agent_name: Optional agent name to use instead of parsing from the string.
+                If provided, only the key portion is extracted from session_id_string
+                (for @name@key format) or the entire string is used as the key
+                (for plain strings).
 
         Returns:
             AgentSessionId instance
 
         Raises:
-            ValueError: If the string format is invalid
+            ValueError: If the string format is invalid and agent_name is not provided
         """
-        if not session_id_string.startswith("@"):
-            raise ValueError(f"Invalid agent session ID format: {session_id_string}")
+        # Check if string is in @name@key format
+        if session_id_string.startswith("@") and "@" in session_id_string[1:]:
+            parts = session_id_string[1:].split("@", 1)
+            name = agent_name if agent_name is not None else parts[0]
+            return AgentSessionId(name=name, key=parts[1])
 
-        parts = session_id_string[1:].split("@", 1)
-        if len(parts) != 2:
-            raise ValueError(f"Invalid agent session ID format: {session_id_string}")
+        # Plain string format - only valid when agent_name is provided
+        if agent_name is not None:
+            return AgentSessionId(name=agent_name, key=session_id_string)
 
-        return AgentSessionId(name=parts[0], key=parts[1])
+        raise ValueError(f"Invalid agent session ID format: {session_id_string}")
 
 
 class DurableAgentThread(AgentThread):

--- a/python/packages/azurefunctions/tests/test_app.py
+++ b/python/packages/azurefunctions/tests/test_app.py
@@ -1090,6 +1090,36 @@ class TestMCPToolEndpoint:
             assert entity_id.name == "dafx-PlantAdvisor"
             assert entity_id.key == "test123"
 
+    async def test_handle_mcp_tool_invocation_uses_plain_thread_id_as_key(self) -> None:
+        """Test that a plain thread_id (not in @name@key format) is used as-is for the key."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        # Plain thread_id without @name@key format
+        context = json.dumps({"arguments": {"query": "test query", "threadId": "simple-thread-123"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            client.signal_entity.assert_called_once()
+            call_args = client.signal_entity.call_args
+            entity_id = call_args[0][0]
+
+            assert entity_id.name == "dafx-TestAgent"
+            assert entity_id.key == "simple-thread-123"
+
     def test_health_check_includes_mcp_tool_enabled(self) -> None:
         """Test that health check endpoint includes mcp_tool_enabled field."""
         mock_agent = Mock()

--- a/python/packages/azurefunctions/tests/test_models.py
+++ b/python/packages/azurefunctions/tests/test_models.py
@@ -120,6 +120,34 @@ class TestAgentSessionId:
         assert parsed.name == original.name
         assert parsed.key == original.key
 
+    def test_parse_with_agent_name_override(self) -> None:
+        """Test parsing @name@key format with agent_name parameter overrides the name."""
+        session_id = AgentSessionId.parse("@OriginalAgent@test-key-123", agent_name="OverriddenAgent")
+
+        assert session_id.name == "OverriddenAgent"
+        assert session_id.key == "test-key-123"
+
+    def test_parse_without_agent_name_uses_parsed_name(self) -> None:
+        """Test parsing @name@key format without agent_name uses name from string."""
+        session_id = AgentSessionId.parse("@ParsedAgent@test-key-123")
+
+        assert session_id.name == "ParsedAgent"
+        assert session_id.key == "test-key-123"
+
+    def test_parse_plain_string_with_agent_name(self) -> None:
+        """Test parsing plain string with agent_name uses entire string as key."""
+        session_id = AgentSessionId.parse("simple-thread-123", agent_name="TestAgent")
+
+        assert session_id.name == "TestAgent"
+        assert session_id.key == "simple-thread-123"
+
+    def test_parse_plain_string_without_agent_name_raises(self) -> None:
+        """Test parsing plain string without agent_name raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            AgentSessionId.parse("simple-thread-123")
+
+        assert "Invalid agent session ID format" in str(exc_info.value)
+
     def test_to_entity_name_adds_prefix(self) -> None:
         """Test that to_entity_name adds the dafx- prefix."""
         entity_name = AgentSessionId.to_entity_name("TestAgent")


### PR DESCRIPTION
### Motivation and Context

 **Summary**

Fixed an issue for MCP tool invocations to route to the correct agent based on the thread id.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.