### PR TITLE
Python: Fix array input in Chat Completions format losing user message content

### DIFF
--- a/python/packages/devui/agent_framework_devui/_executor.py
+++ b/python/packages/devui/agent_framework_devui/_executor.py
@@ -859,8 +859,7 @@ class AgentFrameworkExecutor:
         # arrays into the conversion path where all items would be skipped,
         # silently producing an empty message.
         return any(
-            isinstance(item, dict) and item.get("role") == "user"
-            for item in input_data_items
+            isinstance(item, dict) and cast(dict[str, Any], item).get("role") == "user" for item in input_data_items
         )
 
     async def _parse_workflow_input(self, workflow: Any, raw_input: Any) -> Any:

--- a/python/packages/devui/tests/devui/test_multimodal_workflow.py
+++ b/python/packages/devui/tests/devui/test_multimodal_workflow.py
@@ -296,10 +296,13 @@ class TestMultimodalWorkflowInput:
 
         # Non-user roles are accepted when a user-role item is also present
         for role in ("system", "assistant", "tool", "developer"):
-            assert executor._is_openai_multimodal_format([
-                {"role": role, "content": "hi"},
-                {"role": "user", "content": "hello"},
-            ]) is True, f"Expected role {role!r} to be accepted alongside user"
+            assert (
+                executor._is_openai_multimodal_format([
+                    {"role": role, "content": "hi"},
+                    {"role": "user", "content": "hello"},
+                ])
+                is True
+            ), f"Expected role {role!r} to be accepted alongside user"
 
     def test_is_openai_multimodal_format_rejects_non_user_only(self):
         """Arrays with no user-role message are rejected to prevent silent empty message fallback."""
@@ -309,15 +312,21 @@ class TestMultimodalWorkflowInput:
 
         # Non-user-only Chat Completions format
         assert executor._is_openai_multimodal_format([{"role": "system", "content": "hi"}]) is False
-        assert executor._is_openai_multimodal_format([
-            {"role": "system", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-        ]) is False
+        assert (
+            executor._is_openai_multimodal_format([
+                {"role": "system", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ])
+            is False
+        )
 
         # Non-user-only Responses API format
-        assert executor._is_openai_multimodal_format([
-            {"type": "message", "role": "system", "content": "hi"},
-        ]) is False
+        assert (
+            executor._is_openai_multimodal_format([
+                {"type": "message", "role": "system", "content": "hi"},
+            ])
+            is False
+        )
 
     def test_is_openai_multimodal_format_rejects_malformed_input(self):
         """Test that _is_openai_multimodal_format rejects inputs missing content or with invalid roles."""


### PR DESCRIPTION
### Motivation and Context

When users send input to the `/responses` endpoint as an array of message objects using Chat Completions format (`{"role": "user", "content": "..."}` without a `"type"` field), the executor fails to recognize it as structured input. This causes the agent to ignore the user's actual query and return unfiltered tool output instead of properly analyzing and filtering results per the user's request.

Fixes #5112

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause is that `_is_openai_multimodal_format` and `_convert_input_to_chat_message` only recognized message objects containing an explicit `"type": "message"` field (Responses API format), but Chat Completions format messages use `{"role": "..", "content": "..."}` without a `type` field. The fix extends both methods to also detect and handle the Chat Completions format by checking for the presence of a `"role"` key when `"type"` is absent. This ensures that array-based input is correctly parsed into a `Message` object with the user's text preserved, so the agent processes the query identically regardless of whether input is sent as a plain string or a message array. Regression tests verify detection and conversion of Chat Completions format messages with both string and list content.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by giles17's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5112,"repo":"microsoft/agent-framework","rid":"46d3265f10bf485e9f5bf32124802037","rt":"fix","sf":"pr","ts":"2026-04-06T23:01:28.896335+00:00","u":"giles17","v":1}
-->
