### PR TITLE
.NET: Skip flaky integration tests blocking merge queue

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 [Trait("Category", "SampleValidation")]
 public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) : SamplesValidationBase(outputHelper)
 {
+    private const string SkipFlakyTimingTest = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971";
+
     private static readonly string s_samplesPath = Path.GetFullPath(
         Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..", "samples", "04-hosting", "DurableAgents", "ConsoleApps"));
 
@@ -235,7 +237,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         Assert.True(foundSuccess, "Orchestration did not complete successfully.");
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task SingleAgentOrchestrationHITLSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "05_AgentOrchestration_HITL");
@@ -309,7 +311,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task LongRunningToolsSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "06_LongRunningTools");
@@ -394,7 +396,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task ReliableStreamingSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "07_ReliableStreaming");

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ExternalClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ExternalClientTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 [Trait("Category", "Integration")]
 public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDisposable
 {
+    private const string SkipFlakyTimingTest = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971";
+
     private static readonly TimeSpan s_defaultTimeout = Debugger.IsAttached
         ? TimeSpan.FromMinutes(5)
         : TimeSpan.FromSeconds(60);
@@ -75,7 +77,7 @@ public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDispo
         Assert.Contains(agentLogs, log => log.EventId.Name == "LogAgentResponse");
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task CallFunctionToolsAsync()
     {
         int weatherToolInvocationCount = 0;
@@ -127,7 +129,7 @@ public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDispo
         Assert.Equal(1, packingListToolInvocationCount);
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task CallLongRunningFunctionToolsAsync()
     {
         [Description("Starts a greeting workflow and returns the workflow instance ID")]

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests;
 [Trait("Category", "SampleValidation")]
 public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLifetime
 {
+    private const string SkipFlakyTimingTest = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971";
+
     private const string AzureFunctionsPort = "7071";
     private const string AzuritePort = "10000";
     private const string DtsPort = "8080";
@@ -272,7 +274,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task LongRunningToolsSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "06_LongRunningTools");
@@ -402,7 +404,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [Fact(Skip = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971")]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task ReliableStreamingSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "08_ReliableStreaming");


### PR DESCRIPTION
## Summary

Skip 7 flaky integration tests that are causing a **73% failure rate** in the merge queue over the past 3 days (22 out of 30 runs failing). All failures are timing/latency-dependent and occur across 7 unrelated PRs — this is systemic flakiness, not PR-specific bugs.

## Tracking Issue

Fixes #4971 — full investigation with detailed failure catalog, per-PR statistics, and recommended long-term fixes.

## Skipped Tests

### `ConsoleAppSamplesValidation.cs` (DurableTask.IntegrationTests)
| Test | Error | Frequency |
|------|-------|-----------|
| `ReliableStreamingSampleValidationAsync` | "Not enough content before interrupt (got 0)" | 5+ PRs |
| `SingleAgentOrchestrationHITLSampleValidationAsync` | "Wasn't prompted with the draft" | 3+ runs |
| `LongRunningToolsSampleValidationAsync` | "Wasn't prompted with first draft" | 1+ runs |

### `SamplesValidation.cs` (AzureFunctions.IntegrationTests)
| Test | Error | Frequency |
|------|-------|-----------|
| `LongRunningToolsSampleValidationAsync` | TimeoutException waiting for log messages | 3+ runs |
| `ReliableStreamingSampleValidationAsync` | HttpClient.Timeout at 100s | 1+ runs |

### `ExternalClientTests.cs` (DurableTask.IntegrationTests)
| Test | Error | Frequency |
|------|-------|-----------|
| `CallFunctionToolsAsync` | TaskCanceledException at exactly 60s | 1+ runs |
| `CallLongRunningFunctionToolsAsync` | TaskCanceledException at exactly 60s | 1+ runs |

## Root Cause

All tests hit a real Azure OpenAI endpoint (`gpt-5-nano` on France region), making them inherently non-deterministic. The hard-coded timeouts (60s–100s) are too tight for LLM-backed orchestrations, causing failures when the model responds slower than expected.

## What This PR Does NOT Do

This PR only skips the flaky tests to unblock the merge queue. Long-term fixes (increasing timeouts, adding retries, mocking LLM calls) are tracked in #4971.
