### PR TITLE
.NET: Fix Usage and Annotations not present in AG-UI events (#3752)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIEventTypes.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIEventTypes.cs
@@ -31,4 +31,6 @@ internal static class AGUIEventTypes
     public const string StateSnapshot = "STATE_SNAPSHOT";
 
     public const string StateDelta = "STATE_DELTA";
+
+    public const string Custom = "CUSTOM";
 }

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIJsonSerializerContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/AGUIJsonSerializerContext.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Agents.AI.AGUI;
 [JsonSerializable(typeof(ToolCallResultEvent))]
 [JsonSerializable(typeof(StateSnapshotEvent))]
 [JsonSerializable(typeof(StateDeltaEvent))]
+[JsonSerializable(typeof(CustomEvent))]
 [JsonSerializable(typeof(IDictionary<string, object?>))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSerializable(typeof(IDictionary<string, System.Text.Json.JsonElement?>))]

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEventJsonConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEventJsonConverter.cs
@@ -47,6 +47,7 @@ internal sealed class BaseEventJsonConverter : JsonConverter<BaseEvent>
             AGUIEventTypes.ToolCallEnd => jsonElement.Deserialize(options.GetTypeInfo(typeof(ToolCallEndEvent))) as ToolCallEndEvent,
             AGUIEventTypes.ToolCallResult => jsonElement.Deserialize(options.GetTypeInfo(typeof(ToolCallResultEvent))) as ToolCallResultEvent,
             AGUIEventTypes.StateSnapshot => jsonElement.Deserialize(options.GetTypeInfo(typeof(StateSnapshotEvent))) as StateSnapshotEvent,
+            AGUIEventTypes.Custom => jsonElement.Deserialize(options.GetTypeInfo(typeof(CustomEvent))) as CustomEvent,
             _ => throw new JsonException($"Unknown BaseEvent type discriminator: '{discriminator}'")
         };
 
@@ -101,6 +102,9 @@ internal sealed class BaseEventJsonConverter : JsonConverter<BaseEvent>
                 break;
             case StateDeltaEvent stateDelta:
                 JsonSerializer.Serialize(writer, stateDelta, options.GetTypeInfo(typeof(StateDeltaEvent)));
+                break;
+            case CustomEvent customEvent:
+                JsonSerializer.Serialize(writer, customEvent, options.GetTypeInfo(typeof(CustomEvent)));
                 break;
             default:
                 throw new InvalidOperationException($"Unknown event type: {value.GetType().Name}");

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/CustomEvent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/CustomEvent.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#if ASPNETCORE
+namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.Shared;
+#else
+namespace Microsoft.Agents.AI.AGUI.Shared;
+#endif
+
+internal sealed class CustomEvent : BaseEvent
+{
+    public CustomEvent()
+    {
+        this.Type = AGUIEventTypes.Custom;
+    }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("value")]
+    public JsonElement? Value { get; set; }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
@@ -153,18 +153,29 @@ public sealed class UsageAndAnnotationsTests
 
         List<BaseEvent> events = await CollectEventsAsync(updates);
 
-        // Assert — Serialize all events to JSON and check that token counts appear
-        string allEventsJson = SerializeAllEvents(events);
+        // Assert — find the usage custom event and verify its payload contains the expected token counts
+        List<CustomEvent> usageEvents = events
+            .OfType<CustomEvent>()
+            .Where(e => e.Name == "usage")
+            .ToList();
 
-        // The token counts should be present in the serialized event stream
-        Assert.True(
-            allEventsJson.Contains("500") || allEventsJson.Contains("input"),
-            "InputTokenCount (500) should be present in the serialized AGUI events. " +
+        Assert.Single(
+            usageEvents,
+            "Exactly one usage custom event should be present in the AGUI events. " +
             "See https://github.com/microsoft/agent-framework/issues/3752");
-        Assert.True(
-            allEventsJson.Contains("200") || allEventsJson.Contains("output"),
-            "OutputTokenCount (200) should be present in the serialized AGUI events. " +
-            "See https://github.com/microsoft/agent-framework/issues/3752");
+
+        string usageJson = usageEvents[0].Value ?? string.Empty;
+
+        // The token counts should be present in the usage event payload
+        Assert.Contains(
+            "500",
+            usageJson);
+        Assert.Contains(
+            "200",
+            usageJson);
+        Assert.Contains(
+            "700",
+            usageJson);
     }
 
     #endregion

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
@@ -1,0 +1,412 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.Shared;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests;
+
+/// <summary>
+/// Tests verifying that Usage (token consumption) and Annotations (citations, file references)
+/// are properly preserved when converting ChatResponseUpdates to AG-UI SSE events.
+/// Regression tests for https://github.com/microsoft/agent-framework/issues/3752.
+/// </summary>
+public sealed class UsageAndAnnotationsTests
+{
+    private const string ThreadId = "thread1";
+    private const string RunId = "run1";
+
+    #region Usage Tests
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithUsageContent_DoesNotThrowAsync()
+    {
+        // Arrange — ChatResponseUpdate containing UsageContent alongside text
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate(ChatRole.Assistant, "Hello") { MessageId = "msg1" },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 100,
+                    OutputTokenCount = 50,
+                    TotalTokenCount = 150
+                })],
+                MessageId = "msg1"
+            }
+        ];
+
+        // Act — Should not throw even if UsageContent is not mapped to an event
+        List<BaseEvent> events = [];
+        await foreach (BaseEvent evt in updates.ToAsyncEnumerableAsync()
+            .AsAGUIEventStreamAsync(ThreadId, RunId, AGUIJsonSerializerContext.Default.Options, CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+
+        // Assert — Stream should at least contain lifecycle events
+        Assert.Contains(events, e => e is RunStartedEvent);
+        Assert.Contains(events, e => e is RunFinishedEvent);
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithUsageContentOnly_UsageDataIsNotSilentlyDroppedAsync()
+    {
+        // Arrange — Baseline: empty stream produces only RunStarted + RunFinished
+        List<ChatResponseUpdate> baselineUpdates = [];
+        List<BaseEvent> baselineEvents = await CollectEventsAsync(baselineUpdates);
+        int baselineCount = baselineEvents.Count;
+
+        // Test: stream with UsageContent only (no text, no tool calls)
+        List<ChatResponseUpdate> usageUpdates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 250,
+                    OutputTokenCount = 120,
+                    TotalTokenCount = 370
+                })],
+                MessageId = "msg1"
+            }
+        ];
+        List<BaseEvent> usageEvents = await CollectEventsAsync(usageUpdates);
+
+        // Assert — Usage data should produce at least one additional event beyond lifecycle events.
+        // Currently (before fix), UsageContent is silently dropped and usageEvents.Count == baselineCount.
+        Assert.True(
+            usageEvents.Count > baselineCount,
+            "UsageContent should produce additional events beyond lifecycle events. " +
+            "Got " + usageEvents.Count + " events, same as baseline (" + baselineCount + "). " +
+            "Usage data (InputTokenCount=250, OutputTokenCount=120) is being silently dropped. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithUsageContentAndText_BothContentTypesPreservedAsync()
+    {
+        // Arrange — A realistic scenario: agent returns text + usage in the same response
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate(ChatRole.Assistant, "Here is the answer.") { MessageId = "msg1" },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 45,
+                    OutputTokenCount = 12,
+                    TotalTokenCount = 57
+                })],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+
+        // Assert — Text content should produce text events
+        Assert.Contains(events, e => e is TextMessageStartEvent);
+        Assert.Contains(events, e => e is TextMessageContentEvent tce && tce.Delta == "Here is the answer.");
+        Assert.Contains(events, e => e is TextMessageEndEvent);
+
+        // Assert — Usage data should ALSO be present somewhere in the event stream
+        // Excluding lifecycle events and text events, there should be at least one event for usage
+        int textAndLifecycleCount = events.Count(e =>
+            e is RunStartedEvent or RunFinishedEvent or
+            TextMessageStartEvent or TextMessageContentEvent or TextMessageEndEvent);
+
+        Assert.True(
+            events.Count > textAndLifecycleCount,
+            "When both text and usage content are present, usage data should produce additional events. " +
+            $"Total events: {events.Count}, text+lifecycle events: {textAndLifecycleCount}. " +
+            "Usage data is being silently dropped. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithUsageContent_UsageTokenCountsAccessibleInEventsAsync()
+    {
+        // Arrange
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate(ChatRole.Assistant, "Response text") { MessageId = "msg1" },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 500,
+                    OutputTokenCount = 200,
+                    TotalTokenCount = 700
+                })],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+
+        // Assert — Serialize all events to JSON and check that token counts appear
+        string allEventsJson = SerializeAllEvents(events);
+
+        // The token counts should be present in the serialized event stream
+        Assert.True(
+            allEventsJson.Contains("500") || allEventsJson.Contains("input"),
+            "InputTokenCount (500) should be present in the serialized AGUI events. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+        Assert.True(
+            allEventsJson.Contains("200") || allEventsJson.Contains("output"),
+            "OutputTokenCount (200) should be present in the serialized AGUI events. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    #endregion
+
+    #region Annotations Tests
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithAnnotatedTextContent_DoesNotThrowAsync()
+    {
+        // Arrange — TextContent with annotations (citations)
+        TextContent textContent = new("According to research, the answer is 42.");
+        textContent.Annotations =
+        [
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://example.com/source"),
+                Title = "Source Document"
+            }
+        ];
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [textContent],
+                MessageId = "msg1"
+            }
+        ];
+
+        // Act — Should not throw even if annotations are not mapped
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+
+        // Assert — Text content should still be emitted
+        Assert.Contains(events, e => e is TextMessageContentEvent tce && tce.Delta.Contains("42"));
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithAnnotatedTextContent_AnnotationDataNotSilentlyDroppedAsync()
+    {
+        // Arrange — TextContent with citation annotations
+        TextContent textContent = new("The earth orbits the sun.");
+        textContent.Annotations =
+        [
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://example.com/astronomy-source"),
+                Title = "Astronomy 101"
+            }
+        ];
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [textContent],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+
+        // Assert — Annotation data (URL, title) should be present somewhere in the event stream
+        string allEventsJson = SerializeAllEvents(events);
+
+        Assert.True(
+            allEventsJson.Contains("example.com/astronomy-source") ||
+            allEventsJson.Contains("Astronomy 101") ||
+            allEventsJson.Contains("annotation"),
+            "Annotation data (URL: 'https://example.com/astronomy-source', Title: 'Astronomy 101') " +
+            "should be present in AGUI events. Annotations are being silently dropped. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithMultipleAnnotations_AllAnnotationsPreservedAsync()
+    {
+        // Arrange — TextContent with multiple citation annotations
+        TextContent textContent = new("Summary based on multiple sources.");
+        textContent.Annotations =
+        [
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://source-a.com/doc"),
+                Title = "Source A"
+            },
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://source-b.com/paper"),
+                Title = "Source B"
+            }
+        ];
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [textContent],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+        string allEventsJson = SerializeAllEvents(events);
+
+        // Assert — Both annotations should be present
+        Assert.True(
+            allEventsJson.Contains("source-a.com") || allEventsJson.Contains("Source A"),
+            "First annotation (Source A) should be present in AGUI events. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+        Assert.True(
+            allEventsJson.Contains("source-b.com") || allEventsJson.Contains("Source B"),
+            "Second annotation (Source B) should be present in AGUI events. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithAnnotationsOnStreamingText_AnnotationsPreservedAsync()
+    {
+        // Arrange — Streaming scenario: multiple text deltas, last one carries annotations
+        TextContent delta1 = new("Hello ");
+        TextContent delta2 = new("world.");
+        delta2.Annotations =
+        [
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://reference.com/greeting"),
+                Title = "Greeting Reference"
+            }
+        ];
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [delta1],
+                MessageId = "msg1"
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [delta2],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+        string allEventsJson = SerializeAllEvents(events);
+
+        // Assert — Annotation on the last delta should not be lost
+        Assert.True(
+            allEventsJson.Contains("reference.com/greeting") ||
+            allEventsJson.Contains("Greeting Reference"),
+            "Annotations on streaming text deltas should be preserved in AGUI events. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    #endregion
+
+    #region Combined Tests
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithTextAnnotationsAndUsage_AllDataPreservedAsync()
+    {
+        // Arrange — Realistic scenario: text with annotations + usage data
+        TextContent textContent = new("The answer is documented here.");
+        textContent.Annotations =
+        [
+            new CitationAnnotation
+            {
+                Url = new System.Uri("https://docs.example.com/answer"),
+                Title = "Answer Documentation"
+            }
+        ];
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [textContent],
+                MessageId = "msg1"
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 80,
+                    OutputTokenCount = 25,
+                    TotalTokenCount = 105
+                })],
+                MessageId = "msg1"
+            }
+        ];
+
+        List<BaseEvent> events = await CollectEventsAsync(updates);
+        string allEventsJson = SerializeAllEvents(events);
+
+        // Assert — Text should be present
+        Assert.Contains(events, e => e is TextMessageContentEvent tce && tce.Delta.Contains("documented"));
+
+        // Assert — Annotations should be present
+        Assert.True(
+            allEventsJson.Contains("docs.example.com/answer") || allEventsJson.Contains("Answer Documentation"),
+            "Annotation data should be preserved in AGUI events when text and usage are both present. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+
+        // Assert — Usage should be present
+        List<BaseEvent> baselineEvents = await CollectEventsAsync([]);
+        int textAndLifecycleCount = events.Count(e =>
+            e is RunStartedEvent or RunFinishedEvent or
+            TextMessageStartEvent or TextMessageContentEvent or TextMessageEndEvent);
+        Assert.True(
+            events.Count > textAndLifecycleCount,
+            "Usage data should produce additional events when combined with annotated text. " +
+            "See https://github.com/microsoft/agent-framework/issues/3752");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static async Task<List<BaseEvent>> CollectEventsAsync(List<ChatResponseUpdate> updates)
+    {
+        List<BaseEvent> events = [];
+        await foreach (BaseEvent evt in updates.ToAsyncEnumerableAsync()
+            .AsAGUIEventStreamAsync(ThreadId, RunId, AGUIJsonSerializerContext.Default.Options, CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+        return events;
+    }
+
+    private static string SerializeAllEvents(List<BaseEvent> events)
+    {
+        return string.Join("\n", events.Select(e =>
+            JsonSerializer.Serialize(e, AGUIJsonSerializerContext.Default.Options)));
+    }
+
+    #endregion
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/UsageAndAnnotationsTests.cs
@@ -42,7 +42,7 @@ public sealed class UsageAndAnnotationsTests
             }
         ];
 
-        // Act — Should not throw even if UsageContent is not mapped to an event
+        // Act — Should not throw when handling UsageContent mapped to a CustomEvent
         List<BaseEvent> events = [];
         await foreach (BaseEvent evt in updates.ToAsyncEnumerableAsync()
             .AsAGUIEventStreamAsync(ThreadId, RunId, AGUIJsonSerializerContext.Default.Options, CancellationToken.None))


### PR DESCRIPTION
## .NET: Fix Usage and Annotations not present in AG-UI events

`UsageContent` and `TextContent.Annotations` from `Microsoft.Extensions.AI` were silently dropped when converting `ChatResponseUpdate` streams to AG-UI SSE events via `AsAGUIEventStreamAsync`. Both content types fell through all `if`/`else if` branches without matching, producing no AG-UI events.

Changes:

- Add `CustomEvent` type (`CUSTOM`) aligned with the AG-UI protocol spec (`ag_ui.core.CustomEvent`), with `Name` and `Value` (`JsonElement?`) properties

- Handle `UsageContent`: emit `CustomEvent(name="usage", value={inputTokenCount, outputTokenCount, totalTokenCount})`

- Handle `TextContent.Annotations`: emit `CustomEvent(name="annotations", value=[{type, title, url, fileId, toolName, snippet}])` for `CitationAnnotation`

- Register `CustomEvent` in `AGUIEventTypes`, `AGUIJsonSerializerContext` (AOT), and `BaseEventJsonConverter` (read/write)

- Add 9 regression tests in UsageAndAnnotationsTests.cs covering usage-only, annotations-only, combined, and streaming scenarios

Fixes #3752

### Motivation and Context

When an LLM provider returns token usage data (`UsageContent`) or citation annotations (`TextContent.Annotations`) in a `ChatResponseUpdate` stream, the AG-UI hosting layer was silently discarding this information. The `AsAGUIEventStreamAsync` method in ChatResponseUpdateAGUIExtensions.cs had handling branches for `TextContent`, `FunctionCallContent`, `FunctionResultContent`, and `DataContent`, but no branch for `UsageContent` — it fell through to the end of the loop body without producing any event. Similarly, `TextContent.Annotations` (e.g., `CitationAnnotation` with URL, title, file references) was never read: only `TextContent.Text` was extracted into `TextMessageContentEvent`, and the annotations collection was completely ignored.

This meant that AG-UI frontend clients consuming the SSE stream had no visibility into:
1. **Token consumption** — input/output/total token counts returned by the model, needed for cost tracking, rate limiting, and UX display
2. **Source citations** — URLs, document titles, file IDs, and snippets that the model referenced in its response, needed for attribution, transparency, and grounded AI experiences

The gap existed in both the .NET and Python implementations (Python's `_emit_content()` also returns `[]` for unknown content types, and `_emit_text()` never reads `content.annotations`). This fix addresses the .NET side.

The AG-UI protocol already defines a `CustomEvent` type (used in the Python SDK for `function_approval_request` and `PredictState`), but the .NET implementation did not have this event type. Adding `CustomEvent` is the correct protocol-aligned approach to emit extensible metadata without requiring changes to the AG-UI spec.

### Description

**Root cause analysis:**

In `ChatResponseUpdateAGUIExtensions.AsAGUIEventStreamAsync` (shared code compiled into both `Microsoft.Agents.AI.AGUI` and `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore`), the content dispatch logic iterated over `chatResponse.Contents` with branches for:
- `FunctionCallContent` → `ToolCallStartEvent` / `ToolCallArgsEvent` / `ToolCallEndEvent`
- `FunctionResultContent` → `ToolCallResultEvent`
- `DataContent` → `StateSnapshotEvent` / `StateDeltaEvent` / `TextMessageContentEvent`

Any other `AIContent` subtype (including `UsageContent`) was silently ignored. Additionally, `TextContent` was handled separately (before the `foreach` loop) and only `textContent.Text` was read — the `Annotations` collection was never accessed.

**Solution design:**

1. **`CustomEvent` (new type)** — Internal event class inheriting `BaseEvent`, with `Name` (string) and `Value` (JsonElement?) properties, using discriminator `"CUSTOM"`. Aligned with `ag_ui.core.CustomEvent` from the AG-UI protocol used by the Python SDK.

2. **`UsageContent` handling** — Added an `else if (content is UsageContent usageContent)` branch in the content dispatch loop. Serializes token counts using `Utf8JsonWriter` directly (no reflection, AOT-safe) into a JSON object `{inputTokenCount, outputTokenCount, totalTokenCount}` and emits as `CustomEvent(name="usage")`.

3. **`TextContent.Annotations` handling** — After emitting `TextMessageContentEvent` for text, checks `textContent.Annotations` and if non-empty, serializes each annotation using `Utf8JsonWriter`. For `CitationAnnotation`, writes `type`, `title`, `url`, `fileId`, `toolName`, and `snippet` (all null-guarded). Emits as `CustomEvent(name="annotations")`.

4. **Serialization registration** — `CustomEvent` registered in:
   - `AGUIEventTypes.Custom = "CUSTOM"` (constant)
   - `AGUIJsonSerializerContext` (`[JsonSerializable(typeof(CustomEvent))]` for AOT)
   - `BaseEventJsonConverter.Read()` (discriminator → type mapping)
   - `BaseEventJsonConverter.Write()` (concrete type → serialization)

5. **Both projects build** — Since the shared code is compiled into both packages via `<Compile Include>`, changes to the Shared folder automatically apply to `Microsoft.Agents.AI.AGUI` (netstandard2.0/net10.0) and `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore` (net8.0/net9.0/net10.0).

**Files changed:**

| File | Type | Description |
|------|------|-------------|
| CustomEvent.cs | New | `CUSTOM` event with `Name` and `Value` properties |
| AGUIEventTypes.cs | Modified | Added `Custom = "CUSTOM"` constant |
| AGUIJsonSerializerContext.cs | Modified | Registered `CustomEvent` for AOT serialization |
| BaseEventJsonConverter.cs | Modified | Added Read/Write for `CustomEvent` discriminator |
| ChatResponseUpdateAGUIExtensions.cs | Modified | Handle `UsageContent` and `TextContent.Annotations` via `CustomEvent`; added `CreateUsageCustomEvent` and `CreateAnnotationsCustomEvent` helpers |
| UsageAndAnnotationsTests.cs | New | 9 regression tests |

**Test coverage:**

| Test | Scenario |
|------|----------|
| `WithUsageContent_DoesNotThrow` | UsageContent alongside text doesn't crash |
| `WithUsageContentOnly_UsageDataIsNotSilentlyDropped` | UsageContent-only stream produces events beyond lifecycle |
| `WithUsageContentAndText_BothContentTypesPreserved` | Text + usage both produce their respective events |
| `WithUsageContent_UsageTokenCountsAccessibleInEvents` | Token counts (500/200/700) appear in serialized events |
| `WithAnnotatedTextContent_DoesNotThrow` | CitationAnnotation on text doesn't crash |
| `WithAnnotatedTextContent_AnnotationDataNotSilentlyDropped` | URL and title appear in serialized events |
| `WithMultipleAnnotations_AllAnnotationsPreserved` | Multiple citations all preserved |
| `WithAnnotationsOnStreamingText_AnnotationsPreserved` | Annotations on streaming deltas preserved |
| `WithTextAnnotationsAndUsage_AllDataPreserved` | Combined text + annotations + usage all present |

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No. Adds new internal `CustomEvent` type and emits additional events in the SSE stream. No public API changes. Existing consumers that ignore unknown event types are unaffected.