### PR TITLE
Python: Strip reserved kwargs in AgentExecutor to prevent duplicate-argument TypeError

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -417,7 +417,7 @@ class AgentExecutor(Executor):
 
     # Parameters that are explicitly passed to agent.run() by AgentExecutor
     # and must not appear in **run_kwargs to avoid TypeError from duplicate values.
-    _RESERVED_RUN_PARAMS: frozenset[str] = frozenset({"session", "stream", "messages", "options", "additional_function_arguments"})
+    _RESERVED_RUN_PARAMS: frozenset[str] = frozenset({"session", "stream", "messages"})
 
     @staticmethod
     def _prepare_agent_run_args(raw_run_kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
@@ -435,7 +435,7 @@ class AgentExecutor(Executor):
         run_kwargs = dict(raw_run_kwargs)
 
         # Strip reserved params that AgentExecutor passes explicitly to agent.run().
-        for key in ("session", "stream", "messages"):
+        for key in AgentExecutor._RESERVED_RUN_PARAMS:
             if key in run_kwargs:
                 logger.warning(
                     "Workflow kwarg '%s' is reserved by AgentExecutor and will be ignored. "

--- a/python/packages/core/tests/workflow/test_agent_executor.py
+++ b/python/packages/core/tests/workflow/test_agent_executor.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import AsyncIterable, Awaitable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -20,6 +20,9 @@ from agent_framework import (
 from agent_framework._workflows._agent_executor import AgentExecutorResponse
 from agent_framework._workflows._checkpoint import InMemoryCheckpointStorage
 from agent_framework.orchestrations import SequentialBuilder
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
 
 
 class _CountingAgent(BaseAgent):
@@ -284,7 +287,7 @@ async def test_agent_executor_run_streaming_with_stream_kwarg_does_not_raise() -
 
 @pytest.mark.parametrize("reserved_kwarg", ["session", "stream", "messages"])
 async def test_prepare_agent_run_args_strips_reserved_kwargs(
-    reserved_kwarg: str, caplog: pytest.LogCaptureFixture
+    reserved_kwarg: str, caplog: "LogCaptureFixture"
 ) -> None:
     """_prepare_agent_run_args must remove reserved kwargs and log a warning."""
     raw = {reserved_kwarg: "should-be-stripped", "custom_key": "keep-me"}
@@ -294,6 +297,8 @@ async def test_prepare_agent_run_args_strips_reserved_kwargs(
 
     assert reserved_kwarg not in run_kwargs
     assert "custom_key" in run_kwargs
+    assert options is not None
+    assert options["additional_function_arguments"]["custom_key"] == "keep-me"
     assert any(reserved_kwarg in record.message for record in caplog.records)
 
 
@@ -303,3 +308,34 @@ async def test_prepare_agent_run_args_preserves_non_reserved_kwargs() -> None:
     run_kwargs, options = AgentExecutor._prepare_agent_run_args(raw)
     assert run_kwargs["custom_param"] == "value"
     assert run_kwargs["another"] == 42
+
+
+async def test_prepare_agent_run_args_strips_all_reserved_kwargs_at_once(
+    caplog: "LogCaptureFixture",
+) -> None:
+    """All reserved kwargs should be stripped when supplied together, each emitting a warning."""
+    raw = {"session": "x", "stream": True, "messages": [], "custom": 1}
+
+    with caplog.at_level(logging.WARNING):
+        run_kwargs, options = AgentExecutor._prepare_agent_run_args(raw)
+
+    assert "session" not in run_kwargs
+    assert "stream" not in run_kwargs
+    assert "messages" not in run_kwargs
+    assert run_kwargs["custom"] == 1
+    assert options is not None
+    assert options["additional_function_arguments"]["custom"] == 1
+
+    warned_keys = {r.message.split("'")[1] for r in caplog.records if "reserved" in r.message.lower()}
+    assert warned_keys == {"session", "stream", "messages"}
+
+
+async def test_agent_executor_run_with_messages_kwarg_does_not_raise() -> None:
+    """Passing messages= via workflow.run() kwargs should not cause a duplicate-keyword TypeError."""
+    agent = _CountingAgent(id="messages_kwarg_agent", name="MessagesKwargAgent")
+    executor = AgentExecutor(agent, id="messages_kwarg_exec")
+    workflow = SequentialBuilder(participants=[executor]).build()
+
+    result = await workflow.run("hello", messages=["stale"])
+    assert result is not None
+    assert agent.call_count == 1


### PR DESCRIPTION
### Motivation and Context

When users pass `session=`, `stream=`, or `messages=` as keyword arguments through `workflow.run()`, those kwargs are forwarded into `AgentExecutor` which also passes them explicitly to `agent.run()`, causing a `TypeError: got multiple values for keyword argument`. This makes the `session` parameter on `workflow.run()` unusable despite being a natural thing for callers to provide.

Fixes #4295

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause is that `_prepare_agent_run_args` did not filter out kwargs that `AgentExecutor` already supplies positionally/explicitly when calling `agent.run()` (namely `session`, `stream`, and `messages`). The fix strips these reserved parameters from the forwarded `run_kwargs` dict before they reach `agent.run()`, and emits a warning so callers know the value was ignored. Tests verify that passing `session=` or `stream=` through `workflow.run()` no longer raises, and that non-reserved kwargs continue to pass through unchanged.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent