### PR TITLE
.NET: Add Missing CreateSessionAsync(conversationId) to FoundryAgent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgent.cs
@@ -110,6 +110,27 @@ public sealed class FoundryAgent : DelegatingAIAgent
     #region Convenience methods
 
     /// <summary>
+    /// Creates a new agent session instance using an existing conversation identifier to continue that conversation.
+    /// </summary>
+    /// <param name="conversationId">The identifier of an existing conversation to continue.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A value task representing the asynchronous operation. The task result contains a new <see cref="AgentSession"/> instance configured to work with the specified conversation.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This method creates an <see cref="AgentSession"/> that relies on server-side chat history storage, where the chat history
+    /// is maintained by the underlying AI service rather than by a local <see cref="ChatHistoryProvider"/>.
+    /// </para>
+    /// <para>
+    /// Agent sessions created with this method will only work with <see cref="FoundryAgent"/>
+    /// instances that support server-side conversation storage through their underlying <see cref="IChatClient"/>.
+    /// </para>
+    /// </remarks>
+    public ValueTask<AgentSession> CreateSessionAsync(string conversationId, CancellationToken cancellationToken = default)
+        => ((ChatClientAgent)this.InnerAgent).CreateSessionAsync(conversationId, cancellationToken);
+
+    /// <summary>
     /// Creates a server-side conversation session that appears in the Foundry Project UI.
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAgentTests.cs
@@ -196,6 +196,48 @@ public class FoundryAgentTests
 
     #endregion
 
+    #region CreateSessionAsync tests
+
+    [Fact]
+    public async Task CreateSessionAsync_WithConversationId_ReturnsChatClientAgentSessionAsync()
+    {
+        // Arrange
+        FoundryAgent agent = new(
+            s_testEndpoint,
+            new FakeAuthenticationTokenProvider(),
+            model: "gpt-4o-mini",
+            instructions: "Test");
+
+        const string ConversationId = "test-conversation-id";
+
+        // Act
+        AgentSession session = await agent.CreateSessionAsync(ConversationId);
+
+        // Assert
+        ChatClientAgentSession chatSession = Assert.IsType<ChatClientAgentSession>(session);
+        Assert.Equal(ConversationId, chatSession.ConversationId);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WithoutConversationId_ReturnsChatClientAgentSessionWithoutConversationIdAsync()
+    {
+        // Arrange
+        FoundryAgent agent = new(
+            s_testEndpoint,
+            new FakeAuthenticationTokenProvider(),
+            model: "gpt-4o-mini",
+            instructions: "Test");
+
+        // Act
+        AgentSession session = await agent.CreateSessionAsync();
+
+        // Assert
+        ChatClientAgentSession chatSession = Assert.IsType<ChatClientAgentSession>(session);
+        Assert.Null(chatSession.ConversationId);
+    }
+
+    #endregion
+
     #region Functional tests
 
     [Fact]


### PR DESCRIPTION
## Motivation and Context

- Fixes #5138

Users who already have a server-side conversation ID (e.g., created via \ProjectConversationsClient\) cannot pass it to \FoundryAgent.CreateSessionAsync\ because the overload accepting a \conversationId\ parameter only exists on \ChatClientAgent\.

## Description

Adds a public \CreateSessionAsync(string conversationId, CancellationToken)\ method to \FoundryAgent\ that delegates to the inner \ChatClientAgent\, allowing users to create sessions with existing server-side conversation IDs directly from the \FoundryAgent\ type.

### Usage

\\\csharp
// Create or obtain an existing conversation ID
ProjectConversation conversation = await conversationsClient.CreateProjectConversationAsync();

// Now directly usable on FoundryAgent
AgentSession session = await foundryAgent.CreateSessionAsync(conversation.Id);
\\\

## Changes

- **\FoundryAgent.cs\**: Added \CreateSessionAsync(string conversationId, CancellationToken)\ that delegates to \((ChatClientAgent)this.InnerAgent).CreateSessionAsync(conversationId, cancellationToken)\
- **\FoundryAgentTests.cs\**: Added 2 unit tests covering the new method and the parameterless overload

## Checklist

- [x] dotnet format passes (verified via Docker \mcr.microsoft.com/dotnet/sdk:10.0\)
- [x] All 310 existing + new tests pass on both \
et48\ and \
et10.0\
