### PR TITLE
Python/core: make request-info approval tokens replay-safe

### DIFF
--- a/python/packages/core/tests/workflow/test_request_info_event_rehydrate.py
+++ b/python/packages/core/tests/workflow/test_request_info_event_rehydrate.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+import pytest
+
 from agent_framework import (
     FileCheckpointStorage,
     InMemoryCheckpointStorage,
@@ -45,6 +47,25 @@ class SlottedApproval:
 @dataclass
 class TimedApproval:
     issued_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+async def test_send_request_info_response_rejects_replay_for_same_request_id() -> None:
+    """Request IDs should be single-use once a response has been accepted."""
+    runner_context = InProcRunnerContext(InMemoryCheckpointStorage())
+    request_info_event = WorkflowEvent.request_info(
+        request_id="request-123",
+        source_executor_id="review_gateway",
+        request_data=MockRequest(),
+        response_type=bool,
+    )
+    await runner_context.add_request_info_event(request_info_event)
+
+    await runner_context.send_request_info_response("request-123", True)
+    pending_requests = await runner_context.get_pending_request_info_events()
+    assert "request-123" not in pending_requests
+
+    with pytest.raises(ValueError, match="No pending request found for request_id: request-123"):
+        await runner_context.send_request_info_response("request-123", False)
 
 
 async def test_rehydrate_request_info_event() -> None:


### PR DESCRIPTION
## Problem
Request-info approval request IDs are intended to be single-use. There was no direct regression test that proves a second submission for the same request ID is rejected after the first accepted response.

## Why now
Human-in-the-loop retries can replay stale request IDs; without explicit regression coverage, single-use token behavior can regress silently.

## What changed
- Added a workflow test that sends one valid response for a pending request ID.
- Asserted the request ID is removed from pending state after first use.
- Asserted a second response for the same request ID fails with a deterministic error.

## Validation
- `uv run pytest packages/core/tests/workflow/test_request_info_event_rehydrate.py -k replay --maxfail=1`

Refs #4618
