### PR TITLE
Python: A2AAgent defaults name/description from AgentCard

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -130,8 +130,10 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         """
         # Default name/description from agent_card when not explicitly provided
         if agent_card is not None:
-            name = name or agent_card.name
-            description = description or agent_card.description
+            if name is None:
+                name = agent_card.name
+            if description is None:
+                description = agent_card.description
 
         super().__init__(id=id, name=name, description=description, **kwargs)
         self._http_client: httpx.AsyncClient | None = http_client

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -175,6 +175,24 @@ def test_a2a_agent_explicit_name_description_overrides_agent_card(mock_a2a_clien
     assert agent.description == "Explicit description"
 
 
+def test_a2a_agent_empty_string_name_description_not_overridden(mock_a2a_client: MockA2AClient) -> None:
+    """Test that explicitly provided empty strings are not overridden by agent_card values."""
+    mock_card = MagicMock(spec=AgentCard)
+    mock_card.name = "Card Agent Name"
+    mock_card.description = "Card agent description"
+
+    agent = A2AAgent(
+        name="",
+        description="",
+        agent_card=mock_card,
+        client=mock_a2a_client,
+        http_client=None,
+    )
+
+    assert agent.name == ""
+    assert agent.description == ""
+
+
 def test_a2a_agent_initialization_without_client_raises_error() -> None:
     """Test A2AAgent initialization without client or URL raises ValueError."""
     with raises(ValueError, match="Either agent_card or url must be provided"):


### PR DESCRIPTION
### Motivation and Context

When constructing an `A2AAgent` with an `agent_card`, users must redundantly pass `name` and `description` even though the `AgentCard` already contains this information. This is especially problematic when using `A2AAgent` as a participant in `GroupChat` orchestrations, where the agent's name and description are essential for routing decisions.

Fixes #4630

### Description

When `agent_card` is provided and `name`/`description` are not explicitly set, `A2AAgent.__init__()` now falls back to `agent_card.name` and `agent_card.description`. Explicit values still take precedence, so this change is fully backward compatible.

Changes:
- Added fallback logic in `A2AAgent.__init__()` before the `super().__init__()` call
- Updated docstring to document the defaulting behavior
- Added two new unit tests: one for defaulting from card, one for explicit override
- Fixed existing test mock to include `name`/`description` attributes

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No, this is backward compatible.