### PR TITLE
Python: Update project name from 'Semantic Kernel' to 'Agent Framework'

### DIFF
--- a/python/DEV_SETUP.md
+++ b/python/DEV_SETUP.md
@@ -180,7 +180,7 @@ This will show you which files are not covered by the tests, including the speci
 
 ## Catching up with the latest changes
 
-There are many people committing to Semantic Kernel, so it is important to keep your local repository up to date. To do this, you can run the following commands:
+There are many people committing to Agent Framework, so it is important to keep your local repository up to date. To do this, you can run the following commands:
 
 ```bash
     git fetch upstream main


### PR DESCRIPTION
### Description

Small fix to update project name in python setup doc.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.