### PR TITLE
Python: remove function_invocation_configuration from BaseChatClient.as_agent

### DIFF
--- a/python/packages/core/agent_framework/_clients.py
+++ b/python/packages/core/agent_framework/_clients.py
@@ -30,10 +30,7 @@ from pydantic import BaseModel
 from ._docstrings import apply_layered_docstring
 from ._serialization import SerializationMixin
 from ._tools import (
-    FunctionInvocationConfiguration,
-    FunctionInvocationLayer,
     ToolTypes,
-    normalize_function_invocation_configuration,
 )
 from ._types import (
     ChatResponse,
@@ -575,7 +572,6 @@ class BaseChatClient(SerializationMixin, ABC, Generic[OptionsCoT]):
         context_providers: Sequence[Any] | None = None,
         middleware: Sequence[MiddlewareTypes] | None = None,
         require_per_service_call_history_persistence: bool = False,
-        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         additional_properties: Mapping[str, Any] | None = None,
@@ -603,7 +599,6 @@ class BaseChatClient(SerializationMixin, ABC, Generic[OptionsCoT]):
                 chat history persistence. When enabled, history providers are invoked around
                 each model call instead of once per ``run()`` when the service is not already
                 storing history.
-            function_invocation_configuration: Optional function invocation configuration override.
             compaction_strategy: Optional agent-level compaction override. When omitted,
                 client-level compaction defaults remain in effect for each call.
             tokenizer: Optional agent-level tokenizer override. When omitted,
@@ -648,16 +643,6 @@ class BaseChatClient(SerializationMixin, ABC, Generic[OptionsCoT]):
             "tokenizer": tokenizer,
             "additional_properties": dict(additional_properties) if additional_properties is not None else None,
         }
-        if function_invocation_configuration is not None:
-            if isinstance(self, FunctionInvocationLayer):
-                self.function_invocation_configuration = normalize_function_invocation_configuration(
-                    function_invocation_configuration
-                )
-            else:
-                logger.warning(
-                    "function_invocation_configuration was provided, but the chat client does not support "
-                    "function invoking."
-                )
 
         return Agent(**agent_kwargs)
 

--- a/python/packages/core/agent_framework/_clients.py
+++ b/python/packages/core/agent_framework/_clients.py
@@ -31,7 +31,9 @@ from ._docstrings import apply_layered_docstring
 from ._serialization import SerializationMixin
 from ._tools import (
     FunctionInvocationConfiguration,
+    FunctionInvocationLayer,
     ToolTypes,
+    normalize_function_invocation_configuration,
 )
 from ._types import (
     ChatResponse,
@@ -647,7 +649,15 @@ class BaseChatClient(SerializationMixin, ABC, Generic[OptionsCoT]):
             "additional_properties": dict(additional_properties) if additional_properties is not None else None,
         }
         if function_invocation_configuration is not None:
-            agent_kwargs["function_invocation_configuration"] = function_invocation_configuration
+            if isinstance(self, FunctionInvocationLayer):
+                self.function_invocation_configuration = normalize_function_invocation_configuration(
+                    function_invocation_configuration
+                )
+            else:
+                logger.warning(
+                    "function_invocation_configuration was provided, but the chat client does not support "
+                    "function invoking."
+                )
 
         return Agent(**agent_kwargs)
 

--- a/python/packages/core/tests/core/test_clients.py
+++ b/python/packages/core/tests/core/test_clients.py
@@ -15,7 +15,6 @@ from agent_framework import (
     SlidingWindowStrategy,
     SupportsChatGetResponse,
     TruncationStrategy,
-    normalize_function_invocation_configuration,
 )
 
 
@@ -59,16 +58,15 @@ def test_base_client_as_agent_uses_explicit_additional_properties(chat_client_ba
     assert agent.additional_properties == {"team": "core"}
 
 
-def test_base_client_as_agent_applies_function_invocation_configuration_to_client(
+def test_base_client_as_agent_rejects_function_invocation_configuration(
     chat_client_base: SupportsChatGetResponse,
 ) -> None:
-    config = normalize_function_invocation_configuration({"max_iterations": 1, "include_detailed_errors": True})
+    bad_kwargs: dict[str, Any] = {
+        "function_invocation_configuration": {"max_iterations": 1, "include_detailed_errors": True}
+    }
 
-    agent = chat_client_base.as_agent(function_invocation_configuration=config)
-
-    assert agent.client is chat_client_base
-    assert chat_client_base.function_invocation_configuration["max_iterations"] == 1  # type: ignore[attr-defined]
-    assert chat_client_base.function_invocation_configuration["include_detailed_errors"] is True  # type: ignore[attr-defined]
+    with pytest.raises(TypeError, match="function_invocation_configuration"):
+        chat_client_base.as_agent(**bad_kwargs)
 
 
 async def test_base_client_get_response_uses_explicit_client_kwargs(chat_client_base: SupportsChatGetResponse) -> None:

--- a/python/packages/core/tests/core/test_clients.py
+++ b/python/packages/core/tests/core/test_clients.py
@@ -15,6 +15,7 @@ from agent_framework import (
     SlidingWindowStrategy,
     SupportsChatGetResponse,
     TruncationStrategy,
+    normalize_function_invocation_configuration,
 )
 
 
@@ -56,6 +57,18 @@ def test_base_client_as_agent_uses_explicit_additional_properties(chat_client_ba
     agent = chat_client_base.as_agent(additional_properties={"team": "core"})
 
     assert agent.additional_properties == {"team": "core"}
+
+
+def test_base_client_as_agent_applies_function_invocation_configuration_to_client(
+    chat_client_base: SupportsChatGetResponse,
+) -> None:
+    config = normalize_function_invocation_configuration({"max_iterations": 1, "include_detailed_errors": True})
+
+    agent = chat_client_base.as_agent(function_invocation_configuration=config)
+
+    assert agent.client is chat_client_base
+    assert chat_client_base.function_invocation_configuration["max_iterations"] == 1  # type: ignore[attr-defined]
+    assert chat_client_base.function_invocation_configuration["include_detailed_errors"] is True  # type: ignore[attr-defined]
 
 
 async def test_base_client_get_response_uses_explicit_client_kwargs(chat_client_base: SupportsChatGetResponse) -> None:


### PR DESCRIPTION
### Motivation and Context

Fixes #5180.

`BaseChatClient.as_agent()` currently accepts `function_invocation_configuration` but forwards it into `Agent(**agent_kwargs)`, where `Agent.__init__()` does not accept that keyword. In practice this raises a `TypeError` instead of applying the configuration to function-invoking clients.

### Description

This change keeps the override on the client side, which is where `FunctionInvocationLayer` consumes it:

- stop passing `function_invocation_configuration` into `Agent()`
- when the client supports `FunctionInvocationLayer`, normalize and apply the override directly to `self.function_invocation_configuration`
- add a regression test covering `as_agent(function_invocation_configuration=...)` so the issue stays fixed

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.