### PR TITLE
Python: stabilize executor lifecycle ordering in run results

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -604,10 +604,11 @@ class Workflow(DictConvertible):
 
         Filters out internal events for non-streaming callers.
         """
+        ordered_events = Workflow._normalize_executor_lifecycle_order(events)
         filtered: list[WorkflowEvent] = []
         status_events: list[WorkflowEvent] = []
 
-        for ev in events:
+        for ev in ordered_events:
             # Omit started events from result (telemetry-only)
             if ev.type == "started":
                 continue
@@ -620,6 +621,58 @@ class Workflow(DictConvertible):
             filtered.append(ev)
 
         return WorkflowRunResult(filtered, status_events)
+
+    @staticmethod
+    def _normalize_executor_lifecycle_order(
+        events: Sequence[WorkflowEvent],
+    ) -> list[WorkflowEvent]:
+        """Normalize executor lifecycle ordering in non-streaming results.
+
+        Concurrent fan-out paths can enqueue executor lifecycle events in scheduler-dependent
+        order. To keep run results reproducible, sort lifecycle events by executor id
+        within each superstep window while preserving non-lifecycle event positions.
+        """
+
+        def is_lifecycle_event(event: WorkflowEvent) -> bool:
+            return event.type in {"executor_invoked", "executor_completed", "executor_failed"}
+
+        normalized: list[WorkflowEvent] = []
+        segment: list[WorkflowEvent] = []
+
+        def flush_segment() -> None:
+            if not segment:
+                return
+
+            sorted_by_type = {
+                lifecycle_type: iter(
+                    sorted(
+                        [event for event in segment if event.type == lifecycle_type],
+                        key=lambda event: event.executor_id or "",
+                    )
+                )
+                for lifecycle_type in (
+                    "executor_invoked",
+                    "executor_completed",
+                    "executor_failed",
+                )
+            }
+
+            for event in segment:
+                if is_lifecycle_event(event):
+                    normalized.append(next(sorted_by_type[event.type]))
+                else:
+                    normalized.append(event)
+            segment.clear()
+
+        for event in events:
+            if event.type in {"superstep_started", "superstep_completed"}:
+                flush_segment()
+                normalized.append(event)
+                continue
+            segment.append(event)
+
+        flush_segment()
+        return normalized
 
     @staticmethod
     def _validate_run_params(

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -226,6 +226,39 @@ async def test_fan_out_multiple_completed_events():
     assert len(outputs) == 2
 
 
+async def test_parallel_executor_lifecycle_order_is_deterministic_in_run_results():
+    """Ensure non-streaming run results are stable across repeated fan-out runs."""
+    executor_a = IncrementExecutor(id="executor_a")
+    executor_b = IncrementExecutor(id="executor_b", limit=1)
+    executor_c = IncrementExecutor(id="executor_c", limit=1)
+
+    workflow = (
+        WorkflowBuilder(start_executor=executor_a)
+        # Intentionally reverse registration order to verify canonical ordering in results.
+        .add_fan_out_edges(executor_a, [executor_c, executor_b])
+        .build()
+    )
+
+    observed_signatures: list[list[tuple[str, str | None]]] = []
+    for _ in range(5):
+        events = await workflow.run(NumberMessage(data=0))
+        signature = [
+            (event.type, event.executor_id)
+            for event in events
+            if event.type in {"executor_invoked", "executor_completed", "executor_failed"}
+        ]
+        observed_signatures.append(signature)
+
+    assert all(signature == observed_signatures[0] for signature in observed_signatures)
+
+    completed_ids = [
+        executor_id
+        for event_type, executor_id in observed_signatures[0]
+        if event_type == "executor_completed" and executor_id in {"executor_b", "executor_c"}
+    ]
+    assert completed_ids == sorted(completed_ids)
+
+
 async def test_fan_in():
     """Test a fan-in workflow."""
     executor_a = IncrementExecutor(id="executor_a")


### PR DESCRIPTION
### Motivation and Context
Concurrent fan-out paths can emit executor lifecycle events in scheduler-dependent order, which makes repeated non-streaming workflow traces harder to compare. This PR makes non-streaming run results deterministic for lifecycle ordering and adds regression coverage.

Refs #4653.

### Description
- Added normalization in `Workflow._finalize_events` to canonicalize executor lifecycle ordering (`executor_invoked`, `executor_completed`, `executor_failed`) by `executor_id` within each superstep window.
- Kept non-lifecycle event positions intact while normalizing only lifecycle slots.
- Added `test_parallel_executor_lifecycle_order_is_deterministic_in_run_results` to verify repeated fan-out runs produce stable lifecycle signatures.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
