### PR TITLE
Python: docs(observability): add Comet Opik setup example

### DIFF
--- a/python/samples/02-agents/observability/README.md
+++ b/python/samples/02-agents/observability/README.md
@@ -118,7 +118,7 @@ else:
 enable_instrumentation(enable_sensitive_data=False)
 ```
 
-Or with [Comet Opik](https://www.comet.com/docs/opik/):
+Or with [Comet Opik](https://www.comet.com/docs/opik/integrations/microsoft-agent-framework):
 
 ```python
 import os


### PR DESCRIPTION
## Summary
- add Comet Opik setup example to Python observability sample README
- keep existing Langfuse and Azure Monitor examples unchanged
- show OTLP endpoint/header environment-variable pattern for Opik

## Test Plan
- docs-only change
- verified markdown structure and code blocks in `python/samples/02-agents/observability/README.md`
