### PR TITLE
.NET: Disable irrelevant integration test

### DIFF
--- a/dotnet/tests/AzureAI.IntegrationTests/AIProjectClientAgentStructuredOutputRunTests.cs
+++ b/dotnet/tests/AzureAI.IntegrationTests/AIProjectClientAgentStructuredOutputRunTests.cs
@@ -76,7 +76,7 @@ public class AIProjectClientAgentStructuredOutputRunTests() : StructuredOutputRu
 
     [Fact(Skip = NotSupported)]
     public override Task RunWithPrimitiveTypeReturnsExpectedResultAsync() =>
-       base.RunWithPrimitiveTypeReturnsExpectedResultAsync();
+        base.RunWithPrimitiveTypeReturnsExpectedResultAsync();
 }
 
 /// <summary>


### PR DESCRIPTION
Some agents don't support SO types provided per agent run and only support types supplied at the agent initialization phase via the ResponseFormat property that does not support primitives and arrays. Thus, calling `RunAsync<T>` with a primitive or an array does not work. Therefore, the common tests should be disabled for those agents.