### PR TITLE
Python: fix: add to_json to Content for serialization compatibility

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1298,6 +1298,22 @@ class Content:
 
         return result
 
+    def to_json(self, *, exclude_none: bool = True, exclude: set[str] | None = None, **kwargs: Any) -> str:
+        """Serialize the content to a JSON string.
+
+        This is a convenience wrapper around ``to_dict()`` that returns a JSON
+        string via ``json.dumps()``.
+
+        Keyword Args:
+            exclude_none: Whether to exclude None values. Defaults to True.
+            exclude: Field names to exclude from serialization.
+            **kwargs: Additional keyword arguments passed to ``json.dumps()``.
+
+        Returns:
+            JSON string representation of the content.
+        """
+        return json.dumps(self.to_dict(exclude_none=exclude_none, exclude=exclude), **kwargs)
+
     def __eq__(self, other: object) -> bool:
         """Check if two Content instances are equal by comparing their dict representations."""
         if not isinstance(other, Content):


### PR DESCRIPTION
## Summary

- Add `to_json()` method to the `Content` class, fixing `TypeError` when Azure Functions serializes `Message` objects containing `Content` instances.
- `Content` already has `to_dict()` but lacked the corresponding `to_json()` that `SerializationMixin` provides. This adds it following the same pattern: delegates to `json.dumps(self.to_dict())`.

Fixes #4719

## Test plan

- [ ] Verify `Content.from_text("hello").to_json()` returns valid JSON
- [ ] Verify kwargs pass through (e.g. `to_json(indent=2)`)
- [ ] Verify `exclude_none` and `exclude` parameters work as expected
- [ ] Confirm Azure Functions can serialize Message objects containing Content without TypeError