### PR TITLE
Python: Fix python-feature-lifecycle skill YAML frontmatter

### DIFF
--- a/python/.github/skills/python-feature-lifecycle/SKILL.md
+++ b/python/.github/skills/python-feature-lifecycle/SKILL.md
@@ -1,5 +1,3 @@
-# Copyright (c) Microsoft. All rights reserved.
-
 ---
 name: python-feature-lifecycle
 description: >

--- a/python/packages/devui/frontend/README.md
+++ b/python/packages/devui/frontend/README.md
@@ -51,7 +51,7 @@ export default tseslint.config([
 ])
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js


### PR DESCRIPTION
### Motivation and Context

The python-feature-lifecycle skill fails to load with: missing or malformed YAML frontmatter.

### Description

A copyright comment preceded the YAML frontmatter --- delimiter in SKILL.md, preventing the skill from being parsed. The --- block must be on the very first line of the file.

This PR removes the copyright comment so the frontmatter is valid, matching all other skill files in the repo.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add [BREAKING] prefix to the title of the PR.