### PR TITLE
Python: Fix Redis samples for session migration and configurable REDIS_URL

### DIFF
--- a/python/samples/02-agents/context_providers/redis/redis_basics.py
+++ b/python/samples/02-agents/context_providers/redis/redis_basics.py
@@ -37,7 +37,7 @@ from azure.identity import AzureCliCredential
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.utils.vectorize import OpenAITextVectorizer
 
-# Default Redis URL for local Redis Stack (docker run -d -p 6379:6379 redis/redis-stack:latest).
+# Default Redis URL for local Redis Stack.
 # Override via the REDIS_URL environment variable for remote or authenticated instances.
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 

--- a/python/samples/02-agents/context_providers/redis/redis_conversation.py
+++ b/python/samples/02-agents/context_providers/redis/redis_conversation.py
@@ -23,7 +23,7 @@ from azure.identity import AzureCliCredential
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.utils.vectorize import OpenAITextVectorizer
 
-# Default Redis URL for local Redis Stack (docker run -d -p 6379:6379 redis/redis-stack:latest).
+# Default Redis URL for local Redis Stack.
 # Override via the REDIS_URL environment variable for remote or authenticated instances.
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 

--- a/python/samples/02-agents/context_providers/redis/redis_sessions.py
+++ b/python/samples/02-agents/context_providers/redis/redis_sessions.py
@@ -35,7 +35,7 @@ from azure.identity import AzureCliCredential
 from redisvl.extensions.cache.embeddings import EmbeddingsCache
 from redisvl.utils.vectorize import OpenAITextVectorizer
 
-# Default Redis URL for local Redis Stack (docker run -d -p 6379:6379 redis/redis-stack:latest).
+# Default Redis URL for local Redis Stack.
 # Override via the REDIS_URL environment variable for remote or authenticated instances.
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 


### PR DESCRIPTION
## Summary

Update Redis context provider samples to work with the current API after the AgentThread → AgentSession migration.

## Changes

- **Configurable REDIS_URL**: Replace hardcoded `redis://localhost:6379` with `REDIS_URL` env var (defaults to localhost) across all 3 samples
- **Fix SessionContext API**: Use `SessionContext(input_messages=...)` constructor instead of removed `extend_messages()` method in `redis_basics.py`
- **Remove obsolete parameters**: Remove `scope_to_per_operation_thread_id` (no longer exists on `RedisContextProvider`) and stale commented-out `overwrite_redis_index`/`drop_redis_index` params in `redis_sessions.py`

## Files Changed

- `python/samples/02-agents/context_providers/redis/redis_basics.py`
- `python/samples/02-agents/context_providers/redis/redis_conversation.py`
- `python/samples/02-agents/context_providers/redis/redis_sessions.py`