### PR TITLE
Python: Use ad_token_provider for AzureOpenAI

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2871,12 +2871,7 @@ class _ChatOptionsBase(TypedDict, total=False):
     presence_penalty: float
 
     # Tool configuration (forward reference to avoid circular import)
-    tools: (
-        ToolTypes
-        | Callable[..., Any]
-        | Sequence[ToolTypes | Callable[..., Any]]
-        | None
-    )
+    tools: ToolTypes | Callable[..., Any] | Sequence[ToolTypes | Callable[..., Any]] | None
     tool_choice: ToolMode | Literal["auto", "required", "none"]
     allow_multiple_tool_calls: bool
 

--- a/python/packages/core/agent_framework/azure/_shared.py
+++ b/python/packages/core/agent_framework/azure/_shared.py
@@ -9,6 +9,7 @@ from copy import copy
 from typing import Any, ClassVar, Final
 
 from azure.core.credentials import TokenCredential
+from azure.identity import get_bearer_token_provider
 from openai import AsyncOpenAI
 from openai.lib.azure import AsyncAzureOpenAI
 
@@ -16,7 +17,6 @@ from .._settings import SecretString
 from .._telemetry import APP_INFO, prepend_agent_framework_to_user_agent
 from ..exceptions import ServiceInitializationError
 from ..openai._shared import OpenAIBase
-from ._entra_id_authentication import get_entra_auth_token
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -174,10 +174,10 @@ class AzureOpenAIConfigMixin(OpenAIBase):
             merged_headers = prepend_agent_framework_to_user_agent(merged_headers)
         if not client:
             # If the client is None, the api_key is none, the ad_token is none, and the ad_token_provider is none,
-            # then we will attempt to get the ad_token using the default endpoint specified in the Azure OpenAI
+            # then we will set the ad_token_provider using the default endpoint specified in the Azure OpenAI
             # settings.
             if not api_key and not ad_token_provider and not ad_token and token_endpoint and credential:
-                ad_token = get_entra_auth_token(credential, token_endpoint)
+                ad_token_provider = get_bearer_token_provider(credential, token_endpoint)
 
             if not api_key and not ad_token and not ad_token_provider:
                 raise ServiceInitializationError(

--- a/python/packages/core/tests/azure/test_azure_responses_client.py
+++ b/python/packages/core/tests/azure/test_azure_responses_client.py
@@ -167,6 +167,18 @@ def test_init_with_project_endpoint(azure_openai_unit_test_env: dict[str, str]) 
     assert isinstance(azure_responses_client, SupportsChatGetResponse)
 
 
+@pytest.mark.parametrize("exclude_list", [["AZURE_OPENAI_API_KEY"]], indirect=True)
+def test_init_with_credential(azure_openai_unit_test_env: dict[str, str]) -> None:
+    from unittest.mock import patch
+
+    credential = AzureCliCredential()
+    with patch("agent_framework.azure._shared.get_bearer_token_provider") as mock_get_bearer_token_provider:
+        azure_responses_client = AzureOpenAIResponsesClient(credential=credential)
+
+    assert azure_responses_client.model_id == "test_chat_deployment"
+    mock_get_bearer_token_provider.assert_called_once_with(credential, "https://test-token-endpoint.com")
+
+
 def test_create_client_from_project_with_project_client() -> None:
     """Test _create_client_from_project with an existing project client."""
     from openai import AsyncOpenAI


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Closes #3500 

### Description

Use `ad_token_provider` by default in Azure clients when a credential is passed, so that:
- The token is not fetched when the client is created, but instead just before the agent is run
- The token will be refreshed before it expires without creating a new client

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.