### PR TITLE
Python: Set min version of dependent azure-ai-projects to 2.0.0b3

### DIFF
--- a/python/packages/azure-ai/pyproject.toml
+++ b/python/packages/azure-ai/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core",
-    "azure-ai-projects >= 2.0.0b2",
+    "azure-ai-projects >= 2.0.0b3",
     "azure-ai-agents == 1.2.0b5",
     "aiohttp",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -233,7 +233,7 @@ requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
     { name = "aiohttp" },
     { name = "azure-ai-agents", specifier = "==1.2.0b5" },
-    { name = "azure-ai-projects", specifier = ">=2.0.0b2" },
+    { name = "azure-ai-projects", specifier = ">=2.0.0b3" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation and Context

Python Agent framework code uses class name `AgentVersionDetails` which is available in version 2.0.0b3 of azure-ai-projects, not in version 2.0.0b2 (it was renamed from `AgentVersionObject`). So we need to update the min version to 2.0.0b3.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.