### PR TITLE
Python: Fix agent option merge to support dict-defined tools

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -81,6 +81,14 @@ OptionsCoT = TypeVar(
 )
 
 
+def _get_tool_name(tool: Any) -> str | None:
+    """Extract the name from a tool, supporting both objects and dicts."""
+    if isinstance(tool, dict):
+        name: str | None = tool.get("function", {}).get("name")
+        return name
+    return getattr(tool, "name", None)
+
+
 def _merge_options(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """Merge two options dicts, with override values taking precedence.
 
@@ -97,8 +105,9 @@ def _merge_options(base: dict[str, Any], override: dict[str, Any]) -> dict[str, 
             continue
         if key == "tools" and result.get("tools"):
             # Combine tool lists, avoiding duplicates by name
-            existing_names = {getattr(t, "name", None) for t in result["tools"]}
-            unique_new = [t for t in value if getattr(t, "name", None) not in existing_names]
+            existing_names = {_get_tool_name(t) for t in result["tools"]}
+            existing_names.discard(None)
+            unique_new = [t for t in value if _get_tool_name(t) not in existing_names]
             result["tools"] = list(result["tools"]) + unique_new
         elif key == "logit_bias" and result.get("logit_bias"):
             # Merge logit_bias dicts

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -25,7 +25,7 @@ from agent_framework import (
     SupportsChatGetResponse,
     tool,
 )
-from agent_framework._agents import _merge_options, _sanitize_agent_name
+from agent_framework._agents import _get_tool_name, _merge_options, _sanitize_agent_name
 from agent_framework._mcp import MCPTool
 
 
@@ -878,6 +878,71 @@ def test_merge_options_tools_combined():
     tool_names = [t.name for t in result["tools"]]
     assert "tool1" in tool_names
     assert "tool2" in tool_names
+
+
+def test_merge_options_dict_tools_combined():
+    """Test _merge_options combines dict-defined tool lists without dropping tools."""
+    base = {
+        "tools": [
+            {"type": "function", "function": {"name": "tool_a"}},
+        ]
+    }
+    override = {
+        "tools": [
+            {"type": "function", "function": {"name": "tool_b"}},
+        ]
+    }
+
+    result = _merge_options(base, override)
+
+    assert len(result["tools"]) == 2
+    names = [_get_tool_name(t) for t in result["tools"]]
+    assert "tool_a" in names
+    assert "tool_b" in names
+
+
+def test_merge_options_dict_tools_deduplicates():
+    """Test _merge_options deduplicates dict-defined tools by function name."""
+    base = {
+        "tools": [
+            {"type": "function", "function": {"name": "tool_a"}},
+        ]
+    }
+    override = {
+        "tools": [
+            {"type": "function", "function": {"name": "tool_a"}},
+            {"type": "function", "function": {"name": "tool_b"}},
+        ]
+    }
+
+    result = _merge_options(base, override)
+
+    assert len(result["tools"]) == 2
+    names = [_get_tool_name(t) for t in result["tools"]]
+    assert names.count("tool_a") == 1
+    assert "tool_b" in names
+
+
+def test_get_tool_name_dict():
+    """Test _get_tool_name extracts name from dict-defined tools."""
+    tool = {"type": "function", "function": {"name": "my_tool"}}
+    assert _get_tool_name(tool) == "my_tool"
+
+
+def test_get_tool_name_object():
+    """Test _get_tool_name extracts name from object-defined tools."""
+
+    class MockTool:
+        def __init__(self, name):
+            self.name = name
+
+    assert _get_tool_name(MockTool("my_tool")) == "my_tool"
+
+
+def test_get_tool_name_no_name():
+    """Test _get_tool_name returns None when no name is available."""
+    assert _get_tool_name({}) is None
+    assert _get_tool_name(42) is None
 
 
 def test_merge_options_logit_bias_merged():


### PR DESCRIPTION
### Motivation and Context

When tools were defined as plain dicts (the `{"type": "function", "function": {"name": ...}}` format accepted by OpenAI-compatible APIs), `_merge_options` used `getattr(t, "name", None)` to extract tool names for deduplication, which always returned `None` for dicts — causing all override tools to be silently dropped as false-positive duplicates.

Fixes #4303

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause was that `_merge_options` assumed tools were always objects with a `.name` attribute. For dict-defined tools, the name lives at `tool["function"]["name"]`, so `getattr` returned `None` for every tool, and the `None`-populated `existing_names` set incorrectly matched all incoming tools. The fix introduces a `_get_tool_name` helper that handles both object and dict tool formats, and discards `None` from the existing-names set so that unnamed tools never cause spurious deduplication.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent