### PR TITLE
Docs: Fix Python README sample to use correct OpenAIChatClient class and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ from azure.identity import AzureCliCredential
 
 
 async def main():
+    # Initialize a chat agent with OpenAI Responses
+    # the endpoint, deployment name, and api version can be set via environment variables
+    # or they can be passed in directly to the OpenAIChatClient constructor
     agent = OpenAIChatClient(
         # endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         # deployment_name=os.environ["AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME"],


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required? The existing readme example to connect to azure openai endpoint using the python SDK for a simple responses API call is misleading to a non-existent class.
  2. What problem does it solve? Readme will now contain the correct python example
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.

### Description

Self-Explanatory

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.