### PR TITLE
Python: fix: inject synthetic tool results for pending frontend tool calls

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_message_adapters.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_message_adapters.py
@@ -194,6 +194,26 @@ def _sanitize_tool_history(messages: list[Message]) -> list[Message]:
         pending_tool_call_ids = None
         pending_confirm_changes_id = None
 
+    # If the conversation ends with pending tool calls (e.g. a declaration-only
+    # frontend tool was called with no user message following), inject synthetic
+    # results so the next OpenAI call doesn't get a 400 for unmatched tool_call_ids.
+    if pending_tool_call_ids:
+        logger.info(
+            f"Messages ended with {len(pending_tool_call_ids)} pending tool calls - "
+            "injecting synthetic results"
+        )
+        for pending_call_id in pending_tool_call_ids:
+            logger.info(f"Injecting synthetic tool result for pending call_id={pending_call_id}")
+            sanitized.append(Message(
+                role="tool",
+                contents=[
+                    Content.from_function_result(
+                        call_id=pending_call_id,
+                        result="Tool execution skipped - frontend tool result not yet received",
+                    )
+                ],
+            ))
+
     return sanitized
 
 

--- a/python/packages/ag-ui/tests/ag_ui/test_message_adapters.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_message_adapters.py
@@ -984,6 +984,23 @@ def test_sanitize_json_confirm_changes_response():
     assert len(result) >= 1
 
 
+def test_sanitize_pending_tool_at_end_of_history():
+    """Messages ending with an assistant tool call and no following message inject a synthetic result."""
+    from agent_framework_ag_ui._message_adapters import _sanitize_tool_history
+
+    assistant_msg = Message(
+        role="assistant",
+        contents=[Content.from_function_call(call_id="c1", name="pieChart", arguments="{}")],
+    )
+
+    result = _sanitize_tool_history([assistant_msg])
+
+    tool_results = [m for m in result if m.role == "tool"]
+    assert len(tool_results) == 1
+    assert tool_results[0].contents[0].call_id == "c1"
+    assert "skipped" in str(tool_results[0].contents[0].result).lower()
+
+
 # ── Deduplication edge cases ──
 
 


### PR DESCRIPTION
### Description

  When an agent calls a declaration-only (frontend/client-side) tool — such as
  a generative UI component like `pieChart` — and the conversation ends without
  a user message following, the tool call remains "pending" in the message
  history with no corresponding tool result.

  On the next request, OpenAI rejects the conversation with a 400 error:
  "An assistant message with 'tool_calls' must be followed by tool messages
  responding to each 'tool_call_id'."

  _sanitize_tool_history already handles this when a user message arrives while
  calls are pending — it injects synthetic results before the user turn. This
  fix extends that logic to also cover the end-of-messages case, so pending
  tool calls are always resolved before the history is sent to OpenAI.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.