### PR TITLE
Python: Fix HandoffBuilder dropping function-level middleware when cloning agents

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -287,7 +287,7 @@ class HandoffAgentExecutor(AgentExecutor):
             name=agent.name,
             description=agent.description,
             context_providers=agent.context_providers,
-            middleware=agent.agent_middleware,
+            middleware=agent.middleware,
             require_per_service_call_history_persistence=agent.require_per_service_call_history_persistence,
             default_options=cloned_options,  # type: ignore[assignment]
         )

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -26,7 +26,6 @@ from agent_framework._clients import BaseChatClient
 from agent_framework._middleware import (
     ChatMiddlewareLayer,
     FunctionInvocationContext,
-    FunctionMiddleware,
     MiddlewareTermination,
 )
 from agent_framework._tools import FunctionInvocationLayer, FunctionTool
@@ -784,8 +783,9 @@ async def test_handoff_clone_preserves_all_middleware_types() -> None:
     executor = workflow.executors[resolve_agent_id(agent_a)]
     assert isinstance(executor, HandoffAgentExecutor)
     cloned_middleware = executor._agent.middleware or []
-    function_mw = [m for m in cloned_middleware if isinstance(m, FunctionMiddleware)]
-    assert len(function_mw) >= 1, "Function middleware should be preserved on cloned agent"
+    assert tracking_middleware in cloned_middleware, (
+        "User function middleware should be preserved on cloned agent"
+    )
 
 
 def test_clean_conversation_for_handoff_keeps_text_only_history() -> None:

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -783,9 +783,7 @@ async def test_handoff_clone_preserves_all_middleware_types() -> None:
     executor = workflow.executors[resolve_agent_id(agent_a)]
     assert isinstance(executor, HandoffAgentExecutor)
     cloned_middleware = executor._agent.middleware or []
-    assert tracking_middleware in cloned_middleware, (
-        "User function middleware should be preserved on cloned agent"
-    )
+    assert tracking_middleware in cloned_middleware, "User function middleware should be preserved on cloned agent"
 
 
 def test_clean_conversation_for_handoff_keeps_text_only_history() -> None:

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -18,11 +18,12 @@ from agent_framework import (
     ResponseStream,
     WorkflowEvent,
     WorkflowRunState,
+    function_middleware,
     resolve_agent_id,
     tool,
 )
 from agent_framework._clients import BaseChatClient
-from agent_framework._middleware import ChatMiddlewareLayer, FunctionInvocationContext, MiddlewareTermination
+from agent_framework._middleware import ChatMiddlewareLayer, FunctionInvocationContext, FunctionMiddleware, MiddlewareTermination
 from agent_framework._tools import FunctionInvocationLayer, FunctionTool
 from agent_framework.orchestrations import HandoffAgentUserRequest, HandoffBuilder, HandoffSentEvent
 from pytest import param
@@ -743,6 +744,43 @@ async def test_handoff_clone_preserves_per_service_call_history_persistence() ->
     assert [message.role for message in stored_messages] == ["user", "assistant"]
     assert any(content.type == "function_call" for content in stored_messages[-1].contents)
     assert all(message.role != "tool" for message in stored_messages)
+
+
+async def test_handoff_clone_preserves_all_middleware_types() -> None:
+    """Handoff clones should preserve function and agent middleware from the original agent."""
+
+    @function_middleware
+    async def tracking_middleware(context: FunctionInvocationContext, call_next):
+        await call_next()
+
+    agent_a = Agent(
+        id="agent_a",
+        name="agent_a",
+        client=MockChatClient(name="agent_a", handoff_to="agent_b"),
+        middleware=[tracking_middleware],
+        require_per_service_call_history_persistence=True,
+    )
+    agent_b = Agent(
+        id="agent_b",
+        name="agent_b",
+        client=MockChatClient(name="agent_b"),
+        default_options={"tool_choice": "none"},
+        require_per_service_call_history_persistence=True,
+    )
+
+    workflow = (
+        HandoffBuilder(participants=[agent_a, agent_b], termination_condition=lambda _: False)
+        .with_start_agent(agent_a)
+        .add_handoff(agent_a, [agent_b])
+        .add_handoff(agent_b, [agent_a])
+        .build()
+    )
+
+    executor = workflow.executors[resolve_agent_id(agent_a)]
+    assert isinstance(executor, HandoffAgentExecutor)
+    cloned_middleware = executor._agent.middleware or []
+    function_mw = [m for m in cloned_middleware if isinstance(m, FunctionMiddleware)]
+    assert len(function_mw) >= 1, "Function middleware should be preserved on cloned agent"
 
 
 def test_clean_conversation_for_handoff_keeps_text_only_history() -> None:

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -23,7 +23,12 @@ from agent_framework import (
     tool,
 )
 from agent_framework._clients import BaseChatClient
-from agent_framework._middleware import ChatMiddlewareLayer, FunctionInvocationContext, FunctionMiddleware, MiddlewareTermination
+from agent_framework._middleware import (
+    ChatMiddlewareLayer,
+    FunctionInvocationContext,
+    FunctionMiddleware,
+    MiddlewareTermination,
+)
 from agent_framework._tools import FunctionInvocationLayer, FunctionTool
 from agent_framework.orchestrations import HandoffAgentUserRequest, HandoffBuilder, HandoffSentEvent
 from pytest import param


### PR DESCRIPTION
### Motivation and Context

`HandoffAgentExecutor._clone_chat_agent()` used `agent.agent_middleware` (agent-level only) instead of `agent.middleware` (all types), silently discarding any `@function_middleware` registered on the original agent so it never executed during handoff workflows.

Fixes #5173

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause was in `_handoff.py` line 290: the clone constructor was passed `agent.agent_middleware`, which only contains agent-level middleware after `categorize_middleware()` splits the list during `Agent.__init__`. The fix changes this to `agent.middleware`, which holds the full original middleware list including both agent and function middleware. A regression test verifies that function middleware survives the cloning step performed by `HandoffBuilder.build()`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5173,"repo":"microsoft/agent-framework","rid":"6efeca8bdcb84976936d870a6d618718","rt":"fix","sf":"pr","ts":"2026-04-13T03:36:02.587809+00:00","u":"moonbox3","v":1}
-->
