### PR TITLE
Python: Warn on unsupported AzureAIClient runtime tool/structured_output overrides

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_client.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
 import json
 import sys
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from contextlib import suppress
 from typing import Any, ClassVar, Generic, Literal, TypedDict, TypeVar, cast
 
 from agent_framework import (
@@ -419,7 +419,7 @@ class RawAzureAIClient(RawOpenAIResponsesClient[AzureAIClientOptionsT], Generic[
             if tools_changed or structured_output_changed:
                 logger.warning(
                     "AzureAIClient does not support runtime tools or structured_output overrides after agent creation. "
-                    "Use ResponsesClient instead."
+                    "Use AzureOpenAIResponsesClient instead."
                 )
 
         return {"name": self.agent_name, "version": self.agent_version, "type": "agent_reference"}
@@ -472,7 +472,6 @@ class RawAzureAIClient(RawOpenAIResponsesClient[AzureAIClientOptionsT], Generic[
         if isinstance(response_format, Mapping):
             return json.dumps(response_format, sort_keys=True, default=str)
         return str(response_format)
-
 
     def _remove_agent_level_run_options(self, run_options: dict[str, Any]) -> None:
         """Remove request-level options that Azure AI only supports at agent creation time."""

--- a/python/packages/azure-ai/tests/test_azure_ai_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_client.py
@@ -798,7 +798,7 @@ async def test_runtime_tools_override_logs_warning(
             None,
         )
     mock_warning.assert_called_once()
-    assert "Use ResponsesClient instead." in mock_warning.call_args[0][0]
+    assert "Use AzureOpenAIResponsesClient instead." in mock_warning.call_args[0][0]
 
 
 async def test_use_latest_version_existing_agent(
@@ -1023,7 +1023,7 @@ async def test_runtime_structured_output_override_logs_warning(
             {"response_format": AlternateResponseFormatModel},
         )
     mock_warning.assert_called_once()
-    assert "Use ResponsesClient instead." in mock_warning.call_args[0][0]
+    assert "Use AzureOpenAIResponsesClient instead." in mock_warning.call_args[0][0]
 
 
 async def test_prepare_options_excludes_response_format(

--- a/python/packages/azure-ai/tests/test_azure_ai_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_client.py
@@ -1066,7 +1066,7 @@ async def test_prepare_options_excludes_response_format(
 async def test_prepare_options_keeps_values_for_unsupported_option_keys(
     mock_project_client: MagicMock,
 ) -> None:
-    """Test that run_options removal only applies to keys from the concrete options TypedDict."""
+    """Test that run_options removal only applies to known AzureAI agent-level option mappings."""
     client = create_test_azure_ai_client(mock_project_client, agent_name="test-agent", agent_version="1.0")
     messages = [Message(role="user", contents=[Content.from_text(text="Hello")])]
 
@@ -1086,14 +1086,13 @@ async def test_prepare_options_keeps_values_for_unsupported_option_keys(
             "_get_agent_reference_or_create",
             return_value={"name": "test-agent", "version": "1.0", "type": "agent_reference"},
         ),
-        patch.object(client, "_get_supported_option_keys", return_value={"model_id"}),
     ):
         run_options = await client._prepare_options(messages, {})
 
         assert "model" not in run_options
-        assert "tools" in run_options
-        assert "text" in run_options
-        assert "text_format" in run_options
+        assert "tools" not in run_options
+        assert "text" not in run_options
+        assert "text_format" not in run_options
         assert run_options["custom_option"] == "keep-me"
 
 

--- a/python/packages/azure-ai/tests/test_azure_ai_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_client.py
@@ -130,7 +130,7 @@ def create_test_azure_ai_client(
     client.conversation_id = conversation_id
     client._is_application_endpoint = False  # type: ignore
     client._should_close_client = should_close_client  # type: ignore
-    client._tracks_created_agent_configuration = False  # type: ignore
+    client.warn_runtime_tools_and_structure_changed = False  # type: ignore
     client._created_agent_tool_names = set()  # type: ignore
     client._created_agent_structured_output_signature = None  # type: ignore
     client.additional_properties = {}

--- a/python/packages/azure-ai/tests/test_azure_ai_client.py
+++ b/python/packages/azure-ai/tests/test_azure_ai_client.py
@@ -130,6 +130,9 @@ def create_test_azure_ai_client(
     client.conversation_id = conversation_id
     client._is_application_endpoint = False  # type: ignore
     client._should_close_client = should_close_client  # type: ignore
+    client._tracks_created_agent_configuration = False  # type: ignore
+    client._created_agent_tool_names = set()  # type: ignore
+    client._created_agent_structured_output_signature = None  # type: ignore
     client.additional_properties = {}
     client.middleware = None
 
@@ -773,6 +776,31 @@ async def test_agent_creation_with_tools(
     assert call_args[1]["definition"].tools == test_tools
 
 
+async def test_runtime_tools_override_logs_warning(
+    mock_project_client: MagicMock,
+) -> None:
+    """Test warning is logged when runtime tools differ from creation-time tools."""
+    client = create_test_azure_ai_client(mock_project_client, agent_name="test-agent")
+
+    mock_agent = MagicMock()
+    mock_agent.name = "test-agent"
+    mock_agent.version = "1.0"
+    mock_project_client.agents.create_version = AsyncMock(return_value=mock_agent)
+
+    await client._get_agent_reference_or_create(
+        {"model": "test-model", "tools": [{"type": "function", "name": "tool_one"}]},
+        None,
+    )
+
+    with patch("agent_framework_azure_ai._client.logger.warning") as mock_warning:
+        await client._get_agent_reference_or_create(
+            {"model": "test-model", "tools": [{"type": "function", "name": "tool_two"}]},
+            None,
+        )
+    mock_warning.assert_called_once()
+    assert "Use ResponsesClient instead." in mock_warning.call_args[0][0]
+
+
 async def test_use_latest_version_existing_agent(
     mock_project_client: MagicMock,
 ) -> None:
@@ -872,6 +900,13 @@ class ResponseFormatModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class AlternateResponseFormatModel(BaseModel):
+    """Alternate model for structured output warning checks."""
+
+    summary: str
+    confidence: float
+
+
 async def test_agent_creation_with_response_format(
     mock_project_client: MagicMock,
 ) -> None:
@@ -964,6 +999,33 @@ async def test_agent_creation_with_mapping_response_format(
     assert format_config.strict is True
 
 
+async def test_runtime_structured_output_override_logs_warning(
+    mock_project_client: MagicMock,
+) -> None:
+    """Test warning is logged when runtime structured_output differs from creation-time configuration."""
+    client = create_test_azure_ai_client(mock_project_client, agent_name="test-agent")
+
+    mock_agent = MagicMock()
+    mock_agent.name = "test-agent"
+    mock_agent.version = "1.0"
+    mock_project_client.agents.create_version = AsyncMock(return_value=mock_agent)
+
+    await client._get_agent_reference_or_create(
+        {"model": "test-model"},
+        None,
+        {"response_format": ResponseFormatModel},
+    )
+
+    with patch("agent_framework_azure_ai._client.logger.warning") as mock_warning:
+        await client._get_agent_reference_or_create(
+            {"model": "test-model"},
+            None,
+            {"response_format": AlternateResponseFormatModel},
+        )
+    mock_warning.assert_called_once()
+    assert "Use ResponsesClient instead." in mock_warning.call_args[0][0]
+
+
 async def test_prepare_options_excludes_response_format(
     mock_project_client: MagicMock,
 ) -> None:
@@ -999,6 +1061,40 @@ async def test_prepare_options_excludes_response_format(
         # But extra_body should contain agent reference
         assert "extra_body" in run_options
         assert run_options["extra_body"]["agent"]["name"] == "test-agent"
+
+
+async def test_prepare_options_keeps_values_for_unsupported_option_keys(
+    mock_project_client: MagicMock,
+) -> None:
+    """Test that run_options removal only applies to keys from the concrete options TypedDict."""
+    client = create_test_azure_ai_client(mock_project_client, agent_name="test-agent", agent_version="1.0")
+    messages = [Message(role="user", contents=[Content.from_text(text="Hello")])]
+
+    with (
+        patch(
+            "agent_framework.openai._responses_client.RawOpenAIResponsesClient._prepare_options",
+            return_value={
+                "model": "test-model",
+                "tools": [{"type": "function", "name": "weather"}],
+                "text": {"format": {"type": "json_schema", "name": "schema"}},
+                "text_format": ResponseFormatModel,
+                "custom_option": "keep-me",
+            },
+        ),
+        patch.object(
+            client,
+            "_get_agent_reference_or_create",
+            return_value={"name": "test-agent", "version": "1.0", "type": "agent_reference"},
+        ),
+        patch.object(client, "_get_supported_option_keys", return_value={"model_id"}),
+    ):
+        run_options = await client._prepare_options(messages, {})
+
+        assert "model" not in run_options
+        assert "tools" in run_options
+        assert "text" in run_options
+        assert "text_format" in run_options
+        assert run_options["custom_option"] == "keep-me"
 
 
 def test_get_conversation_id_with_store_true_and_conversation_id() -> None:


### PR DESCRIPTION
## Summary
- track AzureAIClient agent-creation tool names and structured output configuration
- log a warning when runtime tools or structured_output differ from creation-time configuration and direct users to ResponsesClient
- update AzureAIClient run option pruning to only remove keys that map to the concrete options TypedDict
- add tests in the existing azure-ai client test file for runtime warnings and typed-dict-based option pruning behavior

## Validation
- uv run ruff format packages/azure-ai/agent_framework_azure_ai/_client.py packages/azure-ai/tests/test_azure_ai_client.py
- uv run ruff check packages/azure-ai/agent_framework_azure_ai/_client.py packages/azure-ai/tests/test_azure_ai_client.py
- uv run --directory packages/azure-ai pytest tests/test_azure_ai_client.py -k runtime_tools_override_logs_warning or runtime_structured_output_override_logs_warning or prepare_options_excludes_response_format or prepare_options_keeps_values_for_unsupported_option_keys -q