### PR TITLE
fix(devui): Fix serialization of dataclass events in workflow mapper

### DIFF
--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -1195,15 +1195,15 @@ class MessageMapper:
                 return [trace_event]
 
             # For unknown/legacy events, still emit as workflow event for backward compatibility
-            # Get event data and serialize if it's a SerializationMixin
+            # Use _serialize_value to handle dataclasses, SerializationMixin, and nested objects
             raw_event_data = getattr(event, "data", None)
-            serialized_event_data: dict[str, Any] | str | None = raw_event_data
-            if raw_event_data is not None and hasattr(raw_event_data, "to_dict"):
-                # SerializationMixin objects - convert to dict for JSON serialization
+            serialized_event_data: dict[str, Any] | str | None = None
+            if raw_event_data is not None:
                 try:
-                    serialized_event_data = raw_event_data.to_dict()
+                    # Use _serialize_value which handles all types: dataclasses, SerializationMixin, etc.
+                    serialized_event_data = self._serialize_value(raw_event_data)
                 except Exception as e:
-                    logger.debug(f"Failed to serialize event data with to_dict(): {e}")
+                    logger.debug(f"Failed to serialize event data: {e}")
                     serialized_event_data = str(raw_event_data)
 
             # Create structured workflow event (keeping for backward compatibility)


### PR DESCRIPTION
## Summary

This PR fixes a serialization bug in the devui package that causes `PydanticSerializationError` when using workflows with group chat orchestrators.

## Problem

When running `devui` with a workflow that uses `AgentBasedGroupChatOrchestrator`, users encounter:

```
PydanticSerializationError: Unable to serialize unknown type: <class 'agent_framework._types.AgentResponse'>
```

## Root Cause

The `_convert_workflow_event` method in `_mapper.py` handles legacy workflow events by serializing their `data` field. The original implementation only checked for `to_dict()` method:

```python
if raw_event_data is not None and hasattr(raw_event_data, "to_dict"):
    serialized_event_data = raw_event_data.to_dict()
```

However, `GroupChatResponseReceivedEvent.data` contains `AgentExecutorResponse`, which is a **dataclass** (not a `SerializationMixin`). This dataclass contains nested `AgentResponse` objects that Pydantic cannot serialize directly.

## Solution

The `MessageMapper` class already has a `_serialize_value()` method that properly handles:
- `SerializationMixin` objects (via `to_dict()`)
- Dataclasses (via recursive field serialization)
- Nested structures
- Primitive types

Changed to use this existing method instead of the limited `to_dict()` check.

## Testing

- Tested with `devui . --log-level DEBUG` running a workflow with `AgentBasedGroupChatOrchestrator`
- Verified `GroupChatResponseReceivedEvent` serializes correctly without errors

## Changes

| File | Change |
|------|--------|
| `python/packages/devui/agent_framework_devui/_mapper.py` | Use `_serialize_value()` for legacy event serialization |

## Backwards Compatibility

✅ **Fully backwards compatible** - This change:
- Uses an existing internal method already used elsewhere in the class
- Doesn't change any public APIs
- Objects with `to_dict()` still serialize correctly via `_serialize_value()`
- Adds support for dataclasses that were previously failing
