### PR TITLE
Python: fix: stop treating backtick-quoted paths as resource references in Fi…

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -58,12 +58,13 @@ _FRONTMATTER_RE = re.compile(
 )
 
 # Matches resource file references in skill markdown. Group 1 = relative file path.
-# Supports two forms:
-#   1. Markdown links: [text](path/file.ext)
-#   2. Backtick-quoted paths: `path/file.ext`
+# Only matches markdown links: [text](path/file.ext)
+# Backtick-quoted paths are intentionally excluded because backticks are standard
+# inline code formatting in markdown and do not imply the referenced file exists
+# in the skill directory.
 # Supports optional ./ or ../ prefixes; excludes URLs (no ":" in the path character class).
 _RESOURCE_LINK_RE = re.compile(
-    r"(?:\[.*?\]\(|`)(\.?\.?/?[\w][\w\-./]*\.\w+)(?:\)|`)",
+    r"\[.*?\]\((\.?\.?/?[\w][\w\-./]*\.\w+)\)",
 )
 
 # Matches YAML "key: value" lines. Group 1 = key, Group 2 = quoted value,

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -117,15 +117,17 @@ class TestExtractResourcePaths:
     def test_empty_content(self) -> None:
         assert _extract_resource_paths("") == []
 
-    def test_extracts_backtick_quoted_paths(self) -> None:
+    def test_ignores_backtick_quoted_paths(self) -> None:
+        """Backtick-quoted filenames are standard markdown code formatting, not resource references."""
         content = "Use the template at `assets/template.md` and the script `./scripts/run.py`."
         paths = _extract_resource_paths(content)
-        assert paths == ["assets/template.md", "scripts/run.py"]
+        assert paths == []
 
-    def test_deduplicates_across_link_and_backtick(self) -> None:
+    def test_backtick_filenames_do_not_shadow_markdown_links(self) -> None:
+        """Markdown links are still extracted even when backtick filenames are present."""
         content = "See [doc](refs/FAQ.md) and also `refs/FAQ.md`."
         paths = _extract_resource_paths(content)
-        assert len(paths) == 1
+        assert paths == ["refs/FAQ.md"]
 
 
 class TestTryParseSkillDocument:
@@ -287,6 +289,18 @@ class TestDiscoverAndLoadSkills:
         )
         skills = _discover_and_load_skills([str(tmp_path)])
         assert len(skills) == 0
+
+    def test_loads_skill_with_backtick_filenames_that_do_not_exist(self, tmp_path: Path) -> None:
+        """Backtick-quoted filenames should not be treated as resource references (issue #4369)."""
+        _write_skill(
+            tmp_path,
+            "my-skill",
+            body="Configure using `config.json` and `deploy.sh`.\nSee [prompt](prompt.jinja2) for the template.",
+            resources={"prompt.jinja2": "template content"},
+        )
+        skills = _discover_and_load_skills([str(tmp_path)])
+        assert "my-skill" in skills
+        assert skills["my-skill"].resource_names == ["prompt.jinja2"]
 
     def test_excludes_skill_with_path_traversal_resource(self, tmp_path: Path) -> None:
         _write_skill(


### PR DESCRIPTION
fix: Stop treating backtick-quoted paths as resource references in
  FileAgentSkillsProvider

   Backtick-quoted filenames in SKILL.md bodies (e.g. `config.json`) were incorrectly
  treated as resource file references by _RESOURCE_LINK_RE. When those files did not
  exist in the skill directory, the entire skill was excluded with a warning.

   Backticks are standard markdown inline code formatting and do not imply the referenced
   file exists locally. Only explicit markdown links [text]\(path\) should be validated
  as resource references.

   Changes:
   - Update _RESOURCE_LINK_RE regex to match only markdown link syntax
   - Update tests to verify backtick paths are ignored
   - Add integration test for the reported scenario (issue #4369)

   Fixes #4369

   ### Motivation and Context

   `FileAgentSkillsProvider` incorrectly treats backtick-quoted filenames (e.g.
  `config.json`) in SKILL.md as resource file references. When those files don't exist in
   the skill directory, the entire skill is excluded. This makes it impossible to use
  standard markdown inline code formatting to mention filenames in skill documentation
  without also providing those files on disk. Fixes #4369.

   ### Description

   Updated `_RESOURCE_LINK_RE` to only match explicit markdown link syntax
  (`[text](path/file.ext)`), removing the backtick alternative. Backticks are standard
  markdown code formatting and should not imply a file exists locally.

   Updated two existing tests to reflect the new behavior and added an integration-level
  test that verifies a skill with backtick-quoted filenames (that don't exist on disk)
  still loads successfully.

   **Note:** The .NET implementation has the same regex in `FileAgentSkillLoader.cs`
  (line 48) and is affected by the same bug. Will open a separate issue for the .NET fix
  after this PR lands.

   ### Contribution Checklist

   - [x] The code builds clean without any errors or warnings
   - [x] The PR follows the [Contribution
  Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
   - [x] All unit tests pass, and I have added new tests where possible
   - [ ] **Is this a breaking change?** Minor behavioral change: skills that relied on
  backtick-quoted paths to register resources will need to switch to markdown link syntax
   (`[text](path)`). Pre-GA.