### PR TITLE
Python: move _ensure_message_ids higher in the chain to avoid duplicate message ids

### DIFF
--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -111,7 +111,6 @@ def group_messages(messages: list[Message]) -> list[dict[str, Any]]:
         Ordered list of lightweight span dicts with keys:
         ``group_id``, ``kind``, ``start_index``, ``end_index``, ``has_reasoning``.
     """
-    _ensure_message_ids(messages)
     spans: list[dict[str, Any]] = []
     i = 0
     group_index = 0
@@ -415,6 +414,8 @@ def annotate_message_groups(
     """
     if not messages:
         return []
+
+    _ensure_message_ids(messages)
 
     if force_reannotate:
         start_index = 0

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -153,6 +153,24 @@ def test_group_annotations_handle_same_message_reasoning_and_function_calls() ->
     assert _group_has_reasoning(messages[1]) is True
 
 
+def test_annotate_message_groups_assigns_unique_ids_after_incremental_calls() -> None:
+    """Regression: ``_ensure_message_ids`` previously ran inside
+    ``group_messages`` against a slice and assigned ``msg_{slice_index}``,
+    which collided with ids already present in the preserved prefix.
+    """
+    messages: list[Message] = []
+    for turn in range(4):
+        messages.append(Message(role="user", contents=[f"u{turn}"]))
+        messages.append(Message(role="assistant", contents=[f"a{turn}"]))
+        annotate_message_groups(messages)
+
+    ids = [m.message_id for m in messages]
+    assert None not in ids
+    assert len(set(ids)) == len(ids), (
+        f"expected unique message_ids across incremental annotation, got {ids}"
+    )
+
+
 def test_annotate_message_groups_with_tokenizer_adds_token_counts() -> None:
     messages = [
         Message(role="user", contents=["hello"]),


### PR DESCRIPTION
### Motivation and Context

Fixes #5237

`_ensure_message_ids` assigns `f"msg_{index}"` where `index` comes from `enumerate` over the list it receives.
`annotate_message_groups` calls it indirectly via `group_messages(messages[start_index:])` on a **slice**, so
`enumerate` restarts from 0 on every incremental call — producing IDs that collide with the preserved prefix.

The most visible failure is in `SummarizationStrategy`: `_group_id_for` derives `group_id` from `message_id`, so
colliding IDs collapse distinct groups into one.

### Description

Move the `_ensure_message_ids(messages)` call from `group_messages()` (which operates on a slice) to the top of
`annotate_message_groups()` (which holds the full list). This ensures every message is indexed against the
complete conversation, producing stable, unique IDs across incremental calls.

**Changes:**
- `_compaction.py`: Remove `_ensure_message_ids` call from `group_messages`, add it at the top of
`annotate_message_groups` before any slicing occurs.
- `test_compaction.py`: Add regression test
`test_annotate_message_groups_assigns_unique_ids_after_incremental_calls` that simulates multi-turn incremental
annotation and asserts all `message_id`s remain unique.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution
Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.