### PR TITLE
Python: fix: IndexError in detect_media_type_from_base64 for non-base64 data …

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -121,6 +121,8 @@ def detect_media_type_from_base64(
         if data is not None:
             raise ValueError("Provide exactly one of data_bytes, data_str, or data_uri.")
         # Remove data URI prefix if present
+        if ";base64," not in data_uri:
+            raise ValueError("Data URI must use base64 encoding.")
         data_str = data_uri.split(";base64,", 1)[1]
     if data_str is not None:
         if data is not None:

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -204,6 +204,11 @@ def test_data_content_detect_image_format_from_base64():
         detect_media_type_from_base64(data_bytes=b"data", data_uri="data:application/octet-stream;base64,AAA")
         detect_media_type_from_base64(data_str="data", data_uri="data:application/octet-stream;base64,AAA")
 
+    with pytest.raises(ValueError, match="Data URI must use base64 encoding"):
+        detect_media_type_from_base64(data_uri="data:text/plain,Hello%20World")
+    with pytest.raises(ValueError, match="Data URI must use base64 encoding"):
+        detect_media_type_from_base64(data_uri="http://example.com/image.png")
+
 
 def test_data_content_create_data_uri_from_base64():
     """Test the create_data_uri_from_base64 class method."""


### PR DESCRIPTION
## fix: IndexError in detect_media_type_from_base64 for non-base64 data URIs

### Motivation and Context

`detect_media_type_from_base64(data_uri=...)` raises an unhandled `IndexError` when the provided URI does not contain the `;base64,` separator (e.g. `data:text/plain,Hello%20World` or a plain HTTP URL). The function blindly calls `data_uri.split(";base64,", 1)[1]` without first checking that the delimiter exists.

The sister function `_get_data_bytes_as_str` in the same file already guards against this case, but `detect_media_type_from_base64` was missing the same check.

### Description

- Added a guard in `detect_media_type_from_base64` that raises a `ValueError("Data URI must use base64 encoding.")` when `data_uri` does not contain `;base64,`, consistent with the existing pattern in `_get_data_bytes_as_str`.
- Added two test assertions to `test_data_content_detect_image_format_from_base64` covering a non-base64 data URI (`data:text/plain,Hello%20World`) and a plain HTTP URL (`http://example.com/image.png`).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [no] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
