### PR TITLE
Python: fix: prevent inner_exception from being lost in AgentFrameworkException

### DIFF
--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -236,6 +236,7 @@ from ._workflows._workflow_executor import (
     WorkflowExecutor,
 )
 from .exceptions import (
+    AgentFrameworkException,
     MiddlewareException,
     UserInputRequiredException,
     WorkflowCheckpointException,
@@ -264,6 +265,7 @@ __all__ = [
     "USER_AGENT_TELEMETRY_DISABLED_ENV_VAR",
     "Agent",
     "AgentContext",
+    "AgentFrameworkException",
     "AgentEvalConverter",
     "AgentExecutor",
     "AgentExecutorRequest",

--- a/python/packages/core/agent_framework/exceptions.py
+++ b/python/packages/core/agent_framework/exceptions.py
@@ -34,7 +34,8 @@ class AgentFrameworkException(Exception):
             logger.log(log_level, message, exc_info=inner_exception)
         if inner_exception:
             super().__init__(message, inner_exception, *args)  # type: ignore
-        super().__init__(message, *args)  # type: ignore
+        else:
+            super().__init__(message, *args)  # type: ignore
 
 
 # region Agent Exceptions

--- a/python/packages/core/tests/core/test_exceptions.py
+++ b/python/packages/core/tests/core/test_exceptions.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for AgentFrameworkException inner_exception handling."""
+
+import pytest
+
+from agent_framework import AgentFrameworkException
+
+
+def test_exception_with_inner_exception():
+    """When inner_exception is provided, it should be set as the second arg."""
+    inner = ValueError("inner error")
+    exc = AgentFrameworkException("test message", inner_exception=inner)
+    assert exc.args[0] == "test message"
+    assert exc.args[1] is inner
+
+
+def test_exception_without_inner_exception():
+    """When inner_exception is None, args should only contain the message."""
+    exc = AgentFrameworkException("test message")
+    assert exc.args == ("test message",)
+    assert len(exc.args) == 1
+
+
+def test_exception_inner_exception_none_explicit():
+    """When inner_exception is explicitly None, args should only contain the message."""
+    exc = AgentFrameworkException("test message", inner_exception=None)
+    assert exc.args == ("test message",)
+    assert len(exc.args) == 1


### PR DESCRIPTION
## Problem

`AgentFrameworkException.__init__()` unconditionally calls `super().__init__(message, *args)` after the conditional `super().__init__(message, inner_exception, *args)`. When `inner_exception` is provided, the second call overwrites the exception args, losing the inner exception reference.

## Root Cause

Missing `else` branch — both `super().__init__()` calls execute when `inner_exception` is truthy.

## Fix

Add `else:` branch so `super().__init__()` is called exactly once with the correct arguments.

**Before:**
```python
if inner_exception:
    super().__init__(message, inner_exception, *args)
super().__init__(message, *args)  # always runs, overwrites args
```

**After:**
```python
if inner_exception:
    super().__init__(message, inner_exception, *args)
else:
    super().__init__(message, *args)
```

Fixes #5155