### PR TITLE
.NET: Fix duplicate messageId in consecutive TOOL_CALL_RESULT SSE eve…

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -406,9 +406,16 @@ internal static class ChatResponseUpdateAGUIExtensions
                     }
                     else if (content is FunctionResultContent functionResultContent)
                     {
+                        // AG-UI requires each TOOL_CALL_RESULT event to carry a unique messageId,
+                        // but multiple FunctionResultContent items within a single ChatResponseUpdate
+                        // share the same MessageId (per M.E.AI semantics, which groups updates into
+                        // logical messages). We compose a deterministic unique id by combining the
+                        // original MessageId with the CallId, preserving traceability back to the
+                        // source ChatResponseUpdate while satisfying the AG-UI uniqueness constraint.
+                        // See: https://github.com/microsoft/agent-framework/issues/3962
                         yield return new ToolCallResultEvent
                         {
-                            MessageId = chatResponse.MessageId,
+                            MessageId = $"{chatResponse.MessageId}_{functionResultContent.CallId}",
                             ToolCallId = functionResultContent.CallId,
                             Content = SerializeResultContent(functionResultContent, jsonSerializerOptions) ?? "",
                             Role = AGUIRoles.Tool


### PR DESCRIPTION
### Motivation and Context

Fixes #3962. The AG-UI protocol requires each `TOOL_CALL_RESULT` SSE event to carry a unique `messageId`. However, when an agent executes 2+ server-side tools, all `FunctionResultContent` items within a single `ChatResponseUpdate` share the same `MessageId` (per M.E.AI semantics). This causes the `@ag-ui/core` client to fail or behave incorrectly.

### Description

In `AsAGUIEventStreamAsync`, the `ToolCallResultEvent.MessageId` is now composed as `"{originalMessageId}_{callId}"` instead of copying `chatResponse.MessageId` directly. This:
- **Guarantees uniqueness** — each tool result gets a distinct `messageId`
- **Preserves traceability** — the original `MessageId` prefix allows correlation back to the source `ChatResponseUpdate`
- **Is deterministic** — no GUIDs; same inputs produce same outputs

Added 4 regression tests covering: single result, consecutive results in same update, results from separate updates with shared MessageId, and 3+ consecutive results.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass (15/15 across net8.0, net9.0, net10.0), and I have added new tests
- [x] **Is this a breaking change?** No