### PR TITLE
Python: Remove pre-release flag from agent-framework installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Still have questions? Join our [weekly office hours](./COMMUNITY.md#public-commu
 Create a simple Azure Responses Agent that writes a haiku about the Microsoft Agent Framework
 
 ```python
-# pip install agent-framework --pre
+# pip install agent-framework
 # Use `az login` to authenticate with Azure CLI
 import os
 import asyncio

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Welcome to Microsoft's comprehensive multi-language framework for building, orch
 Python
 
 ```bash
-pip install agent-framework --pre
+pip install agent-framework
 # This will install all sub-packages, see `python/packages` for individual packages.
 # It may take a minute on first install on Windows.
 ```


### PR DESCRIPTION
### Motivation and Context

This pull request makes a small update to the Python installation instructions in the `README.md` file. The changes remove the `--pre` flag from the `pip install agent-framework` command in both the Installation section and the Python Quickstart code block, simplifying the installation process for users and ensuring consistency throughout the README.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.