### PR TITLE
Python: update agent-framework-a2a to fixed a2a-sdk line

### DIFF
--- a/python/packages/a2a/pyproject.toml
+++ b/python/packages/a2a/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core>=1.0.0rc4",
-    "a2a-sdk>=0.3.5,<0.3.24",
+    "a2a-sdk>=0.3.0,<0.4.0",
 ]
 
 [tool.uv]

--- a/python/packages/a2a/tests/test_package_metadata.py
+++ b/python/packages/a2a/tests/test_package_metadata.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from pathlib import Path
+
+import tomllib
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def test_a2a_sdk_dependency_range_tracks_validated_sdk_line() -> None:
+    pyproject_data = tomllib.loads((Path(__file__).resolve().parents[1] / "pyproject.toml").read_text())
+    a2a_sdk_requirement = next(
+        Requirement(dependency)
+        for dependency in pyproject_data["project"]["dependencies"]
+        if dependency.startswith("a2a-sdk")
+    )
+
+    assert Version("0.3.0") in a2a_sdk_requirement.specifier
+    assert Version("0.3.25") in a2a_sdk_requirement.specifier
+    assert Version("0.4.0") not in a2a_sdk_requirement.specifier

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -54,7 +54,7 @@ members = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.23"
+version = "0.3.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -63,9 +63,9 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/2fe24e0a85240a651006c12f79bdb37156adc760a96c44bc002ebda77916/a2a_sdk-0.3.23.tar.gz", hash = "sha256:7c46b8572c4633a2b41fced2833e11e62871e8539a5b3c782ba2ba1e33d213c2", size = 255265, upload-time = "2026-02-17T08:34:34.648Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/83/3c99b276d09656cce039464509f05bf385e5600d6dc046a131bbcf686930/a2a_sdk-0.3.25.tar.gz", hash = "sha256:afda85bab8d6af0c5d15e82f326c94190f6be8a901ce562d045a338b7127242f", size = 270638, upload-time = "2026-03-10T13:08:46.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/20/77d119f19ab03449d3e6bc0b1f11296d593dae99775c1d891ab1e290e416/a2a_sdk-0.3.23-py3-none-any.whl", hash = "sha256:8c2f01dffbfdd3509eafc15c4684743e6ae75e69a5df5d6f87be214c948e7530", size = 145689, upload-time = "2026-02-17T08:34:33.263Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f9/6a62520b7ecb945188a6e1192275f4732ff9341cd4629bc975a6c146aeab/a2a_sdk-0.3.25-py3-none-any.whl", hash = "sha256:2fce38faea82eb0b6f9f9c2bcf761b0d78612c80ef0e599b50d566db1b2654b5", size = 149609, upload-time = "2026-03-10T13:08:44.7Z" },
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.5,<0.3.24" },
+    { name = "a2a-sdk", specifier = ">=0.3.0,<0.4.0" },
     { name = "agent-framework-core", editable = "packages/core" },
 ]
 


### PR DESCRIPTION
### Motivation and Context

Issue #4676 is caused by the `a2a-sdk` dependency line used by `agent-framework-a2a`, not by framework wrapper code in this repository. This change moves the package onto the validated fixed `0.3.x` SDK line and updates the dependency bounds to match.

Fixes microsoft/agent-framework#4676

### Description

- widen the `a2a-sdk` requirement in `packages/a2a/pyproject.toml` to `>=0.3.0,<0.4.0`
- refresh `uv.lock` so the workspace resolves `a2a-sdk==0.3.25`
- add a regression test that keeps the A2A package metadata aligned with the validated SDK line
- validate the change with A2A package tests and the dependency-bounds workflow for `agent-framework-a2a`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
