### PR TITLE
Python:  Changes tools parameter type hints from `MutableMapping` to `Mapping` for broader type compatibility.

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -616,9 +616,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         description: str | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | Sequence[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | Sequence[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         default_options: OptionsCoT | None = None,
         chat_message_store_factory: Callable[[], ChatMessageStoreProtocol] | None = None,
@@ -683,8 +683,8 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         tools_ = cast(
             FunctionTool
             | Callable[..., Any]
-            | MutableMapping[str, Any]
-            | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any]]
+            | Mapping[str, Any]
+            | list[FunctionTool | Callable[..., Any] | Mapping[str, Any]]
             | None,
             tools_,
         )
@@ -694,7 +694,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
 
         # We ignore the MCP Servers here and store them separately,
         # we add their functions to the tools list at runtime
-        normalized_tools: list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any]] = (  # type:ignore[reportUnknownVariableType]
+        normalized_tools: list[FunctionTool | Callable[..., Any] | Mapping[str, Any]] = (  # type:ignore[reportUnknownVariableType]
             [] if tools_ is None else tools_ if isinstance(tools_, list) else [tools_]  # type: ignore[list-item]
         )
         self.mcp_tools: list[MCPTool] = [tool for tool in normalized_tools if isinstance(tool, MCPTool)]  # type: ignore[misc]
@@ -782,9 +782,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         thread: AgentThread | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         options: ChatOptions[ResponseModelBoundT],
         **kwargs: Any,
@@ -799,9 +799,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         thread: AgentThread | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         options: OptionsCoT | ChatOptions[None] | None = None,
         **kwargs: Any,
@@ -816,9 +816,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         thread: AgentThread | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         options: OptionsCoT | ChatOptions[Any] | None = None,
         **kwargs: Any,
@@ -832,9 +832,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         thread: AgentThread | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         options: OptionsCoT | ChatOptions[Any] | None = None,
         **kwargs: Any,
@@ -987,9 +987,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         thread: AgentThread | None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None,
         options: Mapping[str, Any] | None,
         kwargs: dict[str, Any],
@@ -1005,7 +1005,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         )
 
         # Normalize tools
-        normalized_tools: list[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any] = (
+        normalized_tools: list[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any] = (
             [] if tools_ is None else tools_ if isinstance(tools_, list) else [tools_]
         )
         agent_name = self._get_agent_name()
@@ -1399,9 +1399,9 @@ class Agent(
         description: str | None = None,
         tools: FunctionTool
         | Callable[..., Any]
-        | MutableMapping[str, Any]
+        | Mapping[str, Any]
         | Any
-        | Sequence[FunctionTool | Callable[..., Any] | MutableMapping[str, Any] | Any]
+        | Sequence[FunctionTool | Callable[..., Any] | Mapping[str, Any] | Any]
         | None = None,
         default_options: OptionsCoT | None = None,
         chat_message_store_factory: Callable[[], ChatMessageStoreProtocol] | None = None,


### PR DESCRIPTION
### Motivation and Context
The tools parameter accepts dict-based tool definitions that are only read, never mutated. 
 Resolves #3577. 

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.