### PR TITLE
.NET: Add AGUI session persistence

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -135,7 +135,7 @@ public static class AGUIEndpointRouteBuilderExtensions
                 messages,
                 session,
                 runOptions,
-                cancellationToken).ConfigureAwait(false))
+                CancellationToken.None).ConfigureAwait(false))
             {
                 yield return update;
             }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Agents.AI.Hosting;
 
 namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 
@@ -44,7 +45,7 @@ public static class AGUIEndpointRouteBuilderExtensions
 
             var jsonOptions = context.RequestServices.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
             var jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
-            var sessionStore = context.RequestServices.GetRequiredService<AGUIInMemorySessionStore>();
+            var sessionStore = context.RequestServices.GetRequiredService<AgentSessionStore>();
 
             var messages = input.Messages.AsChatMessages(jsonSerializerOptions);
             var clientTools = input.Tools?.AsAITools().ToList();
@@ -93,7 +94,7 @@ public static class AGUIEndpointRouteBuilderExtensions
     private static async ValueTask<AgentSession?> GetOrCreateSessionAsync(
         AIAgent aiAgent,
         string? threadId,
-        AGUIInMemorySessionStore sessionStore,
+        AgentSessionStore sessionStore,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(threadId))
@@ -101,14 +102,14 @@ public static class AGUIEndpointRouteBuilderExtensions
             return null;
         }
 
-        return await sessionStore.GetOrCreateSessionAsync(aiAgent, threadId, cancellationToken).ConfigureAwait(false);
+        return await sessionStore.GetSessionAsync(aiAgent, threadId, cancellationToken).ConfigureAwait(false);
     }
 
     private static async ValueTask PersistSessionAsync(
         AIAgent aiAgent,
         string? threadId,
         AgentSession? session,
-        AGUIInMemorySessionStore sessionStore,
+        AgentSessionStore sessionStore,
         CancellationToken cancellationToken)
     {
         if (session is null || string.IsNullOrWhiteSpace(threadId))
@@ -125,7 +126,7 @@ public static class AGUIEndpointRouteBuilderExtensions
         AgentRunOptions runOptions,
         AgentSession? session,
         string? threadId,
-        AGUIInMemorySessionStore sessionStore,
+        AgentSessionStore sessionStore,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         try

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -3,7 +3,9 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.Shared;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -42,6 +44,7 @@ public static class AGUIEndpointRouteBuilderExtensions
 
             var jsonOptions = context.RequestServices.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
             var jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
+            var sessionStore = context.RequestServices.GetRequiredService<AGUIInMemorySessionStore>();
 
             var messages = input.Messages.AsChatMessages(jsonSerializerOptions);
             var clientTools = input.Tools?.AsAITools().ToList();
@@ -63,11 +66,17 @@ public static class AGUIEndpointRouteBuilderExtensions
                 }
             };
 
+            AgentSession? session = await GetOrCreateSessionAsync(aiAgent, input.ThreadId, sessionStore, cancellationToken).ConfigureAwait(false);
+
             // Run the agent and convert to AG-UI events
-            var events = aiAgent.RunStreamingAsync(
+            var events = RunStreamingWithSessionPersistenceAsync(
+                aiAgent,
                 messages,
-                options: runOptions,
-                cancellationToken: cancellationToken)
+                runOptions,
+                session,
+                input.ThreadId,
+                sessionStore,
+                cancellationToken)
                 .AsChatResponseUpdatesAsync()
                 .FilterServerToolsFromMixedToolInvocationsAsync(clientTools, cancellationToken)
                 .AsAGUIEventStreamAsync(
@@ -79,5 +88,60 @@ public static class AGUIEndpointRouteBuilderExtensions
             var sseLogger = context.RequestServices.GetRequiredService<ILogger<AGUIServerSentEventsResult>>();
             return new AGUIServerSentEventsResult(events, sseLogger);
         });
+    }
+
+    private static async ValueTask<AgentSession?> GetOrCreateSessionAsync(
+        AIAgent aiAgent,
+        string? threadId,
+        AGUIInMemorySessionStore sessionStore,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+        {
+            return null;
+        }
+
+        return await sessionStore.GetOrCreateSessionAsync(aiAgent, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask PersistSessionAsync(
+        AIAgent aiAgent,
+        string? threadId,
+        AgentSession? session,
+        AGUIInMemorySessionStore sessionStore,
+        CancellationToken cancellationToken)
+    {
+        if (session is null || string.IsNullOrWhiteSpace(threadId))
+        {
+            return;
+        }
+
+        await sessionStore.SaveSessionAsync(aiAgent, threadId, session, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async IAsyncEnumerable<AgentResponseUpdate> RunStreamingWithSessionPersistenceAsync(
+        AIAgent aiAgent,
+        IEnumerable<ChatMessage> messages,
+        AgentRunOptions runOptions,
+        AgentSession? session,
+        string? threadId,
+        AGUIInMemorySessionStore sessionStore,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (AgentResponseUpdate update in aiAgent.RunStreamingAsync(
+                messages,
+                session,
+                runOptions,
+                cancellationToken).ConfigureAwait(false))
+            {
+                yield return update;
+            }
+        }
+        finally
+        {
+            await PersistSessionAsync(aiAgent, threadId, session, sessionStore, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIInMemorySessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIInMemorySessionStore.cs
@@ -1,49 +1,101 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 
-internal sealed class AGUIInMemorySessionStore : IDisposable
+/// <summary>
+/// Provides an in-memory <see cref="AgentSessionStore"/> implementation for AG-UI hosted agents.
+/// </summary>
+/// <remarks>
+/// This store is intended for single-instance development and testing scenarios. Applications that need
+/// durable or distributed session persistence can replace the registered <see cref="AgentSessionStore"/>
+/// service with a custom implementation.
+/// </remarks>
+public sealed class AGUIInMemorySessionStore : AgentSessionStore, IDisposable
 {
     private readonly MemoryCache _cache;
     private readonly MemoryCacheEntryOptions _entryOptions;
+    private readonly ConcurrentDictionary<SessionCacheKey, TaskCompletionSource<AgentSession>> _sessionInitializationTasks = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AGUIInMemorySessionStore"/> class with default options.
+    /// </summary>
     public AGUIInMemorySessionStore()
         : this(options: null)
     {
     }
 
-    internal AGUIInMemorySessionStore(AGUIInMemorySessionStoreOptions? options)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AGUIInMemorySessionStore"/> class.
+    /// </summary>
+    /// <param name="options">The cache options to apply. If <see langword="null"/>, default options are used.</param>
+    public AGUIInMemorySessionStore(AGUIInMemorySessionStoreOptions? options)
     {
         AGUIInMemorySessionStoreOptions resolvedOptions = options ?? new();
         this._cache = new MemoryCache(resolvedOptions.ToMemoryCacheOptions());
         this._entryOptions = resolvedOptions.ToMemoryCacheEntryOptions();
     }
 
+    /// <inheritdoc/>
+    public override ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, CancellationToken cancellationToken = default)
+        => this.GetOrCreateSessionAsync(agent, conversationId, cancellationToken);
+
+    /// <summary>
+    /// Gets the session for the specified conversation or creates a new one when none exists.
+    /// </summary>
+    /// <param name="agent">The agent that owns the session.</param>
+    /// <param name="threadId">The conversation or thread identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The existing or newly created session.</returns>
     public ValueTask<AgentSession> GetOrCreateSessionAsync(AIAgent agent, string threadId, CancellationToken cancellationToken = default)
     {
-        string key = GetKey(agent, threadId);
+        SessionCacheKey key = GetKey(agent, threadId);
         if (this._cache.TryGetValue(key, out AgentSession? session) && session is not null)
         {
             return new(session);
         }
 
-        return this.CreateAndStoreSessionAsync(agent, key, cancellationToken);
+        return this.GetOrCreateSessionCoreAsync(agent, key, cancellationToken);
     }
 
-    public ValueTask SaveSessionAsync(AIAgent agent, string threadId, AgentSession session, CancellationToken cancellationToken = default)
+    /// <inheritdoc/>
+    public override ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, CancellationToken cancellationToken = default)
     {
-        this._cache.Set(GetKey(agent, threadId), session, this._entryOptions);
+        this._cache.Set(GetKey(agent, conversationId), session, this._entryOptions);
         return ValueTask.CompletedTask;
     }
 
-    private async ValueTask<AgentSession> CreateAndStoreSessionAsync(AIAgent agent, string key, CancellationToken cancellationToken)
+    private async ValueTask<AgentSession> GetOrCreateSessionCoreAsync(AIAgent agent, SessionCacheKey key, CancellationToken cancellationToken)
     {
-        AgentSession session = await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
+        TaskCompletionSource<AgentSession> initializationTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<AgentSession> sharedInitializationTask = this._sessionInitializationTasks.GetOrAdd(key, initializationTask);
+
+        if (ReferenceEquals(sharedInitializationTask, initializationTask))
+        {
+            if (this._cache.TryGetValue(key, out AgentSession? existingSession) && existingSession is not null)
+            {
+                initializationTask.TrySetResult(existingSession);
+                this._sessionInitializationTasks.TryRemove(new KeyValuePair<SessionCacheKey, TaskCompletionSource<AgentSession>>(key, initializationTask));
+            }
+            else
+            {
+                _ = this.InitializeSessionAsync(agent, key, initializationTask);
+            }
+        }
+
+        return await sharedInitializationTask.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<AgentSession> CreateAndStoreSessionAsync(AIAgent agent, SessionCacheKey key)
+    {
+        AgentSession session = await agent.CreateSessionAsync(CancellationToken.None).ConfigureAwait(false);
         return this._cache.GetOrCreate(key, entry =>
         {
             entry.SetOptions(this._entryOptions);
@@ -51,20 +103,54 @@ internal sealed class AGUIInMemorySessionStore : IDisposable
         })!;
     }
 
+    private async Task InitializeSessionAsync(AIAgent agent, SessionCacheKey key, TaskCompletionSource<AgentSession> initializationTask)
+    {
+        try
+        {
+            AgentSession session = await this.CreateAndStoreSessionAsync(agent, key).ConfigureAwait(false);
+            initializationTask.TrySetResult(session);
+        }
+        catch (Exception ex)
+        {
+            initializationTask.TrySetException(ex);
+        }
+        finally
+        {
+            this._sessionInitializationTasks.TryRemove(new KeyValuePair<SessionCacheKey, TaskCompletionSource<AgentSession>>(key, initializationTask));
+        }
+    }
+
+    /// <summary>
+    /// Releases the underlying memory cache.
+    /// </summary>
     public void Dispose()
     {
         this._cache.Dispose();
     }
 
-    private static string GetKey(AIAgent agent, string threadId) => $"{agent.Id}:{threadId}";
+    private static SessionCacheKey GetKey(AIAgent agent, string threadId) => new(agent.Id, threadId);
+
+    private sealed record SessionCacheKey(string AgentId, string ThreadId);
 }
 
-internal sealed class AGUIInMemorySessionStoreOptions
+/// <summary>
+/// Configures the default <see cref="AGUIInMemorySessionStore"/> registration used by <c>AddAGUI</c>.
+/// </summary>
+public sealed class AGUIInMemorySessionStoreOptions
 {
+    /// <summary>
+    /// Gets or sets the maximum number of sessions to retain in memory.
+    /// </summary>
     public long? SizeLimit { get; set; } = 1000;
 
+    /// <summary>
+    /// Gets or sets the absolute expiration applied to cached sessions.
+    /// </summary>
     public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
 
+    /// <summary>
+    /// Gets or sets the sliding expiration applied to cached sessions.
+    /// </summary>
     public TimeSpan? SlidingExpiration { get; set; } = TimeSpan.FromHours(1);
 
     internal MemoryCacheOptions ToMemoryCacheOptions() => new()

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIInMemorySessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIInMemorySessionStore.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+
+internal sealed class AGUIInMemorySessionStore : IDisposable
+{
+    private readonly MemoryCache _cache;
+    private readonly MemoryCacheEntryOptions _entryOptions;
+
+    public AGUIInMemorySessionStore()
+        : this(options: null)
+    {
+    }
+
+    internal AGUIInMemorySessionStore(AGUIInMemorySessionStoreOptions? options)
+    {
+        AGUIInMemorySessionStoreOptions resolvedOptions = options ?? new();
+        this._cache = new MemoryCache(resolvedOptions.ToMemoryCacheOptions());
+        this._entryOptions = resolvedOptions.ToMemoryCacheEntryOptions();
+    }
+
+    public ValueTask<AgentSession> GetOrCreateSessionAsync(AIAgent agent, string threadId, CancellationToken cancellationToken = default)
+    {
+        string key = GetKey(agent, threadId);
+        if (this._cache.TryGetValue(key, out AgentSession? session) && session is not null)
+        {
+            return new(session);
+        }
+
+        return this.CreateAndStoreSessionAsync(agent, key, cancellationToken);
+    }
+
+    public ValueTask SaveSessionAsync(AIAgent agent, string threadId, AgentSession session, CancellationToken cancellationToken = default)
+    {
+        this._cache.Set(GetKey(agent, threadId), session, this._entryOptions);
+        return ValueTask.CompletedTask;
+    }
+
+    private async ValueTask<AgentSession> CreateAndStoreSessionAsync(AIAgent agent, string key, CancellationToken cancellationToken)
+    {
+        AgentSession session = await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
+        return this._cache.GetOrCreate(key, entry =>
+        {
+            entry.SetOptions(this._entryOptions);
+            return session;
+        })!;
+    }
+
+    public void Dispose()
+    {
+        this._cache.Dispose();
+    }
+
+    private static string GetKey(AIAgent agent, string threadId) => $"{agent.Id}:{threadId}";
+}
+
+internal sealed class AGUIInMemorySessionStoreOptions
+{
+    public long? SizeLimit { get; set; } = 1000;
+
+    public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+
+    public TimeSpan? SlidingExpiration { get; set; } = TimeSpan.FromHours(1);
+
+    internal MemoryCacheOptions ToMemoryCacheOptions() => new()
+    {
+        SizeLimit = this.SizeLimit
+    };
+
+    internal MemoryCacheEntryOptions ToMemoryCacheEntryOptions() => new()
+    {
+        AbsoluteExpirationRelativeToNow = this.AbsoluteExpirationRelativeToNow,
+        SlidingExpiration = this.SlidingExpiration,
+        Size = 1
+    };
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj" />
+    <ProjectReference Include="..\Microsoft.Agents.AI.Hosting\Microsoft.Agents.AI.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/ServiceCollectionExtensions.cs
@@ -2,8 +2,11 @@
 
 using System;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Hosting;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -22,7 +25,26 @@ public static class MicrosoftAgentAIHostingAGUIServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.Configure<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Add(AGUIJsonSerializerOptions.Default.TypeInfoResolver!));
-        services.AddSingleton<AGUIInMemorySessionStore>();
+        services.AddOptions<AGUIInMemorySessionStoreOptions>();
+        services.TryAddSingleton<AgentSessionStore>(sp =>
+            new AGUIInMemorySessionStore(sp.GetRequiredService<IOptions<AGUIInMemorySessionStoreOptions>>().Value));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds support for exposing <see cref="AIAgent"/> instances via AG-UI and configures the default in-memory session store.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <param name="configureSessionStore">Configures the default <see cref="AGUIInMemorySessionStoreOptions"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> for method chaining.</returns>
+    public static IServiceCollection AddAGUI(this IServiceCollection services, Action<AGUIInMemorySessionStoreOptions> configureSessionStore)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureSessionStore);
+
+        services.AddAGUI();
+        services.Configure(configureSessionStore);
 
         return services;
     }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class MicrosoftAgentAIHostingAGUIServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.Configure<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Add(AGUIJsonSerializerOptions.Default.TypeInfoResolver!));
+        services.AddSingleton<AGUIInMemorySessionStore>();
 
         return services;
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
@@ -164,6 +164,42 @@ public sealed class BasicStreamingTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task ChatClientConversationId_RestoresServerSessionAcrossRequestsAsync()
+    {
+        // Arrange
+        await this.SetupTestServerAsync(useStatefulMemoryAgent: true);
+        var chatClient = new AGUIChatClient(this._client!, "", null);
+        var chatOptions = new ChatOptions();
+
+        // Act
+        ChatResponse firstResponse = await chatClient.GetResponseAsync([new ChatMessage(ChatRole.User, "My name is Alice")], chatOptions);
+        chatOptions.ConversationId = firstResponse.ConversationId;
+        ChatResponse secondResponse = await chatClient.GetResponseAsync([new ChatMessage(ChatRole.User, "What is my name?")], chatOptions);
+
+        // Assert
+        firstResponse.ConversationId.Should().NotBeNullOrEmpty();
+        secondResponse.Text.Should().Contain("Alice");
+    }
+
+    [Fact]
+    public async Task AsAIAgentSession_RestoresServerSessionAcrossRunsAsync()
+    {
+        // Arrange
+        await this.SetupTestServerAsync(useStatefulMemoryAgent: true);
+        var chatClient = new AGUIChatClient(this._client!, "", null);
+        AIAgent agent = chatClient.AsAIAgent(instructions: null, name: "assistant", description: "Stateful assistant", tools: []);
+        AgentSession session = await agent.CreateSessionAsync();
+
+        // Act
+        AgentResponse firstResponse = await agent.RunAsync("My name is Alice", session, new AgentRunOptions(), CancellationToken.None);
+        AgentResponse secondResponse = await agent.RunAsync("What is my name?", session, new AgentRunOptions(), CancellationToken.None);
+
+        // Assert
+        firstResponse.Text.Should().Contain("Alice");
+        secondResponse.Text.Should().Contain("Alice");
+    }
+
+    [Fact]
     public async Task AgentSendsMultipleMessagesInOneTurnAsync()
     {
         // Arrange
@@ -231,14 +267,18 @@ public sealed class BasicStreamingTests : IAsyncDisposable
         response.Messages[0].Text.Should().Be("Hello from fake agent!");
     }
 
-    private async Task SetupTestServerAsync(bool useMultiMessageAgent = false)
+    private async Task SetupTestServerAsync(bool useMultiMessageAgent = false, bool useStatefulMemoryAgent = false)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
 
         builder.Services.AddAGUI();
 
-        if (useMultiMessageAgent)
+        if (useStatefulMemoryAgent)
+        {
+            builder.Services.AddSingleton<FakeStatefulMemoryAgent>();
+        }
+        else if (useMultiMessageAgent)
         {
             builder.Services.AddSingleton<FakeMultiMessageAgent>();
         }
@@ -249,9 +289,11 @@ public sealed class BasicStreamingTests : IAsyncDisposable
 
         this._app = builder.Build();
 
-        AIAgent agent = useMultiMessageAgent
-            ? this._app.Services.GetRequiredService<FakeMultiMessageAgent>()
-            : this._app.Services.GetRequiredService<FakeChatClientAgent>();
+        AIAgent agent = useStatefulMemoryAgent
+            ? this._app.Services.GetRequiredService<FakeStatefulMemoryAgent>()
+            : useMultiMessageAgent
+                ? this._app.Services.GetRequiredService<FakeMultiMessageAgent>()
+                : this._app.Services.GetRequiredService<FakeChatClientAgent>();
 
         this._app.MapAGUI("/agent", agent);
 
@@ -440,4 +482,99 @@ internal sealed class FakeMultiMessageAgent : AIAgent
     }
 
     public override object? GetService(Type serviceType, object? serviceKey = null) => null;
+}
+
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated via dependency injection")]
+internal sealed class FakeStatefulMemoryAgent : AIAgent
+{
+    private const string NameStateKey = "remembered-name";
+
+    protected override string? IdCore => "fake-stateful-memory-agent";
+
+    public override string? Description => "A fake agent that stores simple memory in the session";
+
+    protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default) =>
+        new(new FakeAgentSession());
+
+    protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+        new(serializedState.Deserialize<FakeAgentSession>(jsonSerializerOptions)!);
+
+    protected override ValueTask<JsonElement> SerializeSessionCoreAsync(AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+    {
+        if (session is not FakeAgentSession typedSession)
+        {
+            throw new InvalidOperationException($"The provided session type '{session.GetType().Name}' is not compatible with this agent. Only sessions of type '{nameof(FakeAgentSession)}' can be serialized by this agent.");
+        }
+
+        return new(JsonSerializer.SerializeToElement(typedSession, jsonSerializerOptions));
+    }
+
+    protected override async Task<AgentResponse> RunCoreAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session = null,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        List<AgentResponseUpdate> updates = [];
+        await foreach (AgentResponseUpdate update in this.RunStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
+        {
+            updates.Add(update);
+        }
+
+        return updates.ToAgentResponse();
+    }
+
+    protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session = null,
+        AgentRunOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (session is not FakeAgentSession typedSession)
+        {
+            throw new InvalidOperationException($"The provided session type '{session?.GetType().Name ?? "null"}' is not compatible with this agent. Only sessions of type '{nameof(FakeAgentSession)}' can be used by this agent.");
+        }
+
+        string lastUserInput = messages.Last(m => m.Role == ChatRole.User).Text ?? string.Empty;
+        string responseText;
+
+        if (lastUserInput.StartsWith("My name is ", StringComparison.OrdinalIgnoreCase))
+        {
+            string rememberedName = lastUserInput[11..].Trim();
+            typedSession.StateBag.SetValue(NameStateKey, rememberedName);
+            responseText = $"Nice to meet you {rememberedName}.";
+        }
+        else if (lastUserInput.Equals("What is my name?", StringComparison.OrdinalIgnoreCase))
+        {
+            string? rememberedName = typedSession.StateBag.GetValue<string>(NameStateKey);
+            responseText = rememberedName is null
+                ? "I do not know your name yet."
+                : $"Your name is {rememberedName}.";
+        }
+        else
+        {
+            responseText = "I can remember your name if you tell me 'My name is ...'.";
+        }
+
+        yield return new AgentResponseUpdate
+        {
+            MessageId = Guid.NewGuid().ToString("N"),
+            Role = ChatRole.Assistant,
+            Contents = [new TextContent(responseText)]
+        };
+
+        await Task.Yield();
+    }
+
+    private sealed class FakeAgentSession : AgentSession
+    {
+        public FakeAgentSession()
+        {
+        }
+
+        [JsonConstructor]
+        public FakeAgentSession(AgentSessionStateBag stateBag) : base(stateBag)
+        {
+        }
+    }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIInMemorySessionStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIInMemorySessionStoreTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+
+namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="AGUIInMemorySessionStore"/>.
+/// </summary>
+public sealed class AGUIInMemorySessionStoreTests
+{
+    [Fact]
+    public async Task GetOrCreateSessionAsync_ReusesSessionForSameThreadAsync()
+    {
+        // Arrange
+        var store = new AGUIInMemorySessionStore();
+        var agent = new CountingAgent();
+
+        // Act
+        AgentSession firstSession = await store.GetOrCreateSessionAsync(agent, "thread-1");
+        AgentSession secondSession = await store.GetOrCreateSessionAsync(agent, "thread-1");
+        AgentSession thirdSession = await store.GetOrCreateSessionAsync(agent, "thread-2");
+
+        // Assert
+        Assert.Same(firstSession, secondSession);
+        Assert.NotSame(firstSession, thirdSession);
+        Assert.Equal(2, agent.CreateSessionCallCount);
+    }
+
+    [Fact]
+    public async Task GetOrCreateSessionAsync_UsesAgentIdentityInCacheKeyAsync()
+    {
+        // Arrange
+        var store = new AGUIInMemorySessionStore();
+        var firstAgent = new CountingAgent("agent-1");
+        var secondAgent = new CountingAgent("agent-2");
+
+        // Act
+        AgentSession firstSession = await store.GetOrCreateSessionAsync(firstAgent, "shared-thread");
+        AgentSession secondSession = await store.GetOrCreateSessionAsync(secondAgent, "shared-thread");
+
+        // Assert
+        Assert.NotSame(firstSession, secondSession);
+        Assert.Equal(1, firstAgent.CreateSessionCallCount);
+        Assert.Equal(1, secondAgent.CreateSessionCallCount);
+    }
+
+    [Fact]
+    public async Task GetOrCreateSessionAsync_RecreatesExpiredSessionAsync()
+    {
+        // Arrange
+        var store = new AGUIInMemorySessionStore(new AGUIInMemorySessionStoreOptions
+        {
+            SlidingExpiration = TimeSpan.FromMilliseconds(20)
+        });
+        var agent = new CountingAgent();
+
+        // Act
+        AgentSession firstSession = await store.GetOrCreateSessionAsync(agent, "thread-1");
+        await Task.Delay(TimeSpan.FromMilliseconds(80));
+        AgentSession secondSession = await store.GetOrCreateSessionAsync(agent, "thread-1");
+
+        // Assert
+        Assert.NotSame(firstSession, secondSession);
+        Assert.Equal(2, agent.CreateSessionCallCount);
+    }
+
+    private sealed class CountingAgent : AIAgent
+    {
+        private readonly string _id;
+
+        public CountingAgent(string id = "counting-agent")
+        {
+            this._id = id;
+        }
+
+        public int CreateSessionCallCount { get; private set; }
+
+        protected override string? IdCore => this._id;
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default)
+        {
+            this.CreateSessionCallCount++;
+            return new(new CountingSession());
+        }
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override Task<AgentResponse> RunCoreAsync(IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        private sealed class CountingSession : AgentSession
+        {
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIInMemorySessionStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIInMemorySessionStoreTests.cs
@@ -51,6 +51,24 @@ public sealed class AGUIInMemorySessionStoreTests
     }
 
     [Fact]
+    public async Task GetOrCreateSessionAsync_DoesNotCollideWhenKeyPartsContainColonAsync()
+    {
+        // Arrange
+        var store = new AGUIInMemorySessionStore();
+        var firstAgent = new CountingAgent("a:b");
+        var secondAgent = new CountingAgent("a");
+
+        // Act
+        AgentSession firstSession = await store.GetOrCreateSessionAsync(firstAgent, "c");
+        AgentSession secondSession = await store.GetOrCreateSessionAsync(secondAgent, "b:c");
+
+        // Assert
+        Assert.NotSame(firstSession, secondSession);
+        Assert.Equal(1, firstAgent.CreateSessionCallCount);
+        Assert.Equal(1, secondAgent.CreateSessionCallCount);
+    }
+
+    [Fact]
     public async Task GetOrCreateSessionAsync_RecreatesExpiredSessionAsync()
     {
         // Arrange
@@ -68,6 +86,29 @@ public sealed class AGUIInMemorySessionStoreTests
         // Assert
         Assert.NotSame(firstSession, secondSession);
         Assert.Equal(2, agent.CreateSessionCallCount);
+    }
+
+    [Fact]
+    public async Task GetOrCreateSessionAsync_CreatesSingleSessionUnderConcurrencyAsync()
+    {
+        // Arrange
+        var store = new AGUIInMemorySessionStore();
+        var agent = new BlockingAgent();
+
+        // Act
+        Task<AgentSession> firstTask = store.GetOrCreateSessionAsync(agent, "thread-1").AsTask();
+        await agent.SessionCreationStarted.Task;
+
+        Task<AgentSession> secondTask = store.GetOrCreateSessionAsync(agent, "thread-1").AsTask();
+        Task<AgentSession> thirdTask = store.GetOrCreateSessionAsync(agent, "thread-1").AsTask();
+
+        agent.AllowSessionCreation.TrySetResult();
+        AgentSession[] sessions = await Task.WhenAll(firstTask, secondTask, thirdTask);
+
+        // Assert
+        Assert.Equal(1, agent.CreateSessionCallCount);
+        Assert.Same(sessions[0], sessions[1]);
+        Assert.Same(sessions[1], sessions[2]);
     }
 
     private sealed class CountingAgent : AIAgent
@@ -102,6 +143,41 @@ public sealed class AGUIInMemorySessionStoreTests
             => throw new NotImplementedException();
 
         private sealed class CountingSession : AgentSession
+        {
+        }
+    }
+
+    private sealed class BlockingAgent : AIAgent
+    {
+        public TaskCompletionSource SessionCreationStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowSessionCreation { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CreateSessionCallCount { get; private set; }
+
+        protected override string? IdCore => "blocking-agent";
+
+        protected override async ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default)
+        {
+            this.CreateSessionCallCount++;
+            this.SessionCreationStarted.TrySetResult();
+            await this.AllowSessionCreation.Task.ConfigureAwait(false);
+            return new BlockingSession();
+        }
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override Task<AgentResponse> RunCoreAsync(IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        private sealed class BlockingSession : AgentSession
         {
         }
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIServiceCollectionExtensionsTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="Microsoft.Extensions.DependencyInjection.MicrosoftAgentAIHostingAGUIServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class AGUIServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddAGUI_RegistersDefaultAgentSessionStore()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddAGUI();
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        AgentSessionStore sessionStore = serviceProvider.GetRequiredService<AgentSessionStore>();
+        Assert.IsType<AGUIInMemorySessionStore>(sessionStore);
+    }
+
+    [Fact]
+    public void AddAGUI_DoesNotOverrideCustomAgentSessionStore()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        RecordingAgentSessionStore sessionStore = new();
+        services.AddSingleton<AgentSessionStore>(sessionStore);
+
+        // Act
+        services.AddAGUI();
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        AgentSessionStore resolvedSessionStore = serviceProvider.GetRequiredService<AgentSessionStore>();
+        Assert.Same(sessionStore, resolvedSessionStore);
+    }
+
+    [Fact]
+    public void AddAGUI_ConfiguresDefaultInMemorySessionStoreOptions()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddAGUI(options =>
+        {
+            options.SizeLimit = 42;
+            options.SlidingExpiration = TimeSpan.FromMinutes(5);
+        });
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        AGUIInMemorySessionStoreOptions options = serviceProvider.GetRequiredService<IOptions<AGUIInMemorySessionStoreOptions>>().Value;
+        Assert.Equal(42, options.SizeLimit);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.SlidingExpiration);
+    }
+
+    private sealed class RecordingAgentSessionStore : AgentSessionStore
+    {
+        public override ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public override ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
### Motivation and Context
Fix #4869 
<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
- add an in-memory AGUI session store and register it in DI
- persist agent sessions by thread id during streaming runs
- add integration tests for conversation and session restoration
- add unit tests for cache key isolation and session expiration
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.