### PR TITLE
.NET: Fix GitHubCopilotAgent producing duplicated text content (#3979)

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentDuplicateTextTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentDuplicateTextTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GitHub.Copilot.SDK;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.GitHub.Copilot.UnitTests;
+
+/// <summary>
+/// Tests that verify the fix for issue #3979 — GitHubCopilotAgent produces duplicated text content.
+/// The bug was caused by both AssistantMessageDeltaEvent (incremental chunks) and
+/// AssistantMessageEvent (complete assembled message) producing TextContent in
+/// the streaming output. Consumers concatenating all update text would see the
+/// content twice.
+/// </summary>
+public sealed class GitHubCopilotAgentDuplicateTextTests : IAsyncDisposable
+{
+    private readonly GitHubCopilotAgent _agent;
+
+    public GitHubCopilotAgentDuplicateTextTests()
+    {
+        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        _agent = new GitHubCopilotAgent(copilotClient, sessionConfig: null, ownsClient: false, id: "test-agent", name: "Test Agent", description: "Test agent");
+    }
+
+    public ValueTask DisposeAsync() => _agent.DisposeAsync();
+
+    [Fact]
+    public void ConvertDeltaEvent_ProducesTextContent()
+    {
+        // Arrange
+        var deltaEvent = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData
+            {
+                DeltaContent = "Hello ",
+                MessageId = "msg-1",
+            },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(deltaEvent);
+
+        // Assert — delta events MUST produce TextContent for streaming
+        Assert.NotNull(update);
+        Assert.Single(update.Contents);
+        TextContent textContent = Assert.IsType<TextContent>(update.Contents[0]);
+        Assert.Equal("Hello ", textContent.Text);
+        Assert.Same(deltaEvent, textContent.RawRepresentation);
+    }
+
+    [Fact]
+    public void ConvertDeltaEvent_PreservesMessageId()
+    {
+        // Arrange
+        var deltaEvent = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData
+            {
+                DeltaContent = "test",
+                MessageId = "msg-42",
+            },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(deltaEvent);
+
+        // Assert
+        Assert.Equal("msg-42", update.MessageId);
+        Assert.Equal("test-agent", update.AgentId);
+        Assert.Equal(ChatRole.Assistant, update.Role);
+    }
+
+    [Fact]
+    public void ConvertAssistantMessageEvent_DoesNotProduceTextContent()
+    {
+        // Arrange — AssistantMessageEvent contains the full assembled text
+        var messageEvent = new AssistantMessageEvent
+        {
+            Data = new AssistantMessageData
+            {
+                Content = "Hello world! This is the complete message.",
+                MessageId = "msg-1",
+            },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(messageEvent);
+
+        // Assert — must NOT produce TextContent to avoid duplicating delta text (#3979)
+        Assert.NotNull(update);
+        Assert.Single(update.Contents);
+        Assert.IsNotType<TextContent>(update.Contents[0]);
+        Assert.Same(messageEvent, update.Contents[0].RawRepresentation);
+    }
+
+    [Fact]
+    public void ConvertAssistantMessageEvent_PreservesIdsAndTimestamp()
+    {
+        // Arrange
+        var messageEvent = new AssistantMessageEvent
+        {
+            Data = new AssistantMessageData
+            {
+                Content = "complete text",
+                MessageId = "msg-99",
+            },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(messageEvent);
+
+        // Assert — metadata is preserved even without TextContent
+        Assert.Equal("msg-99", update.MessageId);
+        Assert.Equal("msg-99", update.ResponseId);
+        Assert.Equal("test-agent", update.AgentId);
+        Assert.Equal(ChatRole.Assistant, update.Role);
+    }
+
+    [Fact]
+    public void StreamingSimulation_DeltasPlusComplete_NoDuplicatedText()
+    {
+        // Arrange — simulate the event sequence: 3 deltas + 1 complete message
+        const string Part1 = "Hello ";
+        const string Part2 = "world";
+        const string Part3 = "!";
+        const string FullText = Part1 + Part2 + Part3;
+
+        var delta1 = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData { DeltaContent = Part1, MessageId = "msg-1" },
+        };
+        var delta2 = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData { DeltaContent = Part2, MessageId = "msg-1" },
+        };
+        var delta3 = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData { DeltaContent = Part3, MessageId = "msg-1" },
+        };
+        var completeMessage = new AssistantMessageEvent
+        {
+            Data = new AssistantMessageData { Content = FullText, MessageId = "msg-1" },
+        };
+
+        // Act — convert all events (as would happen in the streaming pipeline)
+        var updates = new List<AgentResponseUpdate>
+        {
+            _agent.ConvertToAgentResponseUpdate(delta1),
+            _agent.ConvertToAgentResponseUpdate(delta2),
+            _agent.ConvertToAgentResponseUpdate(delta3),
+            _agent.ConvertToAgentResponseUpdate(completeMessage),
+        };
+
+        // Assert — collect all TextContent from all updates
+        string collectedText = string.Concat(
+            updates.SelectMany(u => u.Contents)
+                   .OfType<TextContent>()
+                   .Select(tc => tc.Text));
+
+        // The collected text must equal the full text exactly once (no duplication)
+        Assert.Equal(FullText, collectedText);
+    }
+
+    [Fact]
+    public void ConvertDeltaEvent_EmptyDeltaContent_ProducesEmptyTextContent()
+    {
+        // Arrange — DeltaContent is empty string
+        var deltaEvent = new AssistantMessageDeltaEvent
+        {
+            Data = new AssistantMessageDeltaData { DeltaContent = string.Empty, MessageId = "msg-empty" },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(deltaEvent);
+
+        // Assert — empty delta produces empty TextContent (defensive behavior)
+        TextContent textContent = Assert.IsType<TextContent>(update.Contents[0]);
+        Assert.Equal(string.Empty, textContent.Text);
+    }
+
+    [Fact]
+    public void ConvertUsageEvent_ProducesUsageContent_NotTextContent()
+    {
+        // Arrange
+        var usageEvent = new AssistantUsageEvent
+        {
+            Data = new AssistantUsageData
+            {
+                Model = "gpt-4o",
+                InputTokens = 10,
+                OutputTokens = 25,
+            },
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate(usageEvent);
+
+        // Assert — usage events should produce UsageContent, not TextContent
+        Assert.Single(update.Contents);
+        UsageContent usageContent = Assert.IsType<UsageContent>(update.Contents[0]);
+        Assert.Equal(10, usageContent.Details.InputTokenCount);
+        Assert.Equal(25, usageContent.Details.OutputTokenCount);
+        Assert.Equal(35, usageContent.Details.TotalTokenCount);
+    }
+
+    [Fact]
+    public void ConvertSessionEvent_ProducesRawContent_NotTextContent()
+    {
+        // Arrange — generic session event (falls to default handler)
+        var sessionEvent = new SessionIdleEvent
+        {
+            Data = new SessionIdleData(),
+        };
+
+        // Act
+        AgentResponseUpdate update = _agent.ConvertToAgentResponseUpdate((SessionEvent)sessionEvent);
+
+        // Assert
+        Assert.Single(update.Contents);
+        Assert.IsNotType<TextContent>(update.Contents[0]);
+        Assert.Same(sessionEvent, update.Contents[0].RawRepresentation);
+    }
+}


### PR DESCRIPTION
 ### Motivation and Context

This change fixes a bug where `GitHubCopilotAgent` produces duplicated text content during streaming responses (issue #3979).

When streaming, the agent emitted `TextContent` from both `AssistantMessageDeltaEvent` (incremental chunks) and `AssistantMessageEvent` (complete assembled message). Any consumer concatenating all `TextContent` from the streaming updates would see the full response text duplicated — e.g., `"Hello world!Hello world!"` instead of `"Hello world!"`.

This is a correctness bug that affects all downstream integrations relying on the streaming pipeline, including AG-UI and CopilotKit clients.

Fixes #3979

### Description

**Root cause:** `RunCoreStreamingAsync` had an explicit `case AssistantMessageEvent` in its switch statement that called `ConvertToAgentResponseUpdate`, which created a `TextContent` containing the full assembled text — the same text already streamed incrementally via `AssistantMessageDeltaEvent` chunks.

**Fix applied:**

1. **Removed the dedicated `AssistantMessageEvent` case** from the streaming switch so it falls through to the `default` handler, which stores the event as `RawRepresentation` only (no `TextContent`). A code comment explains the intentional omission.
2. **Changed `ConvertToAgentResponseUpdate(AssistantMessageEvent)`** to return a generic `AIContent` with `RawRepresentation` instead of `TextContent`, so even if called directly it cannot produce duplicate text. This follows the same approach used by the Python SDK.
3. **Changed `ConvertToAgentResponseUpdate` methods from `private` to `internal`** to enable direct unit testing of each event type conversion.

**Tests added** (GitHubCopilotAgentDuplicateTextTests.cs — 8 new tests):

| Test | Validates |
|------|-----------|
| `ConvertDeltaEvent_ProducesTextContent` | Delta events correctly produce `TextContent` for streaming |
| `ConvertDeltaEvent_PreservesMessageId` | Delta event metadata (MessageId, AgentId, Role) is preserved |
| `ConvertAssistantMessageEvent_DoesNotProduceTextContent` | Complete message event does **not** produce `TextContent` (the fix) |
| `ConvertAssistantMessageEvent_PreservesIdsAndTimestamp` | Metadata is preserved even without `TextContent` |
| `StreamingSimulation_DeltasPlusComplete_NoDuplicatedText` | End-to-end: 3 deltas + 1 complete → collected text equals expected (no duplication) |
| `ConvertDeltaEvent_EmptyDeltaContent_ProducesEmptyTextContent` | Defensive handling of empty delta content |
| `ConvertUsageEvent_ProducesUsageContent_NotTextContent` | Usage events produce `UsageContent`, not `TextContent` |
| `ConvertSessionEvent_ProducesRawContent_NotTextContent` | Session events produce raw content, not `TextContent` |

All 22 existing + 8 new unit tests pass on net8.0, net9.0, and net10.0.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No. The `AssistantMessageEvent` data remains accessible via `RawRepresentation` for any consumer that needs it; only the spurious `TextContent` duplication is removed.