### PR TITLE
.NET: Fix AGUI reusing same messageId for consecutive TOOL_CALL_RESUL…

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -408,7 +408,7 @@ internal static class ChatResponseUpdateAGUIExtensions
                     {
                         yield return new ToolCallResultEvent
                         {
-                            MessageId = chatResponse.MessageId,
+                            MessageId = $"result_{functionResultContent.CallId}",
                             ToolCallId = functionResultContent.CallId,
                             Content = SerializeResultContent(functionResultContent, jsonSerializerOptions) ?? "",
                             Role = AGUIRoles.Tool


### PR DESCRIPTION
…T events (#3962)

When multiple FunctionResultContent items were emitted (either in the same ChatResponseUpdate or across consecutive updates), the ToolCallResultEvent.MessageId was set from chatResponse.MessageId, causing all results to share the same messageId. This breaks AG-UI clients that rely on unique messageId per event.

The fix derives MessageId from the tool call's CallId using the format 'result_{CallId}', guaranteeing uniqueness across consecutive tool call results.

Added regression tests:

- Regression_3962_ConsecutiveToolCallResults_HaveDistinctMessageIdsAsync

- Regression_3962_ConsecutiveToolCallResultsAcrossUpdates_HaveDistinctMessageIdsAsync

- Regression_3962_ToolCallResult_MessageIdDistinctFromToolCallIdAsync

Fixes #3962

### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.