### PR TITLE
Python: feat(foundry): make FoundryMemoryProvider resolve from session.state user_id at runtime instead of falling back to session_id.

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_memory_provider.py
+++ b/python/packages/foundry/agent_framework_foundry/_memory_provider.py
@@ -56,7 +56,10 @@ class FoundryMemoryProvider(BaseContextProvider):
         source_id: Unique identifier for this provider instance.
         project_client: Azure AI Project client for memory operations.
         memory_store_name: The name of the memory store to use.
-        scope: The namespace that logically groups and isolates memories (e.g., user ID).
+        scope: The namespace that logically groups and isolates memories.
+            If not provided, automatically resolved at runtime from
+            ``session.state["user_id"]`` (combined with ``session.state["org_id"]``
+            when present).
         context_prompt: The prompt to prepend to retrieved memories.
         update_delay: Timeout period before processing memory update in seconds.
             Defaults to 300 (5 minutes). Set to 0 to immediately trigger updates.
@@ -91,8 +94,9 @@ class FoundryMemoryProvider(BaseContextProvider):
                 Required when project_client is not provided.
             allow_preview: Enables preview opt-in on internally-created ``AIProjectClient``.
             memory_store_name: The name of the memory store to use.
-            scope: The namespace that logically groups and isolates memories (e.g., user ID).
-                If None, `session_id` will be used.
+            scope: The namespace that logically groups and isolates memories.
+                If None, resolved at runtime from ``session.state["user_id"]``
+                (combined with ``session.state["org_id"]`` when present).
             context_prompt: The prompt to prepend to retrieved memories.
             update_delay: Timeout period before processing memory update in seconds.
             env_file_path: Path to environment file for loading settings.
@@ -127,12 +131,10 @@ class FoundryMemoryProvider(BaseContextProvider):
 
         if not memory_store_name:
             raise ValueError("memory_store_name is required")
-        if not scope:
-            raise ValueError("scope is required")
 
         self.project_client = project_client
         self.memory_store_name = memory_store_name
-        self.scope = scope
+        self.scope = scope or None
         self.context_prompt = context_prompt or self.DEFAULT_CONTEXT_PROMPT
         self.update_delay = update_delay
 
@@ -149,6 +151,26 @@ class FoundryMemoryProvider(BaseContextProvider):
 
     # -- Hooks pattern ---------------------------------------------------------
 
+    def _resolve_scope(self, session: AgentSession) -> str:
+        """Resolve the memory scope.
+
+        Returns the explicit scope if set, otherwise derives it from
+        ``session.state["user_id"]``
+
+        Raises:
+            ValueError: If scope cannot be resolved.
+        """
+        if self.scope:
+            return self.scope
+
+        user_id = session.state.get("user_id")
+        if not user_id:
+            raise ValueError(
+                "Memory scope cannot be resolved. Provide 'scope' at init time or set 'user_id' in session.state."
+            )
+
+        return str(user_id)
+
     async def before_run(
         self,
         *,
@@ -164,12 +186,14 @@ class FoundryMemoryProvider(BaseContextProvider):
         2. Searches for contextual memories based on input messages
         3. Combines and injects memories into the context
         """
+        resolved_scope = self._resolve_scope(session)
+
         # On first run, retrieve static memories (user profile memories)
         if not state.get("initialized"):
             try:
                 static_search_result = await self.project_client.beta.memory_stores.search_memories(
                     name=self.memory_store_name,
-                    scope=self.scope or context.session_id,  # type: ignore[arg-type]
+                    scope=resolved_scope,
                 )
                 static_memories = [{"content": memory.memory_item.content} for memory in static_search_result.memories]
                 state["static_memories"] = static_memories
@@ -197,7 +221,7 @@ class FoundryMemoryProvider(BaseContextProvider):
         try:
             search_result = await self.project_client.beta.memory_stores.search_memories(
                 name=self.memory_store_name,
-                scope=self.scope or context.session_id,  # type: ignore[arg-type]
+                scope=resolved_scope,
                 items=items,
                 previous_search_id=state.get("previous_search_id"),
             )
@@ -255,10 +279,11 @@ class FoundryMemoryProvider(BaseContextProvider):
             return
 
         try:
+            resolved_scope = self._resolve_scope(session)
             # Fire and forget - don't wait for the update to complete
             update_poller = await self.project_client.beta.memory_stores.begin_update_memories(
                 name=self.memory_store_name,
-                scope=self.scope or context.session_id,  # type: ignore[arg-type]
+                scope=resolved_scope,
                 items=items,
                 previous_update_id=state.get("previous_update_id"),
                 update_delay=self.update_delay,

--- a/python/packages/foundry/tests/foundry/test_foundry_memory_provider.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_memory_provider.py
@@ -129,16 +129,109 @@ def test_init_requires_memory_store_name(mock_project_client: AsyncMock) -> None
         )
 
 
-def test_init_requires_scope(mock_project_client: AsyncMock) -> None:
-    with pytest.raises(ValueError, match="scope is required"):
-        FoundryMemoryProvider(
-            project_client=mock_project_client,
-            memory_store_name="test_store",
-            scope="",
-        )
+def test_init_scope_is_optional(mock_project_client: AsyncMock) -> None:
+    """scope can be omitted; it will be resolved from session.state at runtime."""
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    assert provider.scope is None
+
+
+# -- _resolve_scope tests -------------------------------------------------------
+
+
+def test_resolve_scope_explicit(mock_project_client: AsyncMock) -> None:
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+        scope="explicit_scope",
+    )
+    session = AgentSession(session_id="s1")
+    session.state["user_id"] = "ignored"
+    assert provider._resolve_scope(session) == "explicit_scope"
+
+
+def test_resolve_scope_from_user_id(mock_project_client: AsyncMock) -> None:
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    session = AgentSession(session_id="s1")
+    session.state["user_id"] = "user_42"
+    assert provider._resolve_scope(session) == "user_42"
+
+
+def test_resolve_scope_from_user_id_and_org_id(mock_project_client: AsyncMock) -> None:
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    session = AgentSession(session_id="s1")
+    session.state["user_id"] = "user_42"
+    session.state["org_id"] = "org_7"
+    assert provider._resolve_scope(session) == "user_42_org_7"
+
+
+def test_resolve_scope_raises_without_user_id(mock_project_client: AsyncMock) -> None:
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    session = AgentSession(session_id="s1")
+    with pytest.raises(ValueError, match="Memory scope cannot be resolved"):
+        provider._resolve_scope(session)
 
 
 # -- before_run tests ----------------------------------------------------------
+
+
+async def test_before_run_resolves_scope_from_session_state(mock_project_client: AsyncMock) -> None:
+    """When scope is not set at init, before_run resolves it from session.state."""
+    static_result = Mock()
+    static_result.memories = []
+    contextual_result = Mock()
+    contextual_result.memories = []
+    mock_project_client.beta.memory_stores.search_memories.side_effect = [static_result, contextual_result]
+
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    session = AgentSession(session_id="test-session")
+    session.state["user_id"] = "u1"
+    session.state["org_id"] = "o1"
+    ctx = SessionContext(input_messages=[Message(role="user", text="Hello")], session_id="s1")
+
+    await provider.before_run(  # type: ignore[arg-type]
+        agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
+    )
+
+    for call in mock_project_client.beta.memory_stores.search_memories.call_args_list:
+        assert call.kwargs["scope"] == "u1_o1"
+
+
+async def test_after_run_resolves_scope_from_session_state(mock_project_client: AsyncMock) -> None:
+    """When scope is not set at init, after_run resolves it from session.state."""
+    mock_poller = Mock()
+    mock_poller.update_id = "update-1"
+    mock_project_client.beta.memory_stores.begin_update_memories.return_value = mock_poller
+
+    provider = FoundryMemoryProvider(
+        project_client=mock_project_client,
+        memory_store_name="test_store",
+    )
+    session = AgentSession(session_id="test-session")
+    session.state["user_id"] = "u1"
+    ctx = SessionContext(input_messages=[Message(role="user", text="hi")], session_id="s1")
+    ctx._response = AgentResponse(messages=[Message(role="assistant", text="hey")])
+
+    await provider.after_run(  # type: ignore[arg-type]
+        agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
+    )
+
+    call_kwargs = mock_project_client.beta.memory_stores.begin_update_memories.call_args.kwargs
+    assert call_kwargs["scope"] == "u1"
 
 
 async def test_retrieves_static_memories_on_first_run(mock_project_client: AsyncMock) -> None:

--- a/python/samples/02-agents/context_providers/azure_ai_foundry_memory.py
+++ b/python/samples/02-agents/context_providers/azure_ai_foundry_memory.py
@@ -80,8 +80,6 @@ async def main() -> None:
         memory_provider = FoundryMemoryProvider(
             project_client=project_client,
             memory_store_name=memory_store.name,
-            scope="user_123",  # Scope memories to a specific user, if not set, the session_id
-            # will be used as scope, which means memories are only shared within the same session
             update_delay=0,  # Do not wait to update memories after each interaction (for demo purposes)
             # In production, consider setting a delay to batch updates and reduce costs
         )
@@ -99,6 +97,9 @@ async def main() -> None:
                 # note that we will use the service side storage, nor load messsages from the history provider,
                 # but we include it to demonstrate that it can be used alongside the Foundry provider for other use cases.
                 session = agent.create_session()
+                # Set user identity on the session so the memory provider can scope memories per user
+                # Maybe set the user_id when creating the session instead in the future if that fits better with the API design.
+                session.state["user_id"] = "user_123"
 
                 # First interaction - establish some preferences
                 print("=== First conversation ===")

--- a/python/samples/02-agents/evaluation/evaluate_multimodal.py
+++ b/python/samples/02-agents/evaluation/evaluate_multimodal.py
@@ -22,7 +22,6 @@ from agent_framework import (
     evaluator,
 )
 
-
 # -- Custom evaluators that inspect multimodal content --
 
 


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->
1. Why is this change required?
The FoundryMemoryProvider previously required scope at init time and fell back to session_id when resolving it at runtime. Either the FoundryMemoryProvider is scoped to a single user or to a single session. Since Foundry Memory is designed as persistent cross-session memory (e.g., remembering user preferences across conversations), and the agent tie to it shall be created once and serve multiple users, the scope should be resolved at runtime.

2. What problem does it solve?
It removes the requirement to create a separate FoundryMemoryProvider instance per user (or accept the wrong fallback of session_id). Previously, scope was fixed at construction time, meaning a single agent serving multiple users would either need a distinct provider per user or all users would share the same memory scope. Now, scope is resolved per-request from session.state["user_id"], so one provider instance can correctly isolate memories across many concurrent users — each with their own session carrying their identity.

3. What scenario does it contribute to?
Multi-user agents with persistent per-user memory. A single deployed agent serves many users, each with their own AgentSession carrying session.state["user_id"]. When user A says "I'm allergic to nuts" and user B says "I love spicy food," those memories are stored under separate scopes and recalled correctly in future sessions — all through one shared FoundryMemoryProvider instance.


### Description

This change updates FoundryMemoryProvider (python/packages/foundry/agent_framework_foundry/_memory_provider.py) so scope is optional and can be resolved at runtime from the active AgentSession instead of being fixed when the provider is constructed. The provider now uses session.state["user_id"] as the default memory scope, and can combine it with session.state["org_id"] when present to support tenant-aware isolation.

This aligns the provider with the intended Foundry Memory model of persistent, cross-session user memory. It allows a single agent instance and a single FoundryMemoryProvider instance to serve multiple users safely, while still keeping each user’s memories isolated. The implementation also removes the incorrect fallback to session_id, since session-scoped memory does not match the persistence scenario that Foundry Memory is meant to support.

The change includes updates to the provider logic, tests covering runtime scope resolution (python/packages/foundry/tests/foundry/test_foundry_memory_provider.py), and the sample (python/samples/02-agents/context_providers/azure_ai_foundry_memory.py) showing the recommended pattern of setting identity on session.state rather than binding scope statically during provider initialization.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [X] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.