### PR TITLE
Python: Fix GitHubCopilotAgent to invoke context provider before_run/after_run hooks

### DIFF
--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -361,7 +361,10 @@ class GitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 sess = ctx_holder.get("session")
                 if session_context is not None and sess is not None:
                     session_context._response = response
-                    await self._run_after_providers(session=sess, context=session_context)
+                    try:
+                        await self._run_after_providers(session=sess, context=session_context)
+                    except Exception:
+                        logger.exception("Error running after_run providers in streaming result hook")
 
             def _finalize(updates: Sequence[AgentResponseUpdate]) -> AgentResponse:
                 return AgentResponse.from_updates(updates)
@@ -390,10 +393,13 @@ class GitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
         opts: dict[str, Any] = dict(options) if options else {}
         timeout = opts.get("timeout") or self._settings.get("timeout") or DEFAULT_TIMEOUT_SECONDS
 
-        copilot_session = await self._get_or_create_session(session, streaming=False, runtime_options=opts)
         input_messages = normalize_messages(messages)
 
         session_context = await self._run_before_providers(session=session, input_messages=input_messages, options=opts)
+
+        # NOTE: session is created after providers run so that future provider-contributed
+        # tools/config could be folded into runtime_options before session creation.
+        copilot_session = await self._get_or_create_session(session, streaming=False, runtime_options=opts)
 
         # Build the prompt from the full set of messages in the session context,
         # so that any context/history provider-injected messages are included.
@@ -466,10 +472,13 @@ class GitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
 
         opts: dict[str, Any] = dict(options) if options else {}
 
-        copilot_session = await self._get_or_create_session(session, streaming=True, runtime_options=opts)
         input_messages = normalize_messages(messages)
 
         session_context = await self._run_before_providers(session=session, input_messages=input_messages, options=opts)
+
+        # NOTE: session is created after providers run so that future provider-contributed
+        # tools/config could be folded into runtime_options before session creation.
+        copilot_session = await self._get_or_create_session(session, streaming=True, runtime_options=opts)
 
         if _ctx_holder is not None:
             _ctx_holder["session_context"] = session_context

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -1780,7 +1780,7 @@ class TestGitHubCopilotAgentContextProviders:
                 context: Any,
                 state: dict[str, Any],
             ) -> None:
-                pass
+                self.after_run_called = True
 
             async def get_messages(self, *, session_id: str, **kwargs: Any) -> list[Message]:
                 return []
@@ -1800,6 +1800,9 @@ class TestGitHubCopilotAgentContextProviders:
 
         assert not skipped_provider.before_run_called
         assert active_provider.before_run_called
+        # after_run should still be called even when load_messages=False
+        assert skipped_provider.after_run_called
+        assert active_provider.after_run_called
 
     async def test_streaming_after_run_response_has_updates(
         self,


### PR DESCRIPTION
### Motivation and Context

GitHubCopilotAgent accepts `context_providers` in its constructor but its `_run_impl()` and `_stream_updates()` methods never call `before_run`/`after_run` on them, making memory and context injection silently non-functional. This breaks the documented memory example when used with GitHubCopilotAgent.

Fixes #3984

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause is that `GitHubCopilotAgent` bypasses the `BaseAgent` provider pipeline — it constructs prompts and sends them directly to the Copilot session without invoking any context provider hooks. The fix adds a `_run_before_providers` helper that creates a `SessionContext`, iterates over all registered context providers calling `before_run`, and prepends any provider-injected instructions to the prompt. After the response is received (or streaming completes), `_run_after_providers` is called with the response attached to the context. Both the non-streaming (`_run_impl`) and streaming (`_stream_updates`) paths are updated, along with comprehensive tests covering hook invocation, instruction injection, streaming, and cross-run state preservation.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by giles17's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":3984,"repo":"microsoft/agent-framework","rid":"dadbdb9eba824e75b0589372b6a55f23","rt":"fix","sf":"pr","ts":"2026-03-31T22:22:08.297929+00:00","u":"giles17","v":1}
-->
