### PR TITLE
.NET: Improve local release build perf by only formatting for one build target framework

### DIFF
--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -4,8 +4,9 @@
   <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <!-- Only run 'dotnet format' on dev machines, Release builds. Skip on GitHub Actions -->
-  <!-- as this runs in its own Actions job. -->
-  <Target Name="DotnetFormatOnBuild" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' AND '$(GITHUB_ACTIONS)' == '' ">
+  <!-- as this runs in its own Actions job. Only run for net10.0 target frameworks since the dotnet format command -->
+  <!-- already formats all target frameworks in project. Otherwise it will run format x times x where x is the number of target frameworks -->
+  <Target Name="DotnetFormatOnBuild" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' AND '$(GITHUB_ACTIONS)' == '' AND $(TargetFramework) == 'net10.0' ">
     <Message Text="Running dotnet format" Importance="high" />
     <Exec Command="dotnet format --no-restore -v diag $(ProjectFileName)" />
   </Target>

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -6,7 +6,7 @@
   <!-- Only run 'dotnet format' on dev machines, Release builds. Skip on GitHub Actions -->
   <!-- as this runs in its own Actions job. Only run for net10.0 target frameworks since the dotnet format command -->
   <!-- already formats all target frameworks in project. Otherwise it will run format x times x where x is the number of target frameworks -->
-  <Target Name="DotnetFormatOnBuild" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' AND '$(GITHUB_ACTIONS)' == '' AND $(TargetFramework) == 'net10.0' ">
+  <Target Name="DotnetFormatOnBuild" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' AND '$(GITHUB_ACTIONS)' == '' AND '$(TargetFramework)' == 'net10.0' ">
     <Message Text="Running dotnet format" Importance="high" />
     <Exec Command="dotnet format --no-restore -v diag $(ProjectFileName)" />
   </Target>


### PR DESCRIPTION
### Motivation and Context

Currently when doing a release build locally, it runs dotnet format `(target framework count) squared` times, since it runs dotnet format for each target framework as part of the overall build, but dotnet format already formats for each target framework anyway.

All this only applies when run locally.  This file does not apply when running on the build server, which already does this correctly.

### Description

- Restricting dotnet format to only run for .net 10 builds.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.