### PR TITLE
.NET: Add regression test for AzureAI Foundry conversation ID semantics

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.AzureAI.UnitTests/AzureAIProjectChatClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.AzureAI.UnitTests/AzureAIProjectChatClientTests.cs
@@ -149,7 +149,8 @@ public class AzureAIProjectChatClientTests
         // Assert
         Assert.True(requestTriggered);
         var chatClientSession = Assert.IsType<ChatClientAgentSession>(session);
-        Assert.StartsWith("conv_", chatClientSession.ConversationId);
+        var conversationId = Assert.NotNull(chatClientSession.ConversationId);
+        Assert.StartsWith("conv_", conversationId);
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request adds a new unit test to ensure that a newly created Azure AI session exposes a durable Foundry conversation ID after the first run, rather than a response-chain ID. This helps verify correct behavior in session management for chat clients.

Testing improvements:

* Added a test `ChatClient_UsesFoundryConversationId_ForNewSessionsAsync` in `AzureAIProjectChatClientTests.cs` to verify that new sessions use a durable Foundry conversation ID after the first run, ensuring session IDs are managed correctly.

For #4752

### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x]  The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible