### PR TITLE
Python: fix: include `status` field on `function_call` and `function_call_output` items

### DIFF
--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -1036,16 +1036,20 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                     "type": "function_call",
                     "name": content.name,
                     "arguments": content.arguments,
-                    "status": None,
+                    "status": (
+                        content.additional_properties.get("status")
+                        if content.additional_properties
+                        else None
+                    ) or "completed",
                 }
             case "function_result":
                 # call_id for the result needs to be the same as the call_id for the function call
-                args: dict[str, Any] = {
+                return {
                     "call_id": content.call_id,
                     "type": "function_call_output",
                     "output": content.result if content.result is not None else "",
+                    "status": "completed",
                 }
-                return args
             case "function_approval_request":
                 return {
                     "type": "mcp_approval_request",

--- a/python/packages/core/tests/openai/test_openai_responses_client.py
+++ b/python/packages/core/tests/openai/test_openai_responses_client.py
@@ -2358,6 +2358,73 @@ def test_with_callable_api_key() -> None:
     assert client.client is not None
 
 
+# region _prepare_content_for_openai status field tests
+
+
+def test_prepare_content_function_call_defaults_status_to_completed():
+    """function_call items must include status; default to 'completed' when not set."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_call(
+        call_id="call_abc",
+        name="get_weather",
+        arguments='{"city": "Seattle"}',
+    )
+    result = client._prepare_content_for_openai("assistant", content, call_id_to_id={})
+
+    assert result["type"] == "function_call"
+    assert result["status"] == "completed"
+
+
+def test_prepare_content_function_call_preserves_explicit_status():
+    """function_call items should preserve status from additional_properties when set."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_call(
+        call_id="call_xyz",
+        name="get_weather",
+        arguments='{"city": "Seattle"}',
+        additional_properties={"status": "in_progress"},
+    )
+    result = client._prepare_content_for_openai("assistant", content, call_id_to_id={})
+
+    assert result["type"] == "function_call"
+    assert result["status"] == "in_progress"
+
+
+def test_prepare_content_function_result_includes_status_completed():
+    """function_call_output items must always include status 'completed'."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_result(
+        call_id="call_abc",
+        result='{"temperature": 72}',
+    )
+    result = client._prepare_content_for_openai("tool", content, call_id_to_id={})
+
+    assert result["type"] == "function_call_output"
+    assert result["status"] == "completed"
+    assert result["output"] == '{"temperature": 72}'
+
+
+def test_prepare_content_function_result_none_result():
+    """function_call_output with None result maps to empty string and includes status."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_result(
+        call_id="call_abc",
+        result=None,
+    )
+    result = client._prepare_content_for_openai("tool", content, call_id_to_id={})
+
+    assert result["type"] == "function_call_output"
+    assert result["status"] == "completed"
+    assert result["output"] == ""
+
+
+# endregion
+
+
 # region Integration Tests
 
 


### PR DESCRIPTION
## Motivation and Context

Fixes #4701.

When replaying conversation history that includes tool calls through the Responses API, the `_prepare_content_for_openai` method produced items that violated the API schema:

1. **`function_call` items** set `"status": None` unconditionally. For AG-UI client-side tools where `additional_properties` does not carry an explicit `status`, this resulted in `null` being sent to the API, causing a `400 Bad Request`.
2. **`function_call_output` items** omitted the `status` field entirely, also causing API rejections.

## Changes

### `_responses_client.py`
- **`function_call`**: Resolve `status` from `content.additional_properties` when available, falling back to `"completed"` when absent or `None`.
- **`function_call_output`**: Always include `"status": "completed"`.

### `test_openai_responses_client.py`
Added 4 unit tests:
- `test_prepare_content_function_call_defaults_status_to_completed` — verifies default fallback
- `test_prepare_content_function_call_preserves_explicit_status` — verifies explicit status is preserved
- `test_prepare_content_function_result_includes_status_completed` — verifies function_call_output always has status
- `test_prepare_content_function_result_none_result` — verifies None result maps to empty string with status