### PR TITLE
.NET: Fix sample resource path resolution

### DIFF
--- a/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/01_EdgeCondition/Resources.cs
+++ b/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/01_EdgeCondition/Resources.cs
@@ -9,5 +9,5 @@ internal static class Resources
 {
     private const string ResourceFolder = "Resources";
 
-    public static string Read(string fileName) => File.ReadAllText($"{ResourceFolder}/{fileName}");
+    public static string Read(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, ResourceFolder, fileName));
 }

--- a/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/02_SwitchCase/Resources.cs
+++ b/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/02_SwitchCase/Resources.cs
@@ -9,5 +9,5 @@ internal static class Resources
 {
     private const string ResourceFolder = "Resources";
 
-    public static string Read(string fileName) => File.ReadAllText($"{ResourceFolder}/{fileName}");
+    public static string Read(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, ResourceFolder, fileName));
 }

--- a/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/03_MultiSelection/Resources.cs
+++ b/dotnet/samples/GettingStarted/Workflows/ConditionalEdges/03_MultiSelection/Resources.cs
@@ -9,5 +9,5 @@ internal static class Resources
 {
     private const string ResourceFolder = "Resources";
 
-    public static string Read(string fileName) => File.ReadAllText($"{ResourceFolder}/{fileName}");
+    public static string Read(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, ResourceFolder, fileName));
 }

--- a/dotnet/samples/GettingStarted/Workflows/SharedStates/Resources.cs
+++ b/dotnet/samples/GettingStarted/Workflows/SharedStates/Resources.cs
@@ -9,5 +9,5 @@ internal static class Resources
 {
     private const string ResourceFolder = "Resources";
 
-    public static string Read(string fileName) => File.ReadAllText($"{ResourceFolder}/{fileName}");
+    public static string Read(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, ResourceFolder, fileName));
 }


### PR DESCRIPTION
### Motivation and Context

The samples were working when run from Visual Studio, but failing when using `dotnet run` due to the difference in the path from which they were executed.

### Description

- Change resource resolution to be relative to the executable's path.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.