### PR TITLE
Python: Reduce Azure chat client import overhead

### DIFF
--- a/python/packages/core/agent_framework/azure/_chat_client.py
+++ b/python/packages/core/agent_framework/azure/_chat_client.py
@@ -45,6 +45,8 @@ else:
 
 if TYPE_CHECKING:
     from openai.lib.azure import AsyncAzureOpenAI
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
     from agent_framework._middleware import MiddlewareTypes
 
@@ -288,7 +290,7 @@ class AzureOpenAIChatClient(  # type: ignore[misc]
         )
 
     @override
-    def _parse_text_from_openai(self, choice: Any) -> Content | None:
+    def _parse_text_from_openai(self, choice: Choice | ChunkChoice) -> Content | None:
         """Parse the choice into a Content object with type='text'.
 
         Overwritten from RawOpenAIChatClient to deal with Azure On Your Data function.

--- a/python/packages/core/agent_framework/azure/_chat_client.py
+++ b/python/packages/core/agent_framework/azure/_chat_client.py
@@ -8,9 +8,6 @@ import sys
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Generic, cast
 
-from openai.lib.azure import AsyncAzureOpenAI
-from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from pydantic import BaseModel
 
 from agent_framework import (
@@ -23,8 +20,7 @@ from agent_framework import (
     FunctionInvocationLayer,
 )
 from agent_framework.observability import ChatTelemetryLayer
-from agent_framework.openai import OpenAIChatOptions
-from agent_framework.openai._chat_client import RawOpenAIChatClient
+from agent_framework.openai._chat_client import OpenAIChatOptions, RawOpenAIChatClient
 
 from .._settings import load_settings
 from ._entra_id_authentication import AzureCredentialTypes, AzureTokenProvider
@@ -48,6 +44,8 @@ else:
     from typing_extensions import TypedDict  # type: ignore # pragma: no cover
 
 if TYPE_CHECKING:
+    from openai.lib.azure import AsyncAzureOpenAI
+
     from agent_framework._middleware import MiddlewareTypes
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -290,14 +288,16 @@ class AzureOpenAIChatClient(  # type: ignore[misc]
         )
 
     @override
-    def _parse_text_from_openai(self, choice: Choice | ChunkChoice) -> Content | None:
+    def _parse_text_from_openai(self, choice: Any) -> Content | None:
         """Parse the choice into a Content object with type='text'.
 
         Overwritten from RawOpenAIChatClient to deal with Azure On Your Data function.
         For docs see:
         https://learn.microsoft.com/en-us/azure/ai-foundry/openai/references/on-your-data?tabs=python#context
         """
-        message = choice.message if isinstance(choice, Choice) else choice.delta
+        message = getattr(choice, "message", None)
+        if message is None:
+            message = getattr(choice, "delta", None)
         # When you enable asynchronous content filtering in Azure OpenAI, you may receive empty deltas
         if message is None:  # type: ignore
             return None

--- a/python/packages/core/tests/azure/test_azure_chat_client.py
+++ b/python/packages/core/tests/azure/test_azure_chat_client.py
@@ -652,6 +652,88 @@ async def test_streaming_with_none_delta(
     assert any(msg.contents for msg in results)
 
 
+# region _parse_text_from_openai direct unit tests
+
+
+def test_parse_text_from_openai_with_choice_message(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai correctly reads message from a Choice."""
+    client = AzureOpenAIChatClient()
+    choice = Choice(
+        index=0,
+        message=ChatCompletionMessage(content="hello", role="assistant"),
+        finish_reason="stop",
+    )
+    result = client._parse_text_from_openai(choice)
+    assert result is not None
+    assert result.type == "text"
+    assert result.text == "hello"
+
+
+def test_parse_text_from_openai_with_chunk_choice_delta(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai correctly reads delta from a ChunkChoice."""
+    client = AzureOpenAIChatClient()
+    choice = ChunkChoice(
+        index=0,
+        delta=ChunkChoiceDelta(content="streamed", role="assistant"),
+        finish_reason=None,
+    )
+    result = client._parse_text_from_openai(choice)
+    assert result is not None
+    assert result.type == "text"
+    assert result.text == "streamed"
+
+
+def test_parse_text_from_openai_refusal_choice(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai returns refusal text from a Choice."""
+    client = AzureOpenAIChatClient()
+    choice = Choice(
+        index=0,
+        message=ChatCompletionMessage(content=None, role="assistant", refusal="I cannot help with that"),
+        finish_reason="stop",
+    )
+    result = client._parse_text_from_openai(choice)
+    assert result is not None
+    assert result.type == "text"
+    assert result.text == "I cannot help with that"
+
+
+def test_parse_text_from_openai_refusal_chunk_choice(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai returns refusal text from a ChunkChoice."""
+    client = AzureOpenAIChatClient()
+    choice = ChunkChoice(
+        index=0,
+        delta=ChunkChoiceDelta(content=None, role="assistant", refusal="I cannot help with that"),
+        finish_reason=None,
+    )
+    result = client._parse_text_from_openai(choice)
+    assert result is not None
+    assert result.type == "text"
+    assert result.text == "I cannot help with that"
+
+
+def test_parse_text_from_openai_no_content_no_refusal(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai returns None when no content or refusal."""
+    client = AzureOpenAIChatClient()
+    choice = Choice(
+        index=0,
+        message=ChatCompletionMessage(content=None, role="assistant"),
+        finish_reason="stop",
+    )
+    result = client._parse_text_from_openai(choice)
+    assert result is None
+
+
+def test_parse_text_from_openai_none_delta(azure_openai_unit_test_env: dict[str, str]) -> None:
+    """Test _parse_text_from_openai returns None when delta is None (async content filtering)."""
+    client = AzureOpenAIChatClient()
+    choice = ChunkChoice.model_construct(index=0, delta=None, finish_reason=None)
+    result = client._parse_text_from_openai(choice)
+    assert result is None
+
+
+# endregion
+
+
 @patch.object(AsyncChatCompletions, "create", new_callable=AsyncMock)
 async def test_cmc_with_conversation_id(
     mock_create: AsyncMock,


### PR DESCRIPTION
### Motivation and Context

Latency benchmarking on current `main` showed `import_azure_openai_chat_client` regressed relative to the latest comparable historical baseline. Profiling pointed at `agent_framework.azure._chat_client` eagerly importing heavier OpenAI runtime modules and top-level package surfaces during module import. This change narrows that import path and helps address the latency work tracked in #2752.

### Description

- move `AsyncAzureOpenAI` behind `TYPE_CHECKING` so it is not imported at module load time
- stop eagerly importing OpenAI `Choice` and `ChunkChoice` runtime types
- import `OpenAIChatOptions` directly from `agent_framework.openai._chat_client` instead of the heavier `agent_framework.openai` package surface
- update `_parse_text_from_openai` to read `message` and `delta` via `getattr`, preserving the existing parsing behavior without those runtime type imports

This keeps the change isolated to import-time behavior and avoids changing the public Azure chat client API surface. The change was exercised with the non-integration Azure chat client test suite.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
