### PR TITLE
Python: normalize empty MCP tool output to null

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import re
 import sys
@@ -194,7 +195,7 @@ def _parse_tool_result_from_mcp(
                 result.append(Content.from_text(str(item)))
 
     if not result:
-        result.append(Content.from_text(""))
+        result.append(Content.from_text(json.dumps(None)))
     return result
 
 

--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -88,8 +88,6 @@ def _parse_prompt_result_from_mcp(
     Returns:
         A string representation of the prompt result.
     """
-    import json
-
     parts: list[str] = []
     for message in mcp_type.messages:
         content = message.content
@@ -195,7 +193,7 @@ def _parse_tool_result_from_mcp(
                 result.append(Content.from_text(str(item)))
 
     if not result:
-        result.append(Content.from_text(json.dumps(None)))
+        result.append(Content.from_text("null"))
     return result
 
 

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -195,13 +195,16 @@ def test_parse_tool_result_from_mcp_meta_not_in_string():
 
 
 def test_parse_tool_result_from_mcp_empty_content():
-    """Test that empty content produces list with empty text Content."""
+    """Test that empty MCP content normalizes to JSON null text content."""
     mcp_result = types.CallToolResult(content=[])
     result = _parse_tool_result_from_mcp(mcp_result)
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].type == "text"
-    assert result[0].text == ""
+    assert result[0].text == "null"
+
+    function_result = Content.from_function_result(call_id="call_null", result=result)
+    assert function_result.result == "null"
 
 
 def test_parse_tool_result_from_mcp_audio_content():


### PR DESCRIPTION
### Motivation and Context

Fixes #4677.

MCP tools that return no content currently propagate an empty result, which leads Azure Responses API tool calls to fail with "No tool output found" and stops the agent run.

### Description

- normalize empty `CallToolResult.content` payloads to a single text `null` value
- keep existing parsing behavior for non-empty text and rich MCP content
- add a regression test covering empty MCP tool results and the resulting function output

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
