### PR TITLE
Python: Fix AzureAIAgentClient dropping agent instructions

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
@@ -948,6 +948,10 @@ class AzureAIAgentClient(BaseChatClient[TAzureAIAgentOptions], Generic[TAzureAIA
         if additional_messages:
             run_options["additional_messages"] = additional_messages
 
+        # Add instructions from options (agent's instructions set via as_agent())
+        if options_instructions := options.get("instructions"):
+            instructions.append(options_instructions)
+
         # Add instruction from existing agent at the beginning
         if (
             agent_definition is not None

--- a/python/packages/azure-ai/tests/test_azure_ai_agent_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_agent_client.py
@@ -464,6 +464,56 @@ async def test_azure_ai_chat_client_prepare_options_with_messages(mock_agents_cl
     assert len(run_options["additional_messages"]) == 1  # Only user message
 
 
+async def test_azure_ai_chat_client_prepare_options_with_instructions_from_options(
+    mock_agents_client: MagicMock,
+) -> None:
+    """Test _prepare_options includes instructions passed via options.
+
+    This verifies that agent instructions set via as_agent(instructions=...)
+    are properly included in the API call.
+    """
+    chat_client = create_test_azure_ai_chat_client(mock_agents_client, agent_id="test-agent")
+    mock_agents_client.get_agent = AsyncMock(return_value=None)
+
+    messages = [ChatMessage(role=Role.USER, text="Hello")]
+    chat_options: ChatOptions = {
+        "instructions": "You are a thoughtful reviewer. Give brief feedback.",
+    }
+
+    run_options, _ = await chat_client._prepare_options(messages, chat_options)  # type: ignore
+
+    assert "instructions" in run_options
+    assert "reviewer" in run_options["instructions"].lower()
+
+
+async def test_azure_ai_chat_client_prepare_options_merges_instructions_from_messages_and_options(
+    mock_agents_client: MagicMock,
+) -> None:
+    """Test _prepare_options merges instructions from both system messages and options.
+
+    When instructions come from both system/developer messages AND from options,
+    both should be included in the final instructions.
+    """
+    chat_client = create_test_azure_ai_chat_client(mock_agents_client, agent_id="test-agent")
+    mock_agents_client.get_agent = AsyncMock(return_value=None)
+
+    messages = [
+        ChatMessage(role=Role.SYSTEM, text="Context: You are reviewing marketing copy."),
+        ChatMessage(role=Role.USER, text="Review this tagline"),
+    ]
+    chat_options: ChatOptions = {
+        "instructions": "Be concise and constructive in your feedback.",
+    }
+
+    run_options, _ = await chat_client._prepare_options(messages, chat_options)  # type: ignore
+
+    assert "instructions" in run_options
+    instructions_text = run_options["instructions"]
+    # Both instruction sources should be present
+    assert "marketing" in instructions_text.lower()
+    assert "concise" in instructions_text.lower()
+
+
 async def test_azure_ai_chat_client_inner_get_response(mock_agents_client: MagicMock) -> None:
     """Test _inner_get_response method."""
     chat_client = create_test_azure_ai_chat_client(mock_agents_client, agent_id="test-agent")


### PR DESCRIPTION
### Motivation and Context

In `AzureAIAgentClient._prepare_options()`, the `instructions` key was in the `exclude_keys` set with a comment "handled via messages", but instructions from the options dict were never actually extracted and added to the final instructions list. Only instructions from system/developer messages were being included.

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Fixed bug where `AzureAIAgentClient` silently dropped instructions passed via options, causing agents in sequential workflows to ignore their configured instructions
- Added unit tests for instruction handling in `_prepare_options()`
- Closes #3507

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.