### PR TITLE
Python: Remove --pre flag from pip install commands in READMEs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -9,10 +9,10 @@ We recommend two common installation paths depending on your use case.
 If you are exploring or developing locally, install the entire framework with all sub-packages:
 
 ```bash
-pip install agent-framework --pre
+pip install agent-framework
 ```
 
-This installs the core and every integration package, making sure that all features are available without additional steps. The `--pre` flag is required while Agent Framework is in preview. This is the simplest way to get started.
+This installs the core and every integration package, making sure that all features are available without additional steps. This is the simplest way to get started.
 
 ### 2. Selective install
 
@@ -22,16 +22,16 @@ If you only need specific integrations, you can install at a more granular level
 # Core only
 # includes Azure OpenAI and OpenAI support by default
 # also includes workflows and orchestrations
-pip install agent-framework-core --pre
+pip install agent-framework-core
 
 # Core + Azure AI Foundry integration
-pip install agent-framework-foundry --pre
+pip install agent-framework-foundry
 
 # Core + Microsoft Copilot Studio integration
-pip install agent-framework-copilotstudio --pre
+pip install agent-framework-copilotstudio
 
 # Core + both Microsoft Copilot Studio and Azure AI Foundry integration
-pip install agent-framework-microsoft agent-framework-foundry --pre
+pip install agent-framework-microsoft agent-framework-foundry
 ```
 
 This selective approach is useful when you know which integrations you need, and it is the recommended way to set up lightweight environments.

--- a/python/packages/a2a/README.md
+++ b/python/packages/a2a/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-a2a --pre
+pip install agent-framework-a2a
 ```
 
 ## A2A Agent Integration

--- a/python/packages/anthropic/README.md
+++ b/python/packages/anthropic/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-anthropic --pre
+pip install agent-framework-anthropic
 ```
 
 ## Anthropic Integration

--- a/python/packages/azure-ai-search/README.md
+++ b/python/packages/azure-ai-search/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-azure-ai-search --pre
+pip install agent-framework-azure-ai-search
 ```
 
 ## Azure AI Search Integration

--- a/python/packages/azure-ai/README.md
+++ b/python/packages/azure-ai/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-azure-ai --pre
+pip install agent-framework-azure-ai
 ```
 
 ## Foundry Memory Context Provider

--- a/python/packages/azure-cosmos/README.md
+++ b/python/packages/azure-cosmos/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-azure-cosmos --pre
+pip install agent-framework-azure-cosmos
 ```
 
 ## Azure Cosmos DB History Provider

--- a/python/packages/azurefunctions/README.md
+++ b/python/packages/azurefunctions/README.md
@@ -5,7 +5,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-azurefunctions --pre
+pip install agent-framework-azurefunctions
 ```
 
 ## Durable Agent Extension

--- a/python/packages/bedrock/README.md
+++ b/python/packages/bedrock/README.md
@@ -3,7 +3,7 @@
 Install the provider package:
 
 ```bash
-pip install agent-framework-bedrock --pre
+pip install agent-framework-bedrock
 ```
 
 ## Bedrock Integration

--- a/python/packages/chatkit/README.md
+++ b/python/packages/chatkit/README.md
@@ -15,7 +15,7 @@ Specifically, it mirrors the [Agent SDK integration](https://github.com/openai/c
 ## Installation
 
 ```bash
-pip install agent-framework-chatkit --pre
+pip install agent-framework-chatkit
 ```
 
 This will install `agent-framework-core` and `openai-chatkit` as dependencies.

--- a/python/packages/claude/README.md
+++ b/python/packages/claude/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-claude --pre
+pip install agent-framework-claude
 ```
 
 ## Claude Agent

--- a/python/packages/copilotstudio/README.md
+++ b/python/packages/copilotstudio/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-copilotstudio --pre
+pip install agent-framework-copilotstudio
 ```
 
 ## Copilot Studio Agent

--- a/python/packages/core/README.md
+++ b/python/packages/core/README.md
@@ -13,11 +13,11 @@ Highlights
 ## Quick Install
 
 ```bash
-pip install agent-framework-core --pre
+pip install agent-framework-core
 # Optional: Add Azure AI Foundry integration
-pip install agent-framework-foundry --pre
+pip install agent-framework-foundry
 # Optional: Add OpenAI integration
-pip install agent-framework-openai --pre
+pip install agent-framework-openai
 ```
 
 Supported Platforms:

--- a/python/packages/declarative/README.md
+++ b/python/packages/declarative/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-declarative --pre
+pip install agent-framework-declarative
 ```
 
 ## Declarative features

--- a/python/packages/durabletask/README.md
+++ b/python/packages/durabletask/README.md
@@ -5,7 +5,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-durabletask --pre
+pip install agent-framework-durabletask
 ```
 
 ## Durable Task Integration

--- a/python/packages/github_copilot/README.md
+++ b/python/packages/github_copilot/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-github-copilot --pre
+pip install agent-framework-github-copilot
 ```
 
 ## GitHub Copilot Agent

--- a/python/packages/mem0/README.md
+++ b/python/packages/mem0/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-mem0 --pre
+pip install agent-framework-mem0
 ```
 
 ## Memory Context Provider

--- a/python/packages/ollama/README.md
+++ b/python/packages/ollama/README.md
@@ -3,7 +3,7 @@
 Please install this package as the extra for `agent-framework`:
 
 ```bash
-pip install agent-framework-ollama --pre
+pip install agent-framework-ollama
 ```
 
 and see the [README](https://github.com/microsoft/agent-framework/tree/main/python/README.md) for more information.

--- a/python/packages/openai/README.md
+++ b/python/packages/openai/README.md
@@ -11,7 +11,7 @@ This package provides:
 ## Installation
 
 ```bash
-pip install agent-framework-openai --pre
+pip install agent-framework-openai
 ```
 
 ## Which chat client should I use?

--- a/python/packages/orchestrations/README.md
+++ b/python/packages/orchestrations/README.md
@@ -5,7 +5,7 @@ Orchestration patterns for Microsoft Agent Framework. This package provides high
 ## Installation
 
 ```bash
-pip install agent-framework-orchestrations --pre
+pip install agent-framework-orchestrations
 ```
 
 ## Orchestration Patterns

--- a/python/packages/redis/README.md
+++ b/python/packages/redis/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-redis --pre
+pip install agent-framework-redis
 ```
 
 ## Components

--- a/python/samples/01-get-started/README.md
+++ b/python/samples/01-get-started/README.md
@@ -6,7 +6,7 @@ concepts of **Agent Framework** one step at a time.
 ## Prerequisites
 
 ```bash
-pip install agent-framework --pre
+pip install agent-framework
 ```
 
 Set the required environment variables:

--- a/python/samples/02-agents/declarative/README.md
+++ b/python/samples/02-agents/declarative/README.md
@@ -7,7 +7,7 @@ This folder contains sample code demonstrating how to use the **Microsoft Agent 
 Install the declarative package via pip:
 
 ```bash
-pip install agent-framework-declarative --pre
+pip install agent-framework-declarative
 ```
 
 ## What is Declarative Agent Framework?
@@ -43,7 +43,7 @@ Shows how to create an agent that can search and retrieve information from Micro
 - Uses Azure CLI credentials for authentication
 - Leverages MCP to access Microsoft documentation tools
 
-**Requirements**: `pip install agent-framework-foundry --pre`
+**Requirements**: `pip install agent-framework-foundry`
 
 **Key concepts**: Azure AI Foundry integration, MCP server usage, async patterns, resource management
 
@@ -53,7 +53,7 @@ Shows how to create an agent using an inline YAML string rather than a file.
 
 - Uses Azure AI Foundry v2 Client with instructions.
 
-**Requirements**: `pip install agent-framework-foundry --pre`
+**Requirements**: `pip install agent-framework-foundry`
 
 **Key concepts**: Inline YAML definition.
 

--- a/python/samples/02-agents/declarative/inline_yaml.py
+++ b/python/samples/02-agents/declarative/inline_yaml.py
@@ -15,7 +15,7 @@ This sample shows how to create an agent using an inline YAML string rather than
 It uses a Azure AI Client so it needs the credential to be passed into the AgentFactory.
 
 Prerequisites:
-- `pip install agent-framework-foundry agent-framework-declarative --pre`
+- `pip install agent-framework-foundry agent-framework-declarative`
 - Set the following environment variables in a .env file or your environment:
     - FOUNDRY_PROJECT_ENDPOINT
     - FOUNDRY_MODEL

--- a/python/samples/02-agents/declarative/mcp_tool_yaml.py
+++ b/python/samples/02-agents/declarative/mcp_tool_yaml.py
@@ -18,7 +18,7 @@ Authentication Options:
   (no secrets passed in API calls - connection name references pre-configured auth)
 
 Prerequisites:
-- `pip install agent-framework-openai agent-framework-declarative --pre`
+- `pip install agent-framework-openai agent-framework-declarative`
 - For OpenAI example: Set OPENAI_API_KEY and GITHUB_PAT environment variables
 - For Azure AI example: Set up a Foundry connection in your Azure AI project
 """

--- a/python/samples/02-agents/providers/github_copilot/README.md
+++ b/python/samples/02-agents/providers/github_copilot/README.md
@@ -10,7 +10,7 @@ This directory contains examples demonstrating how to use the `GitHubCopilotAgen
 2. **GitHub Copilot Subscription**: An active GitHub Copilot subscription
 3. **Install the package**:
    ```bash
-   pip install agent-framework-github-copilot --pre
+   pip install agent-framework-github-copilot
    ```
 
 ## Environment Variables

--- a/python/samples/AGENTS.md
+++ b/python/samples/AGENTS.md
@@ -102,10 +102,10 @@ code here
 ## Package install
 
 ```bash
-pip install agent-framework --pre
+pip install agent-framework
 ```
 
-The `--pre` flag is needed during preview. `openai` is a core dependency.
+`openai` is a core dependency.
 
 ## Current API notes
 

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -26,7 +26,7 @@ Start with `01-get-started/` and work through the numbered files:
 ## Prerequisites
 
 ```bash
-pip install agent-framework --pre
+pip install agent-framework
 ```
 
 ### Environment Variables


### PR DESCRIPTION
### Motivation and Context

Addresses the first item in #5031: Remove `--pre` from all installs of released packages in READMEs.

As Agent Framework moves to v1.0, the `--pre` flag is no longer needed for released packages.

### Description

- Removed `--pre` from all `pip install agent-framework-*` commands across 27 markdown files (package READMEs, sample READMEs, and the root README).
- Updated explanatory text in `python/README.md` and `python/samples/AGENTS.md` that referenced the `--pre` flag being required during preview.
- Kept `--prerelease=allow` flags in `samples/05-end-to-end/hosted_agents/` as those reference third-party preview packages (`azure-ai-agentserver-agentframework`).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No
