### PR TITLE
Python: Fix handoff workflow with store=False sending server-assigned item IDs

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -849,7 +849,7 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
 
         # When store=False, strip server-assigned IDs from reasoning and function_call
         # items. These IDs (rs_*, fc_*) reference server-persisted objects that don't exist
-        # when store is disabled, causing "Item not found" API errors during handoff workflows.
+        # when store is disabled, causing "Item not found" API errors.
         if run_options.get("store") is False:
             for item in run_options.get("input", []):
                 if isinstance(item, dict):

--- a/python/packages/core/tests/openai/test_openai_responses_client.py
+++ b/python/packages/core/tests/openai/test_openai_responses_client.py
@@ -2889,12 +2889,12 @@ async def test_prepare_options_strips_reasoning_and_function_call_ids_when_store
     items when store=False.
 
     When store is disabled, server-assigned IDs (rs_*, fc_*) reference non-existent
-    server-persisted objects, causing 'Item not found' API errors during handoff workflows.
+    server-persisted objects, causing 'Item not found' API errors.
     See: https://github.com/microsoft/agent-framework/issues/4357
     """
     client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
 
-    # Simulate a handoff conversation with reasoning + function_call from a previous turn
+    # Simulate a multi-turn conversation with reasoning + function_call from a previous turn
     messages = [
         Message(role="user", contents=[Content.from_text(text="search for hotels")]),
         Message(


### PR DESCRIPTION
## Motivation and Context

Fixes #4357

When `store=False`, server-assigned item IDs (`rs_*` for reasoning, `fc_*` for function calls) reference non-existent server-persisted objects. During handoff workflows, these IDs are replayed in the input, causing `Item not found` API errors:

```
openai.BadRequestError: Error code: 400 - {
    'error': {
        'message': "Item 'rs_...' not found in the session's conversation.",
        'type': 'invalid_request_error',
        ...
    }
}
```

## Description

This PR adds a post-processing step in `_prepare_options()` that strips the `id` field from `reasoning` and `function_call` input items when `store=False`. This ensures these items are replayed **by value** rather than **by reference** when server-side persistence is disabled.

### Changes

**`_responses_client.py`**
- Added ID-stripping logic at the end of `_prepare_options()`, right before returning `run_options`
- Only activates when `store` is explicitly `False`
- Targets only `reasoning` and `function_call` item types

**`test_openai_responses_client.py`**
- Added `test_prepare_options_strips_reasoning_and_function_call_ids_when_store_false` — verifies IDs are removed from reasoning and function_call items when `store=False`
- Added `test_prepare_options_preserves_reasoning_and_function_call_ids_when_store_true` — verifies IDs are preserved when `store=True`

Both tests simulate a realistic handoff conversation with reasoning + function_call + function_result + text messages.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR title follows the repo convention
- [x] Tests added to cover the change
- [x] All new and existing tests pass