### PR TITLE
.NET: Expose Executor Binding Metadata from Workflows

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
@@ -52,6 +52,15 @@ public class Workflow
     }
 
     /// <summary>
+    /// Gets the collection of executor bindings, keyed by their ID.
+    /// </summary>
+    /// <returns>A copy of the executor bindings dictionary. Modifications do not affect the workflow.</returns>
+    public Dictionary<string, ExecutorBinding> ReflectExecutors()
+    {
+        return new Dictionary<string, ExecutorBinding>(this.ExecutorBindings);
+    }
+
+    /// <summary>
     /// Gets the identifier of the starting executor of the workflow.
     /// </summary>
     public string StartExecutorId { get; }


### PR DESCRIPTION
### Motivation and Context

As part of adding Durable support for workflows, we need access to executor binding metadata so that the Durable orchestration workflow runner can correctly route messages at runtime. The runner itself will be introduced in a follow-up PR from the corresponding feature branch.

#### Additional Context

The Python implementation already exposes executor binding information, whereas the .NET implementation does not. This PR closes that gap and brings feature parity between the two.

### Description

This PR exposes executor binding information from a workflow, similar to the existing APIs that expose ports and edges.

```csharp
public Dictionary<string, ExecutorBinding> ReflectExecutors()
```
This method allows callers to retrieve a copy of the executor bindings defined in a workflow.



<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.