### PR TITLE
.NET Workflows - Remove empty message injection in declarative workflow agent provider.

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.AzureAI/AzureAgentProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.AzureAI/AzureAgentProvider.cs
@@ -123,7 +123,7 @@ public sealed class AzureAgentProvider(Uri projectEndpoint, TokenCredential proj
         IAsyncEnumerable<AgentResponseUpdate> agentResponse =
             messages is not null ?
                 agent.RunStreamingAsync([.. messages], null, runOptions, cancellationToken) :
-                agent.RunStreamingAsync([new ChatMessage(ChatRole.User, string.Empty)], null, runOptions, cancellationToken);
+                agent.RunStreamingAsync([], null, runOptions, cancellationToken);
 
         await foreach (AgentResponseUpdate update in agentResponse.ConfigureAwait(false))
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/InputArguments.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/InputArguments.json
@@ -10,7 +10,6 @@
     "conversation_count": 1,
     "min_action_count": 1,
     "min_response_count": 1,
-    "min_message_count": 2,
     "actions": {
       "start": [
         "invoke_poem"

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/Marketing.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/Marketing.json
@@ -10,7 +10,6 @@
     "conversation_count": 1,
     "min_action_count": 3,
     "min_response_count": 3,
-    "min_message_count": 6,
     "actions": {
       "start": [
         "invoke_analyst",


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Removing workaround for SDK limitation.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

SDK no longers requires an input message when conversation-id is present.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.