### PR TITLE
Python: Fix StandardMagenticManager to propagate session to manager agent

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -744,7 +744,7 @@ class StandardMagenticManager(MagenticManagerBase):
             except Exception:  # pragma: no cover - defensive
                 logger.warning("Failed to restore manager task ledger from checkpoint state")
         session_payload = state.get("agent_session")
-        if session_payload:
+        if session_payload is not None:
             try:
                 self._session = AgentSession.from_dict(session_payload)
             except Exception:  # pragma: no cover - defensive

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, TypeVar, cast
 
 from agent_framework import (
     AgentResponse,
+    AgentSession,
     Message,
     SupportsAgentRun,
 )
@@ -559,6 +560,7 @@ class StandardMagenticManager(MagenticManagerBase):
         )
 
         self._agent: SupportsAgentRun = agent
+        self._session: AgentSession = self._agent.create_session()
         self.task_ledger: _MagenticTaskLedger | None = task_ledger
 
         # Prompts may be overridden if needed
@@ -587,7 +589,7 @@ class StandardMagenticManager(MagenticManagerBase):
         The agent's run method is called which applies the agent's configured options
         (temperature, seed, instructions, etc.).
         """
-        response: AgentResponse = await self._agent.run(messages)
+        response: AgentResponse = await self._agent.run(messages, session=self._session)
         if not response.messages:
             raise RuntimeError("Agent returned no messages in response.")
         if len(response.messages) > 1:
@@ -730,6 +732,7 @@ class StandardMagenticManager(MagenticManagerBase):
         state: dict[str, Any] = {}
         if self.task_ledger is not None:
             state["task_ledger"] = self.task_ledger.to_dict()
+        state["agent_session"] = self._session.to_dict()
         return state
 
     @override
@@ -740,6 +743,12 @@ class StandardMagenticManager(MagenticManagerBase):
                 self.task_ledger = _MagenticTaskLedger.from_dict(ledger)
             except Exception:  # pragma: no cover - defensive
                 logger.warning("Failed to restore manager task ledger from checkpoint state")
+        session_payload = state.get("agent_session")
+        if session_payload:
+            try:
+                self._session = AgentSession.from_dict(session_payload)
+            except Exception:  # pragma: no cover - defensive
+                logger.warning("Failed to restore manager agent session from checkpoint state")
 
 
 # endregion Magentic Manager

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1110,23 +1110,23 @@ async def test_standard_manager_propagates_session_to_agent():
     assert len(captured_sessions) == 2
     assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
     assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
-    assert captured_sessions[0] is getattr(mgr, "_session")
+    assert captured_sessions[0] is mgr._session
 
 
 async def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session_id = getattr(mgr, "_session").session_id
+    original_session_id = mgr._session.session_id
 
     state = mgr.on_checkpoint_save()
     assert "agent_session" in state
 
     # Restore into a fresh manager and verify session_id is preserved
     mgr2 = StandardMagenticManager(agent=agent)
-    assert getattr(mgr2, "_session").session_id != original_session_id
+    assert mgr2._session.session_id != original_session_id
     mgr2.on_checkpoint_restore(state)
-    assert getattr(mgr2, "_session").session_id == original_session_id
+    assert mgr2._session.session_id == original_session_id
 
 
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1110,35 +1110,35 @@ async def test_standard_manager_propagates_session_to_agent():
     assert len(captured_sessions) == 2
     assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
     assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
-    assert captured_sessions[0] is getattr(mgr, "_session")
+    assert captured_sessions[0] is mgr._session
 
 
 def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session_id = getattr(mgr, "_session").session_id
+    original_session_id = mgr._session.session_id
 
     state = mgr.on_checkpoint_save()
     assert "agent_session" in state
 
     # Restore into a fresh manager and verify session_id is preserved
     mgr2 = StandardMagenticManager(agent=agent)
-    assert getattr(mgr2, "_session").session_id != original_session_id
+    assert mgr2._session.session_id != original_session_id
     mgr2.on_checkpoint_restore(state)
-    assert getattr(mgr2, "_session").session_id == original_session_id
+    assert mgr2._session.session_id == original_session_id
 
 
 def test_standard_manager_checkpoint_restore_empty_state():
     """Verify that restoring from a state without agent_session leaves the session intact."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session = getattr(mgr, "_session")
+    original_session = mgr._session
     original_session_id = original_session.session_id
 
     mgr.on_checkpoint_restore({})
-    assert getattr(mgr, "_session") is original_session
-    assert getattr(mgr, "_session").session_id == original_session_id
+    assert mgr._session is original_session
+    assert mgr._session.session_id == original_session_id
 
 
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1074,4 +1074,59 @@ def test_magentic_agent_factory_with_standard_manager_options():
     assert manager.final_answer_prompt == custom_final_prompt
 
 
+async def test_standard_manager_propagates_session_to_agent():
+    """Verify StandardMagenticManager passes a consistent session to the underlying agent.
+
+    Regression test for #4371: context providers (e.g. RedisHistoryProvider) configured on
+    the manager agent silently failed because no session was propagated.
+    """
+    captured_sessions: list[AgentSession | None] = []
+
+    class SessionCapturingAgent(BaseAgent):
+        """Agent that records the session passed to each run() call."""
+
+        def run(
+            self,
+            messages: str | Content | Message | Sequence[str | Content | Message] | None = None,
+            *,
+            stream: bool = False,
+            session: Any = None,
+            **kwargs: Any,
+        ) -> Awaitable[AgentResponse] | AsyncIterable[AgentResponseUpdate]:
+            captured_sessions.append(session)
+
+            async def _run() -> AgentResponse:
+                return AgentResponse(messages=[Message("assistant", ["ok"])])
+
+            return _run()
+
+    agent = SessionCapturingAgent()
+    mgr = StandardMagenticManager(agent=agent)
+    ctx = MagenticContext(task="task", participant_descriptions={"a": "desc"})
+
+    await mgr.plan(ctx.clone())
+
+    # plan() calls _complete twice (facts + plan), both should receive the same session
+    assert len(captured_sessions) == 2
+    assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
+    assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
+    assert captured_sessions[0] is mgr._session
+
+
+async def test_standard_manager_checkpoint_preserves_session():
+    """Verify that checkpoint save/restore preserves the manager's session identity."""
+    agent = StubManagerAgent()
+    mgr = StandardMagenticManager(agent=agent)
+    original_session_id = mgr._session.session_id
+
+    state = mgr.on_checkpoint_save()
+    assert "agent_session" in state
+
+    # Restore into a fresh manager and verify session_id is preserved
+    mgr2 = StandardMagenticManager(agent=agent)
+    assert mgr2._session.session_id != original_session_id
+    mgr2.on_checkpoint_restore(state)
+    assert mgr2._session.session_id == original_session_id
+
+
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1110,23 +1110,23 @@ async def test_standard_manager_propagates_session_to_agent():
     assert len(captured_sessions) == 2
     assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
     assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
-    assert captured_sessions[0] is mgr._session
+    assert captured_sessions[0] is mgr._session  # type: ignore[reportPrivateUsage]
 
 
 async def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session_id = mgr._session.session_id
+    original_session_id = mgr._session.session_id  # type: ignore[reportPrivateUsage]
 
     state = mgr.on_checkpoint_save()
     assert "agent_session" in state
 
     # Restore into a fresh manager and verify session_id is preserved
     mgr2 = StandardMagenticManager(agent=agent)
-    assert mgr2._session.session_id != original_session_id
+    assert mgr2._session.session_id != original_session_id  # type: ignore[reportPrivateUsage]
     mgr2.on_checkpoint_restore(state)
-    assert mgr2._session.session_id == original_session_id
+    assert mgr2._session.session_id == original_session_id  # type: ignore[reportPrivateUsage]
 
 
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1110,23 +1110,23 @@ async def test_standard_manager_propagates_session_to_agent():
     assert len(captured_sessions) == 2
     assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
     assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
-    assert captured_sessions[0] is mgr._session  # type: ignore[reportPrivateUsage]
+    assert captured_sessions[0] is getattr(mgr, "_session")
 
 
 async def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session_id = mgr._session.session_id  # type: ignore[reportPrivateUsage]
+    original_session_id = getattr(mgr, "_session").session_id
 
     state = mgr.on_checkpoint_save()
     assert "agent_session" in state
 
     # Restore into a fresh manager and verify session_id is preserved
     mgr2 = StandardMagenticManager(agent=agent)
-    assert mgr2._session.session_id != original_session_id  # type: ignore[reportPrivateUsage]
+    assert getattr(mgr2, "_session").session_id != original_session_id
     mgr2.on_checkpoint_restore(state)
-    assert mgr2._session.session_id == original_session_id  # type: ignore[reportPrivateUsage]
+    assert getattr(mgr2, "_session").session_id == original_session_id
 
 
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1110,23 +1110,35 @@ async def test_standard_manager_propagates_session_to_agent():
     assert len(captured_sessions) == 2
     assert all(s is not None for s in captured_sessions), "session must be passed to agent.run()"
     assert captured_sessions[0] is captured_sessions[1], "same session instance must be reused across calls"
-    assert captured_sessions[0] is mgr._session
+    assert captured_sessions[0] is getattr(mgr, "_session")
 
 
 async def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
-    original_session_id = mgr._session.session_id
+    original_session_id = getattr(mgr, "_session").session_id
 
     state = mgr.on_checkpoint_save()
     assert "agent_session" in state
 
     # Restore into a fresh manager and verify session_id is preserved
     mgr2 = StandardMagenticManager(agent=agent)
-    assert mgr2._session.session_id != original_session_id
+    assert getattr(mgr2, "_session").session_id != original_session_id
     mgr2.on_checkpoint_restore(state)
-    assert mgr2._session.session_id == original_session_id
+    assert getattr(mgr2, "_session").session_id == original_session_id
+
+
+async def test_standard_manager_checkpoint_restore_empty_state():
+    """Verify that restoring from a state without agent_session leaves the session intact."""
+    agent = StubManagerAgent()
+    mgr = StandardMagenticManager(agent=agent)
+    original_session = getattr(mgr, "_session")
+    original_session_id = original_session.session_id
+
+    mgr.on_checkpoint_restore({})
+    assert getattr(mgr, "_session") is original_session
+    assert getattr(mgr, "_session").session_id == original_session_id
 
 
 # endregion

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -1113,7 +1113,7 @@ async def test_standard_manager_propagates_session_to_agent():
     assert captured_sessions[0] is getattr(mgr, "_session")
 
 
-async def test_standard_manager_checkpoint_preserves_session():
+def test_standard_manager_checkpoint_preserves_session():
     """Verify that checkpoint save/restore preserves the manager's session identity."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)
@@ -1129,7 +1129,7 @@ async def test_standard_manager_checkpoint_preserves_session():
     assert getattr(mgr2, "_session").session_id == original_session_id
 
 
-async def test_standard_manager_checkpoint_restore_empty_state():
+def test_standard_manager_checkpoint_restore_empty_state():
     """Verify that restoring from a state without agent_session leaves the session intact."""
     agent = StubManagerAgent()
     mgr = StandardMagenticManager(agent=agent)


### PR DESCRIPTION
### Motivation and Context

`StandardMagenticManager` did not create or pass an `AgentSession` when calling its internal agent's `run()` method. This caused context providers (e.g. `RedisHistoryProvider`) configured on the manager agent to silently fail, since they rely on a session to scope and retrieve conversation history.

Fixes #4371

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause was that `StandardMagenticManager._complete()` called `self._agent.run(messages)` without a `session` argument, so context providers never received the session they need to function. The fix creates a persistent `AgentSession` during manager initialization and passes it on every `run()` call. Additionally, the session is included in checkpoint save/restore so it survives orchestration snapshots.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent