### PR TITLE
.NET: bug fix for duplicate output on GitHubCopilotAgent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
@@ -346,7 +346,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
         };
     }
 
-    private AgentResponseUpdate ConvertToAgentResponseUpdate(AssistantMessageEvent assistantMessage)
+    internal AgentResponseUpdate ConvertToAgentResponseUpdate(AssistantMessageEvent assistantMessage)
     {
         AIContent content = new()
         {

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
 using GitHub.Copilot.SDK;
 using Microsoft.Extensions.AI;
@@ -237,14 +236,7 @@ public sealed class GitHubCopilotAgentTests
         CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
         const string TestId = "agent-id";
         var agent = new GitHubCopilotAgent(copilotClient, ownsClient: false, id: TestId, tools: null);
-        MethodInfo method = typeof(GitHubCopilotAgent).GetMethod(
-            "ConvertToAgentResponseUpdate",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            binder: null,
-            types: [typeof(AssistantMessageEvent)],
-            modifiers: null)!;
-
-        var result = (AgentResponseUpdate)method.Invoke(agent, [assistantMessage])!;
+        AgentResponseUpdate result = agent.ConvertToAgentResponseUpdate(assistantMessage);
 
         // result.Text need to be empty because the content was already delivered via delta events, and we want to avoid emitting duplicate content in the response update.
         // The content should be delivered through TextContent in the Contents collection instead.


### PR DESCRIPTION
### Motivation and Context

When using GitHubCopilotAgent, the final assistant message output was duplicated. The AssistantMessageDeltaEvent handlers already stream text content incrementally via TextContent, but the AssistantMessageEvent handler was also emitting a TextContent with the full message. This caused downstream consumers to render the same text twice.

### Description

Changed the ConvertToAgentResponseUpdate(AssistantMessageEvent) method in GitHubCopilotAgent.cs to emit a plain AIContent instead of a TextContent. The AssistantMessageEvent is a completion signal that carries metadata (message ID, timestamp, raw representation) — it should not re-emit the text content that was already streamed through AssistantMessageDeltaEvent. By using AIContent instead of TextContent, the event still preserves its RawRepresentation for inspection without producing duplicate text output.

### Contribution Checklist

 The code builds clean without any errors or warnings
 The PR follows the Contribution Guidelines
 All unit tests pass, and I have added new tests where possible