### PR TITLE
Python: fix(python): handle function_invocation_configuration in as_agent

### DIFF
--- a/python/packages/core/agent_framework/_clients.py
+++ b/python/packages/core/agent_framework/_clients.py
@@ -646,8 +646,10 @@ class BaseChatClient(SerializationMixin, ABC, Generic[OptionsCoT]):
             "tokenizer": tokenizer,
             "additional_properties": dict(additional_properties) if additional_properties is not None else None,
         }
-        if function_invocation_configuration is not None:
-            agent_kwargs["function_invocation_configuration"] = function_invocation_configuration
+        if function_invocation_configuration is not None and hasattr(self, "function_invocation_configuration"):
+            client_function_invocation_configuration = getattr(self, "function_invocation_configuration")
+            if isinstance(client_function_invocation_configuration, dict):
+                client_function_invocation_configuration.update(function_invocation_configuration)
 
         return Agent(**agent_kwargs)
 

--- a/python/packages/core/tests/core/test_clients.py
+++ b/python/packages/core/tests/core/test_clients.py
@@ -58,6 +58,14 @@ def test_base_client_as_agent_uses_explicit_additional_properties(chat_client_ba
     assert agent.additional_properties == {"team": "core"}
 
 
+def test_base_client_as_agent_applies_function_invocation_configuration(
+    chat_client_base: SupportsChatGetResponse,
+) -> None:
+    chat_client_base.as_agent(function_invocation_configuration={"max_iterations": 8})  # type: ignore[attr-defined]
+
+    assert chat_client_base.function_invocation_configuration["max_iterations"] == 8  # type: ignore[attr-defined]
+
+
 async def test_base_client_get_response_uses_explicit_client_kwargs(chat_client_base: SupportsChatGetResponse) -> None:
     async def fake_inner_get_response(**kwargs):
         assert kwargs["trace_id"] == "trace-123"


### PR DESCRIPTION
Fixes #4985

`BaseChatClient.as_agent()` accepted `function_invocation_configuration` but forwarded it to `Agent(...)`, which no longer has that constructor argument. That produced a `TypeError`.

This change keeps `as_agent()` compatible by applying the provided config to the client-level function invocation configuration when available, and then creating the agent without unsupported kwargs.

Also adds a regression test to verify that `as_agent(function_invocation_configuration=...)` updates the client config without raising.

Greetings, saschabuehrle
