### PR TITLE
.NET: Re-enable AzureAI.Persistent packaging and integration tests

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AzureAI.Persistent/Microsoft.Agents.AI.AzureAI.Persistent.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.AzureAI.Persistent/Microsoft.Agents.AI.AzureAI.Persistent.csproj
@@ -20,8 +20,7 @@
     <!-- NuGet Package Settings -->
     <Title>Microsoft Agent Framework AzureAI Persistent Agents</Title>
     <Description>Provides Microsoft Agent Framework support for Azure AI Persistent Agents.</Description>
-    <!-- Disabled until Azure.AI.Agents.Persistent targets ME.AI 10.4.0+ (https://github.com/microsoft/agent-framework/issues/4769) -->
-    <IsPackable>false</IsPackable>
+
   </PropertyGroup>
 
 </Project>

--- a/dotnet/src/Microsoft.Agents.AI.AzureAI.Persistent/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.AzureAI.Persistent/README.md
@@ -1,19 +1,3 @@
 # Microsoft.Agents.AI.AzureAI.Persistent
 
 Provides integration between the Microsoft Agent Framework and Azure AI Agents Persistent (`Azure.AI.Agents.Persistent`).
-
-## ⚠️ Known Compatibility Limitation
-
-The underlying `Azure.AI.Agents.Persistent` package (currently 1.2.0-beta.9) targets `Microsoft.Extensions.AI.Abstractions` 10.1.x and references types that were renamed in 10.4.0 (e.g., `McpServerToolApprovalResponseContent` → `ToolApprovalResponseContent`). This causes `TypeLoadException` at runtime when used with ME.AI 10.4.0+.
-
-**Compatible versions:**
-
-| Package | Compatible Version |
-|---|---|
-| `Azure.AI.Agents.Persistent` | 1.2.0-beta.9 (targets ME.AI 10.1.x) |
-| `Microsoft.Extensions.AI.Abstractions` | ≤ 10.3.0 |
-| `OpenAI` | ≤ 2.8.0 |
-
-**Resolution:** An updated version of `Azure.AI.Agents.Persistent` targeting ME.AI 10.4.0+ is expected in 1.2.0-beta.10. The upstream fix is tracked in [Azure/azure-sdk-for-net#56929](https://github.com/Azure/azure-sdk-for-net/pull/56929).
-
-**Tracking issue:** [microsoft/agent-framework#4769](https://github.com/microsoft/agent-framework/issues/4769)

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
@@ -4,10 +4,7 @@ using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsChatClientAgentRunStreamingTests() : ChatClientAgentRunStreamingTests<AzureAIAgentsPersistentFixture>(() => new())
 {
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
@@ -4,10 +4,7 @@ using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsChatClientAgentRunTests() : ChatClientAgentRunTests<AzureAIAgentsPersistentFixture>(() => new())
 {
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
@@ -14,10 +14,7 @@ using Shared.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentCreateTests
 {
     private const string SkipCodeInterpreterReason = "Azure AI Code Interpreter intermittently fails to execute uploaded files in CI";

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
@@ -4,10 +4,7 @@ using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentRunStreamingTests() : RunStreamingTests<AzureAIAgentsPersistentFixture>(() => new())
 {
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
@@ -4,10 +4,7 @@ using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentRunTests() : RunTests<AzureAIAgentsPersistentFixture>(() => new())
 {
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentStructuredOutputRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentStructuredOutputRunTests.cs
@@ -5,10 +5,7 @@ using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
 
-// Disabled: Azure.AI.Agents.Persistent 1.2.0-beta.9 references McpServerToolApprovalResponseContent
-// which was removed in ME.AI 10.4.0. Re-enable once Persistent targets ME.AI 10.4.0+ (expected in 1.2.0-beta.10).
-// Tracking: https://github.com/microsoft/agent-framework/issues/4769
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentStructuredOutputRunTests() : StructuredOutputRunTests<AzureAIAgentsPersistentFixture>(() => new())
 {
     private const string SkipReason = "Fails intermittently on the build agent/CI";


### PR DESCRIPTION
### Motivation and Context

`Azure.AI.Agents.Persistent` 1.2.0-beta.10 now targets `Microsoft.Extensions.AI` 10.4.0+, resolving the compatibility issue (`McpServerToolApprovalResponseContent` → `ToolApprovalResponseContent` rename) that required disabling this package from NuGet shipping and its integration tests.

Closes #4769

### Description

- Removed `<IsPackable>false</IsPackable>` from `Microsoft.Agents.AI.AzureAI.Persistent.csproj` to re-enable NuGet packaging
- Re-enabled all 6 integration test classes by changing `[Trait("Category", "IntegrationDisabled")]` → `[Trait("Category", "Integration")]` and removing the associated disable comments
- Removed the outdated compatibility warning section from `README.md`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
