### PR TITLE
.NET: Introduce ToolResultReductionStrategy

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultCompactionStrategy.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultCompactionStrategy.cs
@@ -3,10 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI.Compaction;
@@ -37,8 +34,9 @@ namespace Microsoft.Agents.AI.Compaction;
 /// built-in default and can be reused inside a custom formatter when needed.
 /// </para>
 /// <para>
-/// <see cref="MinimumPreservedGroups"/> is a hard floor: even if the <see cref="CompactionStrategy.Target"/>
-/// has not been reached, compaction will not touch the last <see cref="MinimumPreservedGroups"/> non-system groups.
+/// <see cref="ToolResultStrategyBase.MinimumPreservedGroups"/> is a hard floor: even if the
+/// <see cref="CompactionStrategy.Target"/> has not been reached, compaction will not touch the last
+/// <see cref="ToolResultStrategyBase.MinimumPreservedGroups"/> non-system groups.
 /// </para>
 /// <para>
 /// The <see cref="CompactionTrigger"/> predicate controls when compaction proceeds. Use
@@ -46,7 +44,7 @@ namespace Microsoft.Agents.AI.Compaction;
 /// </para>
 /// </remarks>
 [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
-public sealed class ToolResultCompactionStrategy : CompactionStrategy
+public sealed class ToolResultCompactionStrategy : ToolResultStrategyBase
 {
     /// <summary>
     /// The default minimum number of most-recent non-system groups to preserve.
@@ -73,16 +71,9 @@ public sealed class ToolResultCompactionStrategy : CompactionStrategy
         CompactionTrigger trigger,
         int minimumPreservedGroups = DefaultMinimumPreserved,
         CompactionTrigger? target = null)
-        : base(trigger, target)
+        : base(trigger, minimumPreservedGroups, target)
     {
-        this.MinimumPreservedGroups = EnsureNonNegative(minimumPreservedGroups);
     }
-
-    /// <summary>
-    /// Gets the minimum number of most-recent non-system groups that are always preserved.
-    /// This is a hard floor that compaction cannot exceed, regardless of the target condition.
-    /// </summary>
-    public int MinimumPreservedGroups { get; }
 
     /// <summary>
     /// An optional custom formatter that converts a <see cref="CompactionMessageGroup"/> into a summary string.
@@ -92,73 +83,15 @@ public sealed class ToolResultCompactionStrategy : CompactionStrategy
     public Func<CompactionMessageGroup, string>? ToolCallFormatter { get; init; }
 
     /// <inheritdoc/>
-    protected override ValueTask<bool> CompactCoreAsync(CompactionMessageIndex index, ILogger logger, CancellationToken cancellationToken)
+    protected override (CompactionGroupKind Kind, List<ChatMessage> Messages, string ExcludeReason)
+        TransformToolGroup(CompactionMessageGroup group)
     {
-        // Identify protected groups: the N most-recent non-system, non-excluded groups
-        List<int> nonSystemIncludedIndices = [];
-        for (int i = 0; i < index.Groups.Count; i++)
-        {
-            CompactionMessageGroup group = index.Groups[i];
-            if (!group.IsExcluded && group.Kind != CompactionGroupKind.System)
-            {
-                nonSystemIncludedIndices.Add(i);
-            }
-        }
+        string summary = (this.ToolCallFormatter ?? DefaultToolCallFormatter).Invoke(group);
 
-        int protectedStart = EnsureNonNegative(nonSystemIncludedIndices.Count - this.MinimumPreservedGroups);
-        HashSet<int> protectedGroupIndices = [];
-        for (int i = protectedStart; i < nonSystemIncludedIndices.Count; i++)
-        {
-            protectedGroupIndices.Add(nonSystemIncludedIndices[i]);
-        }
+        ChatMessage summaryMessage = new(ChatRole.Assistant, summary);
+        (summaryMessage.AdditionalProperties ??= [])[CompactionMessageGroup.SummaryPropertyKey] = true;
 
-        // Collect eligible tool groups in order (oldest first)
-        List<int> eligibleIndices = [];
-        for (int i = 0; i < index.Groups.Count; i++)
-        {
-            CompactionMessageGroup group = index.Groups[i];
-            if (!group.IsExcluded && group.Kind == CompactionGroupKind.ToolCall && !protectedGroupIndices.Contains(i))
-            {
-                eligibleIndices.Add(i);
-            }
-        }
-
-        if (eligibleIndices.Count == 0)
-        {
-            return new ValueTask<bool>(false);
-        }
-
-        // Collapse one tool group at a time from oldest, re-checking target after each
-        bool compacted = false;
-        int offset = 0;
-
-        for (int e = 0; e < eligibleIndices.Count; e++)
-        {
-            int idx = eligibleIndices[e] + offset;
-            CompactionMessageGroup group = index.Groups[idx];
-
-            string summary = (this.ToolCallFormatter ?? DefaultToolCallFormatter).Invoke(group);
-
-            // Exclude the original group and insert a collapsed replacement
-            group.IsExcluded = true;
-            group.ExcludeReason = $"Collapsed by {nameof(ToolResultCompactionStrategy)}";
-
-            ChatMessage summaryMessage = new(ChatRole.Assistant, summary);
-            (summaryMessage.AdditionalProperties ??= [])[CompactionMessageGroup.SummaryPropertyKey] = true;
-
-            index.InsertGroup(idx + 1, CompactionGroupKind.Summary, [summaryMessage], group.TurnIndex);
-            offset++; // Each insertion shifts subsequent indices by 1
-
-            compacted = true;
-
-            // Stop when target condition is met
-            if (this.Target(index))
-            {
-                break;
-            }
-        }
-
-        return new ValueTask<bool>(compacted);
+        return (CompactionGroupKind.Summary, [summaryMessage], $"Collapsed by {nameof(ToolResultCompactionStrategy)}");
     }
 
     /// <summary>
@@ -171,38 +104,7 @@ public sealed class ToolResultCompactionStrategy : CompactionStrategy
     /// </remarks>
     public static string DefaultToolCallFormatter(CompactionMessageGroup group)
     {
-        // Collect function calls (callId, name) and results (callId → result text)
-        List<(string CallId, string Name)> functionCalls = [];
-        Dictionary<string, string> resultsByCallId = [];
-        List<string> plainTextResults = [];
-
-        foreach (ChatMessage message in group.Messages)
-        {
-            if (message.Contents is null)
-            {
-                continue;
-            }
-
-            bool hasFunctionResult = false;
-            foreach (AIContent content in message.Contents)
-            {
-                if (content is FunctionCallContent fcc)
-                {
-                    functionCalls.Add((fcc.CallId, fcc.Name));
-                }
-                else if (content is FunctionResultContent frc && frc.CallId is not null)
-                {
-                    resultsByCallId[frc.CallId] = frc.Result?.ToString() ?? string.Empty;
-                    hasFunctionResult = true;
-                }
-            }
-
-            // Collect plain text from Tool-role messages that lack FunctionResultContent
-            if (!hasFunctionResult && message.Role == ChatRole.Tool && message.Text is string text)
-            {
-                plainTextResults.Add(text);
-            }
-        }
+        var (functionCalls, resultsByCallId, plainTextResults) = ExtractToolCallsAndResults(group);
 
         // Match function calls to their results using CallId or positional fallback,
         // grouping by tool name while preserving first-seen order.

--- a/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultReductionStrategy.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultReductionStrategy.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI.Compaction;
+
+/// <summary>
+/// A compaction strategy that applies per-tool reducers to individual tool results,
+/// preserving the original message structure (assistant tool calls + tool result messages)
+/// while transforming the result content.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="ToolResultCompactionStrategy"/> which collapses entire tool call groups
+/// into a single YAML-like summary, this strategy keeps the tool call/result message pairing
+/// intact. Each <see cref="FunctionResultContent"/> is passed through its tool's registered
+/// reducer, and the group is replaced with a structurally identical group containing the
+/// reduced results.
+/// </para>
+/// <para>
+/// This is useful when a tool returns very large results (e.g., a retrieval API returning
+/// hundreds of thousands of tokens with relevance scores) that should be reduced before
+/// the model sees them — even on the current turn. The reducer can deserialize the result,
+/// filter, sort, and re-serialize it. These steps happen outside the framework; the framework
+/// only invokes the <c>Func&lt;object?, object?&gt;</c> delegate.
+/// </para>
+/// <para>
+/// Only <see cref="CompactionGroupKind.ToolCall"/> groups that contain at least one tool name
+/// registered in <see cref="ToolResultReducers"/> are eligible. Groups with no registered tools
+/// are left untouched for other strategies to handle.
+/// </para>
+/// <para>
+/// For tools not registered in the dictionary within an otherwise eligible group, the raw
+/// result text is preserved as-is.
+/// </para>
+/// <para>
+/// <see cref="ToolResultStrategyBase.MinimumPreservedGroups"/> defaults to <c>0</c> so that
+/// reducers apply to all tool results, including the current turn. Set a higher value to
+/// preserve recent results at full fidelity.
+/// </para>
+/// <para>
+/// This strategy composes naturally in a <see cref="PipelineCompactionStrategy"/>. A common
+/// pattern is to place it before <see cref="ToolResultCompactionStrategy"/> — this strategy
+/// reduces result content while preserving structure, then the compaction strategy collapses
+/// older groups into concise summaries.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class ToolResultReductionStrategy : ToolResultStrategyBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolResultReductionStrategy"/> class.
+    /// </summary>
+    /// <param name="toolResultReducers">
+    /// A dictionary mapping tool names to per-tool result reducers. Each reducer receives the
+    /// <see cref="FunctionResultContent.Result"/> value for a single tool invocation and returns
+    /// the transformed result. The result type matches the <c>object?</c> type of
+    /// <see cref="FunctionResultContent.Result"/>.
+    /// </param>
+    /// <param name="trigger">
+    /// The <see cref="CompactionTrigger"/> that controls when reduction proceeds.
+    /// </param>
+    /// <param name="minimumPreservedGroups">
+    /// The minimum number of most-recent non-system message groups to preserve.
+    /// Defaults to <c>0</c> so that reducers apply to all tool results including the current turn.
+    /// </param>
+    /// <param name="target">
+    /// An optional target condition that controls when reduction stops. When <see langword="null"/>,
+    /// defaults to the inverse of the <paramref name="trigger"/>.
+    /// </param>
+    public ToolResultReductionStrategy(
+        IReadOnlyDictionary<string, Func<object?, object?>> toolResultReducers,
+        CompactionTrigger trigger,
+        int minimumPreservedGroups = 0,
+        CompactionTrigger? target = null)
+        : base(trigger, minimumPreservedGroups, target)
+    {
+        this.ToolResultReducers = Throw.IfNull(toolResultReducers);
+    }
+
+    /// <summary>
+    /// Gets the dictionary mapping tool names to per-tool result reducers.
+    /// Each reducer receives the <see cref="FunctionResultContent.Result"/> value for a single
+    /// tool invocation and returns the transformed result.
+    /// </summary>
+    public IReadOnlyDictionary<string, Func<object?, object?>> ToolResultReducers { get; }
+
+    /// <summary>
+    /// Key used to mark tool groups that have already been reduced by this strategy,
+    /// preventing re-reduction on subsequent <see cref="CompactionStrategy.CompactAsync"/> calls.
+    /// </summary>
+    internal const string ReducedPropertyKey = "_microsoft_agents_ai_compaction_tool_result_reduced";
+
+    /// <inheritdoc/>
+    protected override bool IsToolGroupEligible(CompactionMessageGroup group)
+    {
+        if (this.ToolResultReducers.Count == 0)
+        {
+            return false;
+        }
+
+        // Skip groups already reduced by this strategy
+        foreach (ChatMessage message in group.Messages)
+        {
+            if (message.AdditionalProperties?.ContainsKey(ReducedPropertyKey) is true)
+            {
+                return false;
+            }
+        }
+
+        // Build CallId → tool name mapping to verify matching FunctionResultContent exists
+        Dictionary<string, string> callIdToName = [];
+        foreach (ChatMessage message in group.Messages)
+        {
+            if (message.Contents is null)
+            {
+                continue;
+            }
+
+            foreach (AIContent content in message.Contents)
+            {
+                if (content is FunctionCallContent fcc && this.ToolResultReducers.ContainsKey(fcc.Name))
+                {
+                    callIdToName[fcc.CallId] = fcc.Name;
+                }
+            }
+        }
+
+        if (callIdToName.Count == 0)
+        {
+            return false;
+        }
+
+        // Verify at least one FunctionResultContent matches a registered tool call
+        foreach (ChatMessage message in group.Messages)
+        {
+            if (message.Contents is null)
+            {
+                continue;
+            }
+
+            foreach (AIContent content in message.Contents)
+            {
+                if (content is FunctionResultContent frc
+                    && frc.CallId is not null
+                    && callIdToName.ContainsKey(frc.CallId))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override (CompactionGroupKind Kind, List<ChatMessage> Messages, string ExcludeReason)
+        TransformToolGroup(CompactionMessageGroup group)
+    {
+        // Build a CallId → tool name mapping from the shared extraction helper
+        var (functionCalls, _, _) = ExtractToolCallsAndResults(group);
+
+        Dictionary<string, string> callIdToName = [];
+        foreach ((string callId, string name) in functionCalls)
+        {
+            callIdToName[callId] = name;
+        }
+
+        // Rebuild messages with reduced FunctionResultContent
+        List<ChatMessage> reducedMessages = [];
+        foreach (ChatMessage message in group.Messages)
+        {
+            if (message.Contents is null || message.Contents.Count == 0)
+            {
+                reducedMessages.Add(message);
+                continue;
+            }
+
+            bool hasReduction = false;
+            List<AIContent> newContents = [];
+
+            foreach (AIContent content in message.Contents)
+            {
+                if (content is FunctionResultContent frc
+                    && frc.CallId is not null
+                    && callIdToName.TryGetValue(frc.CallId, out string? toolName)
+                    && this.ToolResultReducers.TryGetValue(toolName, out Func<object?, object?>? reducer))
+                {
+                    newContents.Add(CloneWithReducedResult(frc, reducer(frc.Result)));
+                    hasReduction = true;
+                }
+                else
+                {
+                    newContents.Add(content);
+                }
+            }
+
+            if (hasReduction)
+            {
+                ChatMessage reducedMessage = message.Clone();
+                reducedMessage.Contents = newContents;
+                (reducedMessage.AdditionalProperties ??= [])[ReducedPropertyKey] = true;
+                reducedMessages.Add(reducedMessage);
+            }
+            else
+            {
+                reducedMessages.Add(message.Clone());
+            }
+        }
+
+        return (CompactionGroupKind.ToolCall, reducedMessages, $"Reduced by {nameof(ToolResultReductionStrategy)}");
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="FunctionResultContent"/> with the reduced result while
+    /// preserving all metadata (<see cref="AIContent.RawRepresentation"/>,
+    /// <see cref="AIContent.Annotations"/>, <see cref="AIContent.AdditionalProperties"/>)
+    /// from the original.
+    /// </summary>
+    private static FunctionResultContent CloneWithReducedResult(FunctionResultContent original, object? reducedResult)
+    {
+        var clone = new FunctionResultContent(original.CallId, reducedResult)
+        {
+            RawRepresentation = original.RawRepresentation,
+        };
+
+        if (original.Annotations is { Count: > 0 })
+        {
+            foreach (var annotation in original.Annotations)
+            {
+                (clone.Annotations ??= []).Add(annotation);
+            }
+        }
+
+        if (original.AdditionalProperties is { Count: > 0 })
+        {
+            foreach (var kvp in original.AdditionalProperties)
+            {
+                (clone.AdditionalProperties ??= [])[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return clone;
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultStrategyBase.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/ToolResultStrategyBase.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Agents.AI.Compaction;
+
+/// <summary>
+/// Base class for compaction strategies that operate on <see cref="CompactionGroupKind.ToolCall"/>
+/// groups, providing the shared logic for protected-group identification, eligible-group collection,
+/// and the exclude-and-insert processing loop.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subclasses customize behavior through two hook methods:
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="IsToolGroupEligible"/> — determines whether a specific tool call group should be processed.
+/// The default returns <see langword="true"/> for all tool call groups.
+/// </description></item>
+/// <item><description>
+/// <see cref="TransformToolGroup"/> — transforms an eligible group into replacement messages.
+/// Returns the replacement group kind, messages, and an exclude reason for diagnostics.
+/// </description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <see cref="MinimumPreservedGroups"/> is a hard floor: even if the <see cref="CompactionStrategy.Target"/>
+/// has not been reached, processing will not touch the last <see cref="MinimumPreservedGroups"/> non-system groups.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public abstract class ToolResultStrategyBase : CompactionStrategy
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolResultStrategyBase"/> class.
+    /// </summary>
+    /// <param name="trigger">
+    /// The <see cref="CompactionTrigger"/> that controls when processing proceeds.
+    /// </param>
+    /// <param name="minimumPreservedGroups">
+    /// The minimum number of most-recent non-system message groups to preserve.
+    /// This is a hard floor — processing will not touch groups beyond this limit,
+    /// regardless of the target condition.
+    /// </param>
+    /// <param name="target">
+    /// An optional target condition that controls when processing stops. When <see langword="null"/>,
+    /// defaults to the inverse of the <paramref name="trigger"/>.
+    /// </param>
+    protected ToolResultStrategyBase(
+        CompactionTrigger trigger,
+        int minimumPreservedGroups,
+        CompactionTrigger? target = null)
+        : base(trigger, target)
+    {
+        this.MinimumPreservedGroups = EnsureNonNegative(minimumPreservedGroups);
+    }
+
+    /// <summary>
+    /// Gets the minimum number of most-recent non-system groups that are always preserved.
+    /// This is a hard floor that processing cannot exceed, regardless of the target condition.
+    /// </summary>
+    public int MinimumPreservedGroups { get; }
+
+    /// <summary>
+    /// Determines whether the specified <see cref="CompactionGroupKind.ToolCall"/> group should be
+    /// processed by this strategy. Called for each non-excluded, non-protected tool call group.
+    /// </summary>
+    /// <param name="group">The tool call group to evaluate.</param>
+    /// <returns>
+    /// <see langword="true"/> if the group should be processed; <see langword="false"/> to skip it.
+    /// </returns>
+    /// <remarks>
+    /// The default implementation returns <see langword="true"/> for all groups.
+    /// Override to add filtering logic such as checking for specific tool names.
+    /// </remarks>
+    protected virtual bool IsToolGroupEligible(CompactionMessageGroup group) => true;
+
+    /// <summary>
+    /// Transforms an eligible tool call group into replacement messages.
+    /// </summary>
+    /// <param name="group">The tool call group to transform.</param>
+    /// <returns>
+    /// A tuple containing:
+    /// <list type="bullet">
+    /// <item><description><b>Kind</b> — the <see cref="CompactionGroupKind"/> for the replacement group.</description></item>
+    /// <item><description><b>Messages</b> — the replacement messages to insert.</description></item>
+    /// <item><description><b>ExcludeReason</b> — a diagnostic string describing why the original group was excluded.</description></item>
+    /// </list>
+    /// </returns>
+    protected abstract (CompactionGroupKind Kind, List<ChatMessage> Messages, string ExcludeReason)
+        TransformToolGroup(CompactionMessageGroup group);
+
+    /// <inheritdoc/>
+    protected sealed override ValueTask<bool> CompactCoreAsync(
+        CompactionMessageIndex index,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        // Identify protected groups: the N most-recent non-system, non-excluded groups
+        List<int> nonSystemIncludedIndices = [];
+        for (int i = 0; i < index.Groups.Count; i++)
+        {
+            CompactionMessageGroup group = index.Groups[i];
+            if (!group.IsExcluded && group.Kind != CompactionGroupKind.System)
+            {
+                nonSystemIncludedIndices.Add(i);
+            }
+        }
+
+        int protectedStart = EnsureNonNegative(nonSystemIncludedIndices.Count - this.MinimumPreservedGroups);
+        HashSet<int> protectedGroupIndices = [];
+        for (int i = protectedStart; i < nonSystemIncludedIndices.Count; i++)
+        {
+            protectedGroupIndices.Add(nonSystemIncludedIndices[i]);
+        }
+
+        // Collect eligible tool groups in order (oldest first)
+        List<int> eligibleIndices = [];
+        for (int i = 0; i < index.Groups.Count; i++)
+        {
+            CompactionMessageGroup group = index.Groups[i];
+            if (group.IsExcluded || group.Kind != CompactionGroupKind.ToolCall || protectedGroupIndices.Contains(i))
+            {
+                continue;
+            }
+
+            if (!this.IsToolGroupEligible(group))
+            {
+                continue;
+            }
+
+            eligibleIndices.Add(i);
+        }
+
+        if (eligibleIndices.Count == 0)
+        {
+            return new ValueTask<bool>(false);
+        }
+
+        // Process one tool group at a time from oldest, re-checking target after each
+        bool processed = false;
+        int offset = 0;
+
+        for (int e = 0; e < eligibleIndices.Count; e++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            int idx = eligibleIndices[e] + offset;
+            CompactionMessageGroup group = index.Groups[idx];
+
+            var (kind, messages, excludeReason) = this.TransformToolGroup(group);
+
+            group.IsExcluded = true;
+            group.ExcludeReason = excludeReason;
+
+            index.InsertGroup(idx + 1, kind, messages, group.TurnIndex);
+            offset++;
+
+            processed = true;
+
+            if (this.Target(index))
+            {
+                break;
+            }
+        }
+
+        return new ValueTask<bool>(processed);
+    }
+
+    /// <summary>
+    /// Extracts function calls, their results, and plain-text tool results from a
+    /// <see cref="CompactionMessageGroup"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="FunctionCallContent"/> items are collected as ordered (CallId, Name) pairs,
+    /// preserving first-seen order for downstream formatting. <see cref="FunctionResultContent"/>
+    /// items are collected by CallId for lookup-based matching. Plain-text Tool-role messages
+    /// that lack <see cref="FunctionResultContent"/> are collected separately for positional fallback.
+    /// </remarks>
+    protected static (
+        List<(string CallId, string Name)> FunctionCalls,
+        Dictionary<string, string> ResultsByCallId,
+        List<string> PlainTextResults) ExtractToolCallsAndResults(CompactionMessageGroup group)
+    {
+        List<(string CallId, string Name)> functionCalls = [];
+        Dictionary<string, string> resultsByCallId = [];
+        List<string> plainTextResults = [];
+
+        foreach (ChatMessage message in group.Messages)
+        {
+            bool hasFunctionResult = false;
+
+            if (message.Contents is not null)
+            {
+                foreach (AIContent content in message.Contents)
+                {
+                    if (content is FunctionCallContent fcc)
+                    {
+                        functionCalls.Add((fcc.CallId, fcc.Name));
+                    }
+                    else if (content is FunctionResultContent frc && frc.CallId is not null)
+                    {
+                        resultsByCallId[frc.CallId] = frc.Result?.ToString() ?? string.Empty;
+                        hasFunctionResult = true;
+                    }
+                }
+            }
+
+            // Collect plain text from Tool-role messages that lack FunctionResultContent
+            if (!hasFunctionResult && message.Role == ChatRole.Tool && message.Text is string text)
+            {
+                plainTextResults.Add(text);
+            }
+        }
+
+        return (functionCalls, resultsByCallId, plainTextResults);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/ToolResultReductionStrategyTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/ToolResultReductionStrategyTests.cs
@@ -1,0 +1,608 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Compaction;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.UnitTests.Compaction;
+
+/// <summary>
+/// Contains tests for the <see cref="ToolResultReductionStrategy"/> class.
+/// </summary>
+public partial class ToolResultReductionStrategyTests
+{
+    [Fact]
+    public async Task CompactAsyncTriggerNotMetReturnsFalseAsync()
+    {
+        // Arrange — trigger requires > 1000 tokens
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "reduced",
+            },
+            CompactionTriggers.TokensExceed(1000));
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "short")]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CompactAsyncAppliesReducerToRegisteredToolAsync()
+    {
+        // Arrange — register a reducer that uppercases weather results
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["get_weather"] = result => result?.ToString()!.ToUpperInvariant(),
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "get_weather")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "Sunny and 72°F")]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — result reduced but message structure preserved
+        Assert.True(result);
+
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal(3, included.Count);
+        Assert.Equal(ChatRole.User, included[0].Role);
+        Assert.Equal(ChatRole.Assistant, included[1].Role);
+        Assert.Equal(ChatRole.Tool, included[2].Role);
+
+        FunctionResultContent? frc = included[2].Contents.OfType<FunctionResultContent>().SingleOrDefault();
+        Assert.NotNull(frc);
+        Assert.Equal("SUNNY AND 72°F", frc.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncPreservesUnregisteredToolResultsAsync()
+    {
+        // Arrange — reducer registered for search_docs only; get_weather is unregistered
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["search_docs"] = result => $"({result?.ToString()!.Split('\n').Length} results)",
+            },
+            trigger: _ => true);
+
+        ChatMessage multiToolCall = new(ChatRole.Assistant,
+        [
+            new FunctionCallContent("c1", "search_docs"),
+            new FunctionCallContent("c2", "get_weather"),
+        ]);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            multiToolCall,
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "doc1\ndoc2\ndoc3")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c2", "Sunny")]),
+        ]);
+
+        // Act
+        await strategy.CompactAsync(index);
+
+        // Assert — search_docs reduced, get_weather preserved as-is
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal(4, included.Count);
+
+        FunctionResultContent searchResult = included[2].Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("(3 results)", searchResult.Result?.ToString());
+
+        FunctionResultContent weatherResult = included[3].Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("Sunny", weatherResult.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncPreservesMessageStructureAsync()
+    {
+        // Arrange — reducer that truncates long results
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["retrieval_api"] = result => { var s = result?.ToString()!; return s.Length > 20 ? s[..20] + "..." : s; },
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Find relevant documents"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "retrieval_api")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "This is a very long result that exceeds twenty characters")]),
+        ]);
+
+        // Act
+        await strategy.CompactAsync(index);
+
+        // Assert — structure preserved: User + Assistant (with FunctionCallContent) + Tool (with FunctionResultContent)
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal(3, included.Count);
+        Assert.Equal(ChatRole.Assistant, included[1].Role);
+        Assert.IsType<FunctionCallContent>(included[1].Contents[0]);
+        Assert.Equal(ChatRole.Tool, included[2].Role);
+
+        FunctionResultContent frc = included[2].Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("c1", frc.CallId);
+        Assert.Equal("This is a very long ...", frc.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncReducesCurrentTurnByDefaultAsync()
+    {
+        // Arrange — minimumPreservedGroups defaults to 0, so current turn is eligible
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => result?.ToString()!.ToUpperInvariant(),
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "hello")]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — even the only/current tool group was reduced
+        Assert.True(result);
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        FunctionResultContent frc = included[2].Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("HELLO", frc.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncPreservesRecentToolGroupsAsync()
+    {
+        // Arrange — protect 3 recent groups (tool group + user message = protected)
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "SHOULD NOT APPEAR",
+            },
+            trigger: _ => true,
+            minimumPreservedGroups: 3);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "result")]),
+            new ChatMessage(ChatRole.User, "Q2"),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — all groups in protected window, nothing reduced
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CompactAsyncOnlyTargetsGroupsWithRegisteredReducersAsync()
+    {
+        // Arrange — reducer for search_docs only; get_weather-only group is skipped
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["search_docs"] = result => "reduced",
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "get_weather")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "Sunny")]),
+            new ChatMessage(ChatRole.User, "Q2"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c2", "search_docs")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c2", "doc1")]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — only search_docs group reduced; get_weather group untouched
+        Assert.True(result);
+
+        int reducedToolGroups = 0;
+        int preservedToolGroups = 0;
+        foreach (CompactionMessageGroup group in index.Groups)
+        {
+            if (group.Kind == CompactionGroupKind.ToolCall)
+            {
+                if (group.IsExcluded)
+                {
+                    reducedToolGroups++;
+                }
+                else
+                {
+                    preservedToolGroups++;
+                }
+            }
+        }
+
+        Assert.Equal(1, reducedToolGroups);
+        Assert.Equal(2, preservedToolGroups); // get_weather unchanged + search_docs reduced replacement
+    }
+
+    [Fact]
+    public async Task CompactAsyncTargetStopsReducingEarlyAsync()
+    {
+        // Arrange — 2 eligible tool groups, target met after first reduction
+        int reduceCount = 0;
+        bool TargetAfterOne(CompactionMessageIndex _) => ++reduceCount >= 1;
+
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn1"] = result => "reduced1",
+                ["fn2"] = result => "reduced2",
+            },
+            trigger: _ => true,
+            target: TargetAfterOne);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "result1")]),
+            new ChatMessage(ChatRole.User, "Q2"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c2", "fn2")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c2", "result2")]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — only first tool group reduced
+        Assert.True(result);
+
+        int reducedToolGroups = 0;
+        foreach (CompactionMessageGroup group in index.Groups)
+        {
+            if (group.IsExcluded && group.Kind == CompactionGroupKind.ToolCall)
+            {
+                reducedToolGroups++;
+            }
+        }
+
+        Assert.Equal(1, reducedToolGroups);
+    }
+
+    [Fact]
+    public async Task CompactAsyncPreservesSystemMessagesAsync()
+    {
+        // Arrange
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "reduced",
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.System, "You are helpful."),
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "result")]),
+        ]);
+
+        // Act
+        await strategy.CompactAsync(index);
+
+        // Assert
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal("You are helpful.", included[0].Text);
+        Assert.False(index.Groups[0].IsExcluded);
+    }
+
+    [Fact]
+    public async Task CompactAsyncNoToolGroupsReturnsFalseAsync()
+    {
+        // Arrange — trigger fires but no tool groups to reduce
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "reduced",
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Hello"),
+            new ChatMessage(ChatRole.Assistant, "Hi!"),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CompactAsyncSkipsPreExcludedAndSystemGroupsAsync()
+    {
+        // Arrange — pre-excluded and system groups in the enumeration
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "reduced",
+            },
+            CompactionTriggers.Always);
+
+        List<ChatMessage> messages =
+        [
+            new ChatMessage(ChatRole.System, "System prompt"),
+            new ChatMessage(ChatRole.User, "Q0"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "Result 1")]),
+            new ChatMessage(ChatRole.User, "Q1"),
+        ];
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(messages);
+        // Pre-exclude the last user group
+        index.Groups[index.Groups.Count - 1].IsExcluded = true;
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — system never excluded, pre-excluded skipped
+        Assert.True(result);
+        Assert.False(index.Groups[0].IsExcluded); // System stays
+    }
+
+    [Fact]
+    public async Task CompactAsyncComposesWithCompactionInPipelineAsync()
+    {
+        // Arrange — reduction first, then compaction in a pipeline
+        ToolResultReductionStrategy reductionStrategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["search"] = result => $"[{result?.ToString()!.Split('\n').Length} results]",
+            },
+            trigger: _ => true);
+
+        ToolResultCompactionStrategy compactionStrategy = new(
+            trigger: _ => true,
+            minimumPreservedGroups: 1);
+
+        PipelineCompactionStrategy pipeline = new(reductionStrategy, compactionStrategy);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "search")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "doc1\ndoc2\ndoc3")]),
+            new ChatMessage(ChatRole.User, "Q2"),
+        ]);
+
+        // Act
+        await pipeline.CompactAsync(index);
+
+        // Assert — reduction applied first (3 results), then compacted to YAML
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal(3, included.Count); // Q1, collapsed summary, Q2
+        Assert.Contains("[3 results]", included[1].Text);
+        Assert.Contains("[Tool Calls]", included[1].Text);
+    }
+
+    [Fact]
+    public async Task CompactAsyncRetrievalApiSelectsHighestRelevantWithinBudgetAsync()
+    {
+        // Arrange — simulate a retrieval API returning JSON chunks with relevance scores.
+        // The reducer deserializes, orders by relevance, selects top chunks within a
+        // character budget, and re-serializes — the canonical RAG compaction scenario.
+        const string RetrievalResult =
+            """
+            [
+              {"chunk": "Irrelevant filler content that wastes tokens", "relevance": 0.2},
+              {"chunk": "Highly relevant answer about the product pricing model", "relevance": 0.95},
+              {"chunk": "Somewhat relevant context about product history", "relevance": 0.6},
+              {"chunk": "Very relevant details about current pricing tiers", "relevance": 0.9},
+              {"chunk": "Noise from unrelated document section", "relevance": 0.1},
+              {"chunk": "Moderately relevant competitor comparison", "relevance": 0.7}
+            ]
+            """;
+
+        // Only keep chunks whose combined text fits within ~100 chars.
+        // Top-2 by relevance: 0.95 (55 chars) + 0.90 (49 chars) = 104 chars — over budget.
+        // So only the top-1 (0.95) fits.
+        const int CharBudget = 100;
+
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["retrieval_api"] = result =>
+                {
+                    var chunks = JsonSerializer.Deserialize(result?.ToString()!, ChunkSerializerContext.Default.ListChunkResult)!;
+                    var selected = new List<ChunkResult>();
+                    int totalChars = 0;
+
+                    foreach (var chunk in chunks.OrderByDescending(c => c.Relevance))
+                    {
+                        if (totalChars + chunk.Chunk.Length > CharBudget)
+                        {
+                            break;
+                        }
+
+                        selected.Add(chunk);
+                        totalChars += chunk.Chunk.Length;
+                    }
+
+                    return JsonSerializer.Serialize(selected, ChunkSerializerContext.Default.ListChunkResult);
+                },
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "What are the pricing tiers?"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "retrieval_api")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", RetrievalResult)]),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — reduced to only the highest-relevance chunk(s) within budget
+        Assert.True(result);
+
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        Assert.Equal(3, included.Count);
+        Assert.Equal(ChatRole.Tool, included[2].Role);
+
+        FunctionResultContent frc = included[2].Contents.OfType<FunctionResultContent>().Single();
+        string reducedJson = frc.Result!.ToString()!;
+
+        var reducedChunks = JsonSerializer.Deserialize(reducedJson, ChunkSerializerContext.Default.ListChunkResult)!;
+
+        // Should contain only the top chunk(s) that fit the budget
+        Assert.True(reducedChunks.Count >= 1, "Should select at least one chunk");
+        Assert.True(reducedChunks.All(c => c.Relevance >= 0.9), "Should only contain high-relevance chunks");
+        Assert.Equal(0.95, reducedChunks[0].Relevance);
+
+        // Verify total is within budget
+        int totalLength = reducedChunks.Sum(c => c.Chunk.Length);
+        Assert.True(totalLength <= CharBudget, $"Total chunk length {totalLength} should be within budget {CharBudget}");
+    }
+
+    [Fact]
+    public async Task CompactAsyncPreservesMessageMetadataAsync()
+    {
+        // Arrange — message has AuthorName and MessageId that should survive reduction
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "reduced",
+            },
+            trigger: _ => true);
+
+        ChatMessage toolResultMessage = new(ChatRole.Tool, [new FunctionResultContent("c1", "original")])
+        {
+            AuthorName = "tool-author",
+            MessageId = "msg-42",
+        };
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            toolResultMessage,
+        ]);
+
+        // Act
+        await strategy.CompactAsync(index);
+
+        // Assert — metadata preserved on the reduced message
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        ChatMessage reduced = included[2];
+        Assert.Equal("tool-author", reduced.AuthorName);
+        Assert.Equal("msg-42", reduced.MessageId);
+
+        FunctionResultContent frc = reduced.Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("reduced", frc.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncDoesNotReReduceAlreadyReducedGroupsAsync()
+    {
+        // Arrange — calling CompactAsync twice should not re-reduce
+        int callCount = 0;
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => { callCount++; return $"reduced-{callCount}"; },
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("c1", "original")]),
+        ]);
+
+        // Act — reduce twice
+        bool first = await strategy.CompactAsync(index);
+        bool second = await strategy.CompactAsync(index);
+
+        // Assert — first call reduces, second is a no-op
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Equal(1, callCount);
+
+        List<ChatMessage> included = [.. index.GetIncludedMessages()];
+        FunctionResultContent frc = included[2].Contents.OfType<FunctionResultContent>().Single();
+        Assert.Equal("reduced-1", frc.Result?.ToString());
+    }
+
+    [Fact]
+    public async Task CompactAsyncSkipsGroupWithCallButNoMatchingResultAsync()
+    {
+        // Arrange — group has a registered FunctionCallContent but no FunctionResultContent
+        // (tool result is plain text, not FunctionResultContent)
+        ToolResultReductionStrategy strategy = new(
+            new Dictionary<string, Func<object?, object?>>
+            {
+                ["fn"] = result => "should not be called",
+            },
+            trigger: _ => true);
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create(
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("c1", "fn")]),
+            new ChatMessage(ChatRole.Tool, "Plain text result without FunctionResultContent"),
+        ]);
+
+        // Act
+        bool result = await strategy.CompactAsync(index);
+
+        // Assert — group is ineligible, no reduction
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Represents a retrieval API chunk with relevance score, matching the JSON structure
+    /// returned by a typical RAG tool.
+    /// </summary>
+    private sealed class ChunkResult
+    {
+        [JsonPropertyName("chunk")]
+        public string Chunk { get; set; } = string.Empty;
+
+        [JsonPropertyName("relevance")]
+        public double Relevance { get; set; }
+    }
+
+    [JsonSerializable(typeof(List<ChunkResult>))]
+    private sealed partial class ChunkSerializerContext : JsonSerializerContext;
+}


### PR DESCRIPTION
### Motivation and Context

When using tools that return very large results — such as the M365 Retrieval API returning hundreds of thousands of tokens with relevance scores — there is currently no way for a framework user to selectively reduce individual tool results while preserving the tool-call message structure. The existing `ToolResultCompactionStrategy` collapses entire tool-call groups into YAML summaries, which loses the assistant/tool message pairing needed for multi-turn tool interactions.

This PR proposes a new `ToolResultReductionStrategy` that allows users to register per-tool `Func<string, string>` reducers — enabling them to deserialize, filter, sort, and re-serialize tool results within their own logic, while the framework handles the plumbing. I've submitted this as a PR (rather than an issue) to best convey the intent and proposed implementation for discussion.

### Description

**New classes:**

- **`ToolResultStrategyBase`** — Abstract base class extracted from the shared logic between compaction and reduction. Implements a sealed `CompactCoreAsync` with a template-method pattern, delegating to two hooks:
  - `IsToolGroupEligible(group)` — virtual, defaults to `true`
  - `TransformToolGroup(group)` — abstract, returns the transformed messages

- **`ToolResultReductionStrategy`** — Applies per-tool `Func<string, string>` reducers to `FunctionResultContent` while preserving the original message structure (assistant tool-call + tool result messages). Defaults `minimumPreservedGroups` to `0` so reducers apply even to the current turn. Only tool-call groups containing at least one registered tool name are eligible; unregistered tools within a group are preserved as-is.

**Refactored:**

- **`ToolResultCompactionStrategy`** — Now extends `ToolResultStrategyBase` instead of `CompactionStrategy` directly, removing ~110 lines of duplicated loop/protect/eligibility logic. Behavior is unchanged.

**Tests:**

- 13 new tests in `ToolResultReductionStrategyTests` covering: trigger/target, reducer application, unregistered tool preservation, message structure preservation, current-turn reduction, minimum preserved groups, eligibility filtering, system message preservation, pre-excluded groups, no tool groups, pipeline composition, and a **real-world RAG scenario** (JSON chunks with relevance scores filtered within a character budget).

**Key design decisions:**

| | Compaction | Reduction |
|---|---|---|
| Output | YAML summary (single message) | Structure-preserving (rebuilt tool-call group) |
| `minimumPreservedGroups` default | 16 | 0 |
| Group kind | `Summary` | `ToolCall` |
| Customization | `ToolCallFormatter` delegate | Per-tool `Func<string, string>` reducers |

Both strategies compose naturally in a `PipelineCompactionStrategy` — reduction first (shrink results), then compaction (collapse older groups).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x]  **Not a breaking change.** No existing APIs are modified; `ToolResultCompactionStrategy` behavior is identical after the base-class refactor.
