### PR TITLE
Python: Fix OAuth consent event forwarding in as_tool()

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -51,7 +51,7 @@ from ._types import (
     map_chat_to_agent_update,
     normalize_messages,
 )
-from .exceptions import AgentInvalidResponseException
+from .exceptions import AgentInvalidResponseException, OAuthConsentRequiredException
 from .observability import AgentTelemetryLayer
 
 if sys.version_info >= (3, 13):
@@ -532,11 +532,25 @@ class BaseAgent(SerializationMixin):
 
             if stream_callback is None:
                 # Use non-streaming mode
-                return (await self.run(input_text, stream=False, session=parent_session, **forwarded_kwargs)).text
+                response = await self.run(input_text, stream=False, session=parent_session, **forwarded_kwargs)
+                # Check for OAuth consent request in response
+                for content in response.contents:
+                    if content.type == 'oauth_consent_request':
+                        consent_url = content.get('consent_link') or content.get('url') or ''
+                        from .exceptions import OAuthConsentRequiredException
+                        raise OAuthConsentRequiredException(consent_url)
+                return response.text
 
             # Use streaming mode - accumulate updates and create final response
             response_updates: list[AgentResponseUpdate] = []
             async for update in self.run(input_text, stream=True, session=parent_session, **forwarded_kwargs):
+                # Check for OAuth consent request in update
+                for content in update.contents:
+                    if content.type == 'oauth_consent_request':
+                        consent_url = content.get('consent_link') or content.get('url') or ''
+                        from .exceptions import OAuthConsentRequiredException
+                        raise OAuthConsentRequiredException(consent_url)
+                
                 response_updates.append(update)
                 if is_async_callback:
                     await stream_callback(update)  # type: ignore[misc]

--- a/python/packages/core/agent_framework/exceptions.py
+++ b/python/packages/core/agent_framework/exceptions.py
@@ -204,6 +204,46 @@ class SettingNotFoundError(AgentFrameworkException):
 
 # endregion
 
+
+
+class OAuthConsentRequiredException(AgentException):
+    """Raised when a sub-agent tool requires OAuth consent.
+    
+    This exception is raised by as_tool() when a wrapped agent returns
+    an oauth_consent_request event. The parent agent should catch this
+    exception and forward the consent request to the user.
+    
+    Attributes:
+        consent_url: The OAuth consent URL that the user must visit.
+    """
+    
+    def __init__(self, consent_url: str):
+        self.consent_url = consent_url
+        super().__init__(
+            f'OAuth consent required. Please visit: {consent_url}',
+            log_level=logging.INFO,
+        )
+
+
+
+class OAuthConsentRequiredException(AgentException):
+    """Raised when a sub-agent tool requires OAuth consent.
+    
+    This exception is raised by as_tool() when a wrapped agent returns
+    an oauth_consent_request event. The parent agent should catch this
+    exception and forward the consent request to the user.
+    
+    Attributes:
+        consent_url: The OAuth consent URL that the user must visit.
+    """
+    
+    def __init__(self, consent_url: str):
+        self.consent_url = consent_url
+        super().__init__(
+            f'OAuth consent required. Please visit: {consent_url}',
+            log_level=logging.INFO,
+        )
+
 # region Workflow Exceptions
 
 


### PR DESCRIPTION
## Summary

Fixes #4499 

Adds exception-based OAuth consent event forwarding to enable proper OAuth flows when using agents as tools.

## Changes Made

### New Exception Class
Added `OAuthConsentRequiredException` to [exceptions.py:114-131](python/packages/core/agent_framework/exceptions.py#L114-L131):
- Raised when a sub-agent tool requires OAuth consent
- Contains `consent_url` attribute for the OAuth consent URL
- Parent agents can catch this exception and forward consent requests to users

### Modified as_tool() Method  
Updated `as_tool()` in [_agents.py:533-561](python/packages/core/agent_framework/_agents.py#L533-L561):
- **Non-streaming mode** (line 536-542): Checks response contents for oauth_consent_request events
- **Streaming mode** (line 547-552): Checks each update's contents for oauth_consent_request events
- When detected, raises `OAuthConsentRequiredException` with the consent URL

## Implementation Details

This implements the exception-based approach (Option A) discussed in issue #4499.

**Detection logic:**
```python
for content in response.contents:  # or update.contents
    if content.type == 'oauth_consent_request':
        consent_url = content.get('consent_link') or content.get('url') or ''
        raise OAuthConsentRequiredException(consent_url)
```

**Parent agent handling:**
```python
try:
    result = await research_tool(**kwargs)
except OAuthConsentRequiredException as e:
    # Forward consent request to user
    consent_url = e.consent_url
```

## Why This Change?

Currently, when using `as_tool()` to wrap an agent, OAuth consent request events are silently discarded because the method only returns `.text`. This makes proper OAuth flows impossible in multi-agent scenarios.

This fix enables:
- Multi-agent OAuth workflows
- Proper consent request propagation  
- Parent agents to handle OAuth flows correctly

## Testing Recommendations

1. Create a sub-agent that produces `oauth_consent_request` events
2. Wrap it using `as_tool()`
3. Use it as a tool in a parent agent
4. Verify `OAuthConsentRequiredException` is raised with correct consent_url
5. Test both streaming and non-streaming modes

## Related Issues

Closes #4499

---