### PR TITLE
.NET: Mark constructors of InvokingContext and InvokedContext as experimental

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/AIContextProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/AIContextProvider.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -147,6 +149,7 @@ public abstract class AIContextProvider
 
         // Create a filtered context for ProvideAIContextAsync, filtering input messages
         // to exclude non-external messages (e.g. chat history, other AI context provider messages).
+#pragma warning disable MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var filteredContext = new InvokingContext(
             context.Agent,
             context.Session,
@@ -156,6 +159,7 @@ public abstract class AIContextProvider
                 Messages = inputContext.Messages is not null ? this.ProvideInputMessageFilter(inputContext.Messages) : null,
                 Tools = inputContext.Tools
             });
+#pragma warning restore MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         var provided = await this.ProvideAIContextAsync(filteredContext, cancellationToken).ConfigureAwait(false);
 
@@ -294,7 +298,9 @@ public abstract class AIContextProvider
             return default;
         }
 
+#pragma warning disable MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var subContext = new InvokedContext(context.Agent, context.Session, this.StoreInputRequestMessageFilter(context.RequestMessages), this.StoreInputResponseMessageFilter(context.ResponseMessages!));
+#pragma warning restore MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return this.StoreAIContextAsync(subContext, cancellationToken);
     }
 
@@ -372,6 +378,7 @@ public abstract class AIContextProvider
         /// <param name="session">The session associated with the agent invocation.</param>
         /// <param name="aiContext">The AI context to be used by the agent for this invocation.</param>
         /// <exception cref="ArgumentNullException"><paramref name="agent"/> or <paramref name="aiContext"/> is <see langword="null"/>.</exception>
+        [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
         public InvokingContext(
             AIAgent agent,
             AgentSession? session,
@@ -431,6 +438,7 @@ public abstract class AIContextProvider
         /// that were used by the agent for this invocation.</param>
         /// <param name="responseMessages">The response messages generated during this invocation.</param>
         /// <exception cref="ArgumentNullException"><paramref name="agent"/>, <paramref name="requestMessages"/>, or <paramref name="responseMessages"/> is <see langword="null"/>.</exception>
+        [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
         public InvokedContext(
             AIAgent agent,
             AgentSession? session,

--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/ChatHistoryProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/ChatHistoryProvider.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -250,7 +252,9 @@ public abstract class ChatHistoryProvider
             return default;
         }
 
+#pragma warning disable MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var subContext = new InvokedContext(context.Agent, context.Session, this._storeInputRequestMessageFilter(context.RequestMessages), this._storeInputResponseMessageFilter(context.ResponseMessages!));
+#pragma warning restore MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return this.StoreChatHistoryAsync(subContext, cancellationToken);
     }
 
@@ -340,6 +344,7 @@ public abstract class ChatHistoryProvider
         /// <param name="session">The session associated with the agent invocation.</param>
         /// <param name="requestMessages">The messages to be used by the agent for this invocation.</param>
         /// <exception cref="ArgumentNullException"><paramref name="requestMessages"/> is <see langword="null"/>.</exception>
+        [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
         public InvokingContext(
             AIAgent agent,
             AgentSession? session,
@@ -399,6 +404,7 @@ public abstract class ChatHistoryProvider
         /// that were used by the agent for this invocation.</param>
         /// <param name="responseMessages">The response messages generated during this invocation.</param>
         /// <exception cref="ArgumentNullException"><paramref name="agent"/>, <paramref name="requestMessages"/>, or <paramref name="responseMessages"/> is <see langword="null"/>.</exception>
+        [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
         public InvokedContext(
             AIAgent agent,
             AgentSession? session,

--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/MessageAIContextProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/MessageAIContextProvider.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -49,12 +51,14 @@ public abstract class MessageAIContextProvider : AIContextProvider
     {
         // Call ProvideMessagesAsync directly to return only additional messages.
         // The base AIContextProvider.InvokingCoreAsync handles merging with the original input and stamping.
+#pragma warning disable MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return new AIContext
         {
             Messages = await this.ProvideMessagesAsync(
                 new InvokingContext(context.Agent, context.Session, context.AIContext.Messages ?? []),
                 cancellationToken).ConfigureAwait(false)
         };
+#pragma warning restore MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -109,10 +113,12 @@ public abstract class MessageAIContextProvider : AIContextProvider
 
         // Create a filtered context for ProvideMessagesAsync, filtering input messages
         // to exclude non-external messages (e.g. chat history, other AI context provider messages).
+#pragma warning disable MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var filteredContext = new InvokingContext(
             context.Agent,
             context.Session,
             this.ProvideInputMessageFilter(inputMessages));
+#pragma warning restore MAAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         var providedMessages = await this.ProvideMessagesAsync(filteredContext, cancellationToken).ConfigureAwait(false);
 
@@ -163,6 +169,7 @@ public abstract class MessageAIContextProvider : AIContextProvider
         /// <param name="session">The session associated with the agent invocation.</param>
         /// <param name="requestMessages">The messages to be used by the agent for this invocation.</param>
         /// <exception cref="ArgumentNullException"><paramref name="agent"/> or <paramref name="requestMessages"/> is <see langword="null"/>.</exception>
+        [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
         public InvokingContext(
             AIAgent agent,
             AgentSession? session,


### PR DESCRIPTION
### Motivation and Context

These types are not intended to be constructed by customers (except when testing their own custom implementations).
Keeping the constructors experimental will allow us to evolve these with additional required parameters, improving the consumption experience.  The rest of these classes would be considered GA.

### Description

- Mark constructors of InvokingContext and InvokedContext as experimental

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.