### PR TITLE
VerifySamples: Filter projects to net10 only

### DIFF
--- a/.github/workflows/dotnet-verify-samples.yml
+++ b/.github/workflows/dotnet-verify-samples.yml
@@ -63,10 +63,19 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Generate filtered solution
+        shell: pwsh
+        run: |
+          ./dotnet/eng/scripts/New-FilteredSolution.ps1 `
+            -Solution dotnet/agent-framework-dotnet.slnx `
+            -TargetFramework net10.0 `
+            -Configuration Debug `
+            -OutputPath dotnet/filtered.slnx `
+            -Verbose
+
       - name: Build solution
-        working-directory: dotnet
         shell: bash
-        run: dotnet build agent-framework-dotnet.slnx -f net10.0 --warnaserror
+        run: dotnet build dotnet/filtered.slnx -f net10.0 --warnaserror
 
       - name: Run verify-samples
         id: verify


### PR DESCRIPTION
### Motivation and Context

- Verify samples is running on linux, so excluding .net framework projects from build and only building .net core.

### Description

- Filter projects to net10 only

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.