### PR TITLE
Python: fix(python): Use AgentResponse.value instead of model_validate_json in HITL sample

### DIFF
--- a/python/samples/03-workflows/human-in-the-loop/guessing_game_with_human_input.py
+++ b/python/samples/03-workflows/human-in-the-loop/guessing_game_with_human_input.py
@@ -108,7 +108,13 @@ class TurnManager(Executor):
         # Access the parsed structured model output via .value.
         # Since the agent is configured with response_format=GuessOutput,
         # .value returns the parsed GuessOutput instance directly.
-        last_guess = result.agent_response.value.guess
+        agent_value = result.agent_response.value
+        if agent_value is None:
+            raise RuntimeError(
+                "AgentResponse.value is None. Ensure that the agent is invoked with "
+                "options={'response_format': GuessOutput} so structured output is available."
+            )
+        last_guess = agent_value.guess
 
         # Craft a precise human prompt that defines higher and lower relative to the agent's guess.
         prompt = (


### PR DESCRIPTION
## Summary

Fixes #4396

The HITL `guessing_game_with_human_input.py` sample used `model_validate_json()` to manually parse the agent's structured output:

```python
text = result.agent_response.text
last_guess = GuessOutput.model_validate_json(text).guess
```

Since the agent is configured with `response_format=GuessOutput`, the `AgentResponse` object already provides a `.value` property that returns the parsed Pydantic model directly:

```python
last_guess = result.agent_response.value.guess
```

## Changes

### `guessing_game_with_human_input.py`
- Replaced `GuessOutput.model_validate_json(text).guess` → `result.agent_response.value.guess`
- Updated docstring comments to explain `.value` usage
- Removed unused `text` variable assignment

## Notes

Other sample files (`edge_condition.py`, `multi_selection_edge_group.py`) also use `model_validate_json` with structured outputs, but their usage is in edge conditions and non-`AgentExecutorResponse` contexts (e.g. parsing from `ChatClient.get_response().messages[-1].text`), which are more nuanced. This PR focuses on the primary file called out in the issue. A follow-up PR can address the remaining samples if desired.