### PR TITLE
Python: Fix structured-output corruption by joining Message.text without spaces

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1758,12 +1758,14 @@ class Message(SerializationMixin):
 
         Remarks:
             Concatenates the text of every ``TextContent`` in :attr:`contents`
-            without inserting whitespace. Multiple ``TextContent`` blocks are
-            usually a streaming-coalescing artefact (one logical token stream
-            split across deltas), so any spacing the model intended is already
-            inside the chunks. Joining with ``" "`` would inject spurious
-            whitespace mid-token, which corrupts structured JSON output and
-            shows up as field-validation failures downstream.
+            without inserting any separator. Whatever spacing or punctuation
+            the model produced is already inside the chunks, so the join must
+            not add to it — inserting a space would inject whitespace mid-token
+            (a path like ``"report_lines/sofp.json"`` becomes
+            ``"re port_ lines/sof p.jso n"``) and corrupts structured JSON
+            output downstream. This also matches the separator-free behaviour
+            of ``_coalesce_text_content`` (via ``Content.__add__``), which is
+            applied to streamed responses by ``_finalize_response``.
         """
         return "".join(content.text for content in self.contents if content.type == "text")  # type: ignore[misc]
 

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1757,9 +1757,15 @@ class Message(SerializationMixin):
         """Returns the text content of the message.
 
         Remarks:
-            This property concatenates the text of all TextContent objects in Content.
+            Concatenates the text of every ``TextContent`` in :attr:`contents`
+            without inserting whitespace. Multiple ``TextContent`` blocks are
+            usually a streaming-coalescing artefact (one logical token stream
+            split across deltas), so any spacing the model intended is already
+            inside the chunks. Joining with ``" "`` would inject spurious
+            whitespace mid-token, which corrupts structured JSON output and
+            shows up as field-validation failures downstream.
         """
-        return " ".join(content.text for content in self.contents if content.type == "text")  # type: ignore[misc]
+        return "".join(content.text for content in self.contents if content.type == "text")  # type: ignore[misc]
 
 
 AgentRunInputs = str | Content | Message | Sequence[str | Content | Message]

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -733,7 +733,7 @@ def test_chat_message_text():
 def test_chat_message_contents():
     """Test the Message class to ensure it initializes correctly with contents."""
     # Create a Message with a role and multiple contents
-    content1 = Content.from_text("Hello, how are you?")
+    content1 = Content.from_text("Hello, how are you? ")
     content2 = Content.from_text("I'm fine, thank you!")
     message = Message(role="user", contents=[content1, content2])
 
@@ -742,9 +742,38 @@ def test_chat_message_contents():
     assert len(message.contents) == 2
     assert message.contents[0].type == "text"
     assert message.contents[1].type == "text"
-    assert message.contents[0].text == "Hello, how are you?"
+    assert message.contents[0].text == "Hello, how are you? "
     assert message.contents[1].text == "I'm fine, thank you!"
+    # Message.text concatenates without inserting whitespace — any spacing the
+    # model emitted is already inside the chunks.
     assert message.text == "Hello, how are you? I'm fine, thank you!"
+
+
+def test_chat_message_text_concatenates_without_injecting_spaces():
+    """``Message.text`` must concatenate streamed text chunks with no separator.
+
+    When chat responses are streamed the SDK accumulates text deltas as
+    multiple ``TextContent`` blocks. Joining them with a space mid-token
+    corrupts JSON values used for structured output (a path like
+    ``"report_lines/sofp.json"`` becomes ``"re port_ lines/sof p.jso n"``)
+    and breaks any downstream consumer that compares ``message.text`` to a
+    raw model output (logging, telemetry, structured-output parsers).
+    """
+    # Simulate a JSON value split across three streaming deltas — exactly the
+    # shape ``response.value`` and ``response.text`` see when chunks have not
+    # been coalesced.
+    chunks = [
+        Content.from_text(text='{"resp'),
+        Content.from_text(text='onse": "He'),
+        Content.from_text(text='llo"}'),
+    ]
+    message = Message(role="assistant", contents=chunks)
+
+    assert message.text == '{"response": "Hello"}'
+    # And via ``ChatResponse.value``, the structured-output parse round-trips.
+    response = ChatResponse(messages=message, response_format=OutputModel)
+    assert response.value is not None
+    assert response.value.response == "Hello"
 
 
 def test_chat_message_with_chatrole_instance():
@@ -989,7 +1018,10 @@ def test_chat_response_updates_to_chat_response_multiple():
 
     # Check the type and content
     assert len(chat_response.messages) == 1
-    assert chat_response.text == "I'm doing well,  thank you!"
+    # Each chunk contributes its own whitespace; Message.text concatenates without
+    # injecting an extra separator, so the trailing space inside ``message1`` is
+    # the only space between the two segments.
+    assert chat_response.text == "I'm doing well, thank you!"
     assert isinstance(chat_response.messages[0], Message)
     assert len(chat_response.messages[0].contents) == 3
     assert chat_response.messages[0].message_id == "1"
@@ -1027,7 +1059,9 @@ def test_chat_response_updates_to_chat_response_multiple_multiple():
     assert chat_response.messages[0].contents[2].type == "text"
     assert chat_response.messages[0].contents[2].text == "More contextFinal part"
 
-    assert chat_response.text == "I'm doing well, thank you! More contextFinal part"
+    # Message.text skips the reasoning content and concatenates the surviving
+    # text contents directly — no extra separator is inserted between them.
+    assert chat_response.text == "I'm doing well, thank you!More contextFinal part"
 
 
 async def test_chat_response_from_async_generator():

--- a/python/packages/core/tests/workflow/test_workflow_agent.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent.py
@@ -541,7 +541,10 @@ class TestWorkflowAgent:
         assert isinstance(result, AgentResponse)
         assert len(result.messages) == 3
         texts = [message.text for message in result.messages]
-        assert texts == ["first message", "second message", "third fourth"]
+        # Non-streaming path keeps the two TextContent blocks separate; Message.text
+        # concatenates them without inserting a separator (matching the streaming
+        # path above where coalescing produces the same "thirdfourth").
+        assert texts == ["first message", "second message", "thirdfourth"]
 
     async def test_session_conversation_history_included_in_workflow_run(self) -> None:
         """Test that messages provided to agent.run() are passed through to the workflow."""

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -602,7 +602,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = "<=1.0.0b2,>=1.0.0b2" },
+    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = ">=1.0.0b2,<=1.0.0b2" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -602,7 +602,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = ">=1.0.0b2,<=1.0.0b2" },
+    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = "<=1.0.0b2,>=1.0.0b2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`Message.text` aggregates the message's text contents with `" ".join(...)`. For natural language responses returned as a single content that's mostly fine, but a streamed response is delivered as multiple `TextContent` deltas — joining them with spaces injects spurious whitespace mid-token.

This PR changes `Message.text` to use `"".join(...)`. Any spacing the model wanted is already inside the chunks, so concatenating without a separator preserves what the model actually emitted.

## Why fix `Message.text` rather than just `ChatResponse.value` / `AgentResponse.value`

An earlier revision of this PR patched only the two `.value` properties so structured-output parsing would bypass `Message.text`. That helps the parsing call site but leaves every other consumer broken — anything that reads `message.text` or `response.text` directly (logging, telemetry, downstream serializers, provider implementations) still sees the corrupted string.

It also leaves a real inconsistency in place: the streaming path (`from_updates` / `from_update_generator`) coalesces multiple `TextContent` blocks into one and so emits no extra spaces, while the non-streaming path was running through `" ".join` and therefore did. Two test fixtures in this repo previously baked in that disagreement (see "Pre-existing assertions" below).

Fixing `Message.text` itself is the root-cause fix and removes the inconsistency.

## Real-world failures

Observed in production with the OpenAI-compatible chat client (OpenRouter → Gemini) using `response_format` for structured output. Failures were intermittent — retrying the same request usually succeeded.

**Failure 1 — space injected into a JSON key:**
LLM returned `"action": "request_evidence"` but Pydantic received `"action ": "request_evidence"`:
> Field required [type=missing, input_value={'action ': 'request_evid...}]

**Failure 2 — space injected into a JSON value:**
LLM returned `"readiness": "not_started"` but Pydantic received `"readiness": "not_started "`:
> Input should be 'not_started', ... [input_value='not_started ']

In both cases the raw LLM response was valid JSON — the corruption was introduced by `" ".join()` in `Message.text`.

## Pre-existing assertions updated

Three pre-existing tests were asserting the buggy behaviour and have been updated:

- `test_chat_message_contents` — directly asserted that `Message.text` joined two text contents with an inserted space.
- `test_chat_response_updates_to_chat_response_multiple` — asserted `"I'm doing well,  thank you!"` (two spaces: the trailing space inside the chunk plus the one inserted by `" ".join`). Now asserts the single space the model actually produced.
- `test_workflow_as_agent_yield_output_with_list_of_chat_messages` — asserted the streaming path produced `"thirdfourth"` while the non-streaming path produced `"third fourth"`. Both now produce `"thirdfourth"`.

## Changes

- `python/packages/core/agent_framework/_types.py` — `Message.text` now uses `"".join(...)`. Updated docstring explains the rationale.
- New regression test `test_chat_message_text_concatenates_without_injecting_spaces` — builds a JSON value split across three deltas and asserts both `message.text` and `ChatResponse.value` round-trip correctly.

## Test plan

- `uv run pytest packages/core/tests --ignore=packages/core/tests/core/test_observability.py` → 2622 passed.
- `uv run pytest packages/core/tests/core/test_observability.py packages/anthropic/tests` → 269 passed.
