### PR TITLE
Python: Fix AzureAIClient dropping agent instructions (Responses API)

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_client.py
@@ -352,9 +352,10 @@ class AzureAIClient(OpenAIBaseResponsesClient[TAzureAIClientOptions], Generic[TA
                 args["text"] = PromptAgentDefinitionText(format=create_text_format_config(response_format))
 
             # Combine instructions from messages and options
+            # instructions is accessed from chat_options since the base class excludes it from run_options
             combined_instructions = [
                 instructions
-                for instructions in [messages_instructions, run_options.get("instructions")]
+                for instructions in [messages_instructions, chat_options.get("instructions") if chat_options else None]
                 if instructions
             ]
             if combined_instructions:

--- a/python/packages/azure-ai/tests/test_azure_ai_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_client.py
@@ -695,14 +695,35 @@ async def test_agent_creation_with_instructions(
     mock_agent.version = "1.0"
     mock_project_client.agents.create_version = AsyncMock(return_value=mock_agent)
 
-    run_options = {"model": "test-model", "instructions": "Option instructions. "}
+    run_options = {"model": "test-model"}
+    chat_options = {"instructions": "Option instructions. "}
     messages_instructions = "Message instructions. "
 
-    await client._get_agent_reference_or_create(run_options, messages_instructions)  # type: ignore
+    await client._get_agent_reference_or_create(run_options, messages_instructions, chat_options)  # type: ignore
 
     # Verify agent was created with combined instructions
     call_args = mock_project_client.agents.create_version.call_args
     assert call_args[1]["definition"].instructions == "Message instructions. Option instructions. "
+
+
+async def test_agent_creation_with_instructions_from_chat_options(
+    mock_project_client: MagicMock,
+) -> None:
+    """Test agent creation with instructions passed only via chat_options."""
+    client = create_test_azure_ai_client(mock_project_client, agent_name="test-agent")
+
+    mock_agent = MagicMock()
+    mock_agent.name = "test-agent"
+    mock_agent.version = "1.0"
+    mock_project_client.agents.create_version = AsyncMock(return_value=mock_agent)
+
+    run_options = {"model": "test-model"}
+    chat_options = {"instructions": "Chat options instructions."}
+
+    await client._get_agent_reference_or_create(run_options, None, chat_options)  # type: ignore
+
+    call_args = mock_project_client.agents.create_version.call_args
+    assert call_args[1]["definition"].instructions == "Chat options instructions."
 
 
 async def test_agent_creation_with_additional_args(


### PR DESCRIPTION
### Motivation and Context

The fix in #3563 (commit 184ee9d5) addressed instructions being dropped in `AzureAIAgentClient` (Chat API), but the same bug existed in `AzureAIClient` (Responses API).

In `_get_agent_reference_or_create()`, the code was reading `instructions` from `run_options`:

```python
for instructions in [messages_instructions, run_options.get("instructions")]
```
But the base class excludes instructions from run_options, so it should be read from chat_options instead (same pattern used for response_format on lines 351-352).

The fix: changed  `_client.py` to read instructions from chat_options:

`for instructions in [messages_instructions, chat_options.get("instructions") if chat_options else None]`

- Updated existing test to pass instructions via chat_options
- Added new test test_agent_creation_with_instructions_from_chat_options to verify instructions are correctly passed

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

- Fixes #3622

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.