### PR TITLE
.NET: Add Foundry SharePoint Tool Sample

### DIFF
--- a/dotnet/agent-framework-dotnet.slnx
+++ b/dotnet/agent-framework-dotnet.slnx
@@ -184,6 +184,7 @@
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step18_FileSearch/FoundryAgents_Step18_FileSearch.csproj" />
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step19_OpenAPITools/FoundryAgents_Step19_OpenAPITools.csproj" />
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step21_BingCustomSearch/FoundryAgents_Step21_BingCustomSearch.csproj" />
+    <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/FoundryAgents_Step22_SharePoint.csproj" />
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step25_WebSearch/FoundryAgents_Step25_WebSearch.csproj" />
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Step26_MemorySearch/FoundryAgents_Step26_MemorySearch.csproj" />
     <Project Path="samples/GettingStarted/FoundryAgents/FoundryAgents_Evaluations_Step01_RedTeaming/FoundryAgents_Evaluations_Step01_RedTeaming.csproj" />

--- a/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/FoundryAgents_Step22_SharePoint.csproj
+++ b/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/FoundryAgents_Step22_SharePoint.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);CA1812;CS8321</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.AI.Projects" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.AzureAI\Microsoft.Agents.AI.AzureAI.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/Program.cs
+++ b/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/Program.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to use SharePoint Grounding Tool with AI Agents.
+
+using Azure.AI.Projects;
+using Azure.AI.Projects.OpenAI;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using OpenAI.Responses;
+
+string endpoint = Environment.GetEnvironmentVariable("AZURE_FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("AZURE_FOUNDRY_PROJECT_ENDPOINT is not set.");
+string deploymentName = Environment.GetEnvironmentVariable("AZURE_FOUNDRY_PROJECT_DEPLOYMENT_NAME") ?? "gpt-4o-mini";
+string sharepointConnectionId = Environment.GetEnvironmentVariable("SHAREPOINT_PROJECT_CONNECTION_ID") ?? throw new InvalidOperationException("SHAREPOINT_PROJECT_CONNECTION_ID is not set.");
+
+const string AgentInstructions = """
+    You are a helpful agent that can use SharePoint tools to assist users.
+    Use the available SharePoint tools to answer questions and perform tasks.
+    """;
+
+// Get a client to create/retrieve/delete server side agents with Azure Foundry Agents.
+// WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
+// In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
+// latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
+AIProjectClient aiProjectClient = new(new Uri(endpoint), new DefaultAzureCredential());
+
+// Create SharePoint tool options with project connection
+var sharepointOptions = new SharePointGroundingToolOptions();
+sharepointOptions.ProjectConnections.Add(new ToolProjectConnection(sharepointConnectionId));
+
+AIAgent agent = await CreateAgentWithMEAIAsync();
+// AIAgent agent = await CreateAgentWithNativeSDKAsync();
+
+Console.WriteLine($"Created agent: {agent.Name}");
+
+AgentResponse response = await agent.RunAsync("List the documents available in SharePoint");
+
+// Display the response
+Console.WriteLine("\n=== Agent Response ===");
+Console.WriteLine(response);
+
+// Display grounding annotations if any
+foreach (var message in response.Messages)
+{
+    foreach (var content in message.Contents)
+    {
+        if (content.Annotations is not null)
+        {
+            foreach (var annotation in content.Annotations)
+            {
+                Console.WriteLine($"Annotation: {annotation}");
+            }
+        }
+    }
+}
+
+// Cleanup by agent name removes the agent version created.
+await aiProjectClient.Agents.DeleteAgentAsync(agent.Name);
+Console.WriteLine($"\nDeleted agent: {agent.Name}");
+
+// --- Agent Creation Options ---
+
+// Option 1 - Using AgentTool.CreateSharepointTool + AsAITool() (MEAI + AgentFramework)
+async Task<AIAgent> CreateAgentWithMEAIAsync()
+{
+    return await aiProjectClient.CreateAIAgentAsync(
+        model: deploymentName,
+        name: "SharePointAgent-MEAI",
+        instructions: AgentInstructions,
+        tools: [((ResponseTool)AgentTool.CreateSharepointTool(sharepointOptions)).AsAITool()]);
+}
+
+// Option 2 - Using PromptAgentDefinition SDK native type
+async Task<AIAgent> CreateAgentWithNativeSDKAsync()
+{
+    return await aiProjectClient.CreateAIAgentAsync(
+        name: "SharePointAgent-NATIVE",
+        creationOptions: new AgentVersionCreationOptions(
+            new PromptAgentDefinition(model: deploymentName)
+            {
+                Instructions = AgentInstructions,
+                Tools = { AgentTool.CreateSharepointTool(sharepointOptions) }
+            })
+    );
+}

--- a/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/README.md
+++ b/dotnet/samples/GettingStarted/FoundryAgents/FoundryAgents_Step22_SharePoint/README.md
@@ -1,0 +1,50 @@
+# Using SharePoint Grounding with AI Agents
+
+This sample demonstrates how to use the SharePoint grounding tool with AI agents. The SharePoint grounding tool enables agents to search and retrieve information from SharePoint sites.
+
+## What this sample demonstrates
+
+- Creating agents with SharePoint grounding capabilities
+- Using AgentTool.CreateSharepointTool (MEAI abstraction)
+- Using native SDK SharePoint tools (PromptAgentDefinition)
+- Managing agent lifecycle (creation and deletion)
+
+## Prerequisites
+
+Before you begin, ensure you have the following prerequisites:
+
+- .NET 10 SDK or later
+- Azure Foundry service endpoint and deployment configured
+- Azure authentication configured for `DefaultAzureCredential` (for example, Azure CLI logged in with `az login`, environment variables, managed identity, or IDE sign-in)
+- A SharePoint project connection configured in Azure Foundry
+
+**Note**: This demo uses `DefaultAzureCredential` for authentication. This credential will try multiple authentication mechanisms in order (such as environment variables, managed identity, Azure CLI login, and IDE sign-in) and use the first one that works. A common option for local development is to sign in with the Azure CLI using `az login` and ensure you have access to the Azure Foundry resource. For more information, see the [Azure CLI documentation](https://learn.microsoft.com/cli/azure/authenticate-azure-cli-interactively) and the [DefaultAzureCredential documentation](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential).
+
+Set the following environment variables:
+
+```powershell
+$env:AZURE_FOUNDRY_PROJECT_ENDPOINT="https://your-foundry-service.services.ai.azure.com/api/projects/your-foundry-project" # Replace with your Azure Foundry resource endpoint
+$env:AZURE_FOUNDRY_PROJECT_DEPLOYMENT_NAME="gpt-4o-mini"  # Optional, defaults to gpt-4o-mini
+$env:SHAREPOINT_PROJECT_CONNECTION_ID="your-sharepoint-connection-id"  # Required: SharePoint project connection ID
+```
+
+## Run the sample
+
+Navigate to the FoundryAgents sample directory and run:
+
+```powershell
+cd dotnet/samples/GettingStarted/FoundryAgents
+dotnet run --project .\FoundryAgents_Step22_SharePoint
+```
+
+## Expected behavior
+
+The sample will:
+
+1. Create two agents with SharePoint grounding capabilities:
+   - Option 1: Using AgentTool.CreateSharepointTool (MEAI abstraction)
+   - Option 2: Using native SDK SharePoint tools
+2. Run the agent with a query: "List the documents available in SharePoint"
+3. The agent will use SharePoint grounding to search and retrieve relevant documents
+4. Display the response and any grounding annotations
+5. Clean up resources by deleting both agents

--- a/dotnet/samples/GettingStarted/FoundryAgents/README.md
+++ b/dotnet/samples/GettingStarted/FoundryAgents/README.md
@@ -59,6 +59,7 @@ Before you begin, ensure you have the following prerequisites:
 |[Code interpreter](./FoundryAgents_Step14_CodeInterpreter/)|This sample demonstrates how to use the code interpreter tool with a Foundry agent|
 |[Computer use](./FoundryAgents_Step15_ComputerUse/)|This sample demonstrates how to use computer use capabilities with a Foundry agent|
 |[Bing Custom Search](./FoundryAgents_Step21_BingCustomSearch/)|This sample demonstrates how to use Bing Custom Search tool with a Foundry agent|
+|[SharePoint grounding](./FoundryAgents_Step22_SharePoint/)|This sample demonstrates how to use the SharePoint grounding tool with a Foundry agent|
 |[Web search](./FoundryAgents_Step25_WebSearch/)|This sample demonstrates how to use the Responses API web search tool with a Foundry agent|
 |[Memory search](./FoundryAgents_Step26_MemorySearch/)|This sample demonstrates how to use memory search tool with a Foundry agent|
 |[File search](./FoundryAgents_Step18_FileSearch/)|This sample demonstrates how to use the file search tool with a Foundry agent|


### PR DESCRIPTION
### Motivation and Context

Closes #3674

Adds a new FoundryAgents sample demonstrating how to use the **SharePoint grounding tool** with AI Agents. This enables agents to search and retrieve information from SharePoint sites via Azure Foundry.

### Description

Adds `FoundryAgents_Step22_SharePoint` sample with:

- **Two agent creation approaches** (consistent with other tool samples):
  - **Option 1 (MEAI)**: Using `AgentTool.CreateSharepointTool()` + `AsAITool()` wrapper
  - **Option 2 (Native SDK)**: Using `PromptAgentDefinition` with native `AgentTool.CreateSharepointTool()`
- SharePoint grounding tool configuration via `SharePointGroundingToolOptions` and project connections
- Display of grounding annotations from SharePoint search results
- Agent lifecycle management (creation and cleanup)

**Files added/modified:**
- `Program.cs` — Sample implementation with both MEAI and Native SDK approaches
- `FoundryAgents_Step22_SharePoint.csproj` — Project file targeting net10.0
- `README.md` — Sample documentation with prerequisites and usage instructions
- `FoundryAgents/README.md` — Updated samples table with Step 22 entry

**Validated end-to-end** against `agents-e2e-tests-westus2` project with `gpt-4o` deployment.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.