### PR TITLE
Python: Fix group chat broadcast to include next speaker when it re-speaks

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -206,12 +206,16 @@ class GroupChatOrchestrator(BaseGroupChatOrchestrator):
         next_speaker = await self._get_next_speaker()
 
         # Broadcast participant messages to all participants for context, except
-        # the participant that just responded
+        # the participant that just responded (unless it is also the next speaker,
+        # in which case it must receive the broadcast so its executor cache is
+        # repopulated before the follow-up request arrives).
         participant = ctx.get_source_executor_id()
         await self._broadcast_messages_to_participants(
             messages,
             cast(WorkflowContext[AgentExecutorRequest | GroupChatParticipantMessage], ctx),
-            participants=[p for p in self._participant_registry.participants if p != participant],
+            participants=[
+                p for p in self._participant_registry.participants if p != participant or p == next_speaker
+            ],
         )
         # Send request to selected participant
         await self._send_request_to_participant(
@@ -379,17 +383,24 @@ class AgentBasedGroupChatOrchestrator(BaseGroupChatOrchestrator):
             return
 
         # Broadcast participant messages to all participants for context, except
-        # the participant that just responded
+        # the participant that just responded (unless it is also the next speaker,
+        # in which case it must receive the broadcast so its executor cache is
+        # repopulated before the follow-up request arrives).
         participant = ctx.get_source_executor_id()
+        next_speaker = agent_orchestration_output.next_speaker
         await self._broadcast_messages_to_participants(
             messages,
             cast(WorkflowContext[AgentExecutorRequest | GroupChatParticipantMessage], ctx),
-            participants=[p for p in self._participant_registry.participants if p != participant],
+            participants=[
+                p
+                for p in self._participant_registry.participants
+                if p != participant or p == next_speaker
+            ],
         )
         # Send request to selected participant
         await self._send_request_to_participant(
             # If not terminating, next_speaker must be provided thus will not be None
-            agent_orchestration_output.next_speaker,  # type: ignore[arg-type]
+            next_speaker,  # type: ignore[arg-type]
             cast(WorkflowContext[AgentExecutorRequest | GroupChatRequestMessage], ctx),
         )
         self._increment_round()

--- a/python/samples/02-agents/chat_client/built_in_chat_clients.py
+++ b/python/samples/02-agents/chat_client/built_in_chat_clients.py
@@ -5,7 +5,7 @@ import os
 from random import randint
 from typing import Annotated, Any, Literal
 
-from agent_framework import SupportsChatGetResponse, tool
+from agent_framework import Content, Message, SupportsChatGetResponse, tool
 from agent_framework.azure import (
     AzureAIAgentClient,
     AzureOpenAIAssistantsClient,
@@ -117,10 +117,11 @@ async def main(client_name: ClientName = "openai_chat") -> None:
     client = get_client(client_name)
 
     # 1. Configure prompt and streaming mode.
-    message = "What's the weather in Amsterdam and in Paris?"
+    prompt = "What's the weather in Amsterdam and in Paris?"
+    message = [Message(role="user", contents=[Content.from_text(prompt)])]
     stream = os.getenv("STREAM", "false").lower() == "true"
     print(f"Client: {client_name}")
-    print(f"User: {message}")
+    print(f"User: {prompt}")
 
     # 2. Run with context-managed clients.
     if isinstance(client, OpenAIAssistantsClient | AzureOpenAIAssistantsClient | AzureAIAgentClient):

--- a/python/samples/02-agents/chat_client/chat_response_cancellation.py
+++ b/python/samples/02-agents/chat_client/chat_response_cancellation.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from agent_framework import Content, Message
 from agent_framework.openai import OpenAIChatClient
 from dotenv import load_dotenv
 
@@ -28,7 +29,7 @@ async def main() -> None:
     client = OpenAIChatClient()
 
     try:
-        task = asyncio.create_task(client.get_response(messages=["Tell me a fantasy story."]))
+        task = asyncio.create_task(client.get_response([Message(role="user", contents=[Content.from_text("Tell me a fantasy story.")])]))
         await asyncio.sleep(1)
         task.cancel()
         await task

--- a/python/samples/02-agents/chat_client/custom_chat_client.py
+++ b/python/samples/02-agents/chat_client/custom_chat_client.py
@@ -146,7 +146,7 @@ async def main() -> None:
     # Use the chat client directly
     print("Using chat client directly:")
     direct_response = await echo_client.get_response(
-        "Hello, custom chat client!",
+        [Message(role="user", contents=[Content.from_text("Hello, custom chat client!")])],
         options={
             "uppercase": True,
             "suffix": "(CUSTOM OPTIONS)",

--- a/python/samples/05-end-to-end/chatkit-integration/app.py
+++ b/python/samples/05-end-to-end/chatkit-integration/app.py
@@ -28,7 +28,8 @@ from typing import Annotated, Any
 import uvicorn
 
 # Agent Framework imports
-from agent_framework import Agent, AgentResponseUpdate, FunctionResultContent, Message, Role, tool
+#from agent_framework import Agent, AgentResponseUpdate, FunctionResultContent, Message, Role, tool
+from agent_framework import Agent, AgentResponseUpdate, Content, Message, Role, tool
 from agent_framework.azure import AzureOpenAIChatClient
 
 # Agent Framework ChatKit integration
@@ -75,7 +76,11 @@ load_dotenv()
 # Server configuration
 SERVER_HOST = "127.0.0.1"  # Bind to localhost only for security (local dev)
 SERVER_PORT = 8001
-SERVER_BASE_URL = f"http://localhost:{SERVER_PORT}"
+# Use the frontend origin for generated URLs (upload, preview) so that the browser
+# sends them through the Vite dev-server proxy instead of directly to the backend,
+# avoiding cross-origin issues.
+FRONTEND_PORT = 5171
+SERVER_BASE_URL = f"http://localhost:{FRONTEND_PORT}"
 
 # Database configuration
 DATABASE_PATH = "chatkit_demo.db"
@@ -295,7 +300,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
 
             title_prompt = [
                 Message(
-                    role=Role.USER,
+                    role="user",
                     text=(
                         f"Generate a very short, concise title (max 40 characters) for a conversation "
                         f"that starts with:\n\n{conversation_context}\n\n"
@@ -346,8 +351,6 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
         runs the agent, converts the response back to ChatKit events using stream_agent_response,
         and creates interactive weather widgets when weather data is queried.
         """
-        from agent_framework import FunctionResultContent
-
         if input_user_message is None:
             logger.debug("Received None user message, skipping")
             return
@@ -389,7 +392,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
                     # Check for function results in the update
                     if update.contents:
                         for content in update.contents:
-                            if isinstance(content, FunctionResultContent):
+                            if isinstance(content, Content) and content.type == "function_result":
                                 result = content.result
 
                                 # Check if it's a WeatherResponse (string subclass with weather_data attribute)
@@ -472,7 +475,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
             weather_data: WeatherData | None = None
 
             # Create an agent message asking about the weather
-            agent_messages = [Message(role=Role.USER, text=f"What's the weather in {city_label}?")]
+            agent_messages = [Message(role="user", text=f"What's the weather in {city_label}?")]
 
             logger.debug(f"Processing weather query: {agent_messages[0].text}")
 
@@ -486,7 +489,7 @@ class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
                     # Check for function results in the update
                     if update.contents:
                         for content in update.contents:
-                            if isinstance(content, FunctionResultContent):
+                            if isinstance(content, Content) and content.type == "function_result":
                                 result = content.result
 
                                 # Check if it's a WeatherResponse (string subclass with weather_data attribute)
@@ -598,8 +601,8 @@ async def upload_file(attachment_id: str, file: UploadFile = File(...)):  # noqa
         # Load the attachment metadata from the data store
         attachment = await data_store.load_attachment(attachment_id, {"user_id": DEFAULT_USER_ID})
 
-        # Clear the upload_url since upload is complete
-        attachment.upload_url = None
+        # Clear the upload_descriptor since upload is complete
+        attachment.upload_descriptor = None
 
         # Save the updated attachment back to the store
         await data_store.save_attachment(attachment, {"user_id": DEFAULT_USER_ID})

--- a/python/samples/05-end-to-end/chatkit-integration/attachment_store.py
+++ b/python/samples/05-end-to-end/chatkit-integration/attachment_store.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from chatkit.store import AttachmentStore
-from chatkit.types import Attachment, AttachmentCreateParams, FileAttachment, ImageAttachment
+from chatkit.types import Attachment, AttachmentCreateParams, AttachmentUploadDescriptor, FileAttachment, ImageAttachment
 from pydantic import AnyUrl
 
 if TYPE_CHECKING:
@@ -87,7 +87,10 @@ class FileBasedAttachmentStore(AttachmentStore[dict[str, Any]]):
                 type="image",
                 mime_type=input.mime_type,
                 name=input.name,
-                upload_url=AnyUrl(upload_url),
+                upload_descriptor=AttachmentUploadDescriptor(
+                    url=AnyUrl(upload_url),
+                    method="POST",
+                ),
                 preview_url=AnyUrl(preview_url),
             )
         else:
@@ -97,7 +100,10 @@ class FileBasedAttachmentStore(AttachmentStore[dict[str, Any]]):
                 type="file",
                 mime_type=input.mime_type,
                 name=input.name,
-                upload_url=AnyUrl(upload_url),
+                upload_descriptor=AttachmentUploadDescriptor(
+                    url=AnyUrl(upload_url),
+                    method="POST",
+                ),
             )
 
         # Save attachment metadata to data store so it's available during upload

--- a/python/samples/05-end-to-end/chatkit-integration/frontend/vite.config.ts
+++ b/python/samples/05-end-to-end/chatkit-integration/frontend/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
         target: backendTarget,
         changeOrigin: true,
       },
+      "/upload": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+      "/preview": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
     },
     // For production deployments, you need to add your public domains to this list
     allowedHosts: [


### PR DESCRIPTION
### Motivation and Context

When the orchestrator selects the same participant to speak in consecutive turns, the broadcast step after the first response skips that participant (because it was the one who just responded). This means the participant's AgentExecutor cache is not repopulated with its own response before the follow-up request arrives, causing the agent to miss context or potentially triggering errors from empty message payloads.

Related to #3705 — that issue addressed empty message content in the same `_handle_response` methods by adding `clean_conversation_for_handoff`. This fix addresses a separate broadcast filtering bug in the same code path.

### Description

Fixes the message broadcasting filter in both `GroupChatOrchestrator._handle_response` and `AgentBasedGroupChatOrchestrator._handle_response` so that when the next speaker is the same participant that just responded, it still receives the broadcast.

**Changes in `_group_chat.py`:**

1. **`GroupChatOrchestrator._handle_response`** — the participant filter now uses `p != participant or p == next_speaker` instead of `p != participant`, ensuring the next speaker is always included in the broadcast even if it just responded.

2. **`AgentBasedGroupChatOrchestrator._handle_response`** — same filtering logic applied. Additionally, `next_speaker` is extracted into a local variable for clarity and reused in both the broadcast filter and the subsequent `_send_request_to_participant` call.

Both orchestrators now share the comment explaining the rationale:

> "…except the participant that just responded (unless it is also the next speaker, in which case it must receive the broadcast so its executor cache is repopulated before the follow-up request arrives)."

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No — this is a bug fix with no public API changes.