### PR TITLE
.NET: Sanitize user input in log statements for durable agent samples

### DIFF
--- a/dotnet/samples/04-hosting/DurableAgents/AzureFunctions/06_LongRunningTools/Tools.cs
+++ b/dotnet/samples/04-hosting/DurableAgents/AzureFunctions/06_LongRunningTools/Tools.cs
@@ -17,7 +17,7 @@ internal sealed class Tools(ILogger<Tools> logger)
     [Description("Starts a content generation workflow and returns the instance ID for tracking.")]
     public string StartContentGenerationWorkflow([Description("The topic for content generation")] string topic)
     {
-        this._logger.LogInformation("Starting content generation workflow for topic: {Topic}", topic);
+        this._logger.LogInformation("Starting content generation workflow for topic: {Topic}", SanitizeLogValue(topic));
 
         const int MaxReviewAttempts = 3;
         const float ApprovalTimeoutHours = 72;
@@ -34,7 +34,7 @@ internal sealed class Tools(ILogger<Tools> logger)
 
         this._logger.LogInformation(
             "Content generation workflow scheduled to be started for topic '{Topic}' with instance ID: {InstanceId}",
-            topic,
+            SanitizeLogValue(topic),
             instanceId);
 
         return $"Workflow started with instance ID: {instanceId}";
@@ -45,7 +45,7 @@ internal sealed class Tools(ILogger<Tools> logger)
         [Description("The instance ID of the workflow to check")] string instanceId,
         [Description("Whether to include detailed information")] bool includeDetails = true)
     {
-        this._logger.LogInformation("Getting status for workflow instance: {InstanceId}", instanceId);
+        this._logger.LogInformation("Getting status for workflow instance: {InstanceId}", SanitizeLogValue(instanceId));
 
         // Get the current agent context using the session-static property
         OrchestrationMetadata? status = await DurableAgentContext.Current.GetOrchestrationStatusAsync(
@@ -54,7 +54,7 @@ internal sealed class Tools(ILogger<Tools> logger)
 
         if (status is null)
         {
-            this._logger.LogInformation("Workflow instance '{InstanceId}' not found.", instanceId);
+            this._logger.LogInformation("Workflow instance '{InstanceId}' not found.", SanitizeLogValue(instanceId));
             return new
             {
                 instanceId,
@@ -78,7 +78,16 @@ internal sealed class Tools(ILogger<Tools> logger)
         [Description("The instance ID of the workflow to submit feedback for")] string instanceId,
         [Description("Feedback to submit")] HumanApprovalResponse feedback)
     {
-        this._logger.LogInformation("Submitting human approval for workflow instance: {InstanceId}", instanceId);
+        this._logger.LogInformation("Submitting human approval for workflow instance: {InstanceId}", SanitizeLogValue(instanceId));
         await DurableAgentContext.Current.RaiseOrchestrationEventAsync(instanceId, "HumanApproval", feedback);
     }
+
+    /// <summary>
+    /// Sanitizes a user-provided value for safe inclusion in log entries
+    /// by removing control characters that could be used for log forging.
+    /// </summary>
+    private static string SanitizeLogValue(string value) =>
+        value
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal);
 }

--- a/dotnet/samples/04-hosting/DurableAgents/AzureFunctions/08_ReliableStreaming/FunctionTriggers.cs
+++ b/dotnet/samples/04-hosting/DurableAgents/AzureFunctions/08_ReliableStreaming/FunctionTriggers.cs
@@ -157,8 +157,8 @@ public sealed class FunctionTriggers
 
         this._logger.LogInformation(
             "Resuming stream for conversation {ConversationId} from cursor: {Cursor}",
-            conversationId,
-            cursor ?? "(beginning)");
+            SanitizeLogValue(conversationId),
+            SanitizeLogValue(cursor) ?? "(beginning)");
 
         // Check Accept header to determine response format
         // text/plain = raw text output (ideal for terminals)
@@ -205,7 +205,7 @@ public sealed class FunctionTriggers
             {
                 if (chunk.Error != null)
                 {
-                    this._logger.LogWarning("Stream error for conversation {ConversationId}: {Error}", conversationId, chunk.Error);
+                    this._logger.LogWarning("Stream error for conversation {ConversationId}: {Error}", SanitizeLogValue(conversationId), chunk.Error);
                     await WriteErrorAsync(httpContext.Response, chunk.Error, useSseFormat, cancellationToken);
                     break;
                 }
@@ -224,7 +224,7 @@ public sealed class FunctionTriggers
         }
         catch (OperationCanceledException)
         {
-            this._logger.LogInformation("Client disconnected from stream {ConversationId}", conversationId);
+            this._logger.LogInformation("Client disconnected from stream {ConversationId}", SanitizeLogValue(conversationId));
         }
 
         return new EmptyResult();
@@ -315,5 +315,21 @@ public sealed class FunctionTriggers
         sb.AppendLine(); // Empty line marks end of event
 
         await response.WriteAsync(sb.ToString());
+    }
+
+    /// <summary>
+    /// Sanitizes a user-provided value for safe inclusion in log entries
+    /// by removing control characters that could be used for log forging.
+    /// </summary>
+    private static string? SanitizeLogValue(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
### Description

Sanitize user input in log statements for durable agent samples.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.