### PR TITLE
Python: Fix OpenAI chat client compatibility with third-party endpoints and OTel 0.4.14

### DIFF
--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -543,10 +543,10 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         if message.role in ("system", "developer"):
             texts = [content.text for content in message.contents if content.type == "text" and content.text]
             if texts:
-                args: dict[str, Any] = {"role": message.role, "content": "\n".join(texts)}
+                sys_args: dict[str, Any] = {"role": message.role, "content": "\n".join(texts)}
                 if message.author_name:
-                    args["name"] = message.author_name
-                return [args]
+                    sys_args["name"] = message.author_name
+                return [sys_args]
             return []
 
         all_messages: list[dict[str, Any]] = []
@@ -590,9 +590,9 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         # compatibility with OpenAI-like endpoints (e.g. Foundry Local).
         # See https://github.com/microsoft/agent-framework/issues/4084
         for msg in all_messages:
-            content = msg.get("content")
-            if isinstance(content, list) and all(isinstance(c, dict) and c.get("type") == "text" for c in content):
-                msg["content"] = "\n".join(c.get("text", "") for c in content)
+            msg_content: Any = msg.get("content")
+            if isinstance(msg_content, list) and all(isinstance(c, dict) and c.get("type") == "text" for c in msg_content):
+                msg["content"] = "\n".join(c.get("text", "") for c in msg_content)
 
         return all_messages
 

--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -588,6 +588,15 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     args["content"].append(self._prepare_content_for_openai(content))  # type: ignore
             if "content" in args or "tool_calls" in args:
                 all_messages.append(args)
+
+        # Flatten text-only content lists to plain strings for broader
+        # compatibility with OpenAI-like endpoints (e.g. Foundry Local).
+        # See https://github.com/microsoft/agent-framework/issues/4084
+        for msg in all_messages:
+            content = msg.get("content")
+            if isinstance(content, list) and all(isinstance(c, dict) and c.get("type") == "text" for c in content):
+                msg["content"] = "\n".join(c.get("text", "") for c in content)
+
         return all_messages
 
     def _prepare_content_for_openai(self, content: Content) -> dict[str, Any]:

--- a/python/packages/core/tests/core/test_observability.py
+++ b/python/packages/core/tests/core/test_observability.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock
 
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import StatusCode
 
 from agent_framework import (
@@ -48,8 +47,8 @@ def test_role_event_map():
 def test_enum_values():
     """Test that OtelAttr enum has expected values."""
     assert OtelAttr.OPERATION == "gen_ai.operation.name"
-    assert SpanAttributes.LLM_SYSTEM == "gen_ai.system"
-    assert SpanAttributes.LLM_REQUEST_MODEL == "gen_ai.request.model"
+    assert OtelAttr.SYSTEM == "gen_ai.system"
+    assert OtelAttr.REQUEST_MODEL == "gen_ai.request.model"
     assert OtelAttr.CHAT_COMPLETION_OPERATION == "chat"
     assert OtelAttr.TOOL_EXECUTION_OPERATION == "execute_tool"
     assert OtelAttr.AGENT_INVOKE_OPERATION == "invoke_agent"
@@ -213,7 +212,7 @@ async def test_chat_client_observability(mock_chat_client, span_exporter: InMemo
     span = spans[0]
     assert span.name == "chat Test"
     assert span.attributes[OtelAttr.OPERATION.value] == OtelAttr.CHAT_COMPLETION_OPERATION
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "Test"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "Test"
     assert span.attributes[OtelAttr.INPUT_TOKENS] == 10
     assert span.attributes[OtelAttr.OUTPUT_TOKENS] == 20
     if enable_sensitive_data:
@@ -243,7 +242,7 @@ async def test_chat_client_streaming_observability(
     span = spans[0]
     assert span.name == "chat Test"
     assert span.attributes[OtelAttr.OPERATION.value] == OtelAttr.CHAT_COMPLETION_OPERATION
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "Test"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "Test"
     if enable_sensitive_data:
         assert span.attributes[OtelAttr.INPUT_MESSAGES] is not None
         assert span.attributes[OtelAttr.OUTPUT_MESSAGES] is not None
@@ -392,7 +391,7 @@ async def test_chat_client_without_model_id_observability(mock_chat_client, span
 
     assert span.name == "chat unknown"
     assert span.attributes[OtelAttr.OPERATION.value] == OtelAttr.CHAT_COMPLETION_OPERATION
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "unknown"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "unknown"
 
 
 async def test_chat_client_streaming_without_model_id_observability(
@@ -416,7 +415,7 @@ async def test_chat_client_streaming_without_model_id_observability(
     span = spans[0]
     assert span.name == "chat unknown"
     assert span.attributes[OtelAttr.OPERATION.value] == OtelAttr.CHAT_COMPLETION_OPERATION
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "unknown"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "unknown"
 
 
 def test_prepend_user_agent_with_none_value():
@@ -491,7 +490,7 @@ async def test_agent_instrumentation_enabled(
     assert span.attributes[OtelAttr.AGENT_ID] == "test_agent_id"
     assert span.attributes[OtelAttr.AGENT_NAME] == "test_agent"
     assert span.attributes[OtelAttr.AGENT_DESCRIPTION] == "Test agent description"
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "TestModel"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "TestModel"
     assert span.attributes[OtelAttr.INPUT_TOKENS] == 15
     assert span.attributes[OtelAttr.OUTPUT_TOKENS] == 25
     if enable_sensitive_data:
@@ -521,7 +520,7 @@ async def test_agent_streaming_response_with_diagnostics_enabled(
     assert span.attributes[OtelAttr.AGENT_ID] == "test_agent_id"
     assert span.attributes[OtelAttr.AGENT_NAME] == "test_agent"
     assert span.attributes[OtelAttr.AGENT_DESCRIPTION] == "Test agent description"
-    assert span.attributes[SpanAttributes.LLM_REQUEST_MODEL] == "TestModel"
+    assert span.attributes[OtelAttr.REQUEST_MODEL] == "TestModel"
     if enable_sensitive_data:
         assert span.attributes.get(OtelAttr.OUTPUT_MESSAGES) is not None  # Streaming, so no usage yet
 
@@ -1381,8 +1380,6 @@ def test_get_response_attributes_with_model_id():
     """Test _get_response_attributes includes model_id."""
     from unittest.mock import Mock
 
-    from opentelemetry.semconv_ai import SpanAttributes
-
     from agent_framework.observability import _get_response_attributes
 
     response = Mock()
@@ -1395,7 +1392,7 @@ def test_get_response_attributes_with_model_id():
     attrs = {}
     result = _get_response_attributes(attrs, response)
 
-    assert result[SpanAttributes.LLM_RESPONSE_MODEL] == "gpt-4"
+    assert result[OtelAttr.RESPONSE_MODEL] == "gpt-4"
 
 
 def test_get_response_attributes_with_usage():


### PR DESCRIPTION
## Problems Fixed

1. **System message content as list ([#1407](https://github.com/microsoft/agent-framework/issues/1407))** — Some OpenAI-compatible endpoints (e.g. NVIDIA NIM) reject system messages when `content` is a list of content parts. They only accept plain string content for system/developer roles.

2. **Text-only content as list for all roles ([#4084](https://github.com/microsoft/agent-framework/issues/4084))** — Foundry Local's Neutron/.NET backend cannot deserialize the list format for `content` at all, failing with a 500 JSON serialization error for any message role.

3. **OTel attribute removal ([#4160](https://github.com/microsoft/agent-framework/issues/4160))** — `opentelemetry-semantic-conventions-ai` v0.4.14 removed several `SpanAttributes.LLM_*` attributes (`LLM_SYSTEM`, `LLM_REQUEST_MODEL`, `LLM_RESPONSE_MODEL`, `LLM_REQUEST_MAX_TOKENS`, `LLM_REQUEST_TEMPERATURE`, `LLM_REQUEST_TOP_P`), breaking observability at import time.

4. **Streaming text lost with usage data ([#3434](https://github.com/microsoft/agent-framework/issues/3434))** — Gemini and other providers include both usage data and text content in the same streaming chunk. The early return on `chunk.usage` caused text and tool call parsing to be skipped entirely.

## Changes

### Message content flattening (`_chat_client.py`)
- **System/developer messages**: Early return that flattens all text content into a plain string.
- **All other roles**: Post-processing step that flattens text-only content lists to plain strings. Multimodal content (text + images/audio) remains as a list for the API.

### Streaming fix (`_chat_client.py`)
- Removed early return in `_parse_response_update_from_openai()` when `chunk.usage` is present. Usage is now collected alongside text and tool call content in a single `ChatResponseUpdate`.

### OTel attributes (`observability.py`)
- Moved removed `SpanAttributes.LLM_*` values into the `OtelAttr` enum with their well-known `gen_ai.*` string values. Updated all references in source and tests.

## Tests
- `test_prepare_system_message_content_is_string`
- `test_prepare_developer_message_content_is_string`
- `test_prepare_system_message_multiple_text_contents_joined`
- `test_prepare_user_message_text_content_is_string`
- `test_prepare_user_message_multimodal_content_remains_list`
- `test_prepare_assistant_message_text_content_is_string`
- `test_streaming_chunk_with_usage_and_text`
- All observability tests updated and passing with both semconv-ai 0.4.13 and 0.4.14

Fixes https://github.com/microsoft/agent-framework/issues/1407
Fixes https://github.com/microsoft/agent-framework/issues/4160
Fixes https://github.com/microsoft/agent-framework/issues/3434
Partially fixes https://github.com/microsoft/agent-framework/issues/4084