### PR TITLE
Python: Normalize OpenAI function-call arguments at parse time to prevent uni…

### DIFF
--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -141,6 +141,7 @@ from ._types import (
     detect_media_type_from_base64,
     map_chat_to_agent_update,
     merge_chat_options,
+    normalize_function_call_arguments,
     normalize_messages,
     normalize_tools,
     prepend_instructions_to_messages,

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1511,6 +1511,31 @@ class Content:
         return self.arguments  # type: ignore[return-value]
 
 
+def normalize_function_call_arguments(
+    arguments: str | Mapping[str, Any] | None,
+) -> Mapping[str, Any] | str | None:
+    """Normalize function-call arguments to a mapping when the payload is a JSON object.
+
+    OpenAI chat and responses parsers return function-call arguments as raw JSON
+    strings, while Anthropic already returns parsed dicts.  Eagerly normalizing
+    to a dict avoids a second ``json.loads`` in ``parse_arguments`` that would
+    re-interpret ``\\uXXXX`` escape sequences as Unicode characters — the root
+    cause of escape-corruption bugs when editing source files that contain
+    Python/JS-style ``\\u`` escapes.
+    """
+    if arguments is None or isinstance(arguments, Mapping):
+        return arguments
+    if not isinstance(arguments, str) or not arguments.strip():
+        return arguments
+    try:
+        parsed = json.loads(arguments)
+        if isinstance(parsed, dict):
+            return parsed
+        return arguments
+    except (json.JSONDecodeError, TypeError):
+        return arguments
+
+
 def _combine_additional_props(
     self_additional_properties: dict[str, Any], other_additional_properties: dict[str, Any]
 ) -> dict[str, Any]:

--- a/python/packages/core/agent_framework/openai/_chat_client.py
+++ b/python/packages/core/agent_framework/openai/_chat_client.py
@@ -49,6 +49,7 @@ from .._types import (
     Message,
     ResponseStream,
     UsageDetails,
+    normalize_function_call_arguments,
 )
 from ..exceptions import (
     ChatClientException,
@@ -556,7 +557,9 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     fcc = Content.from_function_call(
                         call_id=tool.id if tool.id else "",
                         name=tool.function.name if tool.function.name else "",
-                        arguments=tool.function.arguments if tool.function.arguments else "",
+                        arguments=normalize_function_call_arguments(
+                            tool.function.arguments if tool.function.arguments else ""
+                        ),
                         raw_representation=tool.function,
                     )
                     resp.append(fcc)

--- a/python/packages/core/agent_framework/openai/_responses_client.py
+++ b/python/packages/core/agent_framework/openai/_responses_client.py
@@ -74,6 +74,7 @@ from .._types import (
     UsageDetails,
     detect_media_type_from_base64,
     prepend_instructions_to_messages,
+    normalize_function_call_arguments,
     validate_tool_mode,
 )
 from ..exceptions import (
@@ -1192,12 +1193,17 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                 if not fc_id.startswith("fc_"):
                     fc_id = f"fc_{fc_id}"
 
+                args = (
+                    json.dumps(content.arguments)
+                    if isinstance(content.arguments, Mapping)
+                    else (content.arguments or "")
+                )
                 function_call_obj = {
                     "call_id": content.call_id,
                     "id": fc_id,
                     "type": "function_call",
                     "name": content.name,
-                    "arguments": content.arguments,
+                    "arguments": args,
                 }
                 if status := content.additional_properties.get("status"):
                     function_call_obj["status"] = status
@@ -1244,10 +1250,12 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                     "output": output,
                 }
             case "function_approval_request":
+                fc_args = content.function_call.arguments  # type: ignore[union-attr]
+                fc_args_str = json.dumps(fc_args) if isinstance(fc_args, Mapping) else (fc_args or "")
                 return {
                     "type": "mcp_approval_request",
                     "id": content.id,  # type: ignore[union-attr]
-                    "arguments": content.function_call.arguments,  # type: ignore[union-attr]
+                    "arguments": fc_args_str,
                     "name": content.function_call.name,  # type: ignore[union-attr]
                     "server_label": content.function_call.additional_properties.get("server_label")  # type: ignore[union-attr]
                     if content.function_call.additional_properties  # type: ignore[union-attr]
@@ -1523,7 +1531,7 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                         Content.from_function_call(
                             call_id=item.call_id,
                             name=item.name,
-                            arguments=item.arguments,
+                            arguments=normalize_function_call_arguments(item.arguments),
                             additional_properties={"fc_id": item.id, "status": item.status},
                             raw_representation=item,
                         )
@@ -1535,7 +1543,7 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                             function_call=Content.from_function_call(
                                 call_id=item.id,
                                 name=item.name,
-                                arguments=item.arguments,
+                                arguments=normalize_function_call_arguments(item.arguments),
                                 additional_properties={"server_label": item.server_label},
                                 raw_representation=item,
                             ),
@@ -1915,7 +1923,7 @@ class RawOpenAIResponsesClient(  # type: ignore[misc]
                                 function_call=Content.from_function_call(
                                     call_id=event_item.id,
                                     name=event_item.name,
-                                    arguments=event_item.arguments,
+                                    arguments=normalize_function_call_arguments(event_item.arguments),
                                     additional_properties={"server_label": event_item.server_label},
                                     raw_representation=event_item,
                                 ),

--- a/python/packages/core/tests/openai/test_openai_responses_client.py
+++ b/python/packages/core/tests/openai/test_openai_responses_client.py
@@ -1037,7 +1037,7 @@ def test_response_content_creation_with_function_call() -> None:
     function_call = response.messages[0].contents[0]
     assert function_call.call_id == "call_123"
     assert function_call.name == "get_weather"
-    assert function_call.arguments == '{"location": "Seattle"}'
+    assert function_call.arguments == {"location": "Seattle"}
 
 
 def test_prepare_content_for_opentool_approval_response() -> None:
@@ -3581,7 +3581,7 @@ def test_parse_response_from_openai_function_call_includes_status() -> None:
     assert function_call.type == "function_call"
     assert function_call.call_id == "call_123"
     assert function_call.name == "get_weather"
-    assert function_call.arguments == '{"location": "Seattle"}'
+    assert function_call.arguments == {"location": "Seattle"}
     # Verify status is included in additional_properties
     assert function_call.additional_properties is not None
     assert function_call.additional_properties.get("status") == "completed"


### PR DESCRIPTION
# Python: Normalize OpenAI function-call arguments at parse time to prevent unicode escape corruption

## Problem

When an LLM-powered agent edits source files containing Python/JavaScript unicode escape sequences like `\u2192`, the OpenAI code path corrupts these sequences due to **double JSON parsing**.

### Root cause

The Anthropic and OpenAI backends handle function-call arguments differently:

- **Anthropic**: Returns `content_block.input` as a **parsed dict**. Stored directly — `parse_arguments()` returns it as-is. **1 JSON parse total.**
- **OpenAI**: Returns `tool.function.arguments` as a **raw JSON string**. Stored as a string, then `parse_arguments()` calls `json.loads()` again. **2 JSON parses total.**

The second `json.loads()` re-interprets `\uXXXX` sequences as JSON unicode escapes, corrupting the original intent:

```python
# A source file contains the Python escape: \u2192
# The model correctly generates \\u2192 in its JSON arguments

# Anthropic path (1 parse):
content_block.input = {"old_string": "\\u2192"}  # SDK parsed → \u2192 ✓

# OpenAI path (2 parses):
tool.function.arguments = '{"old_string": "\\u2192"}'  # stored as string
json.loads(arguments)    → {"old_string": "→"}          # \u2192 interpreted as unicode escape ✗
```

The same model output that works correctly on Anthropic produces a corrupted value on OpenAI. The `\u2192` (literal 6-char Python escape) becomes `→` (a single Unicode character), causing `edit_file` to either fail to match or write incorrect content.

### Impact

This affects any tool that reads/writes source code containing `\uXXXX` escape sequences (Python, JavaScript, Java, C#, JSON). In practice, agents enter retry loops (10+ failed `edit_file` attempts observed) trying different escaping levels, wasting tokens and often ultimately writing corrupted code.

## What changed

- Added `normalize_function_call_arguments()` helper in `_types.py` that eagerly parses JSON-string arguments into dicts at the provider-parsing layer
- Applied normalization in `OpenAIChatClient._parse_tool_calls_from_openai()` and three non-streaming parse sites in `OpenAIResponsesClient`
- Updated `_prepare_content_for_openai()` in the responses client to re-serialize dict arguments back to JSON strings when sending to the API (the chat client already handled this at line 704)
- Updated 2 test assertions that expected raw string arguments to expect parsed dicts

Streaming deltas (`response.function_call_arguments.delta`) are intentionally **not** normalized since they contain partial JSON fragments.

## Validation

```bash
uv run python -m pytest packages/core/tests/openai/test_openai_chat_client.py \
  packages/core/tests/openai/test_openai_responses_client.py \
  -m "not integration" -q
```

All 183 tests pass.

### Before / After comparison

```python
from agent_framework._types import normalize_function_call_arguments

# Model generates \\u2192 in its JSON output — the correct escaping for literal \u2192
args = '{"old_string": "\\\\u2192"}'

# BEFORE: stored as string, then double-parsed
import json
json.loads(args)["old_string"]   # → '\\u2192' (2 backslashes — wrong)

# AFTER: normalized once at parse time, parse_arguments() returns dict directly
normalize_function_call_arguments(args)["old_string"]  # → '\\u2192' (same parse)
# Then parse_arguments() sees a Mapping and returns it — no second json.loads
```

The fix makes the OpenAI path behave identically to the Anthropic path: arguments are parsed once and stored as a dict. `parse_arguments()` returns the dict directly without a second `json.loads()` call.

## Related

- #4740 / #4741 — Same problem space (OpenAI argument envelope normalization), but focused on the string-vs-dict type inconsistency rather than the unicode escape corruption specifically.
