### PR TITLE
Python/core: preserve checkpoint ancestry when workflows resume

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -82,9 +82,7 @@ class Runner:
             raise WorkflowRunnerException("Runner is already running.")
 
         self._running = True
-        previous_checkpoint_id: CheckpointID | None = (
-            self._resume_parent_checkpoint_id if self._resumed_from_checkpoint else None
-        )
+        previous_checkpoint_id: CheckpointID | None = self._resume_parent_checkpoint_id
         try:
             # Emit any events already produced prior to entering loop
             if await self._ctx.has_events():
@@ -156,9 +154,9 @@ class Runner:
                 raise WorkflowConvergenceException(f"Runner did not converge after {self._max_iterations} iterations.")
 
             logger.info(f"Workflow completed after {self._iteration} supersteps")
-            self._resumed_from_checkpoint = False  # Reset resume flag for next run
-            self._resume_parent_checkpoint_id = None
         finally:
+            self._resumed_from_checkpoint = False
+            self._resume_parent_checkpoint_id = None
             self._running = False
 
     async def _run_iteration(self) -> None:
@@ -358,7 +356,7 @@ class Runner:
     def _mark_resumed(self, iteration: int, checkpoint_id: CheckpointID) -> None:
         """Mark the runner as having resumed from a checkpoint.
 
-        Optionally set the current iteration and max iterations.
+        Set the current iteration and record the resumed checkpoint ID.
         """
         self._resumed_from_checkpoint = True
         self._iteration = iteration

--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -65,6 +65,7 @@ class Runner:
         self._state = state
         self._running = False
         self._resumed_from_checkpoint = False  # Track whether we resumed
+        self._resume_parent_checkpoint_id: CheckpointID | None = None
 
     @property
     def context(self) -> RunnerContext:
@@ -81,7 +82,9 @@ class Runner:
             raise WorkflowRunnerException("Runner is already running.")
 
         self._running = True
-        previous_checkpoint_id: CheckpointID | None = None
+        previous_checkpoint_id: CheckpointID | None = (
+            self._resume_parent_checkpoint_id if self._resumed_from_checkpoint else None
+        )
         try:
             # Emit any events already produced prior to entering loop
             if await self._ctx.has_events():
@@ -154,6 +157,7 @@ class Runner:
 
             logger.info(f"Workflow completed after {self._iteration} supersteps")
             self._resumed_from_checkpoint = False  # Reset resume flag for next run
+            self._resume_parent_checkpoint_id = None
         finally:
             self._running = False
 
@@ -285,7 +289,7 @@ class Runner:
             # Apply the checkpoint to the context
             await self._ctx.apply_checkpoint(checkpoint)
             # Mark the runner as resumed
-            self._mark_resumed(checkpoint.iteration_count)
+            self._mark_resumed(checkpoint.iteration_count, checkpoint.checkpoint_id)
 
             logger.info(f"Successfully restored workflow from checkpoint: {checkpoint_id}")
         except WorkflowCheckpointException:
@@ -351,13 +355,14 @@ class Runner:
 
         return parsed
 
-    def _mark_resumed(self, iteration: int) -> None:
+    def _mark_resumed(self, iteration: int, checkpoint_id: CheckpointID) -> None:
         """Mark the runner as having resumed from a checkpoint.
 
         Optionally set the current iteration and max iterations.
         """
         self._resumed_from_checkpoint = True
         self._iteration = iteration
+        self._resume_parent_checkpoint_id = checkpoint_id
 
     async def _set_executor_state(self, executor_id: str, state: dict[str, Any]) -> None:
         """Store executor state in state under a reserved key.

--- a/python/packages/core/tests/workflow/test_checkpoint.py
+++ b/python/packages/core/tests/workflow/test_checkpoint.py
@@ -336,6 +336,94 @@ async def test_workflow_checkpoint_chaining_via_previous_checkpoint_id():
         )
 
 
+async def test_resumed_workflow_keeps_previous_checkpoint_id_chain():
+    """New checkpoints created after resume should chain to the restored checkpoint."""
+    from typing_extensions import Never
+
+    from agent_framework import WorkflowBuilder, WorkflowContext, handler
+    from agent_framework._workflows._executor import Executor
+
+    class StartExecutor(Executor):
+        @handler
+        async def run(self, message: str, ctx: WorkflowContext[str]) -> None:
+            await ctx.send_message(message, target_id="middle")
+
+    class MiddleExecutor(Executor):
+        @handler
+        async def process(self, message: str, ctx: WorkflowContext[str]) -> None:
+            await ctx.send_message(message + "-processed", target_id="finish")
+
+    class FinishExecutor(Executor):
+        @handler
+        async def finish(self, message: str, ctx: WorkflowContext[Never, str]) -> None:
+            await ctx.yield_output(message + "-done")
+
+    storage = InMemoryCheckpointStorage()
+
+    start = StartExecutor(id="start")
+    middle = MiddleExecutor(id="middle")
+    finish = FinishExecutor(id="finish")
+
+    workflow_name = "resume-chain-workflow"
+
+    workflow = (
+        WorkflowBuilder(
+            max_iterations=10,
+            name=workflow_name,
+            start_executor=start,
+            checkpoint_storage=storage,
+        )
+        .add_edge(start, middle)
+        .add_edge(middle, finish)
+        .build()
+    )
+
+    _ = [event async for event in workflow.run("hello", stream=True)]
+
+    initial_checkpoints = sorted(
+        await storage.list_checkpoints(workflow_name=workflow.name),
+        key=lambda c: c.timestamp,
+    )
+    assert len(initial_checkpoints) >= 2, (
+        f"Expected at least 2 checkpoints before resume, got {len(initial_checkpoints)}"
+    )
+
+    restore_checkpoint = initial_checkpoints[1]
+    initial_ids = {checkpoint.checkpoint_id for checkpoint in initial_checkpoints}
+
+    resumed_start = StartExecutor(id="start")
+    resumed_middle = MiddleExecutor(id="middle")
+    resumed_finish = FinishExecutor(id="finish")
+
+    resumed_workflow = (
+        WorkflowBuilder(
+            max_iterations=10,
+            name=workflow_name,
+            start_executor=resumed_start,
+            checkpoint_storage=storage,
+        )
+        .add_edge(resumed_start, resumed_middle)
+        .add_edge(resumed_middle, resumed_finish)
+        .build()
+    )
+
+    _ = [event async for event in resumed_workflow.run(checkpoint_id=restore_checkpoint.checkpoint_id, stream=True)]
+
+    all_checkpoints = sorted(
+        await storage.list_checkpoints(workflow_name=workflow.name),
+        key=lambda c: c.timestamp,
+    )
+    resumed_checkpoints = [
+        checkpoint for checkpoint in all_checkpoints if checkpoint.checkpoint_id not in initial_ids
+    ]
+
+    assert resumed_checkpoints, "Expected at least one new checkpoint after resume"
+    assert resumed_checkpoints[0].previous_checkpoint_id == restore_checkpoint.checkpoint_id
+
+    for i in range(1, len(resumed_checkpoints)):
+        assert resumed_checkpoints[i].previous_checkpoint_id == resumed_checkpoints[i - 1].checkpoint_id
+
+
 async def test_memory_checkpoint_storage_roundtrip_json_native_types():
     """Test that JSON-native types (str, int, float, bool, None) roundtrip correctly."""
     storage = InMemoryCheckpointStorage()

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -856,7 +856,7 @@ async def test_runner_checkpoint_with_resumed_flag():
     state = State()
 
     runner = Runner(edges, executors, state, ctx, "test_name", graph_signature_hash="test_hash")
-    runner._mark_resumed(5)  # pyright: ignore[reportPrivateUsage]
+    runner._mark_resumed(5, "resume-parent-checkpoint")  # pyright: ignore[reportPrivateUsage]
 
     # Add a message to trigger the checkpoint creation path
     await ctx.send_message(WorkflowMessage(data=MockMessage(data=8), source_id="START"))


### PR DESCRIPTION
## Problem
When resuming from a checkpoint, newly persisted checkpoints could drop ancestry linkage instead of chaining to the restored checkpoint ID.

## Why now
Checkpoint ancestry is part of deterministic workflow history reconstruction; broken chain continuity complicates restore/replay auditing.

## What changed
- Preserve `previous_checkpoint_id` linkage for the first post-resume checkpoint.
- Keep resumed-run state cleanup deterministic in runner state handling.
- Keep focused regression coverage in workflow checkpoint/runner tests.

## Validation
- `uv run pytest packages/core/tests/workflow/test_checkpoint.py -k 'test_workflow_checkpoint_chaining_via_previous_checkpoint_id or test_resumed_workflow_keeps_previous_checkpoint_id_chain'`
- `uv run pytest packages/core/tests/workflow/test_runner.py -k resumed`

Closes #4588
