### PR TITLE
Python: improve misc-integration test robustness

### DIFF
--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -1503,6 +1503,10 @@ async def test_anthropic_client_integration_function_calling() -> None:
 @skip_if_anthropic_integration_tests_disabled
 async def test_anthropic_client_integration_hosted_tools() -> None:
     """Integration test for hosted tools."""
+    local_mcp_url = os.environ.get("LOCAL_MCP_URL", "")
+    if not local_mcp_url:
+        pytest.skip("LOCAL_MCP_URL not set; skipping hosted tools test")
+
     client = AnthropicClient()
 
     messages = [Message(role="user", contents=["What tools do you have available?"])]
@@ -1510,8 +1514,8 @@ async def test_anthropic_client_integration_hosted_tools() -> None:
         AnthropicClient.get_web_search_tool(),
         AnthropicClient.get_code_interpreter_tool(),
         AnthropicClient.get_mcp_tool(
-            name="example-mcp",
-            url="https://learn.microsoft.com/api/mcp",
+            name="local-mcp",
+            url=local_mcp_url,
         ),
     ]
 
@@ -1607,7 +1611,8 @@ async def test_anthropic_client_integration_images() -> None:
 
     assert response is not None
     assert response.messages[0].text is not None
-    assert "house" in response.messages[0].text.lower()
+    text = response.messages[0].text.lower()
+    assert any(word in text for word in ("house", "home", "building", "cottage", "mansion", "villa"))
 
 
 # Response Format Tests

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 import os
+import re
 from pathlib import Path
 from typing import Annotated, Any
 from unittest.mock import MagicMock, patch
@@ -1504,8 +1505,8 @@ async def test_anthropic_client_integration_function_calling() -> None:
 async def test_anthropic_client_integration_hosted_tools() -> None:
     """Integration test for hosted tools."""
     local_mcp_url = os.environ.get("LOCAL_MCP_URL", "")
-    if not local_mcp_url:
-        pytest.skip("LOCAL_MCP_URL not set; skipping hosted tools test")
+    if not local_mcp_url or not local_mcp_url.startswith(("http://", "https://")):
+        pytest.skip("LOCAL_MCP_URL not set or not an HTTP URL; skipping hosted tools test")
 
     client = AnthropicClient()
 
@@ -1612,7 +1613,7 @@ async def test_anthropic_client_integration_images() -> None:
     assert response is not None
     assert response.messages[0].text is not None
     text = response.messages[0].text.lower()
-    assert any(word in text for word in ("house", "home", "building", "cottage", "mansion", "villa"))
+    assert re.search(r"\b(house|home|building|cottage|mansion|villa)\b", text)
 
 
 # Response Format Tests


### PR DESCRIPTION
## Summary
- Use the local MCP server (already spun up in CI via `LOCAL_MCP_URL`) for the hosted tools integration test instead of `learn.microsoft.com/api/mcp`, which persistently rate-limits and blocks the merge queue.
- Broaden the image description assertion to accept common synonyms (cottage, mansion, villa, etc.) since the model uses varied vocabulary for the same image.

## Test plan
- [x] Unit tests pass locally (113 passed)
- [ ] Verify misc-integration CI job passes with local MCP server