### PR TITLE
Python: fix(python): Handle thread.message.completed event in Assistants API streaming

### DIFF
--- a/python/packages/core/agent_framework/openai/_assistants_client.py
+++ b/python/packages/core/agent_framework/openai/_assistants_client.py
@@ -634,8 +634,6 @@ class OpenAIAssistantsClient(  # type: ignore[misc]
                                     props: dict[str, Any] = {
                                         "text": completed_annotation.text,
                                     }
-                                    if completed_annotation.file_citation and completed_annotation.file_citation.quote:
-                                        props["quote"] = completed_annotation.file_citation.quote
                                     ann = Annotation(
                                         type="citation",
                                         additional_properties=props,

--- a/python/packages/core/tests/openai/test_openai_assistants_client.py
+++ b/python/packages/core/tests/openai/test_openai_assistants_client.py
@@ -1610,7 +1610,6 @@ def _make_file_citation_annotation(
     file_id: str = "file-abc123",
     start_index: int = 10,
     end_index: int = 24,
-    quote: str | None = None,
 ) -> MagicMock:
     """Create a mock FileCitationAnnotation."""
     annotation = MagicMock(spec=FileCitationAnnotation)
@@ -1619,7 +1618,6 @@ def _make_file_citation_annotation(
     annotation.end_index = end_index
     annotation.file_citation = MagicMock()
     annotation.file_citation.file_id = file_id
-    annotation.file_citation.quote = quote
     return annotation
 
 
@@ -1722,41 +1720,7 @@ class TestMessageCompletedAnnotations:
         assert ann["annotated_regions"][0]["start_index"] == 10
         assert ann["annotated_regions"][0]["end_index"] == 24
 
-    @pytest.mark.asyncio
-    async def test_message_completed_with_file_citation_quote(self, client):
-        """Verify the quote field from file_citation is included in additional_properties."""
-        citation = _make_file_citation_annotation(
-            text="【4:0†source】",
-            file_id="file-abc123",
-            start_index=10,
-            end_index=24,
-            quote="The exact quoted text from the source document.",
-        )
-        text_block = _make_text_block("Some text【4:0†source】", [citation])
-        msg = _make_thread_message([text_block])
 
-        events = [_make_stream_event("thread.message.completed", msg)]
-        updates = await _collect_updates(client, events)
-
-        assert len(updates) == 1
-        ann = updates[0].contents[0].annotations[0]
-        assert ann["additional_properties"]["quote"] == "The exact quoted text from the source document."
-
-    @pytest.mark.asyncio
-    async def test_message_completed_with_file_citation_no_quote(self, client):
-        """Verify annotations work when quote is None (not all citations have quotes)."""
-        citation = _make_file_citation_annotation(
-            text="【4:0†source】", file_id="file-abc123", start_index=10, end_index=24, quote=None
-        )
-        text_block = _make_text_block("Some text【4:0†source】", [citation])
-        msg = _make_thread_message([text_block])
-
-        events = [_make_stream_event("thread.message.completed", msg)]
-        updates = await _collect_updates(client, events)
-
-        assert len(updates) == 1
-        ann = updates[0].contents[0].annotations[0]
-        assert "quote" not in ann["additional_properties"]
 
     @pytest.mark.asyncio
     async def test_message_completed_with_file_path(self, client):


### PR DESCRIPTION
## Summary

Fixes #4322

Previously, `thread.message.completed` streaming events fell through to the catch-all `else` branch in `_process_stream_events`, yielding empty `ChatResponseUpdate` objects. This silently discarded fully-resolved annotation data — file citations with IDs, quotes, and character-offset regions.

## Changes

### `_assistants_client.py`

- **New imports**: `FileCitationAnnotation`, `FilePathAnnotation`, `Message as ThreadMessage` from `openai.types.beta.threads`; `Annotation`, `TextSpanRegion` from `_types`
- **New `elif` branch** for `thread.message.completed` in `_process_stream_events` that:
  - Walks the completed `ThreadMessage.content` array
  - Skips non-text blocks (e.g., `image_file`)
  - For text blocks, extracts fully-resolved annotations:
    - `FileCitationAnnotation` → `Annotation(type="citation")` with `file_id` and `TextSpanRegion`
    - `FilePathAnnotation` → same mapping pattern
  - Yields a `ChatResponseUpdate` with the complete text and annotations

### `test_assistants_message_completed.py` (new)

7 test cases covering:
- File citation annotation extraction
- File path annotation extraction
- Multiple annotations on a single text block
- Text-only messages (no annotations)
- Non-text blocks are skipped
- Mixed content blocks (text + image)
- Conversation ID propagation

## Impact

Users of the Assistants API with `file_search` or `code_interpreter` will now receive resolved citation annotations in streaming responses, enabling proper citation rendering.
