### PR TITLE
Python: Replace wildcard imports with explicit imports

### DIFF
--- a/python/CODING_STANDARD.md
+++ b/python/CODING_STANDARD.md
@@ -403,21 +403,36 @@ If in doubt, use the link above to read much more considerations of what to do a
 
 ### Explicit Exports
 
-> **Note:** This convention is being adopted. See [#3605](https://github.com/microsoft/agent-framework/issues/3605) for progress.
+**All wildcard imports (`from ... import *`) are prohibited** in production code, including both `.py` and `.pyi` files. Always use explicit import lists to maintain clarity and avoid namespace pollution.
 
-Define `__all__` in each module to explicitly declare the public API. Avoid using `from module import *` in `__init__.py` files as it can impact performance and makes the public API unclear:
+Define `__all__` in each module to explicitly declare the public API, then import specific symbols by name:
 
 ```python
-# ✅ Preferred - explicit __all__ and imports
+# ✅ Preferred - explicit __all__ and named imports
 __all__ = ["Agent", "Message", "ChatResponse"]
 
 from ._agents import Agent
 from ._types import Message, ChatResponse
 
-# ❌ Avoid - star imports
+# ✅ For many exports, use parenthesized multi-line imports
+from ._types import (
+    AgentResponse,
+    ChatResponse,
+    Message,
+    ResponseStream,
+)
+
+# ❌ Prohibited - wildcard/star imports
 from ._agents import *
 from ._types import *
 ```
+
+**Rationale:**
+- **Clarity**: Explicit imports make it clear exactly what is being exported and used
+- **IDE Support**: Enables better autocomplete, go-to-definition, and refactoring
+- **Type Checking**: Improves static analysis and type checker accuracy
+- **Maintenance**: Makes it easier to track symbol usage and detect breaking changes
+- **Performance**: Avoids unnecessary symbol resolution during module import
 
 ## Performance considerations
 

--- a/python/CODING_STANDARD.md
+++ b/python/CODING_STANDARD.md
@@ -422,9 +422,9 @@ from ._types import (
     ResponseStream,
 )
 
-# ❌ Prohibited - wildcard/star imports
-from ._agents import *
-from ._types import *
+# ❌ Prohibited pattern: wildcard/star imports (do not use)
+# from ._agents import <all public symbols>
+# from ._types import <all public symbols>
 ```
 
 **Rationale:**

--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -9,13 +9,390 @@ except importlib.metadata.PackageNotFoundError:
     _version = "0.0.0"  # Fallback for development mode
 __version__: Final[str] = _version
 
-from ._agents import *  # noqa: F403
-from ._clients import *  # noqa: F403
-from ._logging import *  # noqa: F403
-from ._mcp import *  # noqa: F403
-from ._middleware import *  # noqa: F403
-from ._sessions import *  # noqa: F403
-from ._telemetry import *  # noqa: F403
-from ._tools import *  # noqa: F403
-from ._types import *  # noqa: F403
-from ._workflows import *  # noqa: F403
+from ._agents import Agent as Agent
+from ._agents import BaseAgent as BaseAgent
+from ._agents import RawAgent as RawAgent
+from ._agents import SupportsAgentRun as SupportsAgentRun
+from ._clients import (
+    BaseChatClient as BaseChatClient,
+)
+from ._clients import (
+    SupportsChatGetResponse as SupportsChatGetResponse,
+)
+from ._clients import (
+    SupportsCodeInterpreterTool as SupportsCodeInterpreterTool,
+)
+from ._clients import (
+    SupportsFileSearchTool as SupportsFileSearchTool,
+)
+from ._clients import (
+    SupportsImageGenerationTool as SupportsImageGenerationTool,
+)
+from ._clients import (
+    SupportsMCPTool as SupportsMCPTool,
+)
+from ._clients import (
+    SupportsWebSearchTool as SupportsWebSearchTool,
+)
+from ._logging import get_logger as get_logger
+from ._logging import setup_logging as setup_logging
+from ._mcp import MCPStdioTool as MCPStdioTool
+from ._mcp import MCPStreamableHTTPTool as MCPStreamableHTTPTool
+from ._mcp import MCPWebsocketTool as MCPWebsocketTool
+from ._middleware import (
+    AgentContext as AgentContext,
+)
+from ._middleware import (
+    AgentMiddleware as AgentMiddleware,
+)
+from ._middleware import (
+    AgentMiddlewareLayer as AgentMiddlewareLayer,
+)
+from ._middleware import (
+    AgentMiddlewareTypes as AgentMiddlewareTypes,
+)
+from ._middleware import (
+    ChatAndFunctionMiddlewareTypes as ChatAndFunctionMiddlewareTypes,
+)
+from ._middleware import (
+    ChatContext as ChatContext,
+)
+from ._middleware import (
+    ChatMiddleware as ChatMiddleware,
+)
+from ._middleware import (
+    ChatMiddlewareLayer as ChatMiddlewareLayer,
+)
+from ._middleware import (
+    ChatMiddlewareTypes as ChatMiddlewareTypes,
+)
+from ._middleware import (
+    FunctionInvocationContext as FunctionInvocationContext,
+)
+from ._middleware import (
+    FunctionMiddleware as FunctionMiddleware,
+)
+from ._middleware import (
+    FunctionMiddlewareTypes as FunctionMiddlewareTypes,
+)
+from ._middleware import (
+    MiddlewareException as MiddlewareException,
+)
+from ._middleware import (
+    MiddlewareTermination as MiddlewareTermination,
+)
+from ._middleware import (
+    MiddlewareType as MiddlewareType,
+)
+from ._middleware import (
+    MiddlewareTypes as MiddlewareTypes,
+)
+from ._middleware import (
+    agent_middleware as agent_middleware,
+)
+from ._middleware import (
+    chat_middleware as chat_middleware,
+)
+from ._middleware import (
+    function_middleware as function_middleware,
+)
+from ._sessions import (
+    AgentSession as AgentSession,
+)
+from ._sessions import (
+    BaseContextProvider as BaseContextProvider,
+)
+from ._sessions import (
+    BaseHistoryProvider as BaseHistoryProvider,
+)
+from ._sessions import (
+    InMemoryHistoryProvider as InMemoryHistoryProvider,
+)
+from ._sessions import (
+    SessionContext as SessionContext,
+)
+from ._sessions import (
+    register_state_type as register_state_type,
+)
+from ._telemetry import (
+    AGENT_FRAMEWORK_USER_AGENT as AGENT_FRAMEWORK_USER_AGENT,
+)
+from ._telemetry import (
+    APP_INFO as APP_INFO,
+)
+from ._telemetry import (
+    USER_AGENT_KEY as USER_AGENT_KEY,
+)
+from ._telemetry import (
+    USER_AGENT_TELEMETRY_DISABLED_ENV_VAR as USER_AGENT_TELEMETRY_DISABLED_ENV_VAR,
+)
+from ._telemetry import (
+    prepend_agent_framework_to_user_agent as prepend_agent_framework_to_user_agent,
+)
+from ._tools import (
+    FunctionInvocationConfiguration as FunctionInvocationConfiguration,
+)
+from ._tools import (
+    FunctionInvocationLayer as FunctionInvocationLayer,
+)
+from ._tools import (
+    FunctionTool as FunctionTool,
+)
+from ._tools import (
+    normalize_function_invocation_configuration as normalize_function_invocation_configuration,
+)
+from ._tools import (
+    tool as tool,
+)
+from ._types import (
+    AgentResponse as AgentResponse,
+)
+from ._types import (
+    AgentResponseUpdate as AgentResponseUpdate,
+)
+from ._types import (
+    Annotation as Annotation,
+)
+from ._types import (
+    ChatOptions as ChatOptions,
+)
+from ._types import (
+    ChatResponse as ChatResponse,
+)
+from ._types import (
+    ChatResponseUpdate as ChatResponseUpdate,
+)
+from ._types import (
+    Content as Content,
+)
+from ._types import (
+    ContinuationToken as ContinuationToken,
+)
+from ._types import (
+    FinalT as FinalT,
+)
+from ._types import (
+    FinishReason as FinishReason,
+)
+from ._types import (
+    FinishReasonLiteral as FinishReasonLiteral,
+)
+from ._types import (
+    Message as Message,
+)
+from ._types import (
+    OuterFinalT as OuterFinalT,
+)
+from ._types import (
+    OuterUpdateT as OuterUpdateT,
+)
+from ._types import (
+    ResponseStream as ResponseStream,
+)
+from ._types import (
+    Role as Role,
+)
+from ._types import (
+    RoleLiteral as RoleLiteral,
+)
+from ._types import (
+    TextSpanRegion as TextSpanRegion,
+)
+from ._types import (
+    ToolMode as ToolMode,
+)
+from ._types import (
+    UpdateT as UpdateT,
+)
+from ._types import (
+    UsageDetails as UsageDetails,
+)
+from ._types import (
+    add_usage_details as add_usage_details,
+)
+from ._types import (
+    detect_media_type_from_base64 as detect_media_type_from_base64,
+)
+from ._types import (
+    map_chat_to_agent_update as map_chat_to_agent_update,
+)
+from ._types import (
+    merge_chat_options as merge_chat_options,
+)
+from ._types import (
+    normalize_messages as normalize_messages,
+)
+from ._types import (
+    normalize_tools as normalize_tools,
+)
+from ._types import (
+    prepend_instructions_to_messages as prepend_instructions_to_messages,
+)
+from ._types import (
+    validate_chat_options as validate_chat_options,
+)
+from ._types import (
+    validate_tool_mode as validate_tool_mode,
+)
+from ._types import (
+    validate_tools as validate_tools,
+)
+from ._workflows import (
+    DEFAULT_MAX_ITERATIONS as DEFAULT_MAX_ITERATIONS,
+)
+from ._workflows import (
+    AgentExecutor as AgentExecutor,
+)
+from ._workflows import (
+    AgentExecutorRequest as AgentExecutorRequest,
+)
+from ._workflows import (
+    AgentExecutorResponse as AgentExecutorResponse,
+)
+from ._workflows import (
+    Case as Case,
+)
+from ._workflows import (
+    CheckpointStorage as CheckpointStorage,
+)
+from ._workflows import (
+    Default as Default,
+)
+from ._workflows import (
+    Edge as Edge,
+)
+from ._workflows import (
+    EdgeCondition as EdgeCondition,
+)
+from ._workflows import (
+    EdgeDuplicationError as EdgeDuplicationError,
+)
+from ._workflows import (
+    Executor as Executor,
+)
+from ._workflows import (
+    FanInEdgeGroup as FanInEdgeGroup,
+)
+from ._workflows import (
+    FanOutEdgeGroup as FanOutEdgeGroup,
+)
+from ._workflows import (
+    FileCheckpointStorage as FileCheckpointStorage,
+)
+from ._workflows import (
+    FunctionExecutor as FunctionExecutor,
+)
+from ._workflows import (
+    GraphConnectivityError as GraphConnectivityError,
+)
+from ._workflows import (
+    InMemoryCheckpointStorage as InMemoryCheckpointStorage,
+)
+from ._workflows import (
+    InProcRunnerContext as InProcRunnerContext,
+)
+from ._workflows import (
+    Runner as Runner,
+)
+from ._workflows import (
+    RunnerContext as RunnerContext,
+)
+from ._workflows import (
+    SingleEdgeGroup as SingleEdgeGroup,
+)
+from ._workflows import (
+    SubWorkflowRequestMessage as SubWorkflowRequestMessage,
+)
+from ._workflows import (
+    SubWorkflowResponseMessage as SubWorkflowResponseMessage,
+)
+from ._workflows import (
+    SwitchCaseEdgeGroup as SwitchCaseEdgeGroup,
+)
+from ._workflows import (
+    SwitchCaseEdgeGroupCase as SwitchCaseEdgeGroupCase,
+)
+from ._workflows import (
+    SwitchCaseEdgeGroupDefault as SwitchCaseEdgeGroupDefault,
+)
+from ._workflows import (
+    TypeCompatibilityError as TypeCompatibilityError,
+)
+from ._workflows import (
+    ValidationTypeEnum as ValidationTypeEnum,
+)
+from ._workflows import (
+    Workflow as Workflow,
+)
+from ._workflows import (
+    WorkflowAgent as WorkflowAgent,
+)
+from ._workflows import (
+    WorkflowBuilder as WorkflowBuilder,
+)
+from ._workflows import (
+    WorkflowCheckpoint as WorkflowCheckpoint,
+)
+from ._workflows import (
+    WorkflowCheckpointException as WorkflowCheckpointException,
+)
+from ._workflows import (
+    WorkflowContext as WorkflowContext,
+)
+from ._workflows import (
+    WorkflowConvergenceException as WorkflowConvergenceException,
+)
+from ._workflows import (
+    WorkflowErrorDetails as WorkflowErrorDetails,
+)
+from ._workflows import (
+    WorkflowEvent as WorkflowEvent,
+)
+from ._workflows import (
+    WorkflowEventSource as WorkflowEventSource,
+)
+from ._workflows import (
+    WorkflowEventType as WorkflowEventType,
+)
+from ._workflows import (
+    WorkflowException as WorkflowException,
+)
+from ._workflows import (
+    WorkflowExecutor as WorkflowExecutor,
+)
+from ._workflows import (
+    WorkflowMessage as WorkflowMessage,
+)
+from ._workflows import (
+    WorkflowRunnerException as WorkflowRunnerException,
+)
+from ._workflows import (
+    WorkflowRunResult as WorkflowRunResult,
+)
+from ._workflows import (
+    WorkflowRunState as WorkflowRunState,
+)
+from ._workflows import (
+    WorkflowValidationError as WorkflowValidationError,
+)
+from ._workflows import (
+    WorkflowViz as WorkflowViz,
+)
+from ._workflows import (
+    create_edge_runner as create_edge_runner,
+)
+from ._workflows import (
+    executor as executor,
+)
+from ._workflows import (
+    handler as handler,
+)
+from ._workflows import (
+    resolve_agent_id as resolve_agent_id,
+)
+from ._workflows import (
+    response_handler as response_handler,
+)
+from ._workflows import (
+    validate_workflow_graph as validate_workflow_graph,
+)

--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -9,390 +9,284 @@ except importlib.metadata.PackageNotFoundError:
     _version = "0.0.0"  # Fallback for development mode
 __version__: Final[str] = _version
 
-from ._agents import Agent as Agent
-from ._agents import BaseAgent as BaseAgent
-from ._agents import RawAgent as RawAgent
-from ._agents import SupportsAgentRun as SupportsAgentRun
+from ._agents import Agent, BaseAgent, RawAgent, SupportsAgentRun
 from ._clients import (
-    BaseChatClient as BaseChatClient,
+    BaseChatClient,
+    SupportsChatGetResponse,
+    SupportsCodeInterpreterTool,
+    SupportsFileSearchTool,
+    SupportsImageGenerationTool,
+    SupportsMCPTool,
+    SupportsWebSearchTool,
 )
-from ._clients import (
-    SupportsChatGetResponse as SupportsChatGetResponse,
-)
-from ._clients import (
-    SupportsCodeInterpreterTool as SupportsCodeInterpreterTool,
-)
-from ._clients import (
-    SupportsFileSearchTool as SupportsFileSearchTool,
-)
-from ._clients import (
-    SupportsImageGenerationTool as SupportsImageGenerationTool,
-)
-from ._clients import (
-    SupportsMCPTool as SupportsMCPTool,
-)
-from ._clients import (
-    SupportsWebSearchTool as SupportsWebSearchTool,
-)
-from ._logging import get_logger as get_logger
-from ._logging import setup_logging as setup_logging
-from ._mcp import MCPStdioTool as MCPStdioTool
-from ._mcp import MCPStreamableHTTPTool as MCPStreamableHTTPTool
-from ._mcp import MCPWebsocketTool as MCPWebsocketTool
+from ._logging import get_logger, setup_logging
+from ._mcp import MCPStdioTool, MCPStreamableHTTPTool, MCPWebsocketTool
 from ._middleware import (
-    AgentContext as AgentContext,
-)
-from ._middleware import (
-    AgentMiddleware as AgentMiddleware,
-)
-from ._middleware import (
-    AgentMiddlewareLayer as AgentMiddlewareLayer,
-)
-from ._middleware import (
-    AgentMiddlewareTypes as AgentMiddlewareTypes,
-)
-from ._middleware import (
-    ChatAndFunctionMiddlewareTypes as ChatAndFunctionMiddlewareTypes,
-)
-from ._middleware import (
-    ChatContext as ChatContext,
-)
-from ._middleware import (
-    ChatMiddleware as ChatMiddleware,
-)
-from ._middleware import (
-    ChatMiddlewareLayer as ChatMiddlewareLayer,
-)
-from ._middleware import (
-    ChatMiddlewareTypes as ChatMiddlewareTypes,
-)
-from ._middleware import (
-    FunctionInvocationContext as FunctionInvocationContext,
-)
-from ._middleware import (
-    FunctionMiddleware as FunctionMiddleware,
-)
-from ._middleware import (
-    FunctionMiddlewareTypes as FunctionMiddlewareTypes,
-)
-from ._middleware import (
-    MiddlewareException as MiddlewareException,
-)
-from ._middleware import (
-    MiddlewareTermination as MiddlewareTermination,
-)
-from ._middleware import (
-    MiddlewareType as MiddlewareType,
-)
-from ._middleware import (
-    MiddlewareTypes as MiddlewareTypes,
-)
-from ._middleware import (
-    agent_middleware as agent_middleware,
-)
-from ._middleware import (
-    chat_middleware as chat_middleware,
-)
-from ._middleware import (
-    function_middleware as function_middleware,
+    AgentContext,
+    AgentMiddleware,
+    AgentMiddlewareLayer,
+    AgentMiddlewareTypes,
+    ChatAndFunctionMiddlewareTypes,
+    ChatContext,
+    ChatMiddleware,
+    ChatMiddlewareLayer,
+    ChatMiddlewareTypes,
+    FunctionInvocationContext,
+    FunctionMiddleware,
+    FunctionMiddlewareTypes,
+    MiddlewareException,
+    MiddlewareTermination,
+    MiddlewareType,
+    MiddlewareTypes,
+    agent_middleware,
+    chat_middleware,
+    function_middleware,
 )
 from ._sessions import (
-    AgentSession as AgentSession,
-)
-from ._sessions import (
-    BaseContextProvider as BaseContextProvider,
-)
-from ._sessions import (
-    BaseHistoryProvider as BaseHistoryProvider,
-)
-from ._sessions import (
-    InMemoryHistoryProvider as InMemoryHistoryProvider,
-)
-from ._sessions import (
-    SessionContext as SessionContext,
-)
-from ._sessions import (
-    register_state_type as register_state_type,
+    AgentSession,
+    BaseContextProvider,
+    BaseHistoryProvider,
+    InMemoryHistoryProvider,
+    SessionContext,
+    register_state_type,
 )
 from ._telemetry import (
-    AGENT_FRAMEWORK_USER_AGENT as AGENT_FRAMEWORK_USER_AGENT,
-)
-from ._telemetry import (
-    APP_INFO as APP_INFO,
-)
-from ._telemetry import (
-    USER_AGENT_KEY as USER_AGENT_KEY,
-)
-from ._telemetry import (
-    USER_AGENT_TELEMETRY_DISABLED_ENV_VAR as USER_AGENT_TELEMETRY_DISABLED_ENV_VAR,
-)
-from ._telemetry import (
-    prepend_agent_framework_to_user_agent as prepend_agent_framework_to_user_agent,
+    AGENT_FRAMEWORK_USER_AGENT,
+    APP_INFO,
+    USER_AGENT_KEY,
+    USER_AGENT_TELEMETRY_DISABLED_ENV_VAR,
+    prepend_agent_framework_to_user_agent,
 )
 from ._tools import (
-    FunctionInvocationConfiguration as FunctionInvocationConfiguration,
-)
-from ._tools import (
-    FunctionInvocationLayer as FunctionInvocationLayer,
-)
-from ._tools import (
-    FunctionTool as FunctionTool,
-)
-from ._tools import (
-    normalize_function_invocation_configuration as normalize_function_invocation_configuration,
-)
-from ._tools import (
-    tool as tool,
+    FunctionInvocationConfiguration,
+    FunctionInvocationLayer,
+    FunctionTool,
+    normalize_function_invocation_configuration,
+    tool,
 )
 from ._types import (
-    AgentResponse as AgentResponse,
-)
-from ._types import (
-    AgentResponseUpdate as AgentResponseUpdate,
-)
-from ._types import (
-    Annotation as Annotation,
-)
-from ._types import (
-    ChatOptions as ChatOptions,
-)
-from ._types import (
-    ChatResponse as ChatResponse,
-)
-from ._types import (
-    ChatResponseUpdate as ChatResponseUpdate,
-)
-from ._types import (
-    Content as Content,
-)
-from ._types import (
-    ContinuationToken as ContinuationToken,
-)
-from ._types import (
-    FinalT as FinalT,
-)
-from ._types import (
-    FinishReason as FinishReason,
-)
-from ._types import (
-    FinishReasonLiteral as FinishReasonLiteral,
-)
-from ._types import (
-    Message as Message,
-)
-from ._types import (
-    OuterFinalT as OuterFinalT,
-)
-from ._types import (
-    OuterUpdateT as OuterUpdateT,
-)
-from ._types import (
-    ResponseStream as ResponseStream,
-)
-from ._types import (
-    Role as Role,
-)
-from ._types import (
-    RoleLiteral as RoleLiteral,
-)
-from ._types import (
-    TextSpanRegion as TextSpanRegion,
-)
-from ._types import (
-    ToolMode as ToolMode,
-)
-from ._types import (
-    UpdateT as UpdateT,
-)
-from ._types import (
-    UsageDetails as UsageDetails,
-)
-from ._types import (
-    add_usage_details as add_usage_details,
-)
-from ._types import (
-    detect_media_type_from_base64 as detect_media_type_from_base64,
-)
-from ._types import (
-    map_chat_to_agent_update as map_chat_to_agent_update,
-)
-from ._types import (
-    merge_chat_options as merge_chat_options,
-)
-from ._types import (
-    normalize_messages as normalize_messages,
-)
-from ._types import (
-    normalize_tools as normalize_tools,
-)
-from ._types import (
-    prepend_instructions_to_messages as prepend_instructions_to_messages,
-)
-from ._types import (
-    validate_chat_options as validate_chat_options,
-)
-from ._types import (
-    validate_tool_mode as validate_tool_mode,
-)
-from ._types import (
-    validate_tools as validate_tools,
+    AgentResponse,
+    AgentResponseUpdate,
+    Annotation,
+    ChatOptions,
+    ChatResponse,
+    ChatResponseUpdate,
+    Content,
+    ContinuationToken,
+    FinalT,
+    FinishReason,
+    FinishReasonLiteral,
+    Message,
+    OuterFinalT,
+    OuterUpdateT,
+    ResponseStream,
+    Role,
+    RoleLiteral,
+    TextSpanRegion,
+    ToolMode,
+    UpdateT,
+    UsageDetails,
+    add_usage_details,
+    detect_media_type_from_base64,
+    map_chat_to_agent_update,
+    merge_chat_options,
+    normalize_messages,
+    normalize_tools,
+    prepend_instructions_to_messages,
+    validate_chat_options,
+    validate_tool_mode,
+    validate_tools,
 )
 from ._workflows import (
-    DEFAULT_MAX_ITERATIONS as DEFAULT_MAX_ITERATIONS,
+    DEFAULT_MAX_ITERATIONS,
+    AgentExecutor,
+    AgentExecutorRequest,
+    AgentExecutorResponse,
+    Case,
+    CheckpointStorage,
+    Default,
+    Edge,
+    EdgeCondition,
+    EdgeDuplicationError,
+    Executor,
+    FanInEdgeGroup,
+    FanOutEdgeGroup,
+    FileCheckpointStorage,
+    FunctionExecutor,
+    GraphConnectivityError,
+    InMemoryCheckpointStorage,
+    InProcRunnerContext,
+    Runner,
+    RunnerContext,
+    SingleEdgeGroup,
+    SubWorkflowRequestMessage,
+    SubWorkflowResponseMessage,
+    SwitchCaseEdgeGroup,
+    SwitchCaseEdgeGroupCase,
+    SwitchCaseEdgeGroupDefault,
+    TypeCompatibilityError,
+    ValidationTypeEnum,
+    Workflow,
+    WorkflowAgent,
+    WorkflowBuilder,
+    WorkflowCheckpoint,
+    WorkflowCheckpointException,
+    WorkflowContext,
+    WorkflowConvergenceException,
+    WorkflowErrorDetails,
+    WorkflowEvent,
+    WorkflowEventSource,
+    WorkflowEventType,
+    WorkflowException,
+    WorkflowExecutor,
+    WorkflowMessage,
+    WorkflowRunnerException,
+    WorkflowRunResult,
+    WorkflowRunState,
+    WorkflowValidationError,
+    WorkflowViz,
+    create_edge_runner,
+    executor,
+    handler,
+    resolve_agent_id,
+    response_handler,
+    validate_workflow_graph,
 )
-from ._workflows import (
-    AgentExecutor as AgentExecutor,
-)
-from ._workflows import (
-    AgentExecutorRequest as AgentExecutorRequest,
-)
-from ._workflows import (
-    AgentExecutorResponse as AgentExecutorResponse,
-)
-from ._workflows import (
-    Case as Case,
-)
-from ._workflows import (
-    CheckpointStorage as CheckpointStorage,
-)
-from ._workflows import (
-    Default as Default,
-)
-from ._workflows import (
-    Edge as Edge,
-)
-from ._workflows import (
-    EdgeCondition as EdgeCondition,
-)
-from ._workflows import (
-    EdgeDuplicationError as EdgeDuplicationError,
-)
-from ._workflows import (
-    Executor as Executor,
-)
-from ._workflows import (
-    FanInEdgeGroup as FanInEdgeGroup,
-)
-from ._workflows import (
-    FanOutEdgeGroup as FanOutEdgeGroup,
-)
-from ._workflows import (
-    FileCheckpointStorage as FileCheckpointStorage,
-)
-from ._workflows import (
-    FunctionExecutor as FunctionExecutor,
-)
-from ._workflows import (
-    GraphConnectivityError as GraphConnectivityError,
-)
-from ._workflows import (
-    InMemoryCheckpointStorage as InMemoryCheckpointStorage,
-)
-from ._workflows import (
-    InProcRunnerContext as InProcRunnerContext,
-)
-from ._workflows import (
-    Runner as Runner,
-)
-from ._workflows import (
-    RunnerContext as RunnerContext,
-)
-from ._workflows import (
-    SingleEdgeGroup as SingleEdgeGroup,
-)
-from ._workflows import (
-    SubWorkflowRequestMessage as SubWorkflowRequestMessage,
-)
-from ._workflows import (
-    SubWorkflowResponseMessage as SubWorkflowResponseMessage,
-)
-from ._workflows import (
-    SwitchCaseEdgeGroup as SwitchCaseEdgeGroup,
-)
-from ._workflows import (
-    SwitchCaseEdgeGroupCase as SwitchCaseEdgeGroupCase,
-)
-from ._workflows import (
-    SwitchCaseEdgeGroupDefault as SwitchCaseEdgeGroupDefault,
-)
-from ._workflows import (
-    TypeCompatibilityError as TypeCompatibilityError,
-)
-from ._workflows import (
-    ValidationTypeEnum as ValidationTypeEnum,
-)
-from ._workflows import (
-    Workflow as Workflow,
-)
-from ._workflows import (
-    WorkflowAgent as WorkflowAgent,
-)
-from ._workflows import (
-    WorkflowBuilder as WorkflowBuilder,
-)
-from ._workflows import (
-    WorkflowCheckpoint as WorkflowCheckpoint,
-)
-from ._workflows import (
-    WorkflowCheckpointException as WorkflowCheckpointException,
-)
-from ._workflows import (
-    WorkflowContext as WorkflowContext,
-)
-from ._workflows import (
-    WorkflowConvergenceException as WorkflowConvergenceException,
-)
-from ._workflows import (
-    WorkflowErrorDetails as WorkflowErrorDetails,
-)
-from ._workflows import (
-    WorkflowEvent as WorkflowEvent,
-)
-from ._workflows import (
-    WorkflowEventSource as WorkflowEventSource,
-)
-from ._workflows import (
-    WorkflowEventType as WorkflowEventType,
-)
-from ._workflows import (
-    WorkflowException as WorkflowException,
-)
-from ._workflows import (
-    WorkflowExecutor as WorkflowExecutor,
-)
-from ._workflows import (
-    WorkflowMessage as WorkflowMessage,
-)
-from ._workflows import (
-    WorkflowRunnerException as WorkflowRunnerException,
-)
-from ._workflows import (
-    WorkflowRunResult as WorkflowRunResult,
-)
-from ._workflows import (
-    WorkflowRunState as WorkflowRunState,
-)
-from ._workflows import (
-    WorkflowValidationError as WorkflowValidationError,
-)
-from ._workflows import (
-    WorkflowViz as WorkflowViz,
-)
-from ._workflows import (
-    create_edge_runner as create_edge_runner,
-)
-from ._workflows import (
-    executor as executor,
-)
-from ._workflows import (
-    handler as handler,
-)
-from ._workflows import (
-    resolve_agent_id as resolve_agent_id,
-)
-from ._workflows import (
-    response_handler as response_handler,
-)
-from ._workflows import (
-    validate_workflow_graph as validate_workflow_graph,
-)
+
+__all__ = [
+    "AGENT_FRAMEWORK_USER_AGENT",
+    "APP_INFO",
+    "DEFAULT_MAX_ITERATIONS",
+    "USER_AGENT_KEY",
+    "USER_AGENT_TELEMETRY_DISABLED_ENV_VAR",
+    "Agent",
+    "AgentContext",
+    "AgentExecutor",
+    "AgentExecutorRequest",
+    "AgentExecutorResponse",
+    "AgentMiddleware",
+    "AgentMiddlewareLayer",
+    "AgentMiddlewareTypes",
+    "AgentResponse",
+    "AgentResponseUpdate",
+    "AgentSession",
+    "Annotation",
+    "BaseAgent",
+    "BaseChatClient",
+    "BaseContextProvider",
+    "BaseHistoryProvider",
+    "Case",
+    "ChatAndFunctionMiddlewareTypes",
+    "ChatContext",
+    "ChatMiddleware",
+    "ChatMiddlewareLayer",
+    "ChatMiddlewareTypes",
+    "ChatOptions",
+    "ChatResponse",
+    "ChatResponseUpdate",
+    "CheckpointStorage",
+    "Content",
+    "ContinuationToken",
+    "Default",
+    "Edge",
+    "EdgeCondition",
+    "EdgeDuplicationError",
+    "Executor",
+    "FanInEdgeGroup",
+    "FanOutEdgeGroup",
+    "FileCheckpointStorage",
+    "FinalT",
+    "FinishReason",
+    "FinishReasonLiteral",
+    "FunctionExecutor",
+    "FunctionInvocationConfiguration",
+    "FunctionInvocationContext",
+    "FunctionInvocationLayer",
+    "FunctionMiddleware",
+    "FunctionMiddlewareTypes",
+    "FunctionTool",
+    "GraphConnectivityError",
+    "InMemoryCheckpointStorage",
+    "InMemoryHistoryProvider",
+    "InProcRunnerContext",
+    "MCPStdioTool",
+    "MCPStreamableHTTPTool",
+    "MCPWebsocketTool",
+    "Message",
+    "MiddlewareException",
+    "MiddlewareTermination",
+    "MiddlewareType",
+    "MiddlewareTypes",
+    "OuterFinalT",
+    "OuterUpdateT",
+    "RawAgent",
+    "ResponseStream",
+    "Role",
+    "RoleLiteral",
+    "Runner",
+    "RunnerContext",
+    "SessionContext",
+    "SingleEdgeGroup",
+    "SubWorkflowRequestMessage",
+    "SubWorkflowResponseMessage",
+    "SupportsAgentRun",
+    "SupportsChatGetResponse",
+    "SupportsCodeInterpreterTool",
+    "SupportsFileSearchTool",
+    "SupportsImageGenerationTool",
+    "SupportsMCPTool",
+    "SupportsWebSearchTool",
+    "SwitchCaseEdgeGroup",
+    "SwitchCaseEdgeGroupCase",
+    "SwitchCaseEdgeGroupDefault",
+    "TextSpanRegion",
+    "ToolMode",
+    "TypeCompatibilityError",
+    "UpdateT",
+    "UsageDetails",
+    "ValidationTypeEnum",
+    "Workflow",
+    "WorkflowAgent",
+    "WorkflowBuilder",
+    "WorkflowCheckpoint",
+    "WorkflowCheckpointException",
+    "WorkflowContext",
+    "WorkflowConvergenceException",
+    "WorkflowErrorDetails",
+    "WorkflowEvent",
+    "WorkflowEventSource",
+    "WorkflowEventType",
+    "WorkflowException",
+    "WorkflowExecutor",
+    "WorkflowMessage",
+    "WorkflowRunResult",
+    "WorkflowRunState",
+    "WorkflowRunnerException",
+    "WorkflowValidationError",
+    "WorkflowViz",
+    "add_usage_details",
+    "agent_middleware",
+    "chat_middleware",
+    "create_edge_runner",
+    "detect_media_type_from_base64",
+    "executor",
+    "function_middleware",
+    "get_logger",
+    "handler",
+    "map_chat_to_agent_update",
+    "merge_chat_options",
+    "normalize_function_invocation_configuration",
+    "normalize_messages",
+    "normalize_tools",
+    "prepend_agent_framework_to_user_agent",
+    "prepend_instructions_to_messages",
+    "register_state_type",
+    "resolve_agent_id",
+    "response_handler",
+    "setup_logging",
+    "tool",
+    "validate_chat_options",
+    "validate_tool_mode",
+    "validate_tools",
+    "validate_workflow_graph",
+]

--- a/python/packages/core/agent_framework/openai/__init__.py
+++ b/python/packages/core/agent_framework/openai/__init__.py
@@ -1,29 +1,33 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from ._assistant_provider import OpenAIAssistantProvider as OpenAIAssistantProvider
+from ._assistant_provider import OpenAIAssistantProvider
 from ._assistants_client import (
-    AssistantToolResources as AssistantToolResources,
+    AssistantToolResources,
+    OpenAIAssistantsClient,
+    OpenAIAssistantsOptions,
 )
-from ._assistants_client import (
-    OpenAIAssistantsClient as OpenAIAssistantsClient,
-)
-from ._assistants_client import (
-    OpenAIAssistantsOptions as OpenAIAssistantsOptions,
-)
-from ._chat_client import OpenAIChatClient as OpenAIChatClient
-from ._chat_client import OpenAIChatOptions as OpenAIChatOptions
-from ._exceptions import ContentFilterResultSeverity as ContentFilterResultSeverity
-from ._exceptions import OpenAIContentFilterException as OpenAIContentFilterException
+from ._chat_client import OpenAIChatClient, OpenAIChatOptions
+from ._exceptions import ContentFilterResultSeverity, OpenAIContentFilterException
 from ._responses_client import (
-    OpenAIContinuationToken as OpenAIContinuationToken,
+    OpenAIContinuationToken,
+    OpenAIResponsesClient,
+    OpenAIResponsesOptions,
+    RawOpenAIResponsesClient,
 )
-from ._responses_client import (
-    OpenAIResponsesClient as OpenAIResponsesClient,
-)
-from ._responses_client import (
-    OpenAIResponsesOptions as OpenAIResponsesOptions,
-)
-from ._responses_client import (
-    RawOpenAIResponsesClient as RawOpenAIResponsesClient,
-)
-from ._shared import OpenAISettings as OpenAISettings
+from ._shared import OpenAISettings
+
+__all__ = [
+    "AssistantToolResources",
+    "ContentFilterResultSeverity",
+    "OpenAIAssistantProvider",
+    "OpenAIAssistantsClient",
+    "OpenAIAssistantsOptions",
+    "OpenAIChatClient",
+    "OpenAIChatOptions",
+    "OpenAIContentFilterException",
+    "OpenAIContinuationToken",
+    "OpenAIResponsesClient",
+    "OpenAIResponsesOptions",
+    "OpenAISettings",
+    "RawOpenAIResponsesClient",
+]

--- a/python/packages/core/agent_framework/openai/__init__.py
+++ b/python/packages/core/agent_framework/openai/__init__.py
@@ -1,8 +1,29 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from ._assistant_provider import *  # noqa: F403
-from ._assistants_client import *  # noqa: F403
-from ._chat_client import *  # noqa: F403
-from ._exceptions import *  # noqa: F403
-from ._responses_client import *  # noqa: F403
-from ._shared import *  # noqa: F403
+from ._assistant_provider import OpenAIAssistantProvider as OpenAIAssistantProvider
+from ._assistants_client import (
+    AssistantToolResources as AssistantToolResources,
+)
+from ._assistants_client import (
+    OpenAIAssistantsClient as OpenAIAssistantsClient,
+)
+from ._assistants_client import (
+    OpenAIAssistantsOptions as OpenAIAssistantsOptions,
+)
+from ._chat_client import OpenAIChatClient as OpenAIChatClient
+from ._chat_client import OpenAIChatOptions as OpenAIChatOptions
+from ._exceptions import ContentFilterResultSeverity as ContentFilterResultSeverity
+from ._exceptions import OpenAIContentFilterException as OpenAIContentFilterException
+from ._responses_client import (
+    OpenAIContinuationToken as OpenAIContinuationToken,
+)
+from ._responses_client import (
+    OpenAIResponsesClient as OpenAIResponsesClient,
+)
+from ._responses_client import (
+    OpenAIResponsesOptions as OpenAIResponsesOptions,
+)
+from ._responses_client import (
+    RawOpenAIResponsesClient as RawOpenAIResponsesClient,
+)
+from ._shared import OpenAISettings as OpenAISettings

--- a/python/packages/lab/namespace/agent_framework/lab/gaia/__init__.py
+++ b/python/packages/lab/namespace/agent_framework/lab/gaia/__init__.py
@@ -1,4 +1,28 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 # Import and re-export from the actual implementation
-from agent_framework_lab_gaia import *  # noqa: F403
+from agent_framework_lab_gaia import (
+    GAIA,
+    Evaluation,
+    Evaluator,
+    GAIATelemetryConfig,
+    Prediction,
+    Task,
+    TaskResult,
+    TaskRunner,
+    gaia_scorer,
+    viewer_main,
+)
+
+__all__ = [
+    "GAIA",
+    "Evaluation",
+    "Evaluator",
+    "GAIATelemetryConfig",
+    "Prediction",
+    "Task",
+    "TaskResult",
+    "TaskRunner",
+    "gaia_scorer",
+    "viewer_main",
+]

--- a/python/packages/lab/namespace/agent_framework/lab/lightning/__init__.py
+++ b/python/packages/lab/namespace/agent_framework/lab/lightning/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 # Import and re-export from the actual implementation
-from agent_framework_lab_lightning import *  # noqa: F403
+from agent_framework_lab_lightning import AgentFrameworkTracer
+
+__all__ = ["AgentFrameworkTracer"]

--- a/python/packages/lab/namespace/agent_framework/lab/tau2/__init__.py
+++ b/python/packages/lab/namespace/agent_framework/lab/tau2/__init__.py
@@ -1,4 +1,20 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 # Import and re-export from the actual implementation
-from agent_framework_lab_tau2 import *  # noqa: F403
+from agent_framework_lab_tau2 import (
+    ASSISTANT_AGENT_ID,
+    ORCHESTRATOR_ID,
+    USER_SIMULATOR_ID,
+    TaskRunner,
+    patch_env_set_state,
+    unpatch_env_set_state,
+)
+
+__all__ = [
+    "ASSISTANT_AGENT_ID",
+    "ORCHESTRATOR_ID",
+    "USER_SIMULATOR_ID",
+    "TaskRunner",
+    "patch_env_set_state",
+    "unpatch_env_set_state",
+]


### PR DESCRIPTION
Fixes #3605

## Summary
Replaced all wildcard imports (`from ... import *`) with explicit symbol imports across the Python codebase.

## Changes
- **Core package** (`agent_framework/__init__.py`): Replaced 10 wildcard imports with explicit imports for ~100 symbols
- **OpenAI subpackage** (`agent_framework/openai/__init__.py`): Replaced 6 wildcard imports with explicit imports
- **Lab namespace packages**: Replaced 3 wildcard imports with explicit imports and added `__all__` declarations for re-exports
- **CODING_STANDARD.md**: Added explicit guidance prohibiting wildcard imports with rationale

## Impact
- **API**: No breaking changes - all previously exported symbols remain available
- **Clarity**: Makes public API explicit and improves code navigation
- **Performance**: Eliminates unnecessary symbol resolution during imports
- **Tooling**: Better IDE autocomplete, go-to-definition, and type checking

## Testing
- Ran core test suite: 812 passed, 18 skipped
- Verified ruff checks pass on all modified files
- Confirmed wildcard import count: 19 → 0

## Wildcard Count
- **Before**: 19 wildcard imports
- **After**: 0 wildcard imports