### PR TITLE
Python: Fix `chat_response_cancellation.py` sample to use Message objects

### DIFF
--- a/python/samples/02-agents/chat_client/chat_response_cancellation.py
+++ b/python/samples/02-agents/chat_client/chat_response_cancellation.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from agent_framework import Message
 from agent_framework.openai import OpenAIChatClient
 from dotenv import load_dotenv
 
@@ -28,7 +29,7 @@ async def main() -> None:
     client = OpenAIChatClient()
 
     try:
-        task = asyncio.create_task(client.get_response(messages=["Tell me a fantasy story."]))
+        task = asyncio.create_task(client.get_response(messages=[Message(role="user", text="Tell me a fantasy story.")]))
         await asyncio.sleep(1)
         task.cancel()
         await task


### PR DESCRIPTION
The chat_response_cancellation.py sample was passing raw strings in a list to get_response(), which expects Message objects. This caused an AttributeError: 'str' object has no attribute 'role'.

Fix: Import Message from agent_framework and wrap the user prompt in Message(role="user", text="...").

Fixes #4491 