### PR TITLE
.NET: fix: include MessageId in AGUIToolMessage to ChatMessage transformation

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIChatMessageExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIChatMessageExtensions.cs
@@ -72,7 +72,8 @@ internal static class AGUIChatMessageExtensions
                             new FunctionResultContent(
                                     toolMessage.ToolCallId,
                                     result)
-                        ]);
+                        ])
+                    { MessageId = message.Id };
                     break;
                 }
 

--- a/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/AGUIChatMessageExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/AGUIChatMessageExtensionsTests.cs
@@ -288,6 +288,7 @@ public sealed class AGUIChatMessageExtensionsTests
         FunctionResultContent result = Assert.IsType<FunctionResultContent>(message.Contents[0]);
         Assert.Equal("call_abc", result.CallId);
         Assert.NotNull(result.Result);
+        Assert.Equal("msg1", message.MessageId);
     }
 
     [Fact]
@@ -312,6 +313,7 @@ public sealed class AGUIChatMessageExtensionsTests
         FunctionResultContent result = Assert.IsType<FunctionResultContent>(message.Contents[0]);
         Assert.Equal("call_def", result.CallId);
         Assert.Equal(string.Empty, result.Result);
+        Assert.Equal("msg1", message.MessageId);
     }
 
     [Fact]
@@ -336,6 +338,7 @@ public sealed class AGUIChatMessageExtensionsTests
         Assert.Equal(ChatRole.Tool, message.Role);
         var resultContent = Assert.IsType<FunctionResultContent>(message.Contents.First());
         Assert.Equal(string.Empty, resultContent.CallId);
+        Assert.Equal("msg1", message.MessageId);
     }
 
     [Fact]
@@ -696,6 +699,7 @@ public sealed class AGUIChatMessageExtensionsTests
         Assert.Equal("Seattle", ((System.Text.Json.JsonElement)toolCallContent.Arguments["location"]!).GetString());
         Assert.Equal("fahrenheit", ((System.Text.Json.JsonElement)toolCallContent.Arguments["units"]!).GetString());
         Assert.True(toolCallContent.Arguments["includeForecast"] is System.Text.Json.JsonElement j && j.GetBoolean());
+        Assert.Equal("msg1", message.MessageId);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request ensures that the `MessageId` property is correctly set when converting AGUIToolMessage to `ChatMessage` objects, and updates the corresponding unit tests to verify this behavior.  References https://github.com/microsoft/agent-framework/issues/3365

**Enhancements to message conversion logic:**

* [`AGUIChatMessageExtensions.cs`](diffhunk://#diff-951ae18ef0b49f8612451bdfe75378c36d3e7caf03d7b32814b03e5143e7b7f5L54-R55): Sets the `MessageId` property when creating a `ChatMessage` from a AGUIToolMessage in the `AsChatMessages` method.

**Testing improvements:**

* [`AGUIChatMessageExtensionsTests.cs`](diffhunk://#diff-039a7160265024b8ef8b1a286aeaf322cfd05258bef181571da6fe0e072ebe1dR289): Adds assertions to multiple test cases to verify that the `MessageId` of the resulting `ChatMessage` is correctly assigned. [[1]](diffhunk://#diff-039a7160265024b8ef8b1a286aeaf322cfd05258bef181571da6fe0e072ebe1dR289) [[2]](diffhunk://#diff-039a7160265024b8ef8b1a286aeaf322cfd05258bef181571da6fe0e072ebe1dR314) [[3]](diffhunk://#diff-039a7160265024b8ef8b1a286aeaf322cfd05258bef181571da6fe0e072ebe1dR339) [[4]](diffhunk://#diff-039a7160265024b8ef8b1a286aeaf322cfd05258bef181571da6fe0e072ebe1dR429)
