### PR TITLE
Python: Fix response_format resolution in streaming path to respect default_options

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -935,6 +935,15 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
                 session.service_session_id = conv_id
             return update
 
+        def _get_merged_response_format() -> Any | None:
+            ctx = ctx_holder["ctx"]
+            if ctx is not None:
+                return ctx["chat_options"].get("response_format")
+            return options.get("response_format") if options else None
+
+        def _finalize_with_merged_options(updates: Sequence[AgentResponseUpdate]) -> AgentResponse:
+            return self._finalize_response_updates(updates, response_format=_get_merged_response_format())
+
         return (
             ResponseStream
             .from_awaitable(_get_stream())
@@ -943,9 +952,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
                     map_chat_to_agent_update,
                     agent_name=self.name,
                 ),
-                finalizer=partial(
-                    self._finalize_response_updates, response_format=options.get("response_format") if options else None
-                ),
+                finalizer=_finalize_with_merged_options,
             )
             .with_transform_hook(_propagate_conversation_id)
             .with_result_hook(_post_hook)

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -1136,4 +1136,47 @@ async def test_stores_by_default_with_store_false_injects_inmemory(client: Suppo
 # endregion
 
 
+async def test_streaming_run_uses_default_options_response_format(client: SupportsChatGetResponse) -> None:
+    """Streaming run should honor default_options response_format for final value parsing (#4300)."""
+    from pydantic import BaseModel
+
+    class Out(BaseModel):
+        x: int
+
+    client.streaming_responses = [  # type: ignore[attr-defined]
+        [ChatResponseUpdate(contents=[Content.from_text('{"x": 42}')], role="assistant")],
+    ]
+
+    agent = Agent(client=client, default_options={"response_format": Out})
+
+    stream = agent.run("hi", stream=True)
+    async for _ in stream:
+        pass
+    final = await stream.get_final_response()
+
+    assert final.value is not None
+    assert isinstance(final.value, Out)
+    assert final.value.x == 42
+
+
+async def test_non_streaming_run_uses_default_options_response_format(client: SupportsChatGetResponse) -> None:
+    """Non-streaming run should honor default_options response_format for value parsing."""
+    from pydantic import BaseModel
+
+    class Out(BaseModel):
+        x: int
+
+    client.responses = [  # type: ignore[attr-defined]
+        ChatResponse(messages=Message(role="assistant", text='{"x": 42}')),
+    ]
+
+    agent = Agent(client=client, default_options={"response_format": Out})
+
+    result = await agent.run("hi")
+
+    assert result.value is not None
+    assert isinstance(result.value, Out)
+    assert result.value.x == 42
+
+
 # endregion


### PR DESCRIPTION
### Motivation and Context

When using `Agent.run(stream=True)`, the finalizer that parses the streamed response into a structured value only checked the per-call `options` for `response_format`, completely ignoring `default_options`. This meant agents configured with a default `response_format` (e.g., a Pydantic model) would never parse the final streamed value, even though non-streaming runs worked correctly.

Fixes #4300

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause was that the streaming finalizer was constructed via `partial()` at stream-creation time using only the per-call `options` dict, before the merged context (which includes `default_options`) was available. The fix replaces the eager `partial` with a closure (`_finalize_with_merged_options`) that defers reading `response_format` until finalization time, when the merged context (`ctx`) is populated. It first checks the merged `chat_options` from the context and falls back to the per-call `options`, matching the resolution order used in the non-streaming path. Two new tests verify that both streaming and non-streaming runs correctly parse structured output when `response_format` is set via `default_options`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent