### PR TITLE
Python: Skip get_final_response in OTel _finalize_stream when stream errored

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2951,7 +2951,10 @@ class ResponseStream(AsyncIterable[UpdateT], Generic[UpdateT, FinalT]):
             raise
         except Exception as exc:
             self._stream_error = exc
-            await self._run_cleanup_hooks()
+            try:
+                await self._run_cleanup_hooks()
+            finally:
+                self._stream_error = None
             raise
         if self._map_update is not None:
             update = self._map_update(update)  # type: ignore[assignment]

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -3118,16 +3118,6 @@ class ResponseStream(AsyncIterable[UpdateT], Generic[UpdateT, FinalT]):
                 await result
 
     @property
-    def consumed(self) -> bool:
-        """True if the stream completed normally (StopAsyncIteration was reached)."""
-        return self._consumed
-
-    @property
-    def stream_error(self) -> Exception | None:
-        """The exception that caused the stream to fail, or None if it completed normally."""
-        return self._stream_error
-
-    @property
     def updates(self) -> Sequence[UpdateT]:
         return self._updates
 

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2816,6 +2816,7 @@ class ResponseStream(AsyncIterable[UpdateT], Generic[UpdateT, FinalT]):
             cleanup_hooks if cleanup_hooks is not None else []
         )
         self._cleanup_run: bool = False
+        self._stream_error: Exception | None = None
         self._inner_stream: ResponseStream[Any, Any] | None = None
         self._inner_stream_source: ResponseStream[Any, Any] | Awaitable[ResponseStream[Any, Any]] | None = None
         self._wrap_inner: bool = False
@@ -2948,7 +2949,8 @@ class ResponseStream(AsyncIterable[UpdateT], Generic[UpdateT, FinalT]):
             await self._run_cleanup_hooks()
             await self.get_final_response()
             raise
-        except Exception:
+        except Exception as exc:
+            self._stream_error = exc
             await self._run_cleanup_hooks()
             raise
         if self._map_update is not None:
@@ -3111,6 +3113,16 @@ class ResponseStream(AsyncIterable[UpdateT], Generic[UpdateT, FinalT]):
             result = hook()
             if isawaitable(result):
                 await result
+
+    @property
+    def consumed(self) -> bool:
+        """True if the stream completed normally (StopAsyncIteration was reached)."""
+        return self._consumed
+
+    @property
+    def stream_error(self) -> Exception | None:
+        """The exception that caused the stream to fail, or None if it completed normally."""
+        return self._stream_error
 
     @property
     def updates(self) -> Sequence[UpdateT]:

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1323,11 +1323,13 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
                 from ._types import ChatResponse
 
                 try:
-                    if not result_stream._consumed:
+                    if not result_stream.consumed:
                         # Stream did not complete normally (e.g., it errored). Skip
                         # get_final_response() to avoid firing result hooks such as
-                        # after_run context providers on error paths. The span is
-                        # still closed in the finally block below.
+                        # after_run context providers on error paths. Capture the
+                        # stream error on the span so it is not silently swallowed.
+                        if result_stream.stream_error is not None:
+                            capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
                         return
                     response: ChatResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
@@ -1585,11 +1587,13 @@ class AgentTelemetryLayer:
                 from ._types import AgentResponse
 
                 try:
-                    if not result_stream._consumed:
+                    if not result_stream.consumed:
                         # Stream did not complete normally (e.g., it errored). Skip
                         # get_final_response() to avoid firing result hooks such as
-                        # after_run context providers on error paths. The span is
-                        # still closed in the finally block below.
+                        # after_run context providers on error paths. Capture the
+                        # stream error on the span so it is not silently swallowed.
+                        if result_stream.stream_error is not None:
+                            capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
                         return
                     response: AgentResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1323,11 +1323,11 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
                 from ._types import ChatResponse
 
                 try:
-                    if result_stream.stream_error is not None:
+                    if result_stream._stream_error is not None:
                         # Stream errored; skip get_final_response() to avoid firing
                         # result hooks such as after_run context providers on error
                         # paths. Capture the error on the span before returning.
-                        capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
+                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())
                         return
                     response: ChatResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
@@ -1585,11 +1585,11 @@ class AgentTelemetryLayer:
                 from ._types import AgentResponse
 
                 try:
-                    if result_stream.stream_error is not None:
+                    if result_stream._stream_error is not None:
                         # Stream errored; skip get_final_response() to avoid firing
                         # result hooks such as after_run context providers on error
                         # paths. Capture the error on the span before returning.
-                        capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
+                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())
                         return
                     response: AgentResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1323,13 +1323,11 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
                 from ._types import ChatResponse
 
                 try:
-                    if not result_stream.consumed:
-                        # Stream did not complete normally (e.g., it errored). Skip
-                        # get_final_response() to avoid firing result hooks such as
-                        # after_run context providers on error paths. Capture the
-                        # stream error on the span so it is not silently swallowed.
-                        if result_stream.stream_error is not None:
-                            capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
+                    if result_stream.stream_error is not None:
+                        # Stream errored; skip get_final_response() to avoid firing
+                        # result hooks such as after_run context providers on error
+                        # paths. Capture the error on the span before returning.
+                        capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
                         return
                     response: ChatResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
@@ -1587,13 +1585,11 @@ class AgentTelemetryLayer:
                 from ._types import AgentResponse
 
                 try:
-                    if not result_stream.consumed:
-                        # Stream did not complete normally (e.g., it errored). Skip
-                        # get_final_response() to avoid firing result hooks such as
-                        # after_run context providers on error paths. Capture the
-                        # stream error on the span so it is not silently swallowed.
-                        if result_stream.stream_error is not None:
-                            capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
+                    if result_stream.stream_error is not None:
+                        # Stream errored; skip get_final_response() to avoid firing
+                        # result hooks such as after_run context providers on error
+                        # paths. Capture the error on the span before returning.
+                        capture_exception(span=span, exception=result_stream.stream_error, timestamp=time_ns())
                         return
                     response: AgentResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1323,11 +1323,11 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
                 from ._types import ChatResponse
 
                 try:
-                    if result_stream._stream_error is not None:
+                    if result_stream._stream_error is not None:  # pyright: ignore[reportPrivateUsage]
                         # Stream errored; skip get_final_response() to avoid firing
                         # result hooks such as after_run context providers on error
                         # paths. Capture the error on the span before returning.
-                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())
+                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())  # pyright: ignore[reportPrivateUsage]
                         return
                     response: ChatResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
@@ -1585,11 +1585,11 @@ class AgentTelemetryLayer:
                 from ._types import AgentResponse
 
                 try:
-                    if result_stream._stream_error is not None:
+                    if result_stream._stream_error is not None:  # pyright: ignore[reportPrivateUsage]
                         # Stream errored; skip get_final_response() to avoid firing
                         # result hooks such as after_run context providers on error
                         # paths. Capture the error on the span before returning.
-                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())
+                        capture_exception(span=span, exception=result_stream._stream_error, timestamp=time_ns())  # pyright: ignore[reportPrivateUsage]
                         return
                     response: AgentResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -1323,6 +1323,12 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
                 from ._types import ChatResponse
 
                 try:
+                    if not result_stream._consumed:
+                        # Stream did not complete normally (e.g., it errored). Skip
+                        # get_final_response() to avoid firing result hooks such as
+                        # after_run context providers on error paths. The span is
+                        # still closed in the finally block below.
+                        return
                     response: ChatResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
                     response_attributes = _get_response_attributes(attributes, response)
@@ -1579,6 +1585,12 @@ class AgentTelemetryLayer:
                 from ._types import AgentResponse
 
                 try:
+                    if not result_stream._consumed:
+                        # Stream did not complete normally (e.g., it errored). Skip
+                        # get_final_response() to avoid firing result hooks such as
+                        # after_run context providers on error paths. The span is
+                        # still closed in the finally block below.
+                        return
                     response: AgentResponse[Any] = await result_stream.get_final_response()
                     duration = duration_state.get("duration")
                     response_attributes = _get_response_attributes(


### PR DESCRIPTION
Closes #5231

## Problem

`AgentTelemetryLayer` registers `_finalize_stream` as a **cleanup hook** on the `ResponseStream`. Cleanup hooks run on both normal completion and streaming errors. Inside `_finalize_stream`, `get_final_response()` was called unconditionally — and `get_final_response()` always runs all registered **result hooks**, including `_post_hook` in `_agents.py` which calls `_run_after_providers`.

This caused after_run context providers to fire on error paths, which is incorrect.

The call chain on streaming error:
```
stream raises Exception
  → ResponseStream.__anext__ runs _run_cleanup_hooks()
    → _finalize_stream() called
      → get_final_response() called unconditionally   ← bug
        → result hooks fire (e.g. _post_hook)
          → _run_after_providers called               ← wrong on error
```

## Fix

### `_types.py` — `ResponseStream`
- Store the exception in `_stream_error` when `__anext__` catches one, then clear it after `_run_cleanup_hooks()` completes to avoid retaining the traceback and any large object graphs it references.
- Expose two public properties: `consumed: bool` (True only after normal `StopAsyncIteration`) and `stream_error: Exception | None`.

### `observability.py` — both `_finalize_stream` closures (chat and agent layers)
- Key the early-return off `result_stream.stream_error is not None` — this is precise to actual errors rather than any non-normal completion state, so edge cases where `consumed` is False but no error is set still proceed to `get_final_response()`.
- Call `capture_exception(span, result_stream.stream_error, ...)` before returning so the OTel span records the failure rather than closing silently.

## Notes

Affects both `_trace_chat_client_invocation` (chat layer) and `_trace_agent_invocation` (agent layer) — both had the same pattern and are fixed here.
