### PR TITLE
.NET: [BREAKING] Update type names and source generator to reduce conflicts

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Generation/SourceBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Generation/SourceBuilder.cs
@@ -38,6 +38,7 @@ internal static class SourceBuilder
         sb.AppendLine("using System.Collections.Generic;");
         sb.AppendLine("using Microsoft.Agents.AI.Workflows;");
         sb.AppendLine();
+        sb.AppendLine("using RouteBuilder = Microsoft.Agents.AI.Workflows.RouteBuilder;");
 
         // Namespace
         if (!string.IsNullOrWhiteSpace(info.Namespace))

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ConfigurationExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ConfigurationExtensions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Agents.AI.Workflows;
 /// <summary>
 /// Provides extensions methods for creating <see cref="Configured{TSubject}"/> objects
 /// </summary>
-public static class ConfigurationExtensions
+internal static class ConfigurationExtensions
 {
     /// <summary>
     /// Creates a new configuration that treats the subject as its base type, allowing configuration to be applied at

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ConfigurationExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ConfigurationExtensions.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Agents.AI.Workflows;
 
 /// <summary>
-/// Provides extensions methods for creating <see cref="Configured{TSubject}"/> objects
+/// Provides extension methods for creating <see cref="Configured{TSubject}"/> objects
 /// </summary>
 internal static class ConfigurationExtensions
 {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Configured.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Configured.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Agents.AI.Workflows;
 /// <summary>
 /// Provides methods for creating <see cref="Configured{TSubject}"/> instances.
 /// </summary>
-public static class Configured
+internal static class Configured
 {
     /// <summary>
     /// Creates a <see cref="Configured{TSubject}"/> instance from an existing subject instance.
@@ -53,7 +53,7 @@ public static class Configured
 /// <param name="factoryAsync">A factory to intantiate the subject when desired.</param>
 /// <param name="id">The unique identifier for the configured subject.</param>
 /// <param name="raw"></param>
-public class Configured<TSubject>(Func<Config, string, ValueTask<TSubject>> factoryAsync, string id, object? raw = null)
+internal class Configured<TSubject>(Func<ExecutorConfig, string, ValueTask<TSubject>> factoryAsync, string id, object? raw = null)
 {
     /// <summary>
     /// Gets the raw representation of the configured object, if any.
@@ -66,14 +66,14 @@ public class Configured<TSubject>(Func<Config, string, ValueTask<TSubject>> fact
     public string Id => id;
 
     /// <summary>
-    /// Gets the factory function to create an instance of <typeparamref name="TSubject"/> given a <see cref="Config"/>.
+    /// Gets the factory function to create an instance of <typeparamref name="TSubject"/> given a <see cref="ExecutorConfig"/>.
     /// </summary>
-    public Func<Config, string, ValueTask<TSubject>> FactoryAsync => factoryAsync;
+    public Func<ExecutorConfig, string, ValueTask<TSubject>> FactoryAsync => factoryAsync;
 
     /// <summary>
     /// The configuration for this configured instance.
     /// </summary>
-    public Config Configuration => new(this.Id);
+    public ExecutorConfig Configuration => new(this.Id);
 
     /// <summary>
     /// Gets a "partially" applied factory function that only requires no parameters to create an instance of
@@ -91,7 +91,7 @@ public class Configured<TSubject>(Func<Config, string, ValueTask<TSubject>> fact
 /// <param name="id">The unique identifier for the configured subject.</param>
 /// <param name="options">Additional configuration options for the subject.</param>
 /// <param name="raw"></param>
-public class Configured<TSubject, TOptions>(Func<Config<TOptions>, string, ValueTask<TSubject>> factoryAsync, string id, TOptions? options = default, object? raw = null)
+internal class Configured<TSubject, TOptions>(Func<ExecutorConfig<TOptions>, string, ValueTask<TSubject>> factoryAsync, string id, TOptions? options = default, object? raw = null)
 {
     /// <summary>
     /// The raw representation of the configured object, if any.
@@ -109,14 +109,14 @@ public class Configured<TSubject, TOptions>(Func<Config<TOptions>, string, Value
     public TOptions? Options => options;
 
     /// <summary>
-    /// Gets the factory function to create an instance of <typeparamref name="TSubject"/> given a <see cref="Config{TOptions}"/>.
+    /// Gets the factory function to create an instance of <typeparamref name="TSubject"/> given a <see cref="ExecutorConfig{TOptions}"/>.
     /// </summary>
-    public Func<Config<TOptions>, string, ValueTask<TSubject>> FactoryAsync => factoryAsync;
+    public Func<ExecutorConfig<TOptions>, string, ValueTask<TSubject>> FactoryAsync => factoryAsync;
 
     /// <summary>
     /// The configuration for this configured instance.
     /// </summary>
-    public Config<TOptions> Configuration => new(this.Id, this.Options);
+    public ExecutorConfig<TOptions> Configuration => new(this.Id, this.Options);
 
     /// <summary>
     /// Gets a "partially" applied factory function that only requires no parameters to create an instance of
@@ -124,11 +124,11 @@ public class Configured<TSubject, TOptions>(Func<Config<TOptions>, string, Value
     /// </summary>
     internal Func<string, ValueTask<TSubject>> BoundFactoryAsync => (sessionId) => this.CreateValidatingMemoizedFactory()(this.Configuration, sessionId);
 
-    private Func<Config, string, ValueTask<TSubject>> CreateValidatingMemoizedFactory()
+    private Func<ExecutorConfig, string, ValueTask<TSubject>> CreateValidatingMemoizedFactory()
     {
         return FactoryAsync;
 
-        async ValueTask<TSubject> FactoryAsync(Config configuration, string sessionId)
+        async ValueTask<TSubject> FactoryAsync(ExecutorConfig configuration, string sessionId)
         {
             if (this.Id != configuration.Id)
             {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Configured.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Configured.cs
@@ -50,7 +50,7 @@ internal static class Configured
 /// A representation of a preconfigured, lazy-instantiatable instance of <typeparamref name="TSubject"/>.
 /// </summary>
 /// <typeparam name="TSubject">The type of the preconfigured subject.</typeparam>
-/// <param name="factoryAsync">A factory to intantiate the subject when desired.</param>
+/// <param name="factoryAsync">A factory to instantiate the subject when desired.</param>
 /// <param name="id">The unique identifier for the configured subject.</param>
 /// <param name="raw"></param>
 internal class Configured<TSubject>(Func<ExecutorConfig, string, ValueTask<TSubject>> factoryAsync, string id, object? raw = null)
@@ -87,7 +87,7 @@ internal class Configured<TSubject>(Func<ExecutorConfig, string, ValueTask<TSubj
 /// </summary>
 /// <typeparam name="TSubject">The type of the preconfigured subject.</typeparam>
 /// <typeparam name="TOptions">The type of configuration options for the preconfigured subject.</typeparam>
-/// <param name="factoryAsync">A factory to intantiate the subject when desired.</param>
+/// <param name="factoryAsync">A factory to instantiate the subject when desired.</param>
 /// <param name="id">The unique identifier for the configured subject.</param>
 /// <param name="options">Additional configuration options for the subject.</param>
 /// <param name="raw"></param>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorBindingExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorBindingExtensions.cs
@@ -113,7 +113,7 @@ public static class ExecutorBindingExtensions
     /// <param name="id">An id for the executor to be instantiated.</param>
     /// <param name="options">An optional parameter specifying the options.</param>
     /// <returns>An <see cref="ExecutorBinding"/> instance that resolves to the result of the factory call when messages get sent to it.</returns>
-    public static ExecutorBinding BindExecutor<TExecutor, TOptions>(this Func<Config<TOptions>, string, ValueTask<TExecutor>> factoryAsync, string id, TOptions? options = null)
+    public static ExecutorBinding BindExecutor<TExecutor, TOptions>(this Func<ExecutorConfig<TOptions>, string, ValueTask<TExecutor>> factoryAsync, string id, TOptions? options = null)
         where TExecutor : Executor
         where TOptions : ExecutorOptions
     {
@@ -139,7 +139,7 @@ public static class ExecutorBindingExtensions
     /// <returns>An <see cref="ExecutorBinding"/> instance that resolves to the result of the factory call when messages get sent to it.</returns>
     [Obsolete("Use BindExecutor() instead")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static ExecutorBinding ConfigureFactory<TExecutor, TOptions>(this Func<Config<TOptions>, string, ValueTask<TExecutor>> factoryAsync, string id, TOptions? options = null)
+    public static ExecutorBinding ConfigureFactory<TExecutor, TOptions>(this Func<ExecutorConfig<TOptions>, string, ValueTask<TExecutor>> factoryAsync, string id, TOptions? options = null)
         where TExecutor : Executor
         where TOptions : ExecutorOptions
         => factoryAsync.BindExecutor(id, options);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorConfig.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/ExecutorConfig.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Agents.AI.Workflows;
 /// Represents a configuration for an object with a string identifier. For example, <see cref="IIdentified"/> object.
 /// </summary>
 /// <param name="id">A unique identifier for the configurable object.</param>
-public class Config(string id)
+public class ExecutorConfig(string id)
 {
     /// <summary>
     /// Gets a unique identifier for the configurable object.
@@ -23,7 +23,7 @@ public class Config(string id)
 /// <typeparam name="TOptions">The type of options for the configurable object.</typeparam>
 /// <param name="id">A unique identifier for the configurable object.</param>
 /// <param name="options">The options for the configurable object.</param>
-public class Config<TOptions>(string id, TOptions? options = default) : Config(id)
+public class ExecutorConfig<TOptions>(string id, TOptions? options = default) : ExecutorConfig(id)
 {
     /// <summary>
     /// Gets the options for the configured object.


### PR DESCRIPTION
### Motivation and Context

Some of the names of types used by workflows are likely to be conflicting (or are conflicting) with other types from, e.g. ASPNetCore.WebAPI. (#4174).

### Description

* Rename `Config` to `ExecutorConfig`, as it is only used when binding to an `Executor` factory function.
* Make `Configured` and relevant extension method classes internal (this is implementation details)
* Fix the Source Generator to explicitly import `RouteBuilder`: fixes #4174
* Closes #963

Explicitly not changing `Edge`, or `Run` for now unless we see actual conflicts.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.