### PR TITLE
.NET: Support reflection for discovery of resources and scripts in class-based skills

### DIFF
--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/Agent_Step03_ClassBasedSkills.csproj
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/Agent_Step03_ClassBasedSkills.csproj
@@ -6,7 +6,7 @@
 
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);MAAI001</NoWarn>
+    <NoWarn>$(NoWarn);MAAI001;IDE0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/Program.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// This sample demonstrates how to define Agent Skills as C# classes using AgentClassSkill.
-// Class-based skills bundle all components into a single class implementation.
+// This sample demonstrates how to define Agent Skills as C# classes using AgentClassSkill
+// with attributes for automatic script and resource discovery.
 
+using System.ComponentModel;
 using System.Text.Json;
 using Azure.AI.OpenAI;
 using Azure.Identity;
@@ -44,17 +45,16 @@ AgentResponse response = await agent.RunAsync(
 Console.WriteLine($"Agent: {response.Text}");
 
 /// <summary>
-/// A unit-converter skill defined as a C# class.
+/// A unit-converter skill defined as a C# class using attributes for discovery.
 /// </summary>
 /// <remarks>
-/// Class-based skills bundle all components (name, description, body, resources, scripts)
-/// into a single class.
+/// Properties annotated with <see cref="AgentSkillResourceAttribute"/> are automatically
+/// discovered as skill resources, and methods annotated with <see cref="AgentSkillScriptAttribute"/>
+/// are automatically discovered as skill scripts. Alternatively,
+/// <see cref="AgentSkill.Resources"/> and <see cref="AgentSkill.Scripts"/> can be overridden.
 /// </remarks>
-internal sealed class UnitConverterSkill : AgentClassSkill
+internal sealed class UnitConverterSkill : AgentClassSkill<UnitConverterSkill>
 {
-    private IReadOnlyList<AgentSkillResource>? _resources;
-    private IReadOnlyList<AgentSkillScript>? _scripts;
-
     /// <inheritdoc/>
     public override AgentSkillFrontmatter Frontmatter { get; } = new(
         "unit-converter",
@@ -69,31 +69,40 @@ internal sealed class UnitConverterSkill : AgentClassSkill
         3. Present the result clearly with both units.
         """;
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
-    [
-        CreateResource(
-            "conversion-table",
-            """
-            # Conversion Tables
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> used to marshal parameters and return values
+    /// for scripts and resources.
+    /// </summary>
+    /// <remarks>
+    /// This override is not necessary for this sample, but can be used to provide custom
+    /// serialization options, for example a source-generated <c>JsonTypeInfoResolver</c>
+    /// for Native AOT compatibility.
+    /// </remarks>
+    protected override JsonSerializerOptions? SerializerOptions => null;
 
-            Formula: **result = value × factor**
+    /// <summary>
+    /// A conversion table resource providing multiplication factors.
+    /// </summary>
+    [AgentSkillResource("conversion-table")]
+    [Description("Lookup table of multiplication factors for common unit conversions.")]
+    public string ConversionTable => """
+        # Conversion Tables
 
-            | From        | To          | Factor   |
-            |-------------|-------------|----------|
-            | miles       | kilometers  | 1.60934  |
-            | kilometers  | miles       | 0.621371 |
-            | pounds      | kilograms   | 0.453592 |
-            | kilograms   | pounds      | 2.20462  |
-            """),
-    ];
+        Formula: **result = value × factor**
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
-    [
-        CreateScript("convert", ConvertUnits),
-    ];
+        | From        | To          | Factor   |
+        |-------------|-------------|----------|
+        | miles       | kilometers  | 1.60934  |
+        | kilometers  | miles       | 0.621371 |
+        | pounds      | kilograms   | 0.453592 |
+        | kilograms   | pounds      | 2.20462  |
+        """;
 
+    /// <summary>
+    /// Converts a value by the given factor.
+    /// </summary>
+    [AgentSkillScript("convert")]
+    [Description("Multiplies a value by a conversion factor and returns the result as JSON.")]
     private static string ConvertUnits(double value, double factor)
     {
         double result = Math.Round(value * factor, 4);

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/README.md
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step03_ClassBasedSkills/README.md
@@ -1,12 +1,16 @@
 # Class-Based Agent Skills Sample
 
-This sample demonstrates how to define **Agent Skills as C# classes** using `AgentClassSkill`.
+This sample demonstrates how to define **Agent Skills as C# classes** using `AgentClassSkill`
+with **attributes** for automatic script and resource discovery.
 
 ## What it demonstrates
 
 - Creating skills as classes that extend `AgentClassSkill`
-- Bundling name, description, body, resources, and scripts into a single class
+- Using `[AgentSkillResource]` on properties to define resources
+- Using `[AgentSkillScript]` on methods to define scripts
+- Automatic discovery (no need to override `Resources`/`Scripts`)
 - Using the `AgentSkillsProvider` constructor with class-based skills
+- Overriding `SerializerOptions` for Native AOT compatibility
 
 ## Skills Included
 

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Agent_Step04_MixedSkills.csproj
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Agent_Step04_MixedSkills.csproj
@@ -6,7 +6,7 @@
 
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);MAAI001</NoWarn>
+    <NoWarn>$(NoWarn);MAAI001;IDE0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Program.cs
@@ -8,11 +8,12 @@
 // Three different skill sources are registered here:
 // 1. File-based: unit-converter (miles↔km, pounds↔kg) from SKILL.md on disk
 // 2. Code-defined: volume-converter (gallons↔liters) using AgentInlineSkill
-// 3. Class-based: temperature-converter (°F↔°C↔K) using AgentClassSkill
+// 3. Class-based: temperature-converter (°F↔°C↔K) using AgentClassSkill with attributes
 //
 // For simpler, single-source scenarios, see the earlier steps in this sample series
 // (e.g., Step01 for file-based, Step02 for code-defined, Step03 for class-based).
 
+using System.ComponentModel;
 using System.Text.Json;
 using Azure.AI.OpenAI;
 using Azure.Identity;
@@ -89,13 +90,15 @@ AgentResponse response = await agent.RunAsync(
 Console.WriteLine($"Agent: {response.Text}");
 
 /// <summary>
-/// A temperature-converter skill defined as a C# class.
+/// A temperature-converter skill defined as a C# class using attributes for discovery.
 /// </summary>
+/// <remarks>
+/// Properties annotated with <see cref="AgentSkillResourceAttribute"/> are automatically
+/// discovered as skill resources, and methods annotated with <see cref="AgentSkillScriptAttribute"/>
+/// are automatically discovered as skill scripts.
+/// </remarks>
 internal sealed class TemperatureConverterSkill : AgentClassSkill<TemperatureConverterSkill>
 {
-    private IReadOnlyList<AgentSkillResource>? _resources;
-    private IReadOnlyList<AgentSkillScript>? _scripts;
-
     /// <inheritdoc/>
     public override AgentSkillFrontmatter Frontmatter { get; } = new(
         "temperature-converter",
@@ -110,29 +113,27 @@ internal sealed class TemperatureConverterSkill : AgentClassSkill<TemperatureCon
         3. Present the result clearly with both temperature scales.
         """;
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
-    [
-        this.CreateResource(
-            "temperature-conversion-formulas",
-            """
-            # Temperature Conversion Formulas
+    /// <summary>
+    /// A reference table of temperature conversion formulas.
+    /// </summary>
+    [AgentSkillResource("temperature-conversion-formulas")]
+    [Description("Formulas for converting between Fahrenheit, Celsius, and Kelvin.")]
+    public string ConversionFormulas => """
+        # Temperature Conversion Formulas
 
-            | From        | To          | Formula                   |
-            |-------------|-------------|---------------------------|
-            | Fahrenheit  | Celsius     | °C = (°F − 32) × 5/9     |
-            | Celsius     | Fahrenheit  | °F = (°C × 9/5) + 32     |
-            | Celsius     | Kelvin      | K = °C + 273.15           |
-            | Kelvin      | Celsius     | °C = K − 273.15           |
-            """),
-    ];
+        | From        | To          | Formula                   |
+        |-------------|-------------|---------------------------|
+        | Fahrenheit  | Celsius     | °C = (°F − 32) × 5/9     |
+        | Celsius     | Fahrenheit  | °F = (°C × 9/5) + 32     |
+        | Celsius     | Kelvin      | K = °C + 273.15           |
+        | Kelvin      | Celsius     | °C = K − 273.15           |
+        """;
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
-    [
-        this.CreateScript("convert-temperature", ConvertTemperature),
-    ];
-
+    /// <summary>
+    /// Converts a temperature value between scales.
+    /// </summary>
+    [AgentSkillScript("convert-temperature")]
+    [Description("Converts a temperature value from one scale to another.")]
     private static string ConvertTemperature(double value, string from, string to)
     {
         double result = (from.ToUpperInvariant(), to.ToUpperInvariant()) switch

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step04_MixedSkills/Program.cs
@@ -91,7 +91,7 @@ Console.WriteLine($"Agent: {response.Text}");
 /// <summary>
 /// A temperature-converter skill defined as a C# class.
 /// </summary>
-internal sealed class TemperatureConverterSkill : AgentClassSkill
+internal sealed class TemperatureConverterSkill : AgentClassSkill<TemperatureConverterSkill>
 {
     private IReadOnlyList<AgentSkillResource>? _resources;
     private IReadOnlyList<AgentSkillScript>? _scripts;
@@ -113,7 +113,7 @@ internal sealed class TemperatureConverterSkill : AgentClassSkill
     /// <inheritdoc/>
     public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
     [
-        CreateResource(
+        this.CreateResource(
             "temperature-conversion-formulas",
             """
             # Temperature Conversion Formulas
@@ -130,7 +130,7 @@ internal sealed class TemperatureConverterSkill : AgentClassSkill
     /// <inheritdoc/>
     public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
     [
-        CreateScript("convert-temperature", ConvertTemperature),
+        this.CreateScript("convert-temperature", ConvertTemperature),
     ];
 
     private static string ConvertTemperature(double value, string from, string to)

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Agent_Step05_SkillsWithDI.csproj
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Agent_Step05_SkillsWithDI.csproj
@@ -6,7 +6,7 @@
 
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);MAAI001;CA1812</NoWarn>
+    <NoWarn>$(NoWarn);MAAI001;CA1812;IDE0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Program.cs
@@ -116,7 +116,7 @@ Console.WriteLine($"Agent: {response.Text}");
 /// in both its resource and script functions. This enables clean separation of
 /// concerns and testability while retaining the class-based skill pattern.
 /// </remarks>
-internal sealed class WeightConverterSkill : AgentClassSkill
+internal sealed class WeightConverterSkill : AgentClassSkill<WeightConverterSkill>
 {
     private IReadOnlyList<AgentSkillResource>? _resources;
     private IReadOnlyList<AgentSkillScript>? _scripts;
@@ -138,7 +138,7 @@ internal sealed class WeightConverterSkill : AgentClassSkill
     /// <inheritdoc/>
     public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
     [
-        CreateResource("weight-table", (IServiceProvider serviceProvider) =>
+        this.CreateResource("weight-table", (IServiceProvider serviceProvider) =>
         {
             var service = serviceProvider.GetRequiredService<ConversionService>();
             return service.GetWeightTable();
@@ -148,7 +148,7 @@ internal sealed class WeightConverterSkill : AgentClassSkill
     /// <inheritdoc/>
     public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
     [
-        CreateScript("convert", (double value, double factor, IServiceProvider serviceProvider) =>
+        this.CreateScript("convert", (double value, double factor, IServiceProvider serviceProvider) =>
         {
             var service = serviceProvider.GetRequiredService<ConversionService>();
             return service.Convert(value, factor);

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step05_SkillsWithDI/Program.cs
@@ -13,6 +13,7 @@
 // showing that DI works identically regardless of how the skill is defined.
 // When prompted with a question spanning both domains, the agent uses both skills.
 
+using System.ComponentModel;
 using System.Text.Json;
 using Azure.AI.OpenAI;
 using Azure.Identity;
@@ -62,8 +63,8 @@ var distanceSkill = new AgentInlineSkill(
 // Approach 2: Class-Based Skill with DI (AgentClassSkill)
 // =====================================================================
 // Handles weight conversions (pounds ↔ kilograms).
-// Resources and scripts are encapsulated in a class. Factory methods
-// CreateResource and CreateScript accept delegates with IServiceProvider.
+// Resources and scripts are discovered via reflection using attributes.
+// Methods with an IServiceProvider parameter receive DI automatically.
 //
 // Alternatively, class-based skills can accept dependencies through their
 // constructor. Register the skill class itself in the ServiceCollection and
@@ -113,14 +114,13 @@ Console.WriteLine($"Agent: {response.Text}");
 /// </summary>
 /// <remarks>
 /// This skill resolves <see cref="ConversionService"/> from the DI container
-/// in both its resource and script functions. This enables clean separation of
-/// concerns and testability while retaining the class-based skill pattern.
+/// in both its resource and script methods. Methods with an <see cref="IServiceProvider"/>
+/// parameter are automatically injected by the framework. Properties and methods annotated
+/// with <see cref="AgentSkillResourceAttribute"/> and <see cref="AgentSkillScriptAttribute"/>
+/// are automatically discovered via reflection.
 /// </remarks>
 internal sealed class WeightConverterSkill : AgentClassSkill<WeightConverterSkill>
 {
-    private IReadOnlyList<AgentSkillResource>? _resources;
-    private IReadOnlyList<AgentSkillScript>? _scripts;
-
     /// <inheritdoc/>
     public override AgentSkillFrontmatter Frontmatter { get; } = new(
         "weight-converter",
@@ -135,25 +135,27 @@ internal sealed class WeightConverterSkill : AgentClassSkill<WeightConverterSkil
         3. Present the result clearly with both units.
         """;
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
-    [
-        this.CreateResource("weight-table", (IServiceProvider serviceProvider) =>
-        {
-            var service = serviceProvider.GetRequiredService<ConversionService>();
-            return service.GetWeightTable();
-        }),
-    ];
+    /// <summary>
+    /// Returns the weight conversion table from the DI-registered <see cref="ConversionService"/>.
+    /// </summary>
+    [AgentSkillResource("weight-table")]
+    [Description("Lookup table of multiplication factors for weight conversions.")]
+    private static string GetWeightTable(IServiceProvider serviceProvider)
+    {
+        var service = serviceProvider.GetRequiredService<ConversionService>();
+        return service.GetWeightTable();
+    }
 
-    /// <inheritdoc/>
-    public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
-    [
-        this.CreateScript("convert", (double value, double factor, IServiceProvider serviceProvider) =>
-        {
-            var service = serviceProvider.GetRequiredService<ConversionService>();
-            return service.Convert(value, factor);
-        }),
-    ];
+    /// <summary>
+    /// Converts a value by the given factor using the DI-registered <see cref="ConversionService"/>.
+    /// </summary>
+    [AgentSkillScript("convert")]
+    [Description("Multiplies a value by a conversion factor and returns the result as JSON.")]
+    private static string Convert(double value, double factor, IServiceProvider serviceProvider)
+    {
+        var service = serviceProvider.GetRequiredService<ConversionService>();
+        return service.Convert(value, factor);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Agents.AI;
 /// </para>
 /// <list type="bullet">
 ///   <item><description><strong>Mixed skill types</strong> — combine file-based, code-defined (<see cref="AgentInlineSkill"/>),
-///   and class-based (<see cref="AgentClassSkill"/>) skills in a single provider.</description></item>
+///   and class-based (<see cref="AgentClassSkill{TSelf}"/>) skills in a single provider.</description></item>
 ///   <item><description><strong>Multiple file script runners</strong> — use different script runners for different
 ///   file skill directories via per-source <c>scriptRunner</c> parameters on
 ///   <see cref="UseFileSkill"/> / <see cref="UseFileSkills(IEnumerable{string}, AgentFileSkillsSourceOptions?, AgentFileSkillScriptRunner?)"/>.</description></item>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.DiagnosticIds;
@@ -11,17 +14,55 @@ namespace Microsoft.Agents.AI;
 /// <summary>
 /// Abstract base class for defining skills as C# classes that bundle all components together.
 /// </summary>
+/// <typeparam name="TSelf">
+/// The concrete skill type. This type parameter is annotated with
+/// <see cref="DynamicallyAccessedMembersAttribute"/> to ensure that the IL trimmer and Native AOT compiler
+/// preserve the members needed for attribute-based discovery.
+/// </typeparam>
 /// <remarks>
 /// <para>
 /// Inherit from this class to create a self-contained skill definition. Override the abstract
-/// properties to provide name, description, and instructions. Use <see cref="CreateResource(string, object, string?)"/>,
-/// <see cref="CreateResource(string, Delegate, string?, JsonSerializerOptions?)"/>, and <see cref="CreateScript"/> to define
-/// inline resources and scripts.
+/// properties to provide name, description, and instructions.
+/// </para>
+/// <para>
+/// Scripts and resources can be defined in two ways:
+/// <list type="bullet">
+/// <item>
+/// <b>Attribute-based (recommended):</b> Annotate methods with <see cref="AgentSkillScriptAttribute"/> to define scripts,
+/// and properties or methods with <see cref="AgentSkillResourceAttribute"/> to define resources. These are automatically
+/// discovered via reflection on <typeparamref name="TSelf"/>. This approach is compatible with Native AOT.
+/// </item>
+/// <item>
+/// <b>Explicit override:</b> Override <see cref="AgentSkill.Resources"/> and <see cref="AgentSkill.Scripts"/>, using
+/// <see cref="CreateResource(string, object, string?)"/>, <see cref="CreateResource(string, Delegate, string?, JsonSerializerOptions?)"/>,
+/// and <see cref="CreateScript"/> to define inline resources and scripts. This approach is also compatible with Native AOT.
+/// </item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Multi-level inheritance limitation:</b> Discovery reflects only on <typeparamref name="TSelf"/>,
+/// so if a further-derived subclass adds new attributed members, they will not be discovered unless
+/// that subclass also uses the CRTP pattern
+/// (e.g., <c>class SpecialSkill : AgentClassSkill&lt;SpecialSkill&gt;</c>).
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
-/// public class PdfFormatterSkill : AgentClassSkill
+/// // Attribute-based approach (recommended, AOT-compatible):
+/// public class PdfFormatterSkill : AgentClassSkill&lt;PdfFormatterSkill&gt;
+/// {
+///     public override AgentSkillFrontmatter Frontmatter { get; } = new("pdf-formatter", "Format documents as PDF.");
+///     protected override string Instructions =&gt; "Use this skill to format documents...";
+///
+///     [AgentSkillResource("template")]
+///     public string Template =&gt; "Use this template...";
+///
+///     [AgentSkillScript("format-pdf")]
+///     private static string FormatPdf(string content) =&gt; content;
+/// }
+///
+/// // Explicit override approach (AOT-compatible):
+/// public class ExplicitPdfFormatterSkill : AgentClassSkill&lt;ExplicitPdfFormatterSkill&gt;
 /// {
 ///     private IReadOnlyList&lt;AgentSkillResource&gt;? _resources;
 ///     private IReadOnlyList&lt;AgentSkillScript&gt;? _scripts;
@@ -44,14 +85,40 @@ namespace Microsoft.Agents.AI;
 /// </code>
 /// </example>
 [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
-public abstract class AgentClassSkill : AgentSkill
+public abstract class AgentClassSkill<
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.NonPublicProperties |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.NonPublicMethods)] TSelf>
+    : AgentSkill
+    where TSelf : AgentClassSkill<TSelf>
 {
+    private const BindingFlags DiscoveryBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
     private string? _content;
+    private bool _resourcesDiscovered;
+    private bool _scriptsDiscovered;
+    private IReadOnlyList<AgentSkillResource>? _reflectedResources;
+    private IReadOnlyList<AgentSkillScript>? _reflectedScripts;
 
     /// <summary>
     /// Gets the raw instructions text for this skill.
     /// </summary>
     protected abstract string Instructions { get; }
+
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerOptions"/> used to marshal parameters and return values
+    /// for scripts and resources.
+    /// </summary>
+    /// <remarks>
+    /// Override this property to provide custom serialization options. This value is used by
+    /// reflection-discovered scripts and resources, and also as a fallback by <see cref="CreateScript"/>
+    /// and <see cref="CreateResource(string, Delegate, string?, JsonSerializerOptions?)"/> when no
+    /// explicit <see cref="JsonSerializerOptions"/> is passed to those methods.
+    /// The default value is <see langword="null"/>, which causes <see cref="AIJsonUtilities.DefaultOptions"/> to be used.
+    /// </remarks>
+    protected virtual JsonSerializerOptions? SerializerOptions => null;
 
     /// <inheritdoc/>
     /// <remarks>
@@ -65,6 +132,48 @@ public abstract class AgentClassSkill : AgentSkill
         this.Resources,
         this.Scripts);
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns resources discovered via reflection by scanning <typeparamref name="TSelf"/> for
+    /// members annotated with <see cref="AgentSkillResourceAttribute"/>. This discovery is
+    /// compatible with Native AOT because <typeparamref name="TSelf"/> is annotated with
+    /// <see cref="DynamicallyAccessedMembersAttribute"/>. The result is cached after the first access.
+    /// </remarks>
+    public override IReadOnlyList<AgentSkillResource>? Resources
+    {
+        get
+        {
+            if (!this._resourcesDiscovered)
+            {
+                this._reflectedResources = this.DiscoverResources();
+                this._resourcesDiscovered = true;
+            }
+
+            return this._reflectedResources;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns scripts discovered via reflection by scanning <typeparamref name="TSelf"/> for
+    /// methods annotated with <see cref="AgentSkillScriptAttribute"/>. This discovery is
+    /// compatible with Native AOT because <typeparamref name="TSelf"/> is annotated with
+    /// <see cref="DynamicallyAccessedMembersAttribute"/>. The result is cached after the first access.
+    /// </remarks>
+    public override IReadOnlyList<AgentSkillScript>? Scripts
+    {
+        get
+        {
+            if (!this._scriptsDiscovered)
+            {
+                this._reflectedScripts = this.DiscoverScripts();
+                this._scriptsDiscovered = true;
+            }
+
+            return this._reflectedScripts;
+        }
+    }
+
     /// <summary>
     /// Creates a skill resource backed by a static value.
     /// </summary>
@@ -72,7 +181,7 @@ public abstract class AgentClassSkill : AgentSkill
     /// <param name="value">The static resource value.</param>
     /// <param name="description">An optional description of the resource.</param>
     /// <returns>A new <see cref="AgentSkillResource"/> instance.</returns>
-    protected static AgentSkillResource CreateResource(string name, object value, string? description = null)
+    protected AgentSkillResource CreateResource(string name, object value, string? description = null)
         => new AgentInlineSkillResource(name, value, description);
 
     /// <summary>
@@ -83,11 +192,11 @@ public abstract class AgentClassSkill : AgentSkill
     /// <param name="description">An optional description of the resource.</param>
     /// <param name="serializerOptions">
     /// Optional <see cref="JsonSerializerOptions"/> used to marshal the delegate's parameters and return value.
-    /// When <see langword="null"/>, <see cref="AIJsonUtilities.DefaultOptions"/> is used.
+    /// When <see langword="null"/>, falls back to <see cref="SerializerOptions"/>.
     /// </param>
     /// <returns>A new <see cref="AgentSkillResource"/> instance.</returns>
-    protected static AgentSkillResource CreateResource(string name, Delegate method, string? description = null, JsonSerializerOptions? serializerOptions = null)
-        => new AgentInlineSkillResource(name, method, description, serializerOptions);
+    protected AgentSkillResource CreateResource(string name, Delegate method, string? description = null, JsonSerializerOptions? serializerOptions = null)
+        => new AgentInlineSkillResource(name, method, description, serializerOptions ?? this.SerializerOptions);
 
     /// <summary>
     /// Creates a skill script backed by a delegate.
@@ -97,9 +206,84 @@ public abstract class AgentClassSkill : AgentSkill
     /// <param name="description">An optional description of the script.</param>
     /// <param name="serializerOptions">
     /// Optional <see cref="JsonSerializerOptions"/> used to marshal the delegate's parameters and return value.
-    /// When <see langword="null"/>, <see cref="AIJsonUtilities.DefaultOptions"/> is used.
+    /// When <see langword="null"/>, falls back to <see cref="SerializerOptions"/>.
     /// </param>
     /// <returns>A new <see cref="AgentSkillScript"/> instance.</returns>
-    protected static AgentSkillScript CreateScript(string name, Delegate method, string? description = null, JsonSerializerOptions? serializerOptions = null)
-        => new AgentInlineSkillScript(name, method, description, serializerOptions);
+    protected AgentSkillScript CreateScript(string name, Delegate method, string? description = null, JsonSerializerOptions? serializerOptions = null)
+        => new AgentInlineSkillScript(name, method, description, serializerOptions ?? this.SerializerOptions);
+
+    private List<AgentSkillResource>? DiscoverResources()
+    {
+        List<AgentSkillResource>? resources = null;
+
+        var selfType = typeof(TSelf);
+
+        // Discover resources from properties annotated with [AgentSkillResource].
+        foreach (var property in selfType.GetProperties(DiscoveryBindingFlags))
+        {
+            var attr = property.GetCustomAttribute<AgentSkillResourceAttribute>();
+            if (attr is null)
+            {
+                continue;
+            }
+
+            var getter = property.GetGetMethod(nonPublic: true);
+            if (getter is null)
+            {
+                continue;
+            }
+
+            resources ??= [];
+            resources.Add(new AgentInlineSkillResource(
+                name: attr.Name ?? property.Name,
+                method: getter,
+                target: getter.IsStatic ? null : this,
+                description: property.GetCustomAttribute<DescriptionAttribute>()?.Description,
+                serializerOptions: this.SerializerOptions));
+        }
+
+        // Discover resources from methods annotated with [AgentSkillResource].
+        foreach (var method in selfType.GetMethods(DiscoveryBindingFlags))
+        {
+            var attr = method.GetCustomAttribute<AgentSkillResourceAttribute>();
+            if (attr is null)
+            {
+                continue;
+            }
+
+            resources ??= [];
+            resources.Add(new AgentInlineSkillResource(
+                name: attr.Name ?? method.Name,
+                method: method,
+                target: method.IsStatic ? null : this,
+                description: method.GetCustomAttribute<DescriptionAttribute>()?.Description,
+                serializerOptions: this.SerializerOptions));
+        }
+
+        return resources;
+    }
+
+    private List<AgentSkillScript>? DiscoverScripts()
+    {
+        List<AgentSkillScript>? scripts = null;
+
+        foreach (var method in typeof(TSelf).GetMethods(DiscoveryBindingFlags))
+        {
+            var attr = method.GetCustomAttribute<AgentSkillScriptAttribute>();
+            if (attr is null)
+            {
+                continue;
+            }
+
+            scripts ??= [];
+            scripts.Add(new AgentInlineSkillScript(
+                name: attr.Name ?? method.Name,
+                method: method,
+                target: method.IsStatic ? null : this,
+                description: method.GetCustomAttribute<DescriptionAttribute>()?.Description,
+                serializerOptions: this.SerializerOptions));
+        }
+
+        return scripts;
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.DiagnosticIds;
 
@@ -233,6 +234,15 @@ public abstract class AgentClassSkill<
                 continue;
             }
 
+            // Indexer properties have getter parameters and cannot be used as resources
+            // because ReadAsync invokes the underlying AIFunction with no named arguments.
+            if (getter.GetParameters().Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Property '{property.Name}' on type '{selfType.Name}' is an indexer and cannot be used as a skill resource. " +
+                    "Remove the [AgentSkillResource] attribute or use a non-indexer property.");
+            }
+
             resources ??= [];
             resources.Add(new AgentInlineSkillResource(
                 name: attr.Name ?? property.Name,
@@ -251,6 +261,8 @@ public abstract class AgentClassSkill<
                 continue;
             }
 
+            ValidateResourceMethodParameters(method, selfType);
+
             resources ??= [];
             resources.Add(new AgentInlineSkillResource(
                 name: attr.Name ?? method.Name,
@@ -261,6 +273,22 @@ public abstract class AgentClassSkill<
         }
 
         return resources;
+    }
+
+    private static void ValidateResourceMethodParameters(MethodInfo method, Type skillType)
+    {
+        foreach (var param in method.GetParameters())
+        {
+            if (param.ParameterType != typeof(IServiceProvider) &&
+                param.ParameterType != typeof(CancellationToken))
+            {
+                throw new InvalidOperationException(
+                    $"Method '{method.Name}' on type '{skillType.Name}' has parameter '{param.Name}' of type " +
+                    $"'{param.ParameterType}' which cannot be supplied when reading a resource. " +
+                    "Resource methods may only accept IServiceProvider and/or CancellationToken parameters. " +
+                    "Remove the [AgentSkillResource] attribute or change the method signature.");
+            }
+        }
     }
 
     private List<AgentSkillScript>? DiscoverScripts()

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -243,9 +243,15 @@ public abstract class AgentClassSkill<
                     "Remove the [AgentSkillResource] attribute or use a non-indexer property.");
             }
 
+            var name = attr.Name ?? property.Name;
+            if (resources?.Exists(r => r.Name == name) == true)
+            {
+                throw new InvalidOperationException($"Skill '{this.Frontmatter.Name}' already has a resource named '{name}'. Ensure each [AgentSkillResource] has a unique name.");
+            }
+
             resources ??= [];
             resources.Add(new AgentInlineSkillResource(
-                name: attr.Name ?? property.Name,
+                name: name,
                 method: getter,
                 target: getter.IsStatic ? null : this,
                 description: property.GetCustomAttribute<DescriptionAttribute>()?.Description,
@@ -263,9 +269,15 @@ public abstract class AgentClassSkill<
 
             ValidateResourceMethodParameters(method, selfType);
 
+            var name = attr.Name ?? method.Name;
+            if (resources?.Exists(r => r.Name == name) == true)
+            {
+                throw new InvalidOperationException($"Skill '{this.Frontmatter.Name}' already has a resource named '{name}'. Ensure each [AgentSkillResource] has a unique name.");
+            }
+
             resources ??= [];
             resources.Add(new AgentInlineSkillResource(
-                name: attr.Name ?? method.Name,
+                name: name,
                 method: method,
                 target: method.IsStatic ? null : this,
                 description: method.GetCustomAttribute<DescriptionAttribute>()?.Description,
@@ -303,9 +315,15 @@ public abstract class AgentClassSkill<
                 continue;
             }
 
+            var name = attr.Name ?? method.Name;
+            if (scripts?.Exists(s => s.Name == name) == true)
+            {
+                throw new InvalidOperationException($"Skill '{this.Frontmatter.Name}' already has a script named '{name}'. Ensure each [AgentSkillScript] has a unique name.");
+            }
+
             scripts ??= [];
             scripts.Add(new AgentInlineSkillScript(
-                name: attr.Name ?? method.Name,
+                name: name,
                 method: method,
                 target: method.IsStatic ? null : this,
                 description: method.GetCustomAttribute<DescriptionAttribute>()?.Description,

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillResource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillResource.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +53,28 @@ internal sealed class AgentInlineSkillResource : AgentSkillResource
 
         var options = new AIFunctionFactoryOptions { Name = this.Name, SerializerOptions = serializerOptions };
         this._function = AIFunctionFactory.Create(method, options);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentInlineSkillResource"/> class from a <see cref="MethodInfo"/>.
+    /// The method is invoked via an <see cref="AIFunction"/> each time <see cref="ReadAsync"/> is called,
+    /// producing a dynamic (computed) value.
+    /// </summary>
+    /// <param name="name">The resource name.</param>
+    /// <param name="method">A method that produces the resource value when requested.</param>
+    /// <param name="target">The target instance for instance methods, or <see langword="null"/> for static methods.</param>
+    /// <param name="description">An optional description of the resource.</param>
+    /// <param name="serializerOptions">
+    /// Optional <see cref="JsonSerializerOptions"/> used to marshal the method's parameters and return value.
+    /// When <see langword="null"/>, <see cref="AIJsonUtilities.DefaultOptions"/> is used.
+    /// </param>
+    public AgentInlineSkillResource(string name, MethodInfo method, object? target, string? description = null, JsonSerializerOptions? serializerOptions = null)
+        : base(name, description)
+    {
+        Throw.IfNull(method);
+
+        var options = new AIFunctionFactoryOptions { Name = this.Name, SerializerOptions = serializerOptions };
+        this._function = AIFunctionFactory.Create(method, target, options);
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,27 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
 
         var options = new AIFunctionFactoryOptions { Name = this.Name, SerializerOptions = serializerOptions };
         this._function = AIFunctionFactory.Create(method, options);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentInlineSkillScript"/> class from a <see cref="MethodInfo"/>.
+    /// The method's parameters and return type are automatically marshaled via <see cref="AIFunctionFactory"/>.
+    /// </summary>
+    /// <param name="name">The script name.</param>
+    /// <param name="method">The method to execute when the script is invoked.</param>
+    /// <param name="target">The target instance for instance methods, or <see langword="null"/> for static methods.</param>
+    /// <param name="description">An optional description of the script.</param>
+    /// <param name="serializerOptions">
+    /// Optional <see cref="JsonSerializerOptions"/> used to marshal the method's parameters and return value.
+    /// When <see langword="null"/>, <see cref="AIJsonUtilities.DefaultOptions"/> is used.
+    /// </param>
+    public AgentInlineSkillScript(string name, MethodInfo method, object? target, string? description = null, JsonSerializerOptions? serializerOptions = null)
+        : base(Throw.IfNullOrWhitespace(name), description)
+    {
+        Throw.IfNull(method);
+
+        var options = new AIFunctionFactoryOptions { Name = this.Name, SerializerOptions = serializerOptions };
+        this._function = AIFunctionFactory.Create(method, target, options);
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentSkillResourceAttribute.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentSkillResourceAttribute.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// Marks a property or method as a skill resource that is automatically discovered by <see cref="AgentClassSkill{TSelf}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply this attribute to properties or methods in an <see cref="AgentClassSkill{TSelf}"/> subclass to register
+/// them as skill resources.
+/// </para>
+/// <para>
+/// To provide a description for the resource, apply <see cref="DescriptionAttribute"/>
+/// to the same member.
+/// </para>
+/// <para>
+/// When applied to a <b>property</b>, the property getter is invoked each time the resource is read,
+/// enabling dynamic (computed) resources. When applied to a <b>method</b>, the method is invoked each time
+/// the resource is read, also enabling dynamic resources. Methods with an
+/// <see cref="IServiceProvider"/> parameter support dependency injection.
+/// </para>
+/// <para>
+/// This attribute is compatible with Native AOT when used with <see cref="AgentClassSkill{TSelf}"/>.
+/// Alternatively, override the <see cref="AgentSkill.Resources"/> property and use
+/// <see cref="AgentClassSkill{TSelf}.CreateResource(string, object, string?)"/> instead.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MySkill : AgentClassSkill&lt;MySkill&gt;
+/// {
+///     public override AgentSkillFrontmatter Frontmatter { get; } = new("my-skill", "A skill.");
+///     protected override string Instructions =&gt; "Use this skill to do something.";
+///
+///     [AgentSkillResource("reference-data")]
+///     [Description("Some reference content for the skill.")]
+///     public string ReferenceData =&gt; "Some reference content.";
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class AgentSkillResourceAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentSkillResourceAttribute"/> class.
+    /// The resource name defaults to the property or method name.
+    /// </summary>
+    public AgentSkillResourceAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentSkillResourceAttribute"/> class
+    /// with an explicit resource name.
+    /// </summary>
+    /// <param name="name">The resource name used to identify this resource.</param>
+    public AgentSkillResourceAttribute(string name)
+    {
+        this.Name = name;
+    }
+
+    /// <summary>
+    /// Gets the resource name, or <see langword="null"/> to use the member name.
+    /// </summary>
+    public string? Name { get; }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentSkillScriptAttribute.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentSkillScriptAttribute.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// Marks a method as a skill script that is automatically discovered by <see cref="AgentClassSkill{TSelf}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply this attribute to methods in an <see cref="AgentClassSkill{TSelf}"/> subclass to register them as
+/// skill scripts. The method's parameters and return type are automatically marshaled via
+/// <c>AIFunctionFactory</c>.
+/// </para>
+/// <para>
+/// To provide a description for the script, apply <see cref="DescriptionAttribute"/>
+/// to the same method.
+/// </para>
+/// <para>
+/// Methods can be instance or static, and may have any visibility (public, private, etc.).
+/// Methods with an <see cref="IServiceProvider"/> parameter support dependency injection.
+/// </para>
+/// <para>
+/// This attribute is compatible with Native AOT when used with <see cref="AgentClassSkill{TSelf}"/>.
+/// Alternatively, override the <see cref="AgentSkill.Scripts"/> property and use
+/// <see cref="AgentClassSkill{TSelf}.CreateScript"/> instead.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MySkill : AgentClassSkill&lt;MySkill&gt;
+/// {
+///     public override AgentSkillFrontmatter Frontmatter { get; } = new("my-skill", "A skill.");
+///     protected override string Instructions =&gt; "Use this skill to do something.";
+///
+///     [AgentSkillScript("do-something")]
+///     [Description("Converts the input to upper case.")]
+///     private static string DoSomething(string input) =&gt; input.ToUpperInvariant();
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class AgentSkillScriptAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentSkillScriptAttribute"/> class.
+    /// The script name defaults to the method name.
+    /// </summary>
+    public AgentSkillScriptAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentSkillScriptAttribute"/> class
+    /// with an explicit script name.
+    /// </summary>
+    /// <param name="name">The script name used to identify this script.</param>
+    public AgentSkillScriptAttribute(string name)
+    {
+        this.Name = name;
+    }
+
+    /// <summary>
+    /// Gets the script name, or <see langword="null"/> to use the method name.
+    /// </summary>
+    public string? Name { get; }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
 
@@ -407,6 +408,86 @@ public sealed class AgentClassSkillTests
     }
 
     [Fact]
+    public void IndexerPropertyWithResourceAttribute_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new IndexerResourceSkill();
+
+        // Act & Assert — accessing Resources triggers discovery which should throw
+        var ex = Assert.Throws<InvalidOperationException>(() => skill.Resources);
+        Assert.Contains("indexer", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("IndexerResourceSkill", ex.Message);
+    }
+
+    [Fact]
+    public void ResourceMethodWithUnsupportedParameters_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new UnsupportedParamResourceMethodSkill();
+
+        // Act & Assert — accessing Resources triggers discovery which should throw
+        var ex = Assert.Throws<InvalidOperationException>(() => skill.Resources);
+        Assert.Contains("content", ex.Message);
+        Assert.Contains("String", ex.Message);
+    }
+
+    [Fact]
+    public async Task ResourceMethodWithServiceProviderParam_IsDiscoveredSuccessfullyAsync()
+    {
+        // Arrange
+        var skill = new ServiceProviderResourceMethodSkill();
+        var sp = new ServiceCollection().BuildServiceProvider();
+
+        // Act
+        var resources = skill.Resources;
+
+        // Assert
+        Assert.NotNull(resources);
+        Assert.Single(resources!);
+        Assert.Equal("sp-resource", resources![0].Name);
+
+        var value = await resources[0].ReadAsync(sp);
+        Assert.Equal("from-sp-method", value?.ToString());
+    }
+
+    [Fact]
+    public async Task ResourceMethodWithCancellationTokenParam_IsDiscoveredSuccessfullyAsync()
+    {
+        // Arrange
+        var skill = new CancellationTokenResourceMethodSkill();
+
+        // Act
+        var resources = skill.Resources;
+
+        // Assert
+        Assert.NotNull(resources);
+        Assert.Single(resources!);
+        Assert.Equal("ct-resource", resources![0].Name);
+
+        var value = await resources[0].ReadAsync();
+        Assert.Equal("from-ct-method", value?.ToString());
+    }
+
+    [Fact]
+    public async Task ResourceMethodWithBothServiceProviderAndCancellationToken_IsDiscoveredSuccessfullyAsync()
+    {
+        // Arrange
+        var skill = new BothParamsResourceMethodSkill();
+        var sp = new ServiceCollection().BuildServiceProvider();
+
+        // Act
+        var resources = skill.Resources;
+
+        // Assert
+        Assert.NotNull(resources);
+        Assert.Single(resources!);
+        Assert.Equal("both-resource", resources![0].Name);
+
+        var value = await resources[0].ReadAsync(sp);
+        Assert.Equal("from-both-method", value?.ToString());
+    }
+
+    [Fact]
     public async Task CreateScript_FallsBackToSerializerOptions_WhenNoExplicitJsoAsync()
     {
         // Arrange
@@ -789,6 +870,58 @@ public sealed class AgentClassSkillTests
                 TotalCount = request.MaxResults,
             }, serializerOptions: SkillTestJsonContext.Default.Options),
         ];
+    }
+
+    private sealed class IndexerResourceSkill : AgentClassSkill<IndexerResourceSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("indexer-skill", "Skill with indexer resource.");
+
+        protected override string Instructions => "Body.";
+
+        private readonly Dictionary<string, string> _data = new() { ["key"] = "value" };
+
+        [AgentSkillResource("indexed")]
+        public string this[string key] => this._data[key];
+    }
+
+    private sealed class UnsupportedParamResourceMethodSkill : AgentClassSkill<UnsupportedParamResourceMethodSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("unsupported-param-skill", "Skill with unsupported param resource method.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("bad-resource")]
+        private static string GetData(string content) => content;
+    }
+
+    private sealed class ServiceProviderResourceMethodSkill : AgentClassSkill<ServiceProviderResourceMethodSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("sp-param-skill", "Skill with IServiceProvider param resource method.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("sp-resource")]
+        private static string GetData(IServiceProvider? sp) => "from-sp-method";
+    }
+
+    private sealed class CancellationTokenResourceMethodSkill : AgentClassSkill<CancellationTokenResourceMethodSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("ct-param-skill", "Skill with CancellationToken param resource method.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("ct-resource")]
+        private static string GetData(CancellationToken ct) => "from-ct-method";
+    }
+
+    private sealed class BothParamsResourceMethodSkill : AgentClassSkill<BothParamsResourceMethodSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("both-param-skill", "Skill with both IServiceProvider and CancellationToken param resource method.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("both-resource")]
+        private static string GetData(IServiceProvider? sp, CancellationToken ct) => "from-both-method";
     }
 
     #endregion

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,56 +13,48 @@ using Microsoft.Extensions.AI;
 namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
 
 /// <summary>
-/// Unit tests for <see cref="AgentClassSkill"/> and <see cref="AgentInMemorySkillsSource"/>.
+/// Unit tests for <see cref="AgentClassSkill{TSelf}"/> and <see cref="AgentInMemorySkillsSource"/>.
 /// </summary>
 public sealed class AgentClassSkillTests
 {
     [Fact]
-    public void Resources_DefaultsToNull_WhenNotOverridden()
+    public void MinimalClassSkill_HasNullOverrides_AndSynthesizesContent()
     {
         // Arrange
         var skill = new MinimalClassSkill();
 
-        // Act & Assert
+        // Act & Assert — null overrides
+        Assert.Equal("minimal", skill.Frontmatter.Name);
         Assert.Null(skill.Resources);
-    }
-
-    [Fact]
-    public void Scripts_DefaultsToNull_WhenNotOverridden()
-    {
-        // Arrange
-        var skill = new MinimalClassSkill();
-
-        // Act & Assert
         Assert.Null(skill.Scripts);
+
+        // Act & Assert — synthesized XML content
+        Assert.Contains("<name>minimal</name>", skill.Content);
+        Assert.Contains("<description>A minimal skill.</description>", skill.Content);
+        Assert.Contains("<instructions>", skill.Content);
+        Assert.Contains("Minimal skill body.", skill.Content);
+        Assert.Contains("</instructions>", skill.Content);
     }
 
     [Fact]
-    public void Resources_ReturnsOverriddenList_WhenOverridden()
+    public void FullClassSkill_ReturnsOverriddenLists_AndCachesContent()
     {
         // Arrange
         var skill = new FullClassSkill();
 
-        // Act
-        var resources = skill.Resources;
+        // Act & Assert — overridden resources and scripts
+        Assert.Single(skill.Resources!);
+        Assert.Equal("test-resource", skill.Resources![0].Name);
 
-        // Assert
-        Assert.Single(resources!);
-        Assert.Equal("test-resource", resources![0].Name);
-    }
+        Assert.Single(skill.Scripts!);
+        Assert.Equal("TestScript", skill.Scripts![0].Name);
 
-    [Fact]
-    public void Scripts_ReturnsOverriddenList_WhenOverridden()
-    {
-        // Arrange
-        var skill = new FullClassSkill();
+        // Act & Assert — Content is cached
+        Assert.Same(skill.Content, skill.Content);
 
-        // Act
-        var scripts = skill.Scripts;
-
-        // Assert
-        Assert.Single(scripts!);
-        Assert.Equal("TestScript", scripts![0].Name);
+        // Act & Assert — Content includes parameter schema from typed script
+        Assert.Contains("parameters_schema", skill.Content);
+        Assert.Contains("value", skill.Content);
     }
 
     [Fact]
@@ -86,36 +81,10 @@ public sealed class AgentClassSkillTests
     }
 
     [Fact]
-    public void Name_Content_ReturnClassDefinedValues()
-    {
-        // Arrange
-        var skill = new MinimalClassSkill();
-
-        // Act & Assert
-        Assert.Equal("minimal", skill.Frontmatter.Name);
-        Assert.Contains("<instructions>", skill.Content);
-        Assert.Contains("Minimal skill body.", skill.Content);
-        Assert.Contains("</instructions>", skill.Content);
-    }
-
-    [Fact]
-    public void Content_ReturnsSynthesizedXmlDocument()
-    {
-        // Arrange
-        var skill = new MinimalClassSkill();
-
-        // Act & Assert
-        Assert.Contains("<name>minimal</name>", skill.Content);
-        Assert.Contains("<description>A minimal skill.</description>", skill.Content);
-        Assert.Contains("<instructions>", skill.Content);
-        Assert.Contains("Minimal skill body.", skill.Content);
-    }
-
-    [Fact]
     public async Task AgentInMemorySkillsSource_ReturnsAllSkillsAsync()
     {
         // Arrange
-        var skills = new AgentClassSkill[] { new MinimalClassSkill(), new FullClassSkill() };
+        var skills = new AgentSkill[] { new MinimalClassSkill(), new FullClassSkill() };
         var source = new AgentInMemorySkillsSource(skills);
 
         // Act
@@ -135,126 +104,397 @@ public sealed class AgentClassSkillTests
     }
 
     [Fact]
-    public void SkillWithOnlyResources_HasNullScripts()
+    public void PartialOverrides_OneCollectionNull_OtherHasValues()
     {
         // Arrange
-        var skill = new ResourceOnlySkill();
+        var resourceOnly = new ResourceOnlySkill();
+        var scriptOnly = new ScriptOnlySkill();
 
         // Act & Assert
-        Assert.Single(skill.Resources!);
-        Assert.Null(skill.Scripts);
+        Assert.Single(resourceOnly.Resources!);
+        Assert.Null(resourceOnly.Scripts);
+        Assert.Null(scriptOnly.Resources);
+        Assert.Single(scriptOnly.Scripts!);
     }
 
     [Fact]
-    public void SkillWithOnlyScripts_HasNullResources()
+    public async Task CreateScriptAndResource_WithSerializerOptions_HandleCustomTypesAsync()
     {
         // Arrange
-        var skill = new ScriptOnlySkill();
+        var skill = new CustomTypeSkill();
+        var jso = SkillTestJsonContext.Default.Options;
+
+        // Act — script with custom type deserialization
+        var script = skill.Scripts![0];
+        var inputJson = JsonSerializer.SerializeToElement(new LookupRequest { Query = "test", MaxResults = 5 }, jso);
+        var args = new AIFunctionArguments { ["request"] = inputJson };
+        var scriptResult = await script.RunAsync(skill, args, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(scriptResult);
+        var resultText = scriptResult!.ToString()!;
+        Assert.Contains("result for test", resultText);
+        Assert.Contains("5", resultText);
+
+        // Act — resource with custom type serialization
+        var resourceResult = await skill.Resources![0].ReadAsync();
+
+        // Assert
+        Assert.NotNull(resourceResult);
+        Assert.Contains("dark", resourceResult!.ToString()!);
+    }
+
+    [Fact]
+    public void Scripts_DiscoveredViaAttribute_WithCorrectNamesAndDescriptions()
+    {
+        // Arrange
+        var skill = new AttributedScriptsSkill();
+
+        // Act
+        var scripts = skill.Scripts;
+
+        // Assert — all scripts discovered with correct metadata
+        Assert.NotNull(scripts);
+        Assert.Equal(4, scripts!.Count);
+        Assert.Contains(scripts, s => s.Name == "do-work");
+        Assert.Contains(scripts, s => s.Name == "DefaultNamed");
+        Assert.Contains(scripts, s => s.Name == "append");
+
+        var processScript = scripts.First(s => s.Name == "process");
+        Assert.Equal("Processes the input.", processScript.Description);
+    }
+
+    [Fact]
+    public async Task Scripts_DiscoveredViaAttribute_StaticAndInstance_CanBeInvokedAsync()
+    {
+        // Arrange
+        var skill = new AttributedScriptsSkill();
+
+        // Act & Assert — static method
+        var doWorkScript = skill.Scripts!.First(s => s.Name == "do-work");
+        var doWorkResult = await doWorkScript.RunAsync(skill, new AIFunctionArguments { ["input"] = "hello" }, CancellationToken.None);
+        Assert.Equal("HELLO", doWorkResult?.ToString());
+
+        // Act & Assert — instance method
+        var appendScript = skill.Scripts!.First(s => s.Name == "append");
+        var appendResult = await appendScript.RunAsync(skill, new AIFunctionArguments { ["input"] = "test" }, CancellationToken.None);
+        Assert.Equal("test-suffix", appendResult?.ToString());
+    }
+
+    [Fact]
+    public void Resources_DiscoveredViaAttribute_OnProperties_WithCorrectMetadata()
+    {
+        // Arrange
+        var skill = new AttributedResourcePropertiesSkill();
+
+        // Act
+        var resources = skill.Resources;
+
+        // Assert — all resources discovered with correct metadata
+        Assert.NotNull(resources);
+        Assert.Equal(4, resources!.Count);
+        Assert.Contains(resources, r => r.Name == "ref-data");
+        Assert.Contains(resources, r => r.Name == "DefaultNamed");
+        Assert.Contains(resources, r => r.Name == "static-data");
+
+        var describedResource = resources.First(r => r.Name == "data");
+        Assert.Equal("Some important data.", describedResource.Description);
+    }
+
+    [Fact]
+    public async Task Resources_DiscoveredViaAttribute_OnProperties_CanBeReadAsync()
+    {
+        // Arrange
+        var skill = new AttributedResourcePropertiesSkill();
+
+        // Act & Assert — instance property
+        var refData = skill.Resources!.First(r => r.Name == "ref-data");
+        Assert.Equal("Reference content.", (await refData.ReadAsync())?.ToString());
+
+        // Act & Assert — static property
+        var staticData = skill.Resources!.First(r => r.Name == "static-data");
+        Assert.Equal("Static content.", (await staticData.ReadAsync())?.ToString());
+    }
+
+    [Fact]
+    public async Task Resources_DiscoveredViaAttribute_OnProperty_InvokedEachTimeAsync()
+    {
+        // Arrange
+        var skill = new AttributedResourceDynamicPropertySkill();
+        var resource = skill.Resources![0];
+
+        // Act
+        var first = await resource.ReadAsync();
+        var second = await resource.ReadAsync();
+
+        // Assert — property getter is called on each ReadAsync, producing different values
+        Assert.Equal("call-1", first?.ToString());
+        Assert.Equal("call-2", second?.ToString());
+        Assert.Equal(2, skill.CallCount);
+    }
+
+    [Fact]
+    public void Resources_DiscoveredViaAttribute_OnMethods_WithCorrectMetadata()
+    {
+        // Arrange
+        var skill = new AttributedResourceMethodsSkill();
+
+        // Act
+        var resources = skill.Resources;
+
+        // Assert
+        Assert.NotNull(resources);
+        Assert.Equal(4, resources!.Count);
+        Assert.Contains(resources, r => r.Name == "dynamic");
+        Assert.Contains(resources, r => r.Name == "GetData");
+        Assert.Contains(resources, r => r.Name == "instance-dynamic");
+
+        var describedResource = resources.First(r => r.Name == "info");
+        Assert.Equal("Returns runtime info.", describedResource.Description);
+    }
+
+    [Fact]
+    public async Task Resources_DiscoveredViaAttribute_OnMethods_CanBeReadAsync()
+    {
+        // Arrange
+        var skill = new AttributedResourceMethodsSkill();
+
+        // Act & Assert — static method
+        var dynamicResource = skill.Resources!.First(r => r.Name == "dynamic");
+        Assert.Equal("dynamic-value", (await dynamicResource.ReadAsync())?.ToString());
+
+        // Act & Assert — instance method
+        var instanceResource = skill.Resources!.First(r => r.Name == "instance-dynamic");
+        Assert.Equal("instance-method-value", (await instanceResource.ReadAsync())?.ToString());
+    }
+
+    [Fact]
+    public void AttributedFullSkill_IncludesContentWithSchema_AndCachesMembers()
+    {
+        // Arrange
+        var skill = new AttributedFullSkill();
+
+        // Act & Assert — Content includes reflected resources and scripts
+        Assert.Contains("<resources>", skill.Content);
+        Assert.Contains("conversion-table", skill.Content);
+        Assert.Contains("<scripts>", skill.Content);
+        Assert.Contains("convert", skill.Content);
+
+        // Act & Assert — discovered members are cached
+        Assert.Same(skill.Resources, skill.Resources);
+        Assert.Same(skill.Scripts, skill.Scripts);
+
+        // Act & Assert — script has parameters schema
+        var script = skill.Scripts![0];
+        Assert.NotNull(script.ParametersSchema);
+        Assert.Contains("value", script.ParametersSchema!.Value.GetRawText());
+    }
+
+    [Fact]
+    public void NoAttributedMembers_NoOverrides_ReturnsNull()
+    {
+        // Arrange — skill with no attributes and no overrides; base discovery returns null (not empty list)
+        var skill = new NoAttributesNoOverridesSkill();
+        var baseType = typeof(AgentClassSkill<NoAttributesNoOverridesSkill>);
+        var resourcesDiscoveredField = baseType.GetField("_resourcesDiscovered", BindingFlags.Instance | BindingFlags.NonPublic);
+        var scriptsDiscoveredField = baseType.GetField("_scriptsDiscovered", BindingFlags.Instance | BindingFlags.NonPublic);
+        var reflectedResourcesField = baseType.GetField("_reflectedResources", BindingFlags.Instance | BindingFlags.NonPublic);
+        var reflectedScriptsField = baseType.GetField("_reflectedScripts", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(resourcesDiscoveredField);
+        Assert.NotNull(scriptsDiscoveredField);
+        Assert.NotNull(reflectedResourcesField);
+        Assert.NotNull(reflectedScriptsField);
+        Assert.False((bool)resourcesDiscoveredField!.GetValue(skill)!);
+        Assert.False((bool)scriptsDiscoveredField!.GetValue(skill)!);
 
         // Act & Assert
         Assert.Null(skill.Resources);
-        Assert.Single(skill.Scripts!);
+        Assert.Null(skill.Scripts);
+        Assert.True((bool)resourcesDiscoveredField.GetValue(skill)!);
+        Assert.True((bool)scriptsDiscoveredField.GetValue(skill)!);
+        Assert.Null(reflectedResourcesField!.GetValue(skill));
+        Assert.Null(reflectedScriptsField!.GetValue(skill));
+
+        // Repeated access should not re-trigger discovery even when discovered value is null.
+        Assert.Null(skill.Resources);
+        Assert.Null(skill.Scripts);
+        Assert.True((bool)resourcesDiscoveredField.GetValue(skill)!);
+        Assert.True((bool)scriptsDiscoveredField.GetValue(skill)!);
+        Assert.Null(reflectedResourcesField.GetValue(skill));
+        Assert.Null(reflectedScriptsField.GetValue(skill));
     }
 
     [Fact]
-    public void Content_ReturnsCachedInstance_OnRepeatedAccess()
+    public void SubclassOverride_TakesPrecedence_OverAttributes()
     {
-        // Arrange
-        var skill = new FullClassSkill();
+        // Arrange — skill has attributes AND overrides Resources/Scripts
+        var skill = new AttributedWithOverrideSkill();
 
         // Act
-        var first = skill.Content;
-        var second = skill.Content;
+        var resources = skill.Resources;
+        var scripts = skill.Scripts;
 
-        // Assert
-        Assert.Same(first, second);
+        // Assert — overrides win, not reflected members
+        Assert.NotNull(resources);
+        Assert.Single(resources!);
+        Assert.Equal("manual-resource", resources![0].Name);
+        Assert.NotNull(scripts);
+        Assert.Single(scripts!);
+        Assert.Equal("ManualScript", scripts![0].Name);
     }
 
     [Fact]
-    public void Content_IncludesParametersSchema_WhenScriptsHaveParameters()
+    public async Task MixedStaticAndInstance_AllDiscoveredAndInvocableAsync()
     {
         // Arrange
-        var skill = new FullClassSkill();
+        var skill = new MixedStaticInstanceSkill();
+
+        // Act & Assert — correct counts
+        Assert.NotNull(skill.Resources);
+        Assert.Equal(2, skill.Resources!.Count);
+        Assert.NotNull(skill.Scripts);
+        Assert.Equal(2, skill.Scripts!.Count);
+
+        // Act & Assert — all resources produce values
+        foreach (var resource in skill.Resources!)
+        {
+            var value = await resource.ReadAsync();
+            Assert.NotNull(value);
+        }
+
+        // Act & Assert — all scripts produce values
+        foreach (var script in skill.Scripts!)
+        {
+            var result = await script.RunAsync(skill, new AIFunctionArguments(), CancellationToken.None);
+            Assert.NotNull(result);
+        }
+    }
+
+    [Fact]
+    public async Task SerializerOptions_UsedForReflectedMembersAsync()
+    {
+        // Arrange
+        var skill = new AttributedSkillWithCustomSerializer();
+        var jso = SkillTestJsonContext.Default.Options;
+
+        // Act & Assert — script with custom JSO
+        var script = skill.Scripts![0];
+        var inputJson = JsonSerializer.SerializeToElement(new LookupRequest { Query = "test", MaxResults = 3 }, jso);
+        var args = new AIFunctionArguments { ["request"] = inputJson };
+        var scriptResult = await script.RunAsync(skill, args, CancellationToken.None);
+        Assert.NotNull(scriptResult);
+        Assert.Contains("test", scriptResult!.ToString()!);
+        Assert.Contains("3", scriptResult!.ToString()!);
+
+        // Act & Assert — resource with custom JSO
+        var resourceResult = await skill.Resources![0].ReadAsync();
+        Assert.NotNull(resourceResult);
+        Assert.Contains("light", resourceResult!.ToString()!);
+    }
+
+    [Fact]
+    public void Content_IncludesDescription_ForReflectedResources()
+    {
+        // Arrange
+        var skill = new AttributedResourcePropertiesSkill();
 
         // Act
         var content = skill.Content;
 
-        // Assert — scripts with typed parameters should have their schema included
-        Assert.Contains("parameters_schema", content);
-        Assert.Contains("value", content);
+        // Assert — descriptions from [Description] attribute appear in synthesized content
+        Assert.Contains("Some important data.", content);
     }
 
     [Fact]
-    public void Content_IncludesDerivedResources_WhenResourcesUseBaseTypeOverrides()
+    public async Task CreateScript_FallsBackToSerializerOptions_WhenNoExplicitJsoAsync()
     {
         // Arrange
-        var skill = new DerivedResourceSkill();
+        var skill = new CreateMethodsFallbackSkill();
 
-        // Act
-        var content = skill.Content;
+        // Act — invoke script that uses custom types, relying on SerializerOptions fallback
+        var script = skill.Scripts!.First(s => s.Name == "Lookup");
+        var jso = SkillTestJsonContext.Default.Options;
+        var inputJson = JsonSerializer.SerializeToElement(new LookupRequest { Query = "fallback", MaxResults = 7 }, jso);
+        var args = new AIFunctionArguments { ["request"] = inputJson };
+        var result = await script.RunAsync(skill, args, CancellationToken.None);
 
         // Assert
-        Assert.Contains("<resources>", content);
-        Assert.Contains("custom-resource", content);
-        Assert.Contains("Custom resource description.", content);
+        Assert.NotNull(result);
+        Assert.Contains("fallback", result!.ToString()!);
+        Assert.Contains("7", result!.ToString()!);
     }
 
     [Fact]
-    public void Content_IncludesDerivedScripts_WhenScriptsUseBaseTypeOverrides()
+    public async Task CreateResource_FallsBackToSerializerOptions_WhenNoExplicitJsoAsync()
     {
         // Arrange
-        var skill = new DerivedScriptSkill();
+        var skill = new CreateMethodsFallbackSkill();
 
-        // Act
-        var content = skill.Content;
+        // Act — read resource that uses custom types, relying on SerializerOptions fallback
+        var resource = skill.Resources!.First(r => r.Name == "config");
+        var result = await resource.ReadAsync();
 
         // Assert
-        Assert.Contains("<scripts>", content);
-        Assert.Contains("custom-script", content);
-        Assert.Contains("Custom script description.", content);
+        Assert.NotNull(result);
+        Assert.Contains("dark", result!.ToString()!);
     }
 
     [Fact]
-    public void Content_OmitsParametersSchema_WhenDerivedScriptDoesNotProvideOne()
+    public async Task CreateScript_UsesExplicitJso_OverSerializerOptionsAsync()
     {
         // Arrange
-        var skill = new DerivedScriptSkill();
+        var skill = new CreateMethodsExplicitJsoSkill();
 
-        // Act
-        var content = skill.Content;
+        // Act — invoke script that passes explicit JSO (should take precedence over SerializerOptions)
+        var script = skill.Scripts!.First(s => s.Name == "Lookup");
+        var jso = SkillTestJsonContext.Default.Options;
+        var inputJson = JsonSerializer.SerializeToElement(new LookupRequest { Query = "explicit", MaxResults = 2 }, jso);
+        var args = new AIFunctionArguments { ["request"] = inputJson };
+        var result = await script.RunAsync(skill, args, CancellationToken.None);
 
         // Assert
-        Assert.DoesNotContain("parameters_schema", content);
+        Assert.NotNull(result);
+        Assert.Contains("explicit", result!.ToString()!);
+        Assert.Contains("2", result!.ToString()!);
+    }
+
+    [Fact]
+    public async Task CreateResource_UsesExplicitJso_OverSerializerOptionsAsync()
+    {
+        // Arrange
+        var skill = new CreateMethodsExplicitJsoSkill();
+
+        // Act — read resource that passes explicit JSO (should take precedence over SerializerOptions)
+        var resource = skill.Resources!.First(r => r.Name == "config");
+        var result = await resource.ReadAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("explicit-theme", result!.ToString()!);
     }
 
     #region Test skill classes
 
-    private sealed class MinimalClassSkill : AgentClassSkill
+    private sealed class MinimalClassSkill : AgentClassSkill<MinimalClassSkill>
     {
         public override AgentSkillFrontmatter Frontmatter { get; } = new("minimal", "A minimal skill.");
 
         protected override string Instructions => "Minimal skill body.";
-
-        public override IReadOnlyList<AgentSkillResource>? Resources => null;
-
-        public override IReadOnlyList<AgentSkillScript>? Scripts => null;
     }
 
-    private sealed class FullClassSkill : AgentClassSkill
+    private sealed class FullClassSkill : AgentClassSkill<FullClassSkill>
     {
-        private IReadOnlyList<AgentSkillResource>? _resources;
-        private IReadOnlyList<AgentSkillScript>? _scripts;
-
         public override AgentSkillFrontmatter Frontmatter { get; } = new("full", "A full skill with resources and scripts.");
 
         protected override string Instructions => "Full skill body.";
 
-        public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
+        public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
             CreateResource("test-resource", "resource content"),
         ];
 
-        public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
+        public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
             CreateScript("TestScript", TestScript),
         ];
@@ -263,75 +503,32 @@ public sealed class AgentClassSkillTests
             JsonSerializer.Serialize(new { result = value * 2 });
     }
 
-    private sealed class ResourceOnlySkill : AgentClassSkill
+    private sealed class ResourceOnlySkill : AgentClassSkill<ResourceOnlySkill>
     {
-        private IReadOnlyList<AgentSkillResource>? _resources;
-
         public override AgentSkillFrontmatter Frontmatter { get; } = new("resource-only", "Skill with resources only.");
 
         protected override string Instructions => "Body.";
 
-        public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
+        public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
             CreateResource("data", "some data"),
         ];
-
-        public override IReadOnlyList<AgentSkillScript>? Scripts => null;
     }
 
-    private sealed class ScriptOnlySkill : AgentClassSkill
+    private sealed class ScriptOnlySkill : AgentClassSkill<ScriptOnlySkill>
     {
-        private IReadOnlyList<AgentSkillScript>? _scripts;
-
         public override AgentSkillFrontmatter Frontmatter { get; } = new("script-only", "Skill with scripts only.");
 
         protected override string Instructions => "Body.";
 
-        public override IReadOnlyList<AgentSkillResource>? Resources => null;
-
-        public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
+        public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
             CreateScript("ToUpper", (string input) => input.ToUpperInvariant()),
         ];
     }
 
-    private sealed class DerivedResourceSkill : AgentClassSkill
+    private sealed class LazyLoadedSkill : AgentClassSkill<LazyLoadedSkill>
     {
-        private IReadOnlyList<AgentSkillResource>? _resources;
-
-        public override AgentSkillFrontmatter Frontmatter { get; } = new("derived-resource", "Skill with a derived resource type.");
-
-        protected override string Instructions => "Body.";
-
-        public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??=
-        [
-            new CustomResource("custom-resource", "Custom resource description."),
-        ];
-
-        public override IReadOnlyList<AgentSkillScript>? Scripts => null;
-    }
-
-    private sealed class DerivedScriptSkill : AgentClassSkill
-    {
-        private IReadOnlyList<AgentSkillScript>? _scripts;
-
-        public override AgentSkillFrontmatter Frontmatter { get; } = new("derived-script", "Skill with a derived script type.");
-
-        protected override string Instructions => "Body.";
-
-        public override IReadOnlyList<AgentSkillResource>? Resources => null;
-
-        public override IReadOnlyList<AgentSkillScript>? Scripts => this._scripts ??=
-        [
-            new CustomScript("custom-script", "Custom script description."),
-        ];
-    }
-
-    private sealed class LazyLoadedSkill : AgentClassSkill
-    {
-        private IReadOnlyList<AgentSkillResource>? _resources;
-        private IReadOnlyList<AgentSkillScript>? _scripts;
-
         public override AgentSkillFrontmatter Frontmatter { get; } = new("lazy-loaded", "Skill with lazily created resources and scripts.");
 
         protected override string Instructions => "Body.";
@@ -339,6 +536,9 @@ public sealed class AgentClassSkillTests
         public int ResourceCreationCount { get; private set; }
 
         public int ScriptCreationCount { get; private set; }
+
+        private IReadOnlyList<AgentSkillResource>? _resources;
+        private IReadOnlyList<AgentSkillScript>? _scripts;
 
         public override IReadOnlyList<AgentSkillResource>? Resources => this._resources ??= this.CreateResources();
 
@@ -357,65 +557,7 @@ public sealed class AgentClassSkillTests
         }
     }
 
-    private sealed class CustomResource : AgentSkillResource
-    {
-        public CustomResource(string name, string? description = null)
-            : base(name, description)
-        {
-        }
-
-        public override Task<object?> ReadAsync(IServiceProvider? serviceProvider = null, CancellationToken cancellationToken = default)
-            => Task.FromResult<object?>("resource-value");
-    }
-
-    private sealed class CustomScript : AgentSkillScript
-    {
-        public CustomScript(string name, string? description = null)
-            : base(name, description)
-        {
-        }
-
-        public override Task<object?> RunAsync(AgentSkill skill, AIFunctionArguments arguments, CancellationToken cancellationToken = default)
-            => Task.FromResult<object?>("script-result");
-    }
-
-    #endregion
-
-    [Fact]
-    public async Task CreateScript_WithSerializerOptions_DeserializesCustomInputTypeAsync()
-    {
-        // Arrange
-        var skill = new CustomTypeSkill();
-        var jso = SkillTestJsonContext.Default.Options;
-
-        // Act — pass a custom type as JSON; the JSO enables deserialization
-        var script = skill.Scripts![0];
-        var inputJson = JsonSerializer.SerializeToElement(new LookupRequest { Query = "test", MaxResults = 5 }, jso);
-        var args = new AIFunctionArguments { ["request"] = inputJson };
-        var result = await script.RunAsync(skill, args, CancellationToken.None);
-
-        // Assert — the custom input type was deserialized and the response was produced
-        Assert.NotNull(result);
-        var resultText = result!.ToString()!;
-        Assert.Contains("result for test", resultText);
-        Assert.Contains("5", resultText);
-    }
-
-    [Fact]
-    public async Task CreateResource_WithSerializerOptions_SerializesReturnsCustomTypeAsync()
-    {
-        // Arrange
-        var skill = new CustomTypeSkill();
-
-        // Act
-        var result = await skill.Resources![0].ReadAsync();
-
-        // Assert — the custom type was returned successfully
-        Assert.NotNull(result);
-        Assert.Contains("dark", result!.ToString()!);
-    }
-
-    private sealed class CustomTypeSkill : AgentClassSkill
+    private sealed class CustomTypeSkill : AgentClassSkill<CustomTypeSkill>
     {
         public override AgentSkillFrontmatter Frontmatter { get; } = new("custom-type-skill", "Skill with custom-typed scripts and resources.");
 
@@ -439,4 +581,215 @@ public sealed class AgentClassSkillTests
             }, serializerOptions: SkillTestJsonContext.Default.Options),
         ];
     }
+
+#pragma warning disable IDE0051 // Remove unused private members
+    private sealed class AttributedScriptsSkill : AgentClassSkill<AttributedScriptsSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-scripts", "Skill with various attributed scripts.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillScript("do-work")]
+        private static string DoWork(string input) => input.ToUpperInvariant();
+
+        [AgentSkillScript]
+        private static string DefaultNamed(string input) => input.ToUpperInvariant();
+
+        [AgentSkillScript("process")]
+        [Description("Processes the input.")]
+        private static string Process(string input) => input;
+
+        [AgentSkillScript("append")]
+        private string Append(string input) => input + "-suffix";
+    }
+
+    private sealed class AttributedResourcePropertiesSkill : AgentClassSkill<AttributedResourcePropertiesSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-resource-props", "Skill with various attributed resource properties.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("ref-data")]
+        public string ReferenceData => "Reference content.";
+
+        [AgentSkillResource]
+        public string DefaultNamed => "Some data.";
+
+        [AgentSkillResource("data")]
+        [Description("Some important data.")]
+        public string DescribedData => "content";
+
+        [AgentSkillResource("static-data")]
+        public static string StaticData => "Static content.";
+    }
+
+    private sealed class AttributedResourceMethodsSkill : AgentClassSkill<AttributedResourceMethodsSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-resource-methods", "Skill with various attributed resource methods.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("dynamic")]
+        private static string GetDynamic() => "dynamic-value";
+
+        [AgentSkillResource]
+        private static string GetData() => "data";
+
+        [AgentSkillResource("info")]
+        [Description("Returns runtime info.")]
+        private static string GetInfo() => "runtime-info";
+
+        [AgentSkillResource("instance-dynamic")]
+        private string GetValue() => "instance-method-value";
+    }
+
+    private sealed class AttributedFullSkill : AgentClassSkill<AttributedFullSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-full", "Full skill with attributed resources and scripts.");
+
+        protected override string Instructions => "Convert units using the table.";
+
+        [AgentSkillResource("conversion-table")]
+        public string ConversionTable => "miles -> km: 1.60934";
+
+        [AgentSkillScript("convert")]
+        private static string Convert(double value, double factor) =>
+            JsonSerializer.Serialize(new { result = value * factor });
+    }
+
+    private sealed class NoAttributesNoOverridesSkill : AgentClassSkill<NoAttributesNoOverridesSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("no-attrs", "Skill with no attributes or overrides.");
+
+        protected override string Instructions => "Body.";
+    }
+
+    private sealed class AttributedWithOverrideSkill : AgentClassSkill<AttributedWithOverrideSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-override", "Skill with attributes and overrides.");
+
+        protected override string Instructions => "Body.";
+
+        // These attributes should be ignored because Resources/Scripts are overridden.
+        [AgentSkillResource("ignored-resource")]
+        public string IgnoredData => "ignored";
+
+        [AgentSkillScript("ignored-script")]
+        private static string IgnoredScript() => "ignored";
+
+        public override IReadOnlyList<AgentSkillResource>? Resources =>
+        [
+            CreateResource("manual-resource", "manual content"),
+        ];
+
+        public override IReadOnlyList<AgentSkillScript>? Scripts =>
+        [
+            CreateScript("ManualScript", () => "manual result"),
+        ];
+    }
+
+    private sealed class AttributedResourceDynamicPropertySkill : AgentClassSkill<AttributedResourceDynamicPropertySkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-resource-dynamic-prop", "Skill with dynamic property resource.");
+
+        protected override string Instructions => "Body.";
+
+        public int CallCount { get; private set; }
+
+        [AgentSkillResource("counter")]
+        public string Counter => $"call-{++this.CallCount}";
+    }
+
+    private sealed class AttributedSkillWithCustomSerializer : AgentClassSkill<AttributedSkillWithCustomSerializer>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("attributed-custom-jso", "Skill with custom serializer options.");
+
+        protected override string Instructions => "Body.";
+
+        protected override JsonSerializerOptions? SerializerOptions => SkillTestJsonContext.Default.Options;
+
+        [AgentSkillResource("config")]
+        public SkillConfig Config => new() { Theme = "light", Verbose = false };
+
+        [AgentSkillScript("lookup")]
+        private static LookupResponse Lookup(LookupRequest request) => new()
+        {
+            Items = [$"result for {request.Query}"],
+            TotalCount = request.MaxResults,
+        };
+    }
+
+    private sealed class MixedStaticInstanceSkill : AgentClassSkill<MixedStaticInstanceSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("mixed-static-instance", "Skill with both static and instance members.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("static-resource")]
+        public static string StaticResource => "static-value";
+
+        [AgentSkillResource("instance-resource")]
+        public string InstanceResource => "instance-data";
+
+        [AgentSkillScript("static-script")]
+        private static string StaticScript() => "static-result";
+
+        [AgentSkillScript("instance-script")]
+        private string InstanceScript() => "instance-data";
+    }
+
+    private sealed class CreateMethodsFallbackSkill : AgentClassSkill<CreateMethodsFallbackSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("create-fallback", "Skill testing SerializerOptions fallback for CreateScript/CreateResource.");
+
+        protected override string Instructions => "Body.";
+
+        protected override JsonSerializerOptions? SerializerOptions => SkillTestJsonContext.Default.Options;
+
+        public override IReadOnlyList<AgentSkillResource>? Resources =>
+        [
+            CreateResource("config", () => new SkillConfig
+            {
+                Theme = "dark",
+                Verbose = true,
+            }),
+        ];
+
+        public override IReadOnlyList<AgentSkillScript>? Scripts =>
+        [
+            CreateScript("Lookup", (LookupRequest request) => new LookupResponse
+            {
+                Items = [$"result for {request.Query}"],
+                TotalCount = request.MaxResults,
+            }),
+        ];
+    }
+
+    private sealed class CreateMethodsExplicitJsoSkill : AgentClassSkill<CreateMethodsExplicitJsoSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("create-explicit-jso", "Skill testing explicit JSO overrides SerializerOptions.");
+
+        protected override string Instructions => "Body.";
+
+        // SerializerOptions is intentionally null — explicit JSO passed to CreateScript/CreateResource should be used.
+        public override IReadOnlyList<AgentSkillResource>? Resources =>
+        [
+            CreateResource("config", () => new SkillConfig
+            {
+                Theme = "explicit-theme",
+                Verbose = false,
+            }, serializerOptions: SkillTestJsonContext.Default.Options),
+        ];
+
+        public override IReadOnlyList<AgentSkillScript>? Scripts =>
+        [
+            CreateScript("Lookup", (LookupRequest request) => new LookupResponse
+            {
+                Items = [$"result for {request.Query}"],
+                TotalCount = request.MaxResults,
+            }, serializerOptions: SkillTestJsonContext.Default.Options),
+        ];
+    }
+
+    #endregion
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -491,12 +491,12 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("test-resource", "resource content"),
+            this.CreateResource("test-resource", "resource content"),
         ];
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("TestScript", TestScript),
+            this.CreateScript("TestScript", TestScript),
         ];
 
         private static string TestScript(double value) =>
@@ -511,7 +511,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("data", "some data"),
+            this.CreateResource("data", "some data"),
         ];
     }
 
@@ -523,7 +523,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("ToUpper", (string input) => input.ToUpperInvariant()),
+            this.CreateScript("ToUpper", (string input) => input.ToUpperInvariant()),
         ];
     }
 
@@ -547,13 +547,13 @@ public sealed class AgentClassSkillTests
         private IReadOnlyList<AgentSkillResource> CreateResources()
         {
             this.ResourceCreationCount++;
-            return [CreateResource("lazy-resource", "resource content")];
+            return [this.CreateResource("lazy-resource", "resource content")];
         }
 
         private IReadOnlyList<AgentSkillScript> CreateScripts()
         {
             this.ScriptCreationCount++;
-            return [CreateScript("LazyScript", () => "done")];
+            return [this.CreateScript("LazyScript", () => "done")];
         }
     }
 
@@ -565,7 +565,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("config", () => new SkillConfig
+            this.CreateResource("config", () => new SkillConfig
             {
                 Theme = "dark",
                 Verbose = true
@@ -574,7 +574,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("Lookup", (LookupRequest request) => new LookupResponse
+            this.CreateScript("Lookup", (LookupRequest request) => new LookupResponse
             {
                 Items = [$"result for {request.Query}"],
                 TotalCount = request.MaxResults,
@@ -679,12 +679,12 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("manual-resource", "manual content"),
+            this.CreateResource("manual-resource", "manual content"),
         ];
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("ManualScript", () => "manual result"),
+            this.CreateScript("ManualScript", () => "manual result"),
         ];
     }
 
@@ -748,7 +748,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("config", () => new SkillConfig
+            this.CreateResource("config", () => new SkillConfig
             {
                 Theme = "dark",
                 Verbose = true,
@@ -757,7 +757,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("Lookup", (LookupRequest request) => new LookupResponse
+            this.CreateScript("Lookup", (LookupRequest request) => new LookupResponse
             {
                 Items = [$"result for {request.Query}"],
                 TotalCount = request.MaxResults,
@@ -774,7 +774,7 @@ public sealed class AgentClassSkillTests
         // SerializerOptions is intentionally null — explicit JSO passed to CreateScript/CreateResource should be used.
         public override IReadOnlyList<AgentSkillResource>? Resources =>
         [
-            CreateResource("config", () => new SkillConfig
+            this.CreateResource("config", () => new SkillConfig
             {
                 Theme = "explicit-theme",
                 Verbose = false,
@@ -783,7 +783,7 @@ public sealed class AgentClassSkillTests
 
         public override IReadOnlyList<AgentSkillScript>? Scripts =>
         [
-            CreateScript("Lookup", (LookupRequest request) => new LookupResponse
+            this.CreateScript("Lookup", (LookupRequest request) => new LookupResponse
             {
                 Items = [$"result for {request.Query}"],
                 TotalCount = request.MaxResults,

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -555,6 +555,54 @@ public sealed class AgentClassSkillTests
         Assert.Contains("explicit-theme", result!.ToString()!);
     }
 
+    [Fact]
+    public void DuplicateResourceNames_FromProperties_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new DuplicateResourcePropertiesSkill();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = skill.Resources);
+        Assert.Contains("data", ex.Message);
+        Assert.Contains("already has a resource", ex.Message);
+    }
+
+    [Fact]
+    public void DuplicateResourceNames_FromPropertyAndMethod_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new DuplicateResourcePropertyAndMethodSkill();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = skill.Resources);
+        Assert.Contains("data", ex.Message);
+        Assert.Contains("already has a resource", ex.Message);
+    }
+
+    [Fact]
+    public void DuplicateResourceNames_FromMethods_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new DuplicateResourceMethodsSkill();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = skill.Resources);
+        Assert.Contains("data", ex.Message);
+        Assert.Contains("already has a resource", ex.Message);
+    }
+
+    [Fact]
+    public void DuplicateScriptNames_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var skill = new DuplicateScriptsSkill();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = skill.Scripts);
+        Assert.Contains("do-work", ex.Message);
+        Assert.Contains("already has a script", ex.Message);
+    }
+
     #region Test skill classes
 
     private sealed class MinimalClassSkill : AgentClassSkill<MinimalClassSkill>
@@ -923,6 +971,58 @@ public sealed class AgentClassSkillTests
         [AgentSkillResource("both-resource")]
         private static string GetData(IServiceProvider? sp, CancellationToken ct) => "from-both-method";
     }
+    private sealed class DuplicateResourcePropertiesSkill : AgentClassSkill<DuplicateResourcePropertiesSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("dup-res-props", "Skill with duplicate resource property names.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("data")]
+        public string Data1 => "value1";
+
+        [AgentSkillResource("data")]
+        public string Data2 => "value2";
+    }
+
+    private sealed class DuplicateResourcePropertyAndMethodSkill : AgentClassSkill<DuplicateResourcePropertyAndMethodSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("dup-res-prop-method", "Skill with duplicate resource from property and method.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("data")]
+        public string Data => "property-value";
+
+        [AgentSkillResource("data")]
+        private static string GetData() => "method-value";
+    }
+
+    private sealed class DuplicateResourceMethodsSkill : AgentClassSkill<DuplicateResourceMethodsSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("dup-res-methods", "Skill with duplicate resource method names.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillResource("data")]
+        private static string GetData1() => "value1";
+
+        [AgentSkillResource("data")]
+        private static string GetData2() => "value2";
+    }
+
+    private sealed class DuplicateScriptsSkill : AgentClassSkill<DuplicateScriptsSkill>
+    {
+        public override AgentSkillFrontmatter Frontmatter { get; } = new("dup-scripts", "Skill with duplicate script names.");
+
+        protected override string Instructions => "Body.";
+
+        [AgentSkillScript("do-work")]
+        private static string DoWork1(string input) => input.ToUpperInvariant();
+
+        [AgentSkillScript("do-work")]
+        private static string DoWork2(string input) => input + "-suffix";
+    }
+#pragma warning restore IDE0051 // Remove unused private members
 
     #endregion
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillResourceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillResourceTests.cs
@@ -216,7 +216,7 @@ public sealed class AgentInlineSkillResourceTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new AgentInlineSkillResource("my-res", (MethodInfo)null!, target: null));
+            new AgentInlineSkillResource("my-res", null!, target: null));
     }
 
     private static string StaticResourceHelper() => "static-resource-value";

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillResourceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillResourceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -167,4 +168,58 @@ public sealed class AgentInlineSkillResourceTests
         // Assert
         Assert.Equal("value", result);
     }
+
+    [Fact]
+    public void Constructor_MethodInfo_SetsNameAndDescription()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillResourceTests).GetMethod(nameof(StaticResourceHelper), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        // Act
+        var resource = new AgentInlineSkillResource("method-resource", method, target: null, description: "A method resource.");
+
+        // Assert
+        Assert.Equal("method-resource", resource.Name);
+        Assert.Equal("A method resource.", resource.Description);
+    }
+
+    [Fact]
+    public async Task ReadAsync_MethodInfo_StaticMethod_ReturnsValueAsync()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillResourceTests).GetMethod(nameof(StaticResourceHelper), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var resource = new AgentInlineSkillResource("static-method-res", method, target: null);
+
+        // Act
+        var result = await resource.ReadAsync();
+
+        // Assert
+        Assert.Equal("static-resource-value", result?.ToString());
+    }
+
+    [Fact]
+    public async Task ReadAsync_MethodInfo_InstanceMethod_ReturnsValueAsync()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillResourceTests).GetMethod(nameof(InstanceResourceHelper), BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var resource = new AgentInlineSkillResource("instance-method-res", method, target: this);
+
+        // Act
+        var result = await resource.ReadAsync();
+
+        // Assert
+        Assert.Equal("instance-resource-value", result?.ToString());
+    }
+
+    [Fact]
+    public void Constructor_MethodInfo_NullMethod_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new AgentInlineSkillResource("my-res", (MethodInfo)null!, target: null));
+    }
+
+    private static string StaticResourceHelper() => "static-resource-value";
+
+    private string InstanceResourceHelper() => "instance-resource-value";
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -152,4 +153,77 @@ public sealed class AgentInlineSkillScriptTests
         // Assert
         Assert.Equal("hello world", result?.ToString());
     }
+
+    [Fact]
+    public void Constructor_MethodInfo_SetsNameAndDescription()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillScriptTests).GetMethod(nameof(StaticScriptHelper), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        // Act
+        var script = new AgentInlineSkillScript("method-script", method, target: null, description: "A method script.");
+
+        // Assert
+        Assert.Equal("method-script", script.Name);
+        Assert.Equal("A method script.", script.Description);
+    }
+
+    [Fact]
+    public async Task RunAsync_MethodInfo_StaticMethod_InvokesAndReturnsAsync()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillScriptTests).GetMethod(nameof(StaticScriptHelper), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var script = new AgentInlineSkillScript("static-method-script", method, target: null);
+        var skill = new AgentInlineSkill("test-skill", "Test.", "Instructions.");
+        var args = new AIFunctionArguments { ["input"] = "hello" };
+
+        // Act
+        var result = await script.RunAsync(skill, args, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("HELLO", result?.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_MethodInfo_InstanceMethod_InvokesAndReturnsAsync()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillScriptTests).GetMethod(nameof(InstanceScriptHelper), BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var script = new AgentInlineSkillScript("instance-method-script", method, target: this);
+        var skill = new AgentInlineSkill("test-skill", "Test.", "Instructions.");
+        var args = new AIFunctionArguments { ["input"] = "test" };
+
+        // Act
+        var result = await script.RunAsync(skill, args, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("test-suffix", result?.ToString());
+    }
+
+    [Fact]
+    public void Constructor_MethodInfo_NullMethod_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new AgentInlineSkillScript("my-script", null!, target: null));
+    }
+
+    [Fact]
+    public void ParametersSchema_MethodInfo_ContainsParameterNames()
+    {
+        // Arrange
+        var method = typeof(AgentInlineSkillScriptTests).GetMethod(nameof(StaticScriptHelper), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var script = new AgentInlineSkillScript("param-script", method, target: null);
+
+        // Act
+        var schema = script.ParametersSchema;
+
+        // Assert
+        Assert.NotNull(schema);
+        Assert.Contains("input", schema!.Value.GetRawText());
+    }
+
+    private static string StaticScriptHelper(string input) => input.ToUpperInvariant();
+
+    private string InstanceScriptHelper(string input) => input + "-suffix";
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillResourceAttributeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillResourceAttributeTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
+
+/// <summary>
+/// Unit tests for <see cref="AgentSkillResourceAttribute"/>.
+/// </summary>
+public sealed class AgentSkillResourceAttributeTests
+{
+    [Fact]
+    public void DefaultConstructor_NameIsNull()
+    {
+        // Arrange & Act
+        var attr = new AgentSkillResourceAttribute();
+
+        // Assert
+        Assert.Null(attr.Name);
+    }
+
+    [Fact]
+    public void NamedConstructor_SetsName()
+    {
+        // Arrange & Act
+        var attr = new AgentSkillResourceAttribute("my-resource");
+
+        // Assert
+        Assert.Equal("my-resource", attr.Name);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillScriptAttributeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillScriptAttributeTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
+
+/// <summary>
+/// Unit tests for <see cref="AgentSkillScriptAttribute"/>.
+/// </summary>
+public sealed class AgentSkillScriptAttributeTests
+{
+    [Fact]
+    public void DefaultConstructor_NameIsNull()
+    {
+        // Arrange & Act
+        var attr = new AgentSkillScriptAttribute();
+
+        // Assert
+        Assert.Null(attr.Name);
+    }
+
+    [Fact]
+    public void NamedConstructor_SetsName()
+    {
+        // Arrange & Act
+        var attr = new AgentSkillScriptAttribute("my-script");
+
+        // Assert
+        Assert.Equal("my-script", attr.Name);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -871,7 +871,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
     public async Task Constructor_ClassSkillsEnumerable_ProvidesSkillsAsync()
     {
         // Arrange
-        var skills = new List<AgentClassSkill>
+        var skills = new List<AgentSkill>
         {
             new TestClassSkill("enum-class-a", "Class A", "Instructions A."),
             new TestClassSkill("enum-class-b", "Class B", "Instructions B."),
@@ -928,7 +928,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
         }
     }
 
-    private sealed class TestClassSkill : AgentClassSkill
+    private sealed class TestClassSkill : AgentClassSkill<TestClassSkill>
     {
         private readonly string _instructions;
 


### PR DESCRIPTION
This PR adds support for using reflection to discover resources and scripts in class-based skills, enabling a more declarative approach via attributes.

## Changes

- Add `AgentSkillResourceAttribute` and `AgentSkillScriptAttribute` for declarative resource/script discovery
- Enhance `AgentClassSkill` to discover resources and scripts via reflection
- Update samples to demonstrate the new attribute-based approach