### PR TITLE
Python: Fix MCP tool schema normalization for zero-argument tools missing 'properties' key

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -905,6 +905,8 @@ class MCPTool:
                 # Normalize inputSchema: ensure "properties" exists for object schemas.
                 # Some MCP servers (e.g. zero-argument tools) omit "properties",
                 # which causes OpenAI API to reject the schema with a 400 error.
+                # Guard against non-conforming MCP servers that send inputSchema=None
+                # despite the MCP spec typing it as dict[str, Any].
                 input_schema = dict(tool.inputSchema or {})
                 if input_schema.get("type") == "object" and "properties" not in input_schema:
                     input_schema["properties"] = {}

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -2087,13 +2087,21 @@ async def test_load_tools_adds_properties_to_zero_arg_tool_schema():
             inputSchema=original_empty_schema,
         ),
     ]
+
+    # Simulate a non-conforming MCP server that sends inputSchema=None.
+    # types.Tool requires inputSchema to be a dict, so we use a MagicMock.
+    none_schema_tool = MagicMock()
+    none_schema_tool.name = "none_schema_tool"
+    none_schema_tool.description = "A tool with None inputSchema"
+    none_schema_tool.inputSchema = None
+    page.tools.append(none_schema_tool)
     page.nextCursor = None
 
     mock_session.list_tools = AsyncMock(return_value=page)
 
     await tool.load_tools()
 
-    assert len(tool._functions) == 4
+    assert len(tool._functions) == 5
 
     funcs_by_name = {f.name: f for f in tool._functions}
 
@@ -2117,6 +2125,10 @@ async def test_load_tools_adds_properties_to_zero_arg_tool_schema():
     # Empty schema (no "type" key) must NOT have "properties" injected
     empty_params = funcs_by_name["empty_schema_tool"].parameters()
     assert "properties" not in empty_params
+
+    # None inputSchema must produce an empty dict (guard against non-conforming servers)
+    none_params = funcs_by_name["none_schema_tool"].parameters()
+    assert none_params == {}
 
     # Original inputSchema dicts must not be mutated
     assert "properties" not in original_zero_arg_schema


### PR DESCRIPTION
### Motivation and Context

Some MCP servers (e.g. matlab-mcp-core-server) declare zero-argument tools with `inputSchema={"type": "object"}` but omit the `"properties"` key. When these schemas are forwarded to the OpenAI API (e.g. via LM Studio's `/v1/responses`), the API rejects them with a 400 error because it requires `"properties"` on object-type schemas.

Fixes #4540

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause is that `MCPTool.load_tools()` passed `tool.inputSchema` directly to `FunctionTool` without validating that the schema contained a `"properties"` key. The fix normalizes the `inputSchema` during tool loading: if the schema has `"type": "object"` but no `"properties"` key, an empty `"properties": {}` dict is injected. A regression test verifies that zero-argument tools get the missing key added while normal tools with existing properties are left unchanged.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by giles17's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":4540,"repo":"microsoft/agent-framework","rid":"a829ea6507d9424fb5c7b693c51aad32","rt":"fix","sf":"pr","ts":"2026-03-18T21:50:46.851243+00:00","u":"giles17","v":1}
-->
