### PR TITLE
Python: fix: add missing status field on function_call / function_call_output items

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_message_adapters.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_message_adapters.py
@@ -275,6 +275,7 @@ def _parse_multimodal_media_part(part: dict[str, Any]) -> Content | None:
     url = cast(str | None, part.get("url") or part.get("uri"))
     data = cast(str | None, part.get("data"))
     binary_id = cast(str | None, part.get("id"))
+    filename = cast(str | None, part.get("filename"))
 
     if isinstance(source, dict):
         source_dict = cast(dict[str, Any], source)
@@ -294,20 +295,28 @@ def _parse_multimodal_media_part(part: dict[str, Any]) -> Content | None:
             data = cast(str | None, source_dict.get("data") or data)
             binary_id = cast(str | None, source_dict.get("id") or binary_id)
 
+    additional_props: dict[str, Any] | None = {"filename": filename} if filename else None
+
     if isinstance(url, str) and url:
-        return Content.from_uri(uri=url, media_type=mime_type)
+        return Content.from_uri(uri=url, media_type=mime_type, additional_properties=additional_props)
 
     if isinstance(data, str) and data:
         if data.startswith("data:"):
-            return Content.from_uri(uri=data, media_type=mime_type)
+            return Content.from_uri(uri=data, media_type=mime_type, additional_properties=additional_props)
         try:
             decoded = base64.b64decode(data, validate=True)
-            return Content.from_data(data=decoded, media_type=mime_type or "application/octet-stream")
+            return Content.from_data(
+                data=decoded, media_type=mime_type or "application/octet-stream", additional_properties=additional_props
+            )
         except (binascii.Error, ValueError):
             logger.debug("Strict base64 decode failed for AG-UI media payload (mime_type=%s).", mime_type)
             try:
                 decoded = base64.b64decode(data)
-                return Content.from_data(data=decoded, media_type=mime_type or "application/octet-stream")
+                return Content.from_data(
+                    data=decoded,
+                    media_type=mime_type or "application/octet-stream",
+                    additional_properties=additional_props,
+                )
             except (binascii.Error, ValueError):
                 logger.warning(
                     "Failed to decode AG-UI media payload as base64; falling back to data URI (mime_type=%s).",
@@ -318,10 +327,13 @@ def _parse_multimodal_media_part(part: dict[str, Any]) -> Content | None:
                 return Content.from_uri(
                     uri=f"data:{mime_type or 'application/octet-stream'};base64,{data}",
                     media_type=mime_type,
+                    additional_properties=additional_props,
                 )
 
     if isinstance(binary_id, str) and binary_id:
-        return Content.from_uri(uri=f"ag-ui://binary/{binary_id}", media_type=mime_type)
+        return Content.from_uri(
+            uri=f"ag-ui://binary/{binary_id}", media_type=mime_type, additional_properties=additional_props
+        )
 
     return None
 

--- a/python/packages/ag-ui/tests/ag_ui/test_message_adapters.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_message_adapters.py
@@ -1455,6 +1455,94 @@ def test_parse_multimodal_media_part_binary_source_type():
     assert result.uri == "data:image/png;base64,abc"
 
 
+def test_parse_multimodal_media_part_filename_passthrough_base64():
+    """Filename from AG-UI BinaryInputContent is passed through to Content.from_data()."""
+    import base64
+
+    from agent_framework_ag_ui._message_adapters import _parse_multimodal_media_part
+
+    raw = base64.b64encode(b"PDF content").decode()
+    part = {
+        "type": "document",
+        "data": raw,
+        "mimeType": "application/pdf",
+        "filename": "report.pdf",
+    }
+    result = _parse_multimodal_media_part(part)
+    assert result is not None
+    assert result.type == "data"
+    assert result.additional_properties is not None
+    assert result.additional_properties["filename"] == "report.pdf"
+
+
+def test_parse_multimodal_media_part_filename_passthrough_url():
+    """Filename from AG-UI part with URL is passed through to Content.from_uri()."""
+    from agent_framework_ag_ui._message_adapters import _parse_multimodal_media_part
+
+    part = {
+        "type": "document",
+        "url": "https://example.com/report.pdf",
+        "mimeType": "application/pdf",
+        "filename": "report.pdf",
+    }
+    result = _parse_multimodal_media_part(part)
+    assert result is not None
+    assert result.uri == "https://example.com/report.pdf"
+    assert result.additional_properties is not None
+    assert result.additional_properties["filename"] == "report.pdf"
+
+
+def test_parse_multimodal_media_part_no_filename():
+    """Part without filename does not include filename in additional_properties."""
+    import base64
+
+    from agent_framework_ag_ui._message_adapters import _parse_multimodal_media_part
+
+    raw = base64.b64encode(b"image data").decode()
+    part = {
+        "type": "image",
+        "data": raw,
+        "mimeType": "image/png",
+    }
+    result = _parse_multimodal_media_part(part)
+    assert result is not None
+    assert not result.additional_properties or "filename" not in result.additional_properties
+
+
+def test_parse_multimodal_media_part_filename_passthrough_data_uri():
+    """Filename from AG-UI part with data URI prefix is passed through."""
+    from agent_framework_ag_ui._message_adapters import _parse_multimodal_media_part
+
+    part = {
+        "type": "document",
+        "data": "data:application/pdf;base64,abc",
+        "mimeType": "application/pdf",
+        "filename": "invoice.pdf",
+    }
+    result = _parse_multimodal_media_part(part)
+    assert result is not None
+    assert result.uri == "data:application/pdf;base64,abc"
+    assert result.additional_properties is not None
+    assert result.additional_properties["filename"] == "invoice.pdf"
+
+
+def test_parse_multimodal_media_part_filename_passthrough_binary_id():
+    """Filename from AG-UI part with binary ID is passed through."""
+    from agent_framework_ag_ui._message_adapters import _parse_multimodal_media_part
+
+    part = {
+        "type": "document",
+        "id": "file123",
+        "mimeType": "application/pdf",
+        "filename": "doc.pdf",
+    }
+    result = _parse_multimodal_media_part(part)
+    assert result is not None
+    assert result.uri == "ag-ui://binary/file123"
+    assert result.additional_properties is not None
+    assert result.additional_properties["filename"] == "doc.pdf"
+
+
 def test_snapshot_non_dict_item_in_content_list():
     """Non-dict items in content list are stringified."""
     result = agui_messages_to_snapshot_format([{"role": "user", "content": [42, "text"]}])

--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -1180,16 +1180,17 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                 if not fc_id.startswith("fc_"):
                     fc_id = f"fc_{fc_id}"
 
-                function_call_obj = {
+                status = (
+                    content.additional_properties.get("status") if content.additional_properties else None
+                ) or "completed"
+                return {
                     "call_id": content.call_id,
                     "id": fc_id,
                     "type": "function_call",
                     "name": content.name,
                     "arguments": content.arguments,
+                    "status": status,
                 }
-                if status := content.additional_properties.get("status"):
-                    function_call_obj["status"] = status
-                return function_call_obj
             case "function_result":
                 shell_output_type = (
                     content.additional_properties.get(OPENAI_SHELL_OUTPUT_TYPE_KEY)
@@ -1226,10 +1227,14 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                                 output_parts.append(part)
                     if output_parts:
                         output = output_parts
+                fn_result_status = (
+                    content.additional_properties.get("status") if content.additional_properties else None
+                ) or "completed"
                 return {
                     "call_id": content.call_id,
                     "type": "function_call_output",
                     "output": output,
+                    "status": fn_result_status,
                 }
             case "function_approval_request":
                 return {

--- a/python/packages/core/tests/openai/test_openai_responses_client.py
+++ b/python/packages/core/tests/openai/test_openai_responses_client.py
@@ -2320,6 +2320,7 @@ def test_prepare_content_for_openai_function_result_with_rich_items() -> None:
 
     assert result["type"] == "function_call_output"
     assert result["call_id"] == "call_rich"
+    assert result["status"] == "completed"
     # Output should be a list with text and image parts
     output = result["output"]
     assert isinstance(output, list)
@@ -2343,6 +2344,75 @@ def test_prepare_content_for_openai_function_result_without_items() -> None:
     assert result["type"] == "function_call_output"
     assert result["call_id"] == "call_plain"
     assert result["output"] == "Simple result"
+    assert result["status"] == "completed"
+
+
+def test_prepare_content_for_openai_function_call_status_defaults_to_completed() -> None:
+    """Test _prepare_content_for_openai defaults function_call status to 'completed'."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_call(
+        call_id="call_1",
+        name="get_weather",
+        arguments='{"location": "Seattle"}',
+    )
+
+    result = client._prepare_content_for_openai("assistant", content, {})  # type: ignore
+
+    assert result["type"] == "function_call"
+    assert result["call_id"] == "call_1"
+    assert result["status"] == "completed"
+
+
+def test_prepare_content_for_openai_function_call_preserves_explicit_status() -> None:
+    """Test _prepare_content_for_openai preserves explicit function_call status from additional_properties."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_call(
+        call_id="call_2",
+        name="get_weather",
+        arguments='{"location": "Seattle"}',
+        additional_properties={"status": "in_progress"},
+    )
+
+    result = client._prepare_content_for_openai("assistant", content, {})  # type: ignore
+
+    assert result["type"] == "function_call"
+    assert result["call_id"] == "call_2"
+    assert result["status"] == "in_progress"
+
+
+def test_prepare_content_for_openai_function_result_status_defaults_to_completed() -> None:
+    """Test _prepare_content_for_openai defaults function_call_output status to 'completed'."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_result(
+        call_id="call_3",
+        result="42",
+    )
+
+    result = client._prepare_content_for_openai("user", content, {})  # type: ignore
+
+    assert result["type"] == "function_call_output"
+    assert result["call_id"] == "call_3"
+    assert result["status"] == "completed"
+
+
+def test_prepare_content_for_openai_function_result_preserves_explicit_status() -> None:
+    """Test _prepare_content_for_openai preserves explicit function_call_output status."""
+    client = OpenAIResponsesClient(model_id="test-model", api_key="test-key")
+
+    content = Content.from_function_result(
+        call_id="call_4",
+        result="partial",
+        additional_properties={"status": "incomplete"},
+    )
+
+    result = client._prepare_content_for_openai("user", content, {})  # type: ignore
+
+    assert result["type"] == "function_call_output"
+    assert result["call_id"] == "call_4"
+    assert result["status"] == "incomplete"
 
 
 def test_parse_chunk_from_openai_code_interpreter() -> None:


### PR DESCRIPTION
Fixes #4701

Hey! So the Responses API expects a \`status\` field on both \`function_call\` and \`function_call_output\` items, but we weren't always including it. This leads to 400 errors when the API rejects the request.

### What changed

- **\`_responses_client.py\`** — \`status\` now defaults to \`"completed"\` for both \`function_call\` and \`function_call_output\` items. If someone explicitly sets it via \`additional_properties\`, that value is respected.
- **\`_message_adapters.py\`** — AG-UI media parts with a \`filename\` property now pass it through to the \`Content\` object via \`additional_properties\`, so binary attachments keep their original filenames.

### Tests

Added 9 new tests covering:
- Default status behavior for function_call and function_call_output
- Explicit status override via additional_properties  
- Filename passthrough for base64, URL, data URI, and binary ID media parts
- No filename case (ensures no spurious additional_properties)

All existing tests still pass. Ran ruff, pyright, and the full test suite — everything's clean.