### PR TITLE
.NET: Improve skill name validation: reject consecutive hyphens and enforce directory name match

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/FileAgentSkillLoader.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/FileAgentSkillLoader.cs
@@ -256,7 +256,11 @@ internal sealed partial class FileAgentSkillLoader
         string directoryName = Path.GetFileName(Path.GetDirectoryName(skillFilePath)) ?? string.Empty;
         if (!string.Equals(name, directoryName, StringComparison.Ordinal))
         {
-            LogNameDirectoryMismatch(this._logger, skillFilePath, name, directoryName);
+            if (this._logger.IsEnabled(LogLevel.Error))
+            {
+                LogNameDirectoryMismatch(this._logger, SanitizePathForLog(skillFilePath), name, SanitizePathForLog(directoryName));
+            }
+
             return false;
         }
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
@@ -126,7 +126,7 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
     public void DiscoverAndLoadSkills_InvalidName_ExcludesSkill(string invalidName)
     {
         // Arrange
-        string skillDir = Path.Combine(this._testRoot, "invalid-name-test");
+        string skillDir = Path.Combine(this._testRoot, invalidName);
         if (Directory.Exists(skillDir))
         {
             Directory.Delete(skillDir, recursive: true);


### PR DESCRIPTION
This PR improves skill validation in `FileAgentSkillLoader` with two changes:

   1. Reject consecutive hyphens in skill names — The name regex now disallows names like "my--skill". The error message is updated accordingly.
   2. Enforce skill name matches parent directory name — A new validation ensures the name field in SKILL.md frontmatter matches the parent directory name (e.g., a skill at skills/my-skill/SKILL.md must have name: my-skill). A mismatch logs an error and 
  excludes the skill.

Closes: https://github.com/microsoft/agent-framework/issues/4421