### PR TITLE
.NET: Add shared primitive checkpoint encoding contract tests

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/PrimitiveCheckpointEncodingContractTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/PrimitiveCheckpointEncodingContractTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+public sealed class PrimitiveCheckpointEncodingContractTests
+{
+    [Fact]
+    public async Task PrimitiveCheckpointFixture_RoundTripsThroughJsonCheckpointStoreAsync()
+    {
+        JsonElement fixture = LoadFixture();
+        InMemoryJsonStore store = new();
+
+        CheckpointInfo checkpoint = await store.CreateCheckpointAsync("session-1", fixture);
+        JsonElement restored = await store.RetrieveCheckpointAsync("session-1", checkpoint);
+
+        restored.GetRawText().Should().Be(fixture.GetRawText());
+        restored.GetProperty("string").GetString().Should().Be("hello");
+        restored.GetProperty("integer").GetInt32().Should().Be(42);
+        restored.GetProperty("float").GetDouble().Should().Be(3.5d);
+        restored.GetProperty("boolean").GetBoolean().Should().BeTrue();
+        restored.GetProperty("nullValue").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    private static JsonElement LoadFixture()
+    {
+        string current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            string candidate = Path.Combine(current, "testdata", "checkpoint_primitive_contract.json");
+            if (File.Exists(candidate))
+            {
+                using JsonDocument document = JsonDocument.Parse(File.ReadAllText(candidate));
+                return document.RootElement.Clone();
+            }
+
+            DirectoryInfo? parent = Directory.GetParent(current);
+            if (parent is null)
+            {
+                break;
+            }
+
+            current = parent.FullName;
+        }
+
+        throw new InvalidOperationException("checkpoint primitive contract fixture not found");
+    }
+}

--- a/python/packages/core/tests/workflow/test_checkpoint_encoding_contract.py
+++ b/python/packages/core/tests/workflow/test_checkpoint_encoding_contract.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_framework._workflows._checkpoint_encoding import (
+    decode_checkpoint_value,
+    encode_checkpoint_value,
+)
+
+
+def _fixture_path() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "testdata" / "checkpoint_primitive_contract.json"
+        if candidate.exists():
+            return candidate
+    raise AssertionError("checkpoint primitive contract fixture not found")
+
+
+def test_checkpoint_primitive_contract_fixture_matches_python_encoding() -> None:
+    fixture = json.loads(_fixture_path().read_text(encoding="utf-8"))
+
+    encoded = encode_checkpoint_value(fixture)
+
+    assert encoded == fixture
+    assert decode_checkpoint_value(encoded) == fixture
+
+
+def test_checkpoint_primitive_contract_fixture_preserves_json_native_types() -> None:
+    fixture = json.loads(_fixture_path().read_text(encoding="utf-8"))
+
+    assert isinstance(fixture["string"], str)
+    assert isinstance(fixture["integer"], int)
+    assert isinstance(fixture["float"], float)
+    assert isinstance(fixture["boolean"], bool)
+    assert fixture["nullValue"] is None
+    assert fixture["list"] == [1, "two", False, None]
+    assert fixture["object"] == {"nested": {"value": "ok"}, "count": 2}

--- a/testdata/checkpoint_primitive_contract.json
+++ b/testdata/checkpoint_primitive_contract.json
@@ -1,0 +1,19 @@
+{
+  "string": "hello",
+  "integer": 42,
+  "float": 3.5,
+  "boolean": true,
+  "nullValue": null,
+  "list": [
+    1,
+    "two",
+    false,
+    null
+  ],
+  "object": {
+    "nested": {
+      "value": "ok"
+    },
+    "count": 2
+  }
+}


### PR DESCRIPTION
### Motivation and Context

Checkpoint values that are already JSON primitives, arrays, and objects should round-trip consistently through the Python and .NET checkpoint stores. There was no shared regression fixture proving that narrow contract across both runtimes. Closes #4706.

### Description

This adds a shared `testdata/checkpoint_primitive_contract.json` fixture plus one Python test and one .NET test that assert the same primitive payload can be stored and read back without shape drift. The scope is intentionally limited to the primitive JSON contract that both runtimes already claim to support.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
