### PR TITLE
Python: preserve A2A message context_id

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -493,6 +493,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
             role=A2ARole("user"),
             parts=parts,
             message_id=message.message_id or uuid.uuid4().hex,
+            context_id=message.additional_properties.get("context_id"),
             metadata=metadata,
         )
 

--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -486,7 +486,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                     raise ValueError(f"Unknown content type: {content.type}")
 
         # Exclude framework-internal keys (e.g. attribution) from wire metadata
-        internal_keys = {"_attribution"}
+        internal_keys = {"_attribution", "context_id"}
         metadata = {k: v for k, v in message.additional_properties.items() if k not in internal_keys} or None
 
         return A2AMessage(

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -508,19 +508,20 @@ def test_prepare_message_for_a2a_with_multiple_contents() -> None:
 
 
 def test_prepare_message_for_a2a_forwards_context_id() -> None:
-    """Test conversion of Message preserves context_id on the A2A message."""
+    """Test conversion of Message preserves context_id without duplicating it in metadata."""
 
     agent = A2AAgent(client=MagicMock(), _http_client=None)
 
     message = Message(
         role="user",
         contents=[Content.from_text(text="Continue the task")],
-        additional_properties={"context_id": "ctx-123"},
+        additional_properties={"context_id": "ctx-123", "trace_id": "trace-456"},
     )
 
     result = agent._prepare_message_for_a2a(message)
 
     assert result.context_id == "ctx-123"
+    assert result.metadata == {"trace_id": "trace-456"}
 
 
 def test_parse_contents_from_a2a_with_data_part() -> None:

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -507,6 +507,22 @@ def test_prepare_message_for_a2a_with_multiple_contents() -> None:
     assert result.parts[3].root.kind == "text"  # JSON text remains as text (no parsing)
 
 
+def test_prepare_message_for_a2a_forwards_context_id() -> None:
+    """Test conversion of Message preserves context_id on the A2A message."""
+
+    agent = A2AAgent(client=MagicMock(), _http_client=None)
+
+    message = Message(
+        role="user",
+        contents=[Content.from_text(text="Continue the task")],
+        additional_properties={"context_id": "ctx-123"},
+    )
+
+    result = agent._prepare_message_for_a2a(message)
+
+    assert result.context_id == "ctx-123"
+
+
 def test_parse_contents_from_a2a_with_data_part() -> None:
     """Test conversion of A2A DataPart."""
 


### PR DESCRIPTION
### Motivation and Context

This change fixes #4679 by preserving the `context_id` attached to outbound A2A messages, which keeps multi-turn A2A conversations correlated correctly.

### Description

Forward `context_id` from the framework `Message` into the generated `A2AMessage` and add a regression test that verifies `_prepare_message_for_a2a()` preserves it.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
