### PR TITLE
Python: Fix ChatKit integration sample for latest API changes and proxy setup

### DIFF
--- a/python/samples/02-agents/chat_client/built_in_chat_clients.py
+++ b/python/samples/02-agents/chat_client/built_in_chat_clients.py
@@ -5,7 +5,7 @@ import os
 from random import randint
 from typing import Annotated, Any, Literal
 
-from agent_framework import SupportsChatGetResponse, tool
+from agent_framework import Content, Message, SupportsChatGetResponse, tool
 from agent_framework.azure import (
     AzureAIAgentClient,
     AzureOpenAIAssistantsClient,
@@ -117,10 +117,11 @@ async def main(client_name: ClientName = "openai_chat") -> None:
     client = get_client(client_name)
 
     # 1. Configure prompt and streaming mode.
-    message = "What's the weather in Amsterdam and in Paris?"
+    prompt = "What's the weather in Amsterdam and in Paris?"
+    message = [Message(role="user", contents=[Content.from_text(prompt)])]
     stream = os.getenv("STREAM", "false").lower() == "true"
     print(f"Client: {client_name}")
-    print(f"User: {message}")
+    print(f"User: {prompt}")
 
     # 2. Run with context-managed clients.
     if isinstance(client, OpenAIAssistantsClient | AzureOpenAIAssistantsClient | AzureAIAgentClient):

--- a/python/samples/02-agents/chat_client/chat_response_cancellation.py
+++ b/python/samples/02-agents/chat_client/chat_response_cancellation.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from agent_framework import Content, Message
 from agent_framework.openai import OpenAIChatClient
 from dotenv import load_dotenv
 
@@ -28,7 +29,7 @@ async def main() -> None:
     client = OpenAIChatClient()
 
     try:
-        task = asyncio.create_task(client.get_response(messages=["Tell me a fantasy story."]))
+        task = asyncio.create_task(client.get_response([Message(role="user", contents=[Content.from_text("Tell me a fantasy story.")])]))
         await asyncio.sleep(1)
         task.cancel()
         await task

--- a/python/samples/02-agents/chat_client/custom_chat_client.py
+++ b/python/samples/02-agents/chat_client/custom_chat_client.py
@@ -146,7 +146,7 @@ async def main() -> None:
     # Use the chat client directly
     print("Using chat client directly:")
     direct_response = await echo_client.get_response(
-        "Hello, custom chat client!",
+        [Message(role="user", contents=[Content.from_text("Hello, custom chat client!")])],
         options={
             "uppercase": True,
             "suffix": "(CUSTOM OPTIONS)",

--- a/python/samples/05-end-to-end/chatkit-integration/app.py
+++ b/python/samples/05-end-to-end/chatkit-integration/app.py
@@ -28,7 +28,8 @@ from typing import Annotated, Any
 import uvicorn
 
 # Agent Framework imports
-from agent_framework import Agent, AgentResponseUpdate, FunctionResultContent, Message, Role, tool
+#from agent_framework import Agent, AgentResponseUpdate, FunctionResultContent, Message, Role, tool
+from agent_framework import Agent, AgentResponseUpdate, Content, Message, Role, tool
 from agent_framework.azure import AzureOpenAIChatClient
 
 # Agent Framework ChatKit integration
@@ -75,7 +76,11 @@ load_dotenv()
 # Server configuration
 SERVER_HOST = "127.0.0.1"  # Bind to localhost only for security (local dev)
 SERVER_PORT = 8001
-SERVER_BASE_URL = f"http://localhost:{SERVER_PORT}"
+# Use the frontend origin for generated URLs (upload, preview) so that the browser
+# sends them through the Vite dev-server proxy instead of directly to the backend,
+# avoiding cross-origin issues.
+FRONTEND_PORT = 5171
+SERVER_BASE_URL = f"http://localhost:{FRONTEND_PORT}"
 
 # Database configuration
 DATABASE_PATH = "chatkit_demo.db"
@@ -295,7 +300,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
 
             title_prompt = [
                 Message(
-                    role=Role.USER,
+                    role="user",
                     text=(
                         f"Generate a very short, concise title (max 40 characters) for a conversation "
                         f"that starts with:\n\n{conversation_context}\n\n"
@@ -346,8 +351,6 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
         runs the agent, converts the response back to ChatKit events using stream_agent_response,
         and creates interactive weather widgets when weather data is queried.
         """
-        from agent_framework import FunctionResultContent
-
         if input_user_message is None:
             logger.debug("Received None user message, skipping")
             return
@@ -389,7 +392,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
                     # Check for function results in the update
                     if update.contents:
                         for content in update.contents:
-                            if isinstance(content, FunctionResultContent):
+                            if isinstance(content, Content) and content.type == "function_result":
                                 result = content.result
 
                                 # Check if it's a WeatherResponse (string subclass with weather_data attribute)
@@ -472,7 +475,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
             weather_data: WeatherData | None = None
 
             # Create an agent message asking about the weather
-            agent_messages = [Message(role=Role.USER, text=f"What's the weather in {city_label}?")]
+            agent_messages = [Message(role="user", text=f"What's the weather in {city_label}?")]
 
             logger.debug(f"Processing weather query: {agent_messages[0].text}")
 
@@ -486,7 +489,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
                     # Check for function results in the update
                     if update.contents:
                         for content in update.contents:
-                            if isinstance(content, FunctionResultContent):
+                            if isinstance(content, Content) and content.type == "function_result":
                                 result = content.result
 
                                 # Check if it's a WeatherResponse (string subclass with weather_data attribute)
@@ -598,8 +601,8 @@ async def upload_file(attachment_id: str, file: UploadFile = File(...)):  # noqa
         # Load the attachment metadata from the data store
         attachment = await data_store.load_attachment(attachment_id, {"user_id": DEFAULT_USER_ID})
 
-        # Clear the upload_url since upload is complete
-        attachment.upload_url = None
+        # Clear the upload_descriptor since upload is complete
+        attachment.upload_descriptor = None
 
         # Save the updated attachment back to the store
         await data_store.save_attachment(attachment, {"user_id": DEFAULT_USER_ID})

--- a/python/samples/05-end-to-end/chatkit-integration/attachment_store.py
+++ b/python/samples/05-end-to-end/chatkit-integration/attachment_store.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from chatkit.store import AttachmentStore
-from chatkit.types import Attachment, AttachmentCreateParams, FileAttachment, ImageAttachment
+from chatkit.types import Attachment, AttachmentCreateParams, AttachmentUploadDescriptor, FileAttachment, ImageAttachment
 from pydantic import AnyUrl
 
 if TYPE_CHECKING:
@@ -87,7 +87,10 @@ class FileBasedAttachmentStore(AttachmentStore[dict[str, Any]]):
                 type="image",
                 mime_type=input.mime_type,
                 name=input.name,
-                upload_url=AnyUrl(upload_url),
+                upload_descriptor=AttachmentUploadDescriptor(
+                    url=AnyUrl(upload_url),
+                    method="POST",
+                ),
                 preview_url=AnyUrl(preview_url),
             )
         else:
@@ -97,7 +100,10 @@ class FileBasedAttachmentStore(AttachmentStore[dict[str, Any]]):
                 type="file",
                 mime_type=input.mime_type,
                 name=input.name,
-                upload_url=AnyUrl(upload_url),
+                upload_descriptor=AttachmentUploadDescriptor(
+                    url=AnyUrl(upload_url),
+                    method="POST",
+                ),
             )
 
         # Save attachment metadata to data store so it's available during upload

--- a/python/samples/05-end-to-end/chatkit-integration/frontend/vite.config.ts
+++ b/python/samples/05-end-to-end/chatkit-integration/frontend/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
         target: backendTarget,
         changeOrigin: true,
       },
+      "/upload": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+      "/preview": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
     },
     // For production deployments, you need to add your public domains to this list
     allowedHosts: [


### PR DESCRIPTION
### Motivation and Context

The ChatKit integration sample broke after upstream API changes in the ChatKit and Agent Framework packages. Specifically:
- `FunctionResultContent` was removed/renamed — content type checking must now use `Content` with a `.type` check
- `Attachment.upload_url` was replaced by `Attachment.upload_descriptor` (an `AttachmentUploadDescriptor` with `url` and `method` fields)
- `Role.USER` enum usage was replaced with the string literal `"user"`
- File upload and preview URLs pointed directly at the backend port, causing cross-origin issues when the frontend runs through the Vite dev-server proxy

### Description

**Three files changed across three concerns:**

1. **`app.py`:**
   - Replaced `FunctionResultContent` import with `Content` and updated all `isinstance(content, FunctionResultContent)` checks to `isinstance(content, Content) and content.type == "function_result"`.
   - Changed `Role.USER` to the string literal `"user"` in two `Message(...)` calls.
   - Updated `SERVER_BASE_URL` to use the frontend port (`5171`) instead of the backend port (`8001`) so that generated upload/preview URLs route through the Vite proxy, avoiding CORS issues.
   - Removed a now-unnecessary local `from agent_framework import FunctionResultContent` import.
   - Updated `attachment.upload_url = None` to `attachment.upload_descriptor = None`.

2. **`attachment_store.py`:**
   - Imported `AttachmentUploadDescriptor` from `chatkit.types`.
   - Replaced `upload_url=AnyUrl(upload_url)` with the new `upload_descriptor=AttachmentUploadDescriptor(url=..., method="POST")` structure in both the image and file attachment creation paths.

3. **`frontend/vite.config.ts`:**
   - Added proxy rules for `/upload` and `/preview` routes so the Vite dev server forwards these requests to the backend, completing the CORS fix.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No — this is a sample fix only, no public API surface is affected.