### PR TITLE
[BREAKING] Python: Rename from_agent_run_response_updates to from_agent_response_updates

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -210,7 +210,7 @@ class A2AAgent(BaseAgent):
         """
         # Collect all updates and use framework to consolidate updates into response
         updates = [update async for update in self.run_stream(messages, thread=thread, **kwargs)]
-        return AgentResponse.from_agent_run_response_updates(updates)
+        return AgentResponse.from_agent_response_updates(updates)
 
     async def run_stream(
         self,

--- a/python/packages/ag-ui/agent_framework_ag_ui/_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_run.py
@@ -862,7 +862,7 @@ async def run_agent_stream(
         from pydantic import BaseModel
 
         logger.info(f"Processing structured output, update count: {len(all_updates)}")
-        final_response = AgentResponse.from_agent_run_response_updates(all_updates, output_format_type=response_format)
+        final_response = AgentResponse.from_agent_response_updates(all_updates, output_format_type=response_format)
 
         if final_response.value and isinstance(final_response.value, BaseModel):
             response_dict = final_response.value.model_dump(mode="json", exclude_none=True)

--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -490,7 +490,7 @@ class BaseAgent(SerializationMixin):
                     stream_callback(update)
 
             # Create final text from accumulated updates
-            return AgentResponse.from_agent_run_response_updates(response_updates).text
+            return AgentResponse.from_agent_response_updates(response_updates).text
 
         agent_tool: FunctionTool[BaseModel, str] = FunctionTool(
             name=tool_name,

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2452,7 +2452,7 @@ class AgentResponse(SerializationMixin, Generic[TResponseModel]):
 
             # Combine streaming updates
             updates = [...]  # List of AgentResponseUpdate objects
-            response = AgentResponse.from_agent_run_response_updates(updates)
+            response = AgentResponse.from_agent_response_updates(updates)
 
             # Serialization - to_dict and from_dict
             response_dict = response.to_dict()
@@ -2567,7 +2567,7 @@ class AgentResponse(SerializationMixin, Generic[TResponseModel]):
 
     @overload
     @classmethod
-    def from_agent_run_response_updates(
+    def from_agent_response_updates(
         cls: type["AgentResponse[Any]"],
         updates: Sequence["AgentResponseUpdate"],
         *,
@@ -2576,7 +2576,7 @@ class AgentResponse(SerializationMixin, Generic[TResponseModel]):
 
     @overload
     @classmethod
-    def from_agent_run_response_updates(
+    def from_agent_response_updates(
         cls: type["AgentResponse[Any]"],
         updates: Sequence["AgentResponseUpdate"],
         *,
@@ -2584,7 +2584,7 @@ class AgentResponse(SerializationMixin, Generic[TResponseModel]):
     ) -> "AgentResponse[Any]": ...
 
     @classmethod
-    def from_agent_run_response_updates(
+    def from_agent_response_updates(
         cls: type[TAgentRunResponse],
         updates: Sequence["AgentResponseUpdate"],
         *,

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -453,7 +453,7 @@ class WorkflowAgent(BaseAgent):
         - Group updates by response_id; within each response_id, group by message_id and keep a dangling bucket for
           updates without message_id.
         - Convert each group (per message and dangling) into an intermediate AgentResponse via
-          AgentResponse.from_agent_run_response_updates, then sort by created_at and merge.
+          AgentResponse.from_agent_response_updates, then sort by created_at and merge.
         - Append messages from updates without any response_id at the end (global dangling), while aggregating metadata.
 
         Args:
@@ -548,9 +548,9 @@ class WorkflowAgent(BaseAgent):
             per_message_responses: list[AgentResponse] = []
             for _, msg_updates in by_msg.items():
                 if msg_updates:
-                    per_message_responses.append(AgentResponse.from_agent_run_response_updates(msg_updates))
+                    per_message_responses.append(AgentResponse.from_agent_response_updates(msg_updates))
             if dangling:
-                per_message_responses.append(AgentResponse.from_agent_run_response_updates(dangling))
+                per_message_responses.append(AgentResponse.from_agent_response_updates(dangling))
 
             per_message_responses.sort(key=lambda r: _parse_dt(r.created_at))
 
@@ -584,7 +584,7 @@ class WorkflowAgent(BaseAgent):
         # These are updates that couldn't be associated with any response_id
         # (e.g., orphan FunctionResultContent with no matching FunctionCallContent)
         if global_dangling:
-            flattened = AgentResponse.from_agent_run_response_updates(global_dangling)
+            flattened = AgentResponse.from_agent_response_updates(global_dangling)
             final_messages.extend(flattened.messages)
             if flattened.usage_details:
                 merged_usage = add_usage_details(merged_usage, flattened.usage_details)  # type: ignore[arg-type]

--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -377,12 +377,12 @@ class AgentExecutor(Executor):
         # Build the final AgentResponse from the collected updates
         if isinstance(self._agent, ChatAgent):
             response_format = self._agent.default_options.get("response_format")
-            response = AgentResponse.from_agent_run_response_updates(
+            response = AgentResponse.from_agent_response_updates(
                 updates,
                 output_format_type=response_format,
             )
         else:
-            response = AgentResponse.from_agent_run_response_updates(updates)
+            response = AgentResponse.from_agent_response_updates(updates)
 
         # Handle any user input requests after the streaming completes
         if user_input_requests:

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1450,7 +1450,7 @@ def _trace_agent_run_stream(
                 capture_exception(span=span, exception=exception, timestamp=time_ns())
                 raise
             else:
-                response = AgentResponse.from_agent_run_response_updates(all_updates)
+                response = AgentResponse.from_agent_response_updates(all_updates)
                 attributes = _get_response_attributes(attributes, response, capture_usage=capture_usage)
                 _capture_response(span=span, attributes=attributes)
                 if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and response.messages:

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -1129,7 +1129,7 @@ def test_agent_run_response_text_property_empty() -> None:
 
 def test_agent_run_response_from_updates(agent_response_update: AgentResponseUpdate) -> None:
     updates = [agent_response_update, agent_response_update]
-    response = AgentResponse.from_agent_run_response_updates(updates)
+    response = AgentResponse.from_agent_response_updates(updates)
     assert len(response.messages) > 0
     assert response.text == "Test contentTest content"
 

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_actions_agents.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_actions_agents.py
@@ -348,7 +348,7 @@ async def handle_invoke_azure_agent(ctx: ActionContext) -> AsyncGenerator[Workfl
                         tool_calls.extend(chunk.tool_calls)
 
                 # Build consolidated response from updates
-                response = AgentResponse.from_agent_run_response_updates(updates)
+                response = AgentResponse.from_agent_response_updates(updates)
                 text = response.text
                 response_messages = response.messages
 
@@ -581,7 +581,7 @@ async def handle_invoke_prompt_agent(ctx: ActionContext) -> AsyncGenerator[Workf
                     )
 
             # Build consolidated response from updates
-            response = AgentResponse.from_agent_run_response_updates(updates)
+            response = AgentResponse.from_agent_response_updates(updates)
             text = response.text
             response_messages = response.messages
 

--- a/python/packages/durabletask/agent_framework_durabletask/_entities.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_entities.py
@@ -247,7 +247,7 @@ class AgentEntity:
             await self._notify_stream_update(update, callback_context)
 
         if updates:
-            response = AgentResponse.from_agent_run_response_updates(updates)
+            response = AgentResponse.from_agent_response_updates(updates)
         else:
             logger.debug("[AgentEntity] No streaming updates received; creating empty response")
             response = AgentResponse(messages=[])


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
We have renamed `AgentRunResponse[Update]` to `AgentResponse[Update]`, but we didn't rename some of the methods.

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->
Rename `from_agent_run_response_updates` to `from_agent_response_updates`

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.