### PR TITLE
Python: Fix Azure Redis sample missing session for history persistence

### DIFF
--- a/python/samples/02-agents/context_providers/redis/azure_redis_conversation.py
+++ b/python/samples/02-agents/context_providers/redis/azure_redis_conversation.py
@@ -3,7 +3,11 @@
 """Azure Managed Redis History Provider with Azure AD Authentication
 
 This example demonstrates how to use Azure Managed Redis with Azure AD authentication
-to persist conversational details using RedisHistoryProvider.
+to persist conversation history using RedisHistoryProvider.
+
+Key concepts:
+  - RedisHistoryProvider = durable storage (where messages are persisted)
+  - AgentSession = conversation identity (which conversation the messages belong to)
 
 Requirements:
   - Azure Managed Redis instance with Azure AD authentication enabled
@@ -61,11 +65,11 @@ async def main() -> None:
         print("Get your Object ID from the Azure Portal")
         return
 
-    # Create Azure CLI credential provider (uses 'az login' credentials)
+    # 1. Create Azure CLI credential provider (uses 'az login' credentials)
     azure_credential = AsyncAzureCliCredential()
     credential_provider = AzureCredentialProvider(azure_credential, user_object_id)
 
-    # Create Azure Redis history provider
+    # 2. Create Azure Redis history provider (the durable storage backend)
     history_provider = RedisHistoryProvider(
         source_id="redis_memory",
         credential_provider=credential_provider,
@@ -76,49 +80,54 @@ async def main() -> None:
         max_messages=100,
     )
 
-    # Create chat client
+    # 3. Create chat client
     client = AzureOpenAIResponsesClient(
         project_endpoint=os.environ["AZURE_AI_PROJECT_ENDPOINT"],
         deployment_name=os.environ["AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME"],
         credential=AzureCliCredential(),
     )
 
-    # Create agent with Azure Redis history provider
+    # 4. Create agent with Azure Redis history provider
     agent = client.as_agent(
         name="AzureRedisAssistant",
         instructions="You are a helpful assistant.",
         context_providers=[history_provider],
     )
 
-    # Conversation
+    # 5. Create a session to provide conversation identity.
+    # The session ID is used as the Redis key — all runs sharing the same session
+    # will read/write the same conversation history in Redis.
+    session = agent.create_session()
+
+    # 6. Conversation — each run passes the same session for continuity
     query = "Remember that I enjoy gumbo"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 
     # Ask the agent to recall the stored preference; it should retrieve from memory
     query = "What do I enjoy?"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 
     query = "What did I say to you just now?"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 
     query = "Remember that I have a meeting at 3pm tomorrow"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 
     query = "Tulips are red"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 
     query = "What was the first thing I said to you this conversation?"
-    result = await agent.run(query)
+    result = await agent.run(query, session=session)
     print("User: ", query)
     print("Agent: ", result)
 

--- a/python/samples/02-agents/skills/script_approval/script_approval.py
+++ b/python/samples/02-agents/skills/script_approval/script_approval.py
@@ -90,7 +90,7 @@ async def main() -> None:
         # maintained automatically — just send the approval response)
         while result.user_input_requests:
             for request in result.user_input_requests:
-                print(f"\nApproval needed:")
+                print("\nApproval needed:")
                 print(f"  Function: {request.function_call.name}")  # type: ignore[union-attr]
                 print(f"  Arguments: {request.function_call.arguments}")  # type: ignore[union-attr]
 


### PR DESCRIPTION
### Motivation and Context

The `azure_redis_conversation.py` sample was calling `agent.run()` without passing a session. Since `agent.run()` creates a new ephemeral `AgentSession` with a random UUID each time no session is provided, and `RedisHistoryProvider` keys messages by `session_id`, conversation history was never maintained across calls — each call wrote to a different Redis key.

This was a regression from the earlier `RedisChatMessageStore` API which accepted a `thread_id` at construction, making the key fixed regardless of session management.

### Description

- Create and reuse an `AgentSession` via `agent.create_session()` across all `agent.run()` calls
- Update the module docstring to clarify that `RedisHistoryProvider` is a **storage backend** (where messages are persisted) and an `AgentSession` provides **conversation identity** (which conversation the messages belong to)
- Add numbered step comments for clarity

Closes #4216 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.