### PR TITLE
Python: Fix MCP tool calls sending empty arguments when inputSchema lacks properties

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -667,8 +667,8 @@ def _build_pydantic_model_from_json_schema(
     required = schema.get("required", [])
     definitions = schema.get("$defs", {})
 
-    # Check if 'properties' is missing or not a dictionary
-    if not properties:
+    # Check if 'properties' is missing, empty, or not a dictionary
+    if not properties or not isinstance(properties, Mapping):
         # Allow extra fields so arguments are preserved even when the schema
         # doesn't declare properties (e.g., MCP servers returning {"type": "object"}).
         return create_model(f"{model_name}_input", __config__=ConfigDict(extra="allow"))


### PR DESCRIPTION
 Fixes a bug where `MCPStreamableHTTPTool` (and other MCP tool types) sends empty `{}` arguments to the MCP server when the server's `inputSchema` has no `properties` key (e.g., `{"type": "object"}`).

### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.