### PR TITLE
.NET: fix: FileSystemJsonCheckpointStore does not flush to disk on Checkpoint creation

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/FileSystemJsonCheckpointStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/FileSystemJsonCheckpointStore.cs
@@ -125,6 +125,7 @@ public sealed class FileSystemJsonCheckpointStore : JsonCheckpointStore, IDispos
             JsonSerializer.Serialize(this._indexFile!, key, KeyTypeInfo);
             byte[] bytes = Encoding.UTF8.GetBytes(Environment.NewLine);
             await this._indexFile!.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None).ConfigureAwait(false);
+            await this._indexFile!.FlushAsync(CancellationToken.None).ConfigureAwait(false);
 
             return key;
         }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/FileSystemJsonCheckpointStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/FileSystemJsonCheckpointStoreTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+public sealed class FileSystemJsonCheckpointStoreTests
+{
+    [Fact]
+    public async Task CreateCheckpointAsync_ShouldPersistIndexToDiskBeforeDisposeAsync()
+    {
+        // Arrange
+        DirectoryInfo tempDir = new(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        FileSystemJsonCheckpointStore? store = null;
+
+        try
+        {
+            store = new(tempDir);
+            string runId = Guid.NewGuid().ToString("N");
+            JsonElement testData = JsonSerializer.SerializeToElement(new { test = "data" });
+
+            // Act
+            CheckpointInfo checkpoint = await store.CreateCheckpointAsync(runId, testData);
+
+            // Assert - Check the file size before disposing to verify data was flushed to disk
+            // The index.jsonl file is held exclusively by the store, so we check via FileInfo
+            string indexPath = Path.Combine(tempDir.FullName, "index.jsonl");
+            FileInfo indexFile = new(indexPath);
+            indexFile.Refresh();
+            long fileSizeBeforeDispose = indexFile.Length;
+
+            // Data should already be on disk (file size > 0) before we dispose
+            fileSizeBeforeDispose.Should().BeGreaterThan(0, "index.jsonl should be flushed to disk after CreateCheckpointAsync");
+
+            // Dispose to release file lock before final verification
+            store.Dispose();
+            store = null;
+
+            string[] lines = File.ReadAllLines(indexPath);
+            lines.Should().HaveCount(1);
+            lines[0].Should().Contain(checkpoint.CheckpointId);
+        }
+        finally
+        {
+            store?.Dispose();
+            if (tempDir.Exists)
+            {
+                tempDir.Delete(recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Flushes the index file on checkpoint creation to ensure we get disk status current when control returns to user code after the checkpoint.

Fixes #3169 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] ~~**Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.~~