### PR TITLE
Python: Fix sample bugs in file search and web search samples

### DIFF
--- a/python/packages/core/agent_framework/openai/_assistants_client.py
+++ b/python/packages/core/agent_framework/openai/_assistants_client.py
@@ -670,6 +670,7 @@ class OpenAIAssistantsClient(  # type: ignore[misc]
         tool_choice = options.get("tool_choice")
         tools = options.get("tools")
         response_format = options.get("response_format")
+        tool_resources = options.get("tool_resources")
 
         if max_tokens is not None:
             run_options["max_completion_tokens"] = max_tokens
@@ -682,6 +683,9 @@ class OpenAIAssistantsClient(  # type: ignore[misc]
 
         if allow_multiple_tool_calls is not None:
             run_options["parallel_tool_calls"] = allow_multiple_tool_calls
+
+        if tool_resources is not None:
+            run_options["tool_resources"] = tool_resources
 
         tool_mode = validate_tool_mode(tool_choice)
         tool_definitions: list[MutableMapping[str, Any]] = []

--- a/python/samples/02-agents/providers/azure_openai/azure_responses_client_with_file_search.py
+++ b/python/samples/02-agents/providers/azure_openai/azure_responses_client_with_file_search.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import contextlib
 
-from agent_framework import Agent, Content
+from agent_framework import Agent
 from agent_framework.azure import AzureOpenAIResponsesClient
 from azure.identity import AzureCliCredential
 
@@ -22,7 +23,7 @@ Prerequisites:
 # Helper functions
 
 
-async def create_vector_store(client: AzureOpenAIResponsesClient) -> tuple[str, Content]:
+async def create_vector_store(client: AzureOpenAIResponsesClient) -> tuple[str, str]:
     """Create a vector store with sample documents."""
     file = await client.client.files.create(
         file=("todays_weather.txt", b"The weather today is sunny with a high of 75F."), purpose="assistants"
@@ -35,13 +36,15 @@ async def create_vector_store(client: AzureOpenAIResponsesClient) -> tuple[str, 
     if result.last_error is not None:
         raise Exception(f"Vector store file processing failed with status: {result.last_error.message}")
 
-    return file.id, Content.from_hosted_vector_store(vector_store_id=vector_store.id)
+    return file.id, vector_store.id
 
 
 async def delete_vector_store(client: AzureOpenAIResponsesClient, file_id: str, vector_store_id: str) -> None:
     """Delete the vector store after using it."""
-    await client.client.vector_stores.delete(vector_store_id=vector_store_id)
-    await client.client.files.delete(file_id=file_id)
+    with contextlib.suppress(Exception):
+        await client.client.vector_stores.delete(vector_store_id=vector_store_id)
+    with contextlib.suppress(Exception):
+        await client.client.files.delete(file_id=file_id)
 
 
 async def main() -> None:

--- a/python/samples/02-agents/providers/openai/openai_chat_client_with_web_search.py
+++ b/python/samples/02-agents/providers/openai/openai_chat_client_with_web_search.py
@@ -18,7 +18,12 @@ async def main() -> None:
 
     # Create web search tool with location context
     web_search_tool = client.get_web_search_tool(
-        user_location={"city": "Seattle", "country": "US"},
+        web_search_options={
+            "user_location": {
+                "type": "approximate",
+                "approximate": {"city": "Seattle", "country": "US"},
+            },
+        },
     )
 
     agent = Agent(

--- a/python/samples/02-agents/providers/openai/openai_responses_client_with_file_search.py
+++ b/python/samples/02-agents/providers/openai/openai_responses_client_with_file_search.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from agent_framework import Agent, Content
+from agent_framework import Agent
 from agent_framework.openai import OpenAIResponsesClient
 
 """
@@ -15,7 +15,7 @@ for direct document-based question answering and information retrieval.
 # Helper functions
 
 
-async def create_vector_store(client: OpenAIResponsesClient) -> tuple[str, Content]:
+async def create_vector_store(client: OpenAIResponsesClient) -> tuple[str, str]:
     """Create a vector store with sample documents."""
     file = await client.client.files.create(
         file=("todays_weather.txt", b"The weather today is sunny with a high of 75F."), purpose="user_data"
@@ -28,7 +28,7 @@ async def create_vector_store(client: OpenAIResponsesClient) -> tuple[str, Conte
     if result.last_error is not None:
         raise Exception(f"Vector store file processing failed with status: {result.last_error.message}")
 
-    return file.id, Content.from_hosted_vector_store(vector_store_id=vector_store.id)
+    return file.id, vector_store.id
 
 
 async def delete_vector_store(client: OpenAIResponsesClient, file_id: str, vector_store_id: str) -> None:
@@ -53,14 +53,14 @@ async def main() -> None:
     )
 
     if stream:
-        print("Assistant: ", end="")
+        print("Agent: ", end="")
         async for chunk in agent.run(message, stream=True):
             if chunk.text:
                 print(chunk.text, end="")
         print("")
     else:
         response = await agent.run(message)
-        print(f"Assistant: {response}")
+        print(f"Agent: {response}")
     await delete_vector_store(client, file_id, vector_store_id)
 
 


### PR DESCRIPTION
## Description
Fixes several bugs in Python OpenAI sample scripts that caused runtime errors.

### Changes
- **File search samples** (Azure + OpenAI Responses): `create_vector_store` returned a `Content` object instead of a plain `vector_store.id` string, causing `TypeError: Object of type Content is not JSON serializable` when passed to `get_file_search_tool(vector_store_ids=...)`.
- **Web search sample** (OpenAI Chat): Used `user_location` kwarg (Responses API signature) instead of the correct `web_search_options` parameter for the Chat Completions API.
- **Assistants client**: `_prepare_options` did not extract `tool_resources` from options, so vector store IDs were never passed to thread creation, causing file search to silently fail.
- **Azure file search sample cleanup**: Added `contextlib.suppress` around cleanup calls to handle cases where resources are already deleted.

### Affected files
- `python/packages/core/agent_framework/openai/_assistants_client.py`
- `python/samples/02-agents/providers/azure_openai/azure_responses_client_with_file_search.py`
- `python/samples/02-agents/providers/openai/openai_chat_client_with_web_search.py`
- `python/samples/02-agents/providers/openai/openai_responses_client_with_file_search.py`

### Testing
Manually verified the Azure file search sample runs successfully end-to-end.