### PR TITLE
Python: Fix HostedWebSearchTool failing with AzureOpenAIChatClient

### DIFF
--- a/python/packages/core/agent_framework/azure/_chat_client.py
+++ b/python/packages/core/agent_framework/azure/_chat_client.py
@@ -23,7 +23,7 @@ from agent_framework import (
     FunctionInvocationConfiguration,
     FunctionInvocationLayer,
 )
-from agent_framework.exceptions import ServiceInitializationError, ServiceInvalidRequestError
+from agent_framework.exceptions import ServiceInitializationError
 from agent_framework.observability import ChatTelemetryLayer
 from agent_framework.openai import OpenAIChatOptions
 from agent_framework.openai._chat_client import RawOpenAIChatClient
@@ -291,26 +291,28 @@ class AzureOpenAIChatClient(  # type: ignore[misc]
     def _prepare_tools_for_openai(self, tools: Sequence[Any]) -> dict[str, Any]:
         """Prepare tools for the Azure OpenAI Chat Completions API.
 
-        Overrides the base implementation to raise an error when web search tools
-        are used, since Azure OpenAI's Chat Completions API does not support the
-        ``web_search_options`` parameter.
+        Overrides the base implementation to filter out web search tools,
+        since Azure OpenAI's Chat Completions API does not support the
+        ``web_search_options`` parameter. Web search tools are silently
+        removed with a warning logged.
 
         Args:
             tools: Sequence of tools to prepare.
 
         Returns:
-            Dict containing tools.
-
-        Raises:
-            ServiceInvalidRequestError: If a web search tool is included.
+            Dict containing prepared tools, with web search tools filtered out.
         """
+        filtered_tools: list[Any] = []
         for tool in tools:
             if isinstance(tool, MutableMapping) and tool.get("type") == "web_search":
-                raise ServiceInvalidRequestError(
-                    "Web search tools are not supported by Azure OpenAI's Chat Completions API. "
-                    "Use OpenAIChatClient or AzureOpenAIResponsesClient instead."
+                logger.warning(
+                    "Web search tools are not supported by Azure OpenAI's Chat Completions API "
+                    "and will be skipped. Use OpenAIChatClient or AzureOpenAIResponsesClient "
+                    "for web search support."
                 )
-        return super()._prepare_tools_for_openai(tools)
+                continue
+            filtered_tools.append(tool)
+        return super()._prepare_tools_for_openai(filtered_tools)
 
     @override
     def _parse_text_from_openai(self, choice: Choice | ChunkChoice) -> Content | None:


### PR DESCRIPTION
## Motivation and Context
Fixes #3629

`AzureOpenAIChatClient` inherits `_prepare_tools_for_openai()` from `RawOpenAIChatClient`, which extracts web search tools into a top-level `web_search_options` parameter. Azure OpenAI's Chat Completions API does **not** support this parameter (it's OpenAI-only), resulting in:

```
Error code: 400 - Unknown parameter: 'web_search_options'
```

## Description
Override `_prepare_tools_for_openai()` in `AzureOpenAIChatClient` to gracefully filter out web search tools and log a warning, rather than letting the request fail. 

This ensures robust handling: requests with multiple tools (e.g., weather + web search) will still succeed for the supported tools, while the user is clearly warned that web search is not supported on this endpoint. The warning directs users to use `OpenAIChatClient` or `AzureOpenAIResponsesClient` if web search is required.

## Changes
- **`azure/_chat_client.py`**: Added `_prepare_tools_for_openai()` override that filters out `{"type": "web_search"}` tools and logs a warning
- **`tests/azure/test_azure_chat_client.py`**: Added tests verifying that web search tools are filtered out with a warning and that normal tools are preserved

## Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] The code follows the [SK coding conventions](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)