### PR TITLE
Python: Add snippet tag for Python memory tutorial sample

### DIFF
--- a/python/samples/01-get-started/04_memory.py
+++ b/python/samples/01-get-started/04_memory.py
@@ -78,6 +78,7 @@ async def main() -> None:
     )
     # </create_agent>
 
+    # <run_with_memory>
     session = agent.create_session()
 
     # The provider doesn't know the user yet — it will ask for a name
@@ -93,6 +94,7 @@ async def main() -> None:
     print(f"Agent: {result}\n")
 
     print(f"[Memory] Stored user name: {memory.user_name}")
+    # </run_with_memory>
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a run_with_memory snippet region to python/samples/01-get-started/04_memory.py
- enable docs to reference the runnable memory flow via :::code id=run_with_memory

## Validation
- docs/snippet migration only; no runtime behavior changes