### PR TITLE
.NET: ci: Unblock Merge queue by disabling DurableTask TTL tests

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
               dotnet
               python
               workflow-samples
-              
+
       # Start Cosmos DB Emulator for all integration tests and only for unit tests when CosmosDB changes happened)
       - name: Start Azure Cosmos DB Emulator
         if: ${{ runner.os == 'Windows' && (needs.paths-filter.outputs.cosmosDbChanges == 'true' || (github.event_name != 'pull_request' && matrix.integration-tests)) }}
@@ -139,7 +139,7 @@ jobs:
           popd
           popd
           rm -rf "$TEMP_DIR"
-          
+
       - name: Run Unit Tests
         shell: bash
         run: |
@@ -147,7 +147,7 @@ jobs:
           for project in $UT_PROJECTS; do
             # Query the project's target frameworks using MSBuild with the current configuration
             target_frameworks=$(dotnet msbuild $project -getProperty:TargetFrameworks -p:Configuration=${{ matrix.configuration }} -nologo 2>/dev/null | tr -d '\r')
-            
+
             # Check if the project supports the target framework
             if [[ "$target_frameworks" == *"${{ matrix.targetFramework }}"* ]]; then
               if [[ "${{ matrix.targetFramework }}" == "${{ env.COVERAGE_FRAMEWORK }}" ]]; then
@@ -165,8 +165,8 @@ jobs:
           COSMOSDB_KEY: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
 
       - name: Log event name and matrix integration-tests
-        shell: bash 
-        run: echo "github.event_name:${{ github.event_name }} matrix.integration-tests:${{ matrix.integration-tests }} github.event.action:${{ github.event.action }} github.event.pull_request.merged:${{ github.event.pull_request.merged }}" 
+        shell: bash
+        run: echo "github.event_name:${{ github.event_name }} matrix.integration-tests:${{ matrix.integration-tests }} github.event.action:${{ github.event.action }} github.event.pull_request.merged:${{ github.event.pull_request.merged }}"
 
       - name: Azure CLI Login
         if: github.event_name != 'pull_request' && matrix.integration-tests
@@ -192,10 +192,10 @@ jobs:
           for project in $INTEGRATION_TEST_PROJECTS; do
             # Query the project's target frameworks using MSBuild with the current configuration
             target_frameworks=$(dotnet msbuild $project -getProperty:TargetFrameworks -p:Configuration=${{ matrix.configuration }} -nologo 2>/dev/null | tr -d '\r')
-            
+
             # Check if the project supports the target framework
             if [[ "$target_frameworks" == *"${{ matrix.targetFramework }}"* ]]; then
-              dotnet test -f ${{ matrix.targetFramework }} -c ${{ matrix.configuration }} $project --no-build -v Normal --logger trx
+              dotnet test -f ${{ matrix.targetFramework }} -c ${{ matrix.configuration }} $project --no-build -v Normal --logger trx --filter "Category!=IntegrationDisabled"
             else
               echo "Skipping $project - does not support target framework ${{ matrix.targetFramework }} (supports: $target_frameworks)"
             fi

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TimeToLiveTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/TimeToLiveTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 /// Tests for Time-To-Live (TTL) functionality of durable agent entities.
 /// </summary>
 [Collection("Sequential")]
-[Trait("Category", "Integration")]
+[Trait("Category", "IntegrationDisabled")]
 public sealed class TimeToLiveTests(ITestOutputHelper outputHelper) : IDisposable
 {
     private static readonly TimeSpan s_defaultTimeout = Debugger.IsAttached


### PR DESCRIPTION
The DurableTask Integration tests have some flakiness around the TTL tests. To unblock the queue we will disable them and create an issue #3463 to track fixing/re-enabling.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [x] ~~**Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.~~