### PR TITLE
.NET: Fix JSON arrays of objects parsed as empty records when no schema is defined

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/JsonDocumentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/JsonDocumentExtensions.cs
@@ -111,7 +111,9 @@ internal static class JsonDocumentExtensions
                     VariableType? currentType =
                         element.ValueKind switch
                         {
-                            JsonValueKind.Object => VariableType.Record(targetType.Schema?.Select(kvp => (kvp.Key, kvp.Value)) ?? []),
+                            JsonValueKind.Object => targetType.HasSchema
+                                ? VariableType.Record(targetType.Schema!.Select(kvp => (kvp.Key, kvp.Value)))
+                                : VariableType.RecordType,
                             JsonValueKind.String => typeof(string),
                             JsonValueKind.True => typeof(bool),
                             JsonValueKind.False => typeof(bool),


### PR DESCRIPTION
### Motivation and Context

Fixes #4195 — JSON arrays of objects are parsed as empty records when no schema is defined in declarative workflows.

When an `InvokeAzureAgent` action returns a JSON object containing an array of objects, and the output is captured via `responseObject`, all nested object properties are silently dropped. Each object in the array becomes `{}`. Subsequent `Foreach` iteration over the array crashes with an unhandled workflow failure.

### Description

**Root cause:** In `JsonDocumentExtensions.cs`, the `ParseTable` method's `DetermineElementType()` function creates a schema-bound `VariableType` with an empty (non-null) schema when `targetType.Schema` is null:

```csharp
// Before (broken)
JsonValueKind.Object => VariableType.Record(targetType.Schema?.Select(kvp => (kvp.Key, kvp.Value)) ?? []),
```

When `targetType.Schema` is `null`, the `?? []` fallback passes an empty collection to `VariableType.Record()`, creating a `VariableType` with `Schema` set to an empty `FrozenDictionary` (non-null, count = 0). Downstream, `ParseRecord` checks `targetType.Schema is null` and takes the `ParseSchema` path (which iterates over zero fields), silently discarding all JSON properties.

**Fix:** Check `targetType.HasSchema` (which correctly handles empty schemas) and fall back to `VariableType.RecordType` when no schema is defined:

```csharp
// After (fixed)
JsonValueKind.Object => targetType.HasSchema
    ? VariableType.Record(targetType.Schema!.Select(kvp => (kvp.Key, kvp.Value)))
    : VariableType.RecordType,
```

This ensures `ParseRecord` takes the dynamic `ParseValues()` path that preserves all JSON properties.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No — this is a bug fix that restores expected behavior.