### PR TITLE
.NET: Fix Structured Output for agents configured with function middleware

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/FunctionInvocationDelegatingAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/FunctionInvocationDelegatingAgent.cs
@@ -32,7 +32,13 @@ internal sealed class FunctionInvocationDelegatingAgent : DelegatingAIAgent
     {
         if (options is null || options.GetType() == typeof(AgentRunOptions))
         {
-            options = new ChatClientAgentRunOptions();
+            options = new ChatClientAgentRunOptions()
+            {
+                ResponseFormat = options?.ResponseFormat,
+                AllowBackgroundResponses = options?.AllowBackgroundResponses,
+                ContinuationToken = options?.ContinuationToken,
+                AdditionalProperties = options?.AdditionalProperties,
+            };
         }
 
         if (options is not ChatClientAgentRunOptions aco)


### PR DESCRIPTION
## Summary

Fixes incomplete property preservation in `FunctionInvocationDelegatingAgent.AgentRunOptionsWithFunctionMiddleware()` when converting base `AgentRunOptions` to `ChatClientAgentRunOptions`.

## Changes

- **`FunctionInvocationDelegatingAgent.cs`** — Copy all base `AgentRunOptions` properties (`AllowBackgroundResponses`, `ContinuationToken`, `AdditionalProperties`) when converting to `ChatClientAgentRunOptions`.
- **`FunctionInvocationDelegatingAgentTests.cs`** — Added unit test using an `AnonymousDelegatingAIAgent` spy to verify all original properties are preserved after conversion.

Closes: https://github.com/microsoft/agent-framework/issues/4118