### PR TITLE
Python: Raise NotImplementedError for get_web_search_tool() on AzureOpenAICha…

### DIFF
--- a/python/packages/core/agent_framework/azure/_chat_client.py
+++ b/python/packages/core/agent_framework/azure/_chat_client.py
@@ -282,6 +282,23 @@ class AzureOpenAIChatClient(  # type: ignore[misc]
             **kwargs,
         )
 
+    @staticmethod
+    def get_web_search_tool(
+        *,
+        web_search_options: Any | None = None,
+    ) -> dict[str, Any]:
+        """Web search is not supported by Azure OpenAI's Chat Completions API.
+
+        Use ``OpenAIChatClient`` or ``AzureOpenAIResponsesClient`` for web search support.
+
+        Raises:
+            NotImplementedError: Always, since Azure OpenAI does not support web search.
+        """
+        raise NotImplementedError(
+            "Web search is not supported by Azure OpenAI's Chat Completions API. "
+            "Use OpenAIChatClient or AzureOpenAIResponsesClient for web search support."
+        )
+
     @override
     def _parse_text_from_openai(self, choice: Choice | ChunkChoice) -> Content | None:
         """Parse the choice into a Content object with type='text'.

--- a/python/packages/core/tests/azure/test_azure_chat_client.py
+++ b/python/packages/core/tests/azure/test_azure_chat_client.py
@@ -884,3 +884,12 @@ async def test_azure_chat_client_agent_level_tool_persistence():
         assert second_response.text is not None
         # Should use the agent-level weather tool again
         assert any(term in second_response.text.lower() for term in ["miami", "sunny", "72"])
+
+
+def test_get_web_search_tool_raises_not_implemented() -> None:
+    """Test that get_web_search_tool() raises NotImplementedError on Azure OpenAI.
+
+    Regression test for: https://github.com/microsoft/agent-framework/issues/3629
+    """
+    with pytest.raises(NotImplementedError, match="not supported by Azure OpenAI"):
+        AzureOpenAIChatClient.get_web_search_tool()


### PR DESCRIPTION
### Motivation and Context

Azure OpenAI's Chat Completions API does not support the web_search_options parameter. Previously, calling get_web_search_tool() on AzureOpenAIChatClient inherited the base OpenAI implementation, producing a config that caused a 400 error at runtime. Now raises NotImplementedError at tool creation time with a message directing users to OpenAIChatClient or AzureOpenAIResponsesClient.

Fixes #3629

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ X] The code builds clean without any errors or warnings
- [ X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.