### PR TITLE
.NET: Bump Azure.AI.AgentServer packages to 1.0.0-beta.1/beta.21 and fix br…

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -19,14 +19,14 @@
     <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="$(AspireAppHostSdkVersion)" />
     <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.0.0" />
     <!-- Azure.* -->
-    <PackageVersion Include="Azure.AI.AgentServer.Core" Version="1.0.0-beta.11" />
-    <PackageVersion Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-alpha.20260408.4" />
-    <PackageVersion Include="Azure.AI.AgentServer.Responses" Version="1.0.0-alpha.20260408.4" />
+    <PackageVersion Include="Azure.AI.AgentServer.Core" Version="1.0.0-beta.21" />
+    <PackageVersion Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.1" />
+    <PackageVersion Include="Azure.AI.AgentServer.Responses" Version="1.0.0-beta.1" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.0.0" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
-    <PackageVersion Include="Azure.Core" Version="1.52.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
+    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <!-- Google Gemini  -->

--- a/dotnet/nuget.config
+++ b/dotnet/nuget.config
@@ -3,12 +3,8 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="azure-sdk-for-net">
-      <package pattern="Azure.AI.AgentServer.*" />
-    </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>

--- a/dotnet/samples/04-hosting/FoundryResponsesRepl/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryResponsesRepl/Program.cs
@@ -1,3 +1,5 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
 // Foundry Responses Client REPL
 //
 // Connects to a Foundry Responses agent running on a given endpoint
@@ -66,10 +68,16 @@ while (true)
     Console.ResetColor();
 
     string? input = Console.ReadLine();
-    if (string.IsNullOrWhiteSpace(input)) continue;
+    if (string.IsNullOrWhiteSpace(input))
+    {
+        continue;
+    }
+
     if (input.Equals("quit", StringComparison.OrdinalIgnoreCase) ||
         input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
         break;
+    }
 
     try
     {

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/OutputConverter.cs
@@ -161,7 +161,6 @@ internal static class OutputConverter
                         yield return summaryPart.EmitTextDelta(text);
                         yield return summaryPart.EmitTextDone(text);
                         yield return summaryPart.EmitDone();
-                        reasoningBuilder.EmitSummaryPartDone(summaryPart);
 
                         yield return reasoningBuilder.EmitDone();
                         break;
@@ -236,8 +235,8 @@ internal static class OutputConverter
         if (textBuilder is not null)
         {
             var finalText = accumulatedText?.ToString() ?? string.Empty;
-            yield return textBuilder.EmitDone(finalText);
-            yield return messageBuilder.EmitContentDone(textBuilder);
+            yield return textBuilder.EmitTextDone(finalText);
+            yield return textBuilder.EmitDone();
         }
 
         yield return messageBuilder.EmitDone();


### PR DESCRIPTION
- Azure.AI.AgentServer.Core: 1.0.0-beta.11 -> 1.0.0-beta.21
- Azure.AI.AgentServer.Invocations: 1.0.0-alpha.20260408.4 -> 1.0.0-beta.1
- Azure.AI.AgentServer.Responses: 1.0.0-alpha.20260408.4 -> 1.0.0-beta.1
- Azure.Identity: 1.20.0 -> 1.21.0 (transitive requirement)
- Azure.Core: 1.52.0 -> 1.53.0 (transitive requirement)
- Remove azure-sdk-for-net dev feed (packages now on nuget.org)
- Fix OutputConverter for new builder API (auto-tracked children, split EmitTextDone/EmitDone)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.