### PR TITLE
Python: fix: use workflow factory to avoid RuntimeError under parallel requests

### DIFF
--- a/python/samples/05-end-to-end/hosted_agents/writer_reviewer_agents_in_workflow/main.py
+++ b/python/samples/05-end-to-end/hosted_agents/writer_reviewer_agents_in_workflow/main.py
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+
+from agent_framework import Agent, WorkflowBuilder
+from agent_framework.foundry import FoundryChatClient
+from azure.ai.agentserver.agentframework import from_agent_framework
+from azure.identity.aio import AzureCliCredential, ManagedIdentityCredential
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+# Configure these for your Foundry project
+# Read the explicit variables present in the .env file
+FOUNDRY_PROJECT_ENDPOINT = os.getenv(
+    "FOUNDRY_PROJECT_ENDPOINT"
+)  # e.g., "https://<project>.services.ai.azure.com/api/projects/<project-name>"
+FOUNDRY_MODEL = os.getenv("FOUNDRY_MODEL", "gpt-4.1-mini")  # Your model deployment name e.g., "gpt-4.1-mini"
+
+
+def get_credential():
+    """Will use Managed Identity when running in Azure, otherwise falls back to Azure CLI Credential."""
+    return ManagedIdentityCredential() if os.getenv("MSI_ENDPOINT") else AzureCliCredential()
+
+
+@asynccontextmanager
+async def create_agents():
+    async with get_credential() as credential:
+        client = FoundryChatClient(
+            project_endpoint=FOUNDRY_PROJECT_ENDPOINT,
+            model=FOUNDRY_MODEL,
+            credential=credential,
+        )
+        writer = Agent(
+            client=client,
+            name="Writer",
+            instructions="You are an excellent content writer. You create new content and edit contents based on the feedback.",
+        )
+        reviewer = Agent(
+            client=client,
+            name="Reviewer",
+            instructions="You are an excellent content reviewer. Provide actionable feedback to the writer about the provided content in the most concise manner possible.",
+        )
+        yield writer, reviewer
+
+
+def create_workflow(writer, reviewer):
+    workflow = WorkflowBuilder(start_executor=writer).add_edge(writer, reviewer).build()
+    return Agent(
+        client=workflow,
+    )
+
+
+async def main() -> None:
+    """
+    The writer and reviewer multi-agent workflow.
+
+    Environment variables required:
+    - FOUNDRY_PROJECT_ENDPOINT: Your Microsoft Foundry project endpoint
+    - FOUNDRY_MODEL: Your Microsoft Foundry model deployment name
+    """
+
+    async with create_agents() as (writer, reviewer):
+        # Use a factory lambda so each incoming request gets a fresh Workflow
+        # instance, avoiding RuntimeError from concurrent executions (#4766).
+        await from_agent_framework(lambda: create_workflow(writer, reviewer)).run_async()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Fixes #4766 — Supersedes #4772 (rebased onto current `main`).

The hosted agent sample at `writer_reviewer_agents_in_workflow/main.py` passes a pre-built workflow agent to `from_agent_framework()`. When the endpoint receives parallel requests, the shared `Workflow` instance attempts to run concurrently, raising:

```
RuntimeError: Workflow is already running. Concurrent executions are not allowed.
```

## Fix

```diff
     async with create_agents() as (writer, reviewer):
-        agent = create_workflow(writer, reviewer)
-        await from_agent_framework(agent).run_async()
+        # Use a factory lambda so each incoming request gets a fresh Workflow
+        # instance, avoiding RuntimeError from concurrent executions (#4766).
+        await from_agent_framework(lambda: create_workflow(writer, reviewer)).run_async()
```

`from_agent_framework()` accepts either a pre-built agent or a **factory callable**. When given a factory, it creates a fresh agent per request, avoiding shared state.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] **Is this a breaking change?** No