### PR TITLE
Python: Enforce Foundry package unit test coverage

### DIFF
--- a/.github/workflows/python-check-coverage.py
+++ b/.github/workflows/python-check-coverage.py
@@ -34,15 +34,15 @@ from dataclasses import dataclass
 #   (e.g., "packages/core/agent_framework/observability.py")
 # =============================================================================
 ENFORCED_TARGETS: set[str] = {
-    # Packages
+    # Packages (sorted alphabetically)
+    "packages.anthropic.agent_framework_anthropic",
+    "packages.azure-ai-search.agent_framework_azure_ai_search",
     "packages.azure-ai.agent_framework_azure_ai",
     "packages.core.agent_framework",
     "packages.core.agent_framework._workflows",
-    "packages.purview.agent_framework_purview",
-    "packages.anthropic.agent_framework_anthropic",
-    "packages.azure-ai-search.agent_framework_azure_ai_search",
-    "packages.openai.agent_framework_openai",
     "packages.foundry.agent_framework_foundry",
+    "packages.openai.agent_framework_openai",
+    "packages.purview.agent_framework_purview",
     # Individual files (if you want to enforce specific files instead of whole packages)
     "packages/core/agent_framework/observability.py",
     # Add more targets here as coverage improves

--- a/.github/workflows/python-check-coverage.py
+++ b/.github/workflows/python-check-coverage.py
@@ -42,6 +42,7 @@ ENFORCED_TARGETS: set[str] = {
     "packages.anthropic.agent_framework_anthropic",
     "packages.azure-ai-search.agent_framework_azure_ai_search",
     "packages.openai.agent_framework_openai",
+    "packages.foundry.agent_framework_foundry",
     # Individual files (if you want to enforce specific files instead of whole packages)
     "packages/core/agent_framework/observability.py",
     # Add more targets here as coverage improves


### PR DESCRIPTION
### Motivation and Context

Enforce Foundry package unit test coverage to avoid regression.

### Description

Adds `packages.foundry.agent_framework_foundry` to the enforced coverage targets in the CI coverage check script. The `ENFORCED_TARGETS` list is kept sorted alphabetically to maintain consistent ordering and reduce future merge conflicts.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.