### PR TITLE
Workaround for devcontainer expired key issue

### DIFF
--- a/.devcontainer/dotnet/devcontainer.json
+++ b/.devcontainer/dotnet/devcontainer.json
@@ -1,6 +1,10 @@
 {
   "name": "C# (.NET)",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:2-10.0",
+  //"image": "mcr.microsoft.com/devcontainers/dotnet",
+  // Workaround for https://github.com/devcontainers/images/issues/1752
+  "build": {
+    "dockerfile": "dotnet.Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2.4.2": {},
     "ghcr.io/devcontainers/features/powershell:1.5.1": {},

--- a/.devcontainer/dotnet/dotnet.Dockerfile
+++ b/.devcontainer/dotnet/dotnet.Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/dotnet
+
+# Remove Yarn repository with expired GPG key to prevent apt-get update failures
+# Tracking issue: https://github.com/devcontainers/images/issues/1752
+RUN rm -f /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
### Motivation and Context

Various Microsoft devcontainers including the dotnet one currently don't start due to an expired key issue.

### Description

- Add a dockerfile to work around key issue
- Default to latest dotnet dev container
- Update feature versions

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.