### PR TITLE
Python: feat: implement ParallelToolExecutor for concurrent tool calling #4429

### DIFF
--- a/python/packages/agent-framework/src/agent_framework/tools/parallel/executor.py
+++ b/python/packages/agent-framework/src/agent_framework/tools/parallel/executor.py
@@ -1,0 +1,17 @@
+import asyncio
+from typing import List, Any, Callable
+
+class ParallelToolExecutor:
+    """
+    Executor for parallel tool calls in agentic workflows.
+    Significantly reduces latency for multi-tool operations.
+    """
+    def __init__(self, max_concurrency: int = 5):
+        self.semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def execute_parallel(self, tool_calls: List[Callable[[], Any]]) -> List[Any]:
+        async def _run_tool(call):
+            async with self.semaphore:
+                return await asyncio.to_thread(call)
+        
+        return await asyncio.gather(*[_run_tool(call) for call in tool_calls])


### PR DESCRIPTION
This PR implements the `ParallelToolExecutor` for the Microsoft Agent Framework, addressing the need for parallel tool calling in declarative workflows (#4429).

### Changes:
- Added `ParallelToolExecutor` with configurable concurrency limits.
- Uses `asyncio.gather` and `asyncio.to_thread` for non-blocking execution.
- Essential for complex agents performing multiple tool-based lookups or actions simultaneously.

/claim #4429