### PR TITLE
Python: fix: skip toolChoice when no tools are configured in BedrockChatClient

### DIFF
--- a/python/packages/bedrock/agent_framework_bedrock/_chat_client.py
+++ b/python/packages/bedrock/agent_framework_bedrock/_chat_client.py
@@ -411,14 +411,16 @@ class BedrockChatClient(
                     # Omit toolConfig entirely so the model won't attempt tool calls.
                     tool_config = None
                 case "auto":
-                    tool_config = tool_config or {}
-                    tool_config["toolChoice"] = {"auto": {}}
+                    # Only set toolChoice when tools are present; Bedrock rejects
+                    # toolConfig.toolChoice without a toolConfig.tools list.
+                    if tool_config is not None:
+                        tool_config["toolChoice"] = {"auto": {}}
                 case "required":
-                    tool_config = tool_config or {}
-                    if required_name := tool_mode.get("required_function_name"):
-                        tool_config["toolChoice"] = {"tool": {"name": required_name}}
-                    else:
-                        tool_config["toolChoice"] = {"any": {}}
+                    if tool_config is not None:
+                        if required_name := tool_mode.get("required_function_name"):
+                            tool_config["toolChoice"] = {"tool": {"name": required_name}}
+                        else:
+                            tool_config["toolChoice"] = {"any": {}}
                 case _:
                     raise ValueError(f"Unsupported tool mode for Bedrock: {tool_mode.get('mode')}")
         if tool_config:

--- a/python/packages/bedrock/tests/test_bedrock_client.py
+++ b/python/packages/bedrock/tests/test_bedrock_client.py
@@ -137,3 +137,57 @@ def test_prepare_options_tool_choice_required_includes_any() -> None:
 
     assert "toolConfig" in request
     assert request["toolConfig"]["toolChoice"] == {"any": {}}
+
+
+def test_prepare_options_tool_choice_auto_no_tools_omits_tool_config() -> None:
+    """When tool_choice='auto' but no tools are provided, toolConfig must be omitted.
+
+    Bedrock rejects requests that include toolConfig.toolChoice without
+    toolConfig.tools. Previously, ``tool_config or {}`` would create an
+    empty dict and set toolChoice on it, producing {"toolChoice": {"auto": {}}}
+    with no tools key.
+
+    Fixes #5165.
+    """
+    client = _make_client()
+    messages = [Message(role="user", contents=[Content.from_text(text="What is AI?")])]
+
+    options: dict[str, Any] = {
+        "tool_choice": "auto",
+        # No tools provided
+    }
+
+    request = client._prepare_options(messages, options)
+
+    assert "toolConfig" not in request, (
+        f"toolConfig should be omitted when tool_choice='auto' and no tools are provided, got: {request.get('toolConfig')}"
+    )
+
+
+def test_prepare_options_tool_choice_required_no_tools_omits_tool_config() -> None:
+    """When tool_choice='required' but no tools are provided, toolConfig must be omitted.
+
+    Fixes #5165.
+    """
+    client = _make_client()
+    messages = [Message(role="user", contents=[Content.from_text(text="What is AI?")])]
+
+    options: dict[str, Any] = {
+        "tool_choice": "required",
+    }
+
+    request = client._prepare_options(messages, options)
+
+    assert "toolConfig" not in request, (
+        f"toolConfig should be omitted when tool_choice='required' and no tools are provided, got: {request.get('toolConfig')}"
+    )
+
+
+def test_prepare_options_no_tools_no_tool_choice_omits_tool_config() -> None:
+    """When neither tools nor tool_choice are provided, toolConfig should be absent."""
+    client = _make_client()
+    messages = [Message(role="user", contents=[Content.from_text(text="hello")])]
+
+    request = client._prepare_options(messages, {})
+
+    assert "toolConfig" not in request


### PR DESCRIPTION
## Fixes

**#5165** — `BedrockChatClient` sends `toolConfig.toolChoice` without `toolConfig.tools` when agent has no tools configured, causing a `ParamValidationError` from AWS Bedrock.

## Root Cause

In `_prepare_options`, when `tool_choice` is `"auto"` or `"required"` but no tools are provided:

```python
tool_config = self._prepare_tools(options.get("tools"))  # Returns None
# ...
case "auto":
    tool_config = tool_config or {}       # Creates empty dict!
    tool_config["toolChoice"] = {"auto": {}}  # Sets toolChoice with NO tools
```

This produces `{"toolChoice": {"auto": {}}}` — which Bedrock rejects because `tools` is required when `toolChoice` is present.

## Fix

Guard both `auto` and `required` branches to only set `toolChoice` when `tool_config is not None` (i.e., when `_prepare_tools` found actual tools). This matches the existing behavior of the `none` case (added in #4535) which correctly omits `toolConfig` entirely.

## Tests

Added 3 new tests:
- `test_prepare_options_tool_choice_auto_no_tools_omits_tool_config`
- `test_prepare_options_tool_choice_required_no_tools_omits_tool_config`
- `test_prepare_options_no_tools_no_tool_choice_omits_tool_config`