### PR TITLE
.NET: Fix FileAgentSkillsProvider custom SkillsInstructionPrompt silently dropping skills

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/FileAgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/FileAgentSkillsProvider.cs
@@ -174,7 +174,8 @@ public sealed partial class FileAgentSkillsProvider : AIContextProvider
         {
             try
             {
-                promptTemplate = string.Format(optionsInstructions, string.Empty);
+                _ = string.Format(optionsInstructions, string.Empty);
+                promptTemplate = optionsInstructions;
             }
             catch (FormatException ex)
             {

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillsProviderTests.cs
@@ -108,6 +108,8 @@ public sealed class FileAgentSkillsProviderTests : IDisposable
         // Assert
         Assert.NotNull(result.Instructions);
         Assert.StartsWith("Custom template:", result.Instructions);
+        Assert.Contains("custom-prompt-skill", result.Instructions);
+        Assert.Contains("Custom prompt", result.Instructions);
     }
 
     [Fact]


### PR DESCRIPTION
## Fix

Fixes #4344

### Problem

When providing a custom `SkillsInstructionPrompt` via `FileAgentSkillsProviderOptions`, the template validation in `BuildSkillsInstructionPrompt` prematurely rendered the template with an empty string and assigned the result back to `promptTemplate`:

```csharp
promptTemplate = string.Format(optionsInstructions, string.Empty);
```

This replaced the `{0}` placeholder, so when the actual skills XML was later passed to `string.Format(promptTemplate, sb.ToString())`, it was silently discarded. The LLM never saw any skills in its system instructions.

### Fix

The validation now discards the rendered result and preserves the original template:

```csharp
_ = string.Format(optionsInstructions, string.Empty); // validate only
promptTemplate = optionsInstructions;                  // keep {0} intact
```

### Test improvement

Strengthened the `InvokingCoreAsync_CustomPromptTemplate_UsesCustomTemplateAsync` test to verify that skill name and description actually appear in the rendered output, not just the template prefix.