### PR TITLE
Python: bump misc-integration retry delay to 30s

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -171,7 +171,7 @@ jobs:
           -m integration
           -n logical --dist worksteal
           --timeout=120 --session-timeout=900 --timeout_method thread
-          --retries 2 --retry-delay 5
+          --retries 2 --retry-delay 30
       - name: Stop local MCP server
         if: always()
         shell: bash

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -287,7 +287,7 @@ jobs:
           -m integration
           -n logical --dist worksteal
           --timeout=120 --session-timeout=900 --timeout_method thread
-          --retries 2 --retry-delay 5
+          --retries 2 --retry-delay 30
           --junitxml=pytest.xml
         working-directory: ./python
       - name: Stop local MCP server


### PR DESCRIPTION
The misc-integration job (Anthropic, Ollama, MCP) frequently fails on merge to main when the upstream MCP server (e.g. `learn.microsoft.com/api/mcp`) returns a transient rate-limit error surfaced by Anthropic as a 400. The previous 5s `--retry-delay` is too short to ride out the upstream backoff window, so all `pytest-retry` attempts fail in quick succession and block the merge queue.

Bumping the misc-integration retry delay to 30s gives the upstream a chance to recover before re-running. Scoped to the misc-integration job in both `python-merge-tests.yml` and `python-integration-tests.yml`; other integration lanes are unchanged.