### PR TITLE
.NET: Bump Anthropic SDK to 12.13.0 and Anthropic.Foundry to 0.5.0

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire.* -->
-    <PackageVersion Include="Anthropic" Version="12.11.0" />
-    <PackageVersion Include="Anthropic.Foundry" Version="0.4.2" />
+    <PackageVersion Include="Anthropic" Version="12.13.0" />
+    <PackageVersion Include="Anthropic.Foundry" Version="0.5.0" />
     <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.0.0-preview.1.25560.3" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireAppHostSdkVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="$(AspireAppHostSdkVersion)" />

--- a/dotnet/src/Microsoft.Agents.AI.Anthropic/Microsoft.Agents.AI.Anthropic.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Anthropic/Microsoft.Agents.AI.Anthropic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleaseCandidate>true</IsReleaseCandidate>
+    <IsReleaseCandidate>false</IsReleaseCandidate>
     <ImplicitUsings>enable</ImplicitUsings>
     <InjectSharedThrow>true</InjectSharedThrow>
   </PropertyGroup>

--- a/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicBetaServiceExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicBetaServiceExtensionsTests.cs
@@ -483,6 +483,14 @@ public sealed class AnthropicBetaServiceExtensionsTests
 
             public IBetaMessageService Messages => new Mock<IBetaMessageService>().Object;
 
+            public global::Anthropic.Services.Beta.IAgentService Agents => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.IEnvironmentService Environments => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.ISessionService Sessions => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.IVaultService Vaults => throw new NotImplementedException();
+
             public IBetaService WithOptions(Func<ClientOptions, ClientOptions> modifier)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
## Summary

Bumps the Anthropic NuGet package dependencies to their latest versions and moves the Anthropic project back to preview state.

- Related https://github.com/microsoft/agent-framework/issues/5079

### Changes

| Package | Previous | New |
|---------|----------|-----|
| Anthropic | 12.11.0 | 12.13.0 |
| Anthropic.Foundry | 0.4.2 | 0.5.0 |

### Details

- **Directory.Packages.props**: Updated both Anthropic package versions
- **Microsoft.Agents.AI.Anthropic.csproj**: Changed \IsReleaseCandidate\ from \	rue\ to \alse\ (preview state)
- **AnthropicBetaServiceExtensionsTests.cs**: Added 4 new \IBetaService\ interface members (\Agents\, \Environments\, \Sessions\, \Vaults\) to the test mock, required by Anthropic 12.13.0

### Validation

- Build passes for all Anthropic projects (src, tests, samples)
- All 52 unit tests pass on both net10.0 and net472