### PR TITLE
Python: fix: use agent_name for ChatAgent.name in AzureAIAgentClient.as_agent()

### DIFF
--- a/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
+++ b/python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py
@@ -1486,6 +1486,9 @@ class AzureAIAgentClient(
         Returns:
             A Agent instance configured with this chat client.
         """
+        # Use agent_name from client initialization if name not provided
+        if name is None:
+            name = self.agent_name
         return super().as_agent(
             id=id,
             name=name,


### PR DESCRIPTION
Fixes an issue where AzureAIClient.as_agent() does not use agent_name for ChatAgent.name when the name parameter is not provided.

Problem: When a user creates an AzureAIChatClient with agent_name parameter, then calls as_agent() without providing a name parameter, the agent_name should be used as the default value for the ChatAgent name.

Solution: Added a check in the as_agent() method to use self.agent_name when name is None.

File changed: python/packages/azure-ai/agent_framework_azure_ai/_chat_client.py