### PR TITLE
Python: Fix: Skip model_deployment_name validation for application endpoints (Azure new foundary agents)

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_client.py
@@ -420,6 +420,9 @@ class AzureAIClient(OpenAIBaseResponsesClient[TAzureAIClientOptions], Generic[TA
 
     @override
     def _check_model_presence(self, run_options: dict[str, Any]) -> None:
+        # Skip model check for application endpoints - model is pre-configured on server
+        if self._is_application_endpoint:
+            return
         if not run_options.get("model"):
             if not self.model_id:
                 raise ValueError("model_deployment_name must be a non-empty string")


### PR DESCRIPTION
## Summary
- Skip `model_deployment_name` validation when using application endpoints in `AzureAIClient`. Azure new foundary agents
 
## Problem
When using `AzureAIClient` with an application endpoint (pre-configured Foundry agent), the framework incorrectly requires `model_deployment_name` even though:
1. The model is already pre-configured on the server for the application
2. The `model` field gets stripped from `run_options` anyway for application endpoints (lines 404-417)
 
This forces users to provide a dummy/placeholder value like `model_deployment_name="placeholder"` which is confusing and unnecessary.
 
**Error before fix:**
ValueError: model_deployment_name must be a non-empty string

## Solution
Added a check in `_check_model_presence()` to skip validation when `_is_application_endpoint` is `True`:

```python
@override
def _check_model_presence(self, run_options: dict[str, Any]) -> None:
    # Skip model check for application endpoints - model is pre-configured on server
    if self._is_application_endpoint:
        return
    if not run_options.get("model"):
        if not self.model_id:
            raise ValueError("model_deployment_name must be a non-empty string")
        run_options["model"] = self.model_id
        
        
Test plan

Tested with existing Foundry agent via application endpoint
Verified agent responds correctly without model_deployment_name