### PR TITLE
.NET Workflows - Re-enable media test for declarative workflows

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/MediaInputTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/MediaInputTest.cs
@@ -21,42 +21,51 @@ public sealed class MediaInputTest(ITestOutputHelper output) : IntegrationTest(o
 {
     private const string WorkflowWithConversationFileName = "MediaInputConversation.yaml";
     private const string WorkflowWithAutoSendFileName = "MediaInputAutoSend.yaml";
-    private const string PdfReference = "https://sample-files.com/downloads/documents/pdf/basic-text.pdf";
     private const string ImageReference = "https://sample-files.com/downloads/images/jpg/web_optimized_1200x800_97kb.jpg";
+    private const string PdfReference = "https://sample-files.com/downloads/documents/pdf/basic-text.pdf";
 
     [Theory]
-    [InlineData(ImageReference, "image/jpeg", true, Skip = "Failing due to agent service bug.")]
-    [InlineData(ImageReference, "image/jpeg", false, Skip = "Failing due to agent service bug.")]
+    [InlineData(ImageReference, "image/jpeg", true)]
+    [InlineData(ImageReference, "image/jpeg", false)]
     public async Task ValidateFileUrlAsync(string fileSource, string mediaType, bool useConversation)
     {
-        this.Output.WriteLine($"File: {ImageReference}");
+        // Arrange
+        this.Output.WriteLine($"File: {fileSource}");
+
+        // Act & Assert
         await this.ValidateFileAsync(new UriContent(fileSource, mediaType), useConversation);
     }
 
     [Theory]
     [InlineData(ImageReference, "image/jpeg", true)]
-    [InlineData(ImageReference, "image/jpeg", false, Skip = "Failing due to agent service bug.")]
+    [InlineData(ImageReference, "image/jpeg", false)]
     [InlineData(PdfReference, "application/pdf", true)]
     [InlineData(PdfReference, "application/pdf", false)]
     public async Task ValidateFileDataAsync(string fileSource, string mediaType, bool useConversation)
     {
+        // Arrange
         byte[] fileData = await DownloadFileAsync(fileSource);
         string encodedData = Convert.ToBase64String(fileData);
         string fileUrl = $"data:{mediaType};base64,{encodedData}";
-        this.Output.WriteLine($"Content: {fileUrl.Substring(0, 112)}...");
+        this.Output.WriteLine($"Content: {fileUrl.Substring(0, Math.Min(112, fileUrl.Length))}...");
+
+        // Act & Assert
         await this.ValidateFileAsync(new DataContent(fileUrl), useConversation);
     }
 
     [Theory]
-    [InlineData(PdfReference, "doc.pdf", true, Skip = "Failing due to agent service bug.")]
-    [InlineData(PdfReference, "doc.pdf", false, Skip = "Failing due to agent service bug.")]
+    [InlineData(PdfReference, "doc.pdf", true)]
+    [InlineData(PdfReference, "doc.pdf", false)]
     public async Task ValidateFileUploadAsync(string fileSource, string documentName, bool useConversation)
     {
+        // Arrange
         byte[] fileData = await DownloadFileAsync(fileSource);
         AIProjectClient client = new(this.TestEndpoint, new AzureCliCredential());
         using MemoryStream contentStream = new(fileData);
         OpenAIFileClient fileClient = client.GetProjectOpenAIClient().GetOpenAIFileClient();
         OpenAIFile fileInfo = await fileClient.UploadFileAsync(contentStream, documentName, FileUploadPurpose.Assistants);
+
+        // Act & Assert
         try
         {
             this.Output.WriteLine($"File: {fileInfo.Id}");
@@ -77,6 +86,7 @@ public sealed class MediaInputTest(ITestOutputHelper output) : IntegrationTest(o
 
     private async Task ValidateFileAsync(AIContent fileContent, bool useConversation)
     {
+        // Act
         AgentProvider agentProvider = AgentProvider.Create(this.Configuration, AgentProvider.Names.Vision);
         await agentProvider.CreateAgentsAsync().ConfigureAwait(false);
 
@@ -93,6 +103,8 @@ public sealed class MediaInputTest(ITestOutputHelper output) : IntegrationTest(o
 
         WorkflowHarness harness = new(workflow, runId: Path.GetFileNameWithoutExtension(workflowFileName));
         WorkflowEvents workflowEvents = await harness.RunWorkflowAsync(inputMessage).ConfigureAwait(false);
+
+        // Assert
         Assert.Equal(useConversation ? 1 : 2, workflowEvents.ConversationEvents.Count);
         this.Output.WriteLine("CONVERSATION: " + workflowEvents.ConversationEvents[0].ConversationId);
         AgentResponseEvent agentResponseEvent = Assert.Single(workflowEvents.AgentResponseEvents);


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

The prompt-agent service ability to handle file inputs has been fixed.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Re-enabling tests that were disabled due to a regression in the agent service.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.