### PR TITLE
.NET: Fixing issue with invalid node Ids when visualizing dotnet workflows.

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs
@@ -191,14 +191,14 @@ public static class WorkflowVisualizer
 
         // Add start node
         var startExecutorId = workflow.StartExecutorId;
-        lines.Add($"{indent}{GetSafeId(startExecutorId)}[\"{startExecutorId} (Start)\"];");
+        lines.Add($"{indent}{GetSafeId(startExecutorId)}[\"{EscapeMermaidLabel(startExecutorId)} (Start)\"];");
 
         // Add other executor nodes
         foreach (var executorId in workflow.ExecutorBindings.Keys)
         {
             if (executorId != startExecutorId)
             {
-                lines.Add($"{indent}{GetSafeId(executorId)}[\"{executorId}\"];");
+                lines.Add($"{indent}{GetSafeId(executorId)}[\"{EscapeMermaidLabel(executorId)}\"];");
             }
         }
 
@@ -337,9 +337,10 @@ public static class WorkflowVisualizer
 
     /// <summary>
     /// Converts a raw node ID into a Mermaid-safe identifier that preserves as much
-    /// of the original text as possible. ASCII letters, digits, and underscores are kept;
-    /// everything else (including non-ASCII letters) is replaced with an underscore.
-    /// A leading digit gets a prefix. Consecutive underscores are collapsed.
+    /// of the original text as possible. ASCII letters, digits, and underscores are kept
+    /// as-is (including existing consecutive underscores). All other characters (including
+    /// non-ASCII letters) are replaced with underscores, with consecutive invalid characters
+    /// collapsed into a single underscore. A leading digit gets a prefix.
     /// </summary>
     private static string SanitizeMermaidNodeId(string id)
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs
@@ -294,8 +294,8 @@ public class WorkflowVisualizerTests
 
         // Conditional edge should be dotted with label (using .-> not .-->)
         mermaidContent.Should().Contain("-. conditional .-> ");
-        // Non-conditional edge should be solid
-        mermaidContent.Should().Contain(" --> ");
+        // Non-conditional edge should be a specific solid arrow
+        mermaidContent.Should().Contain("mid --> end");
         // Display labels should be present
         mermaidContent.Should().Contain("\"start (Start)\"");
         mermaidContent.Should().Contain("\"mid\"");
@@ -319,7 +319,23 @@ public class WorkflowVisualizerTests
         var mermaidContent = workflow.ToMermaidString();
 
         // There should be a fan-in node with special styling
-        mermaidContent.Should().Contain("((fan-in))");
+        var lines = mermaidContent.Split('\n');
+        var fanInLines = Array.FindAll(lines, line => line.Contains("((fan-in))"));
+        fanInLines.Should().HaveCount(1);
+
+        // Extract the intermediate fan-in node id from the line
+        var fanInLine = fanInLines[0].Trim();
+        var fanInNodeId = fanInLine.Substring(0, fanInLine.IndexOf("((fan-in))", StringComparison.Ordinal)).Trim();
+        fanInNodeId.Should().NotBeNullOrEmpty();
+
+        // Edges should be routed through the intermediate node
+        mermaidContent.Should().Contain($"s1 --> {fanInNodeId}");
+        mermaidContent.Should().Contain($"s2 --> {fanInNodeId}");
+        mermaidContent.Should().Contain($"{fanInNodeId} --> t");
+
+        // Ensure direct edges are not present
+        mermaidContent.Should().NotContain("s1 --> t");
+        mermaidContent.Should().NotContain("s2 --> t");
 
         // Display labels should be present
         mermaidContent.Should().Contain("\"start (Start)\"");


### PR DESCRIPTION
This pull request improves the generation of Mermaid diagrams for workflows by ensuring node identifiers are always safe for Mermaid syntax, even when workflow executor IDs contain spaces, special characters, or non-ASCII characters. It introduces a new sanitization method for node IDs, updates the diagram generation logic to use these sanitized aliases, and significantly expands unit tests to cover these cases and verify Mermaid compatibility.

Key changes include:

**Mermaid Node ID Safety and Generation:**

* Added the `SanitizeMermaidNodeId` method to convert raw workflow node IDs into Mermaid-safe ASCII-only aliases, handling spaces, special characters, and non-ASCII text, and guaranteeing uniqueness with suffixes if needed. (`dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs`)
* Updated all Mermaid diagram generation logic to use these sanitized node IDs instead of raw IDs, ensuring that all nodes and edges in the output are Mermaid-compliant. (`dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs`) [[1]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L156-R196) [[2]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L178-R207) [[3]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L187-R218) [[4]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L200-R239)

**Unit Test Improvements:**

* Expanded and updated unit tests to verify that Mermaid diagrams contain only safe node IDs, check for correct edge syntax (especially for conditional/dotted edges), and ensure display labels remain readable. Tests now specifically cover edge cases such as IDs with spaces, pipes, newlines, and Unicode characters. (`dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs`) [[1]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L295-R302) [[2]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L319-R340) [[3]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L356-L366) [[4]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L389-R405) [[5]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L414-R422) [[6]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7R464-R547)

**Bug Fixes (Mermaid Syntax Compliance):**

* Fixed conditional edge rendering to use the correct Mermaid syntax (`-. label .->` instead of the invalid `.-->`). (`dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs`, `dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs`) [[1]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L200-R239) [[2]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L295-R302) [[3]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L389-R405) [[4]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7R464-R547)

**Display Label Handling:**

* Ensured that display labels for nodes are always preserved in quotes, even when the underlying node IDs are sanitized, so the diagrams remain human-readable. (`dotnet/src/Microsoft.Agents.AI.Workflows/Visualization/WorkflowVisualizer.cs`, `dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs`) [[1]](diffhunk://#diff-e06f682457fb54fba39b71ce8881f2f6597ddff918a849233a7790b8fb1419b4L156-R196) [[2]](diffhunk://#diff-8ff33d1ac8201c2b64f3faf7b8707ce126a285ef14e74eaa38442961c98ad9e7L356-L366)

**Regression and Issue Coverage:**

* Added targeted tests for issues reported in #1406, covering both Mermaid syntax for conditional edges and node ID safety with spaces and Unicode. (`dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowVisualizerTests.cs`)

These changes together make Mermaid diagram output robust and compatible in all cases, preventing rendering errors due to problematic node identifiers or edge syntax.

Closes #1406 

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.