### PR TITLE
.NET: Disable flaky timing-dependent integration tests

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
@@ -30,7 +30,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         setEnvVar("REDIS_CONNECTION_STRING", $"localhost:{RedisPort}");
     }
 
-    [Fact]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task SingleAgentSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -69,7 +69,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [Fact]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task SingleAgentOrchestrationChainingSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -105,7 +105,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [Fact]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task MultiAgentConcurrencySampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -160,7 +160,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [Fact]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task MultiAgentConditionalSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/WorkflowConsoleAppSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/WorkflowConsoleAppSamplesValidation.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 [Trait("Category", "SampleValidation")]
 public sealed class WorkflowConsoleAppSamplesValidation(ITestOutputHelper outputHelper) : SamplesValidationBase(outputHelper)
 {
+    private const string SkipFlakyTimingTest = "Flaky: timing-dependent LLM test, see https://github.com/microsoft/agent-framework/issues/4971";
+
     // In CI, `dotnet run` builds samples from scratch and LLM calls add latency, so 60s is not enough.
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromSeconds(180);
 
@@ -505,7 +507,7 @@ public sealed class WorkflowConsoleAppSamplesValidation(ITestOutputHelper output
         });
     }
 
-    [Fact]
+    [Fact(Skip = SkipFlakyTimingTest)]
     public async Task WorkflowAndAgentsSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts(s_testTimeout);


### PR DESCRIPTION
## Summary

Skip 5 flaky integration tests in DurableTask that fail with `TaskCanceledException` due to timing-dependent LLM calls in CI (see [run #24241294922](https://github.com/microsoft/agent-framework/actions/runs/24241294922/job/70776516507)).

Uses the existing `SkipFlakyTimingTest` pattern referencing #4971.

### Tests disabled

**DurableTask ConsoleAppSamplesValidation** (4 tests):
- `SingleAgentSampleValidationAsync`
- `SingleAgentOrchestrationChainingSampleValidationAsync`
- `MultiAgentConcurrencySampleValidationAsync`
- `MultiAgentConditionalSampleValidationAsync`

**DurableTask WorkflowConsoleAppSamplesValidation** (1 test):
- `WorkflowAndAgentsSampleValidationAsync`
