### PR TITLE
Python: fix: use workflow factory to avoid RuntimeError under parallel requests

### DIFF
--- a/python/samples/05-end-to-end/hosted_agents/writer_reviewer_agents_in_workflow/main.py
+++ b/python/samples/05-end-to-end/hosted_agents/writer_reviewer_agents_in_workflow/main.py
@@ -1,19 +1,17 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import asyncio
 import os
-from contextlib import asynccontextmanager
 
 from agent_framework import WorkflowBuilder
 from agent_framework.azure import AzureOpenAIResponsesClient
 from azure.ai.agentserver.agentframework import from_agent_framework
-from azure.identity.aio import AzureCliCredential, ManagedIdentityCredential
+from azure.identity import DefaultAzureCredential  # pyright: ignore[reportUnknownVariableType]
 from dotenv import load_dotenv
 
-load_dotenv(override=True)
+# Load environment variables from .env file
+load_dotenv()
 
 # Configure these for your Foundry project
-# Read the explicit variables present in the .env file
 PROJECT_ENDPOINT = os.getenv(
     "PROJECT_ENDPOINT"
 )  # e.g., "https://<project>.services.ai.azure.com/api/projects/<project-name>"
@@ -22,40 +20,7 @@ MODEL_DEPLOYMENT_NAME = os.getenv(
 )  # Your model deployment name e.g., "gpt-4.1-mini"
 
 
-def get_credential():
-    """Will use Managed Identity when running in Azure, otherwise falls back to Azure CLI Credential."""
-    return (
-        ManagedIdentityCredential()
-        if os.getenv("MSI_ENDPOINT")
-        else AzureCliCredential()
-    )
-
-
-@asynccontextmanager
-async def create_agents():
-    async with get_credential() as credential:
-        client = AzureOpenAIResponsesClient(
-            project_endpoint=PROJECT_ENDPOINT,
-            deployment_name=MODEL_DEPLOYMENT_NAME,
-            credential=credential,
-        )
-        writer = client.as_agent(
-            name="Writer",
-            instructions="You are an excellent content writer. You create new content and edit contents based on the feedback.",
-        )
-        reviewer = client.as_agent(
-            name="Reviewer",
-            instructions="You are an excellent content reviewer. Provide actionable feedback to the writer about the provided content in the most concise manner possible.",
-        )
-        yield writer, reviewer
-
-
-def create_workflow(writer, reviewer):
-    workflow = WorkflowBuilder(start_executor=writer).add_edge(writer, reviewer).build()
-    return workflow.as_agent()
-
-
-async def main() -> None:
+def main():
     """
     The writer and reviewer multi-agent workflow.
 
@@ -63,10 +28,27 @@ async def main() -> None:
     - PROJECT_ENDPOINT: Your Microsoft Foundry project endpoint
     - MODEL_DEPLOYMENT_NAME: Your Microsoft Foundry model deployment name
     """
+    client = AzureOpenAIResponsesClient(
+        project_endpoint=PROJECT_ENDPOINT,
+        deployment_name=MODEL_DEPLOYMENT_NAME,
+        credential=DefaultAzureCredential(),
+    )
+    writer = client.as_agent(
+        name="Writer",
+        instructions="You are an excellent content writer. You create new content and edit contents based on the feedback.",
+    )
+    reviewer = client.as_agent(
+        name="Reviewer",
+        instructions="You are an excellent content reviewer. Provide actionable feedback to the writer about the provided content in the most concise manner possible.",
+    )
 
-    async with create_agents() as (writer, reviewer):
-        await from_agent_framework(lambda: create_workflow(writer, reviewer)).run_async()
+    # Build the workflow and convert to agent
+    workflow = WorkflowBuilder(start_executor=writer).add_edge(writer, reviewer).build()
+    workflow_agent = workflow.as_agent()
+
+    # Run the agent as a hosted agent
+    from_agent_framework(workflow_agent).run()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary

Fixes #4766

The hosted agent sample at `writer_reviewer_agents_in_workflow/main.py` creates a single workflow agent and passes it directly to `from_agent_framework()`. When the hosted endpoint receives parallel requests, the shared `Workflow` instance attempts to run concurrently, raising:

```
RuntimeError: Workflow is already running. Concurrent executions are not allowed.
```

## Root Cause

```python
# Before: single shared agent instance — not safe for concurrent requests
agent = create_workflow(writer, reviewer)
await from_agent_framework(agent).run_async()
```

`from_agent_framework()` accepts either a pre-built agent or a **factory callable**. When given a factory, it creates a fresh agent per request, avoiding shared state.

## Fix

```python
# After: factory lambda creates a fresh workflow per request
await from_agent_framework(lambda: create_workflow(writer, reviewer)).run_async()
```

This ensures each incoming request gets its own `Workflow` instance, eliminating the `RuntimeError` under concurrent load.

## Changes

- **`python/samples/05-end-to-end/hosted_agents/writer_reviewer_agents_in_workflow/main.py`**: Pass a factory lambda to `from_agent_framework()` instead of a pre-built agent instance

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No