### PR TITLE
Python: Fix `response_format` crash on background polling with empty text

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1957,6 +1957,8 @@ class ContinuationToken(TypedDict):
 def _parse_structured_response_value(text: str, response_format: Any | None) -> Any | None:
     if response_format is None:
         return None
+    if not text:
+        return None
     if isinstance(response_format, type) and issubclass(response_format, BaseModel):
         return response_format.model_validate_json(text)
     if isinstance(response_format, Mapping):

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -814,7 +814,6 @@ def test_chat_response_with_mapping_response_format() -> None:
     assert response.value["response"] == "Hello"
 
 
-
 def test_parse_structured_response_value_empty_text_with_pydantic_model() -> None:
     """Empty text should return None instead of raising when response_format is a Pydantic model."""
     result = _parse_structured_response_value("", OutputModel)
@@ -839,7 +838,6 @@ def test_agent_response_value_with_empty_text_and_response_format() -> None:
     message = Message(role="assistant", contents=[""])
     response = AgentResponse(messages=message, response_format=OutputModel)
     assert response.value is None
-
 
 
 def test_chat_response_value_raises_on_invalid_schema():

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -39,6 +39,7 @@ from agent_framework._types import (
     _get_data_bytes,
     _get_data_bytes_as_str,
     _parse_content_list,
+    _parse_structured_response_value,
     _validate_uri,
     add_usage_details,
     validate_tool_mode,
@@ -811,6 +812,34 @@ def test_chat_response_with_mapping_response_format() -> None:
     assert response.value is not None
     assert isinstance(response.value, dict)
     assert response.value["response"] == "Hello"
+
+
+
+def test_parse_structured_response_value_empty_text_with_pydantic_model() -> None:
+    """Empty text should return None instead of raising when response_format is a Pydantic model."""
+    result = _parse_structured_response_value("", OutputModel)
+    assert result is None
+
+
+def test_parse_structured_response_value_empty_text_with_mapping() -> None:
+    """Empty text should return None instead of raising when response_format is a mapping."""
+    result = _parse_structured_response_value("", {"type": "object"})
+    assert result is None
+
+
+def test_chat_response_value_with_empty_text_and_response_format() -> None:
+    """ChatResponse.value should return None when text is empty and response_format is set."""
+    message = Message(role="assistant", contents=[""])
+    response = ChatResponse(messages=message, response_format=OutputModel)
+    assert response.value is None
+
+
+def test_agent_response_value_with_empty_text_and_response_format() -> None:
+    """AgentResponse.value should return None when text is empty and response_format is set."""
+    message = Message(role="assistant", contents=[""])
+    response = AgentResponse(messages=message, response_format=OutputModel)
+    assert response.value is None
+
 
 
 def test_chat_response_value_raises_on_invalid_schema():


### PR DESCRIPTION
### Motivation and Context

When using `response_format` with a Pydantic model or dict schema together with `background=True`, the SDK crashes during polling because `_parse_structured_response_value` is called with an empty string while the response is still in-progress, causing `model_validate_json("")` to raise `ValidationError` and `json.loads("")` to raise `JSONDecodeError`.

Fixes #5145

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause is that `_parse_structured_response_value` unconditionally attempts to parse the text even when it is empty, which happens on every poll iteration before the background response completes. The fix adds an early return of `None` when `text` is falsy, before reaching either the Pydantic or dict-schema parsing branches. This allows `.value` to safely return `None` on in-progress polls and the fully parsed result once the response is complete. Regression tests cover both the Pydantic and mapping schema paths as well as the `ChatResponse` and `AgentResponse` wrappers.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by eavanvalkenburg's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5145,"repo":"microsoft/agent-framework","rid":"049afc5a62134c0f87376688a800513d","rt":"fix","sf":"pr","ts":"2026-04-07T12:26:50.323241+00:00","u":"eavanvalkenburg","v":1}
-->
