### PR TITLE
.Net: [WIP] Add Foundry Toolbox Support to Hosted Agents

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Azure.AI.AgentServer.Core" Version="1.0.0-beta.21" />
     <PackageVersion Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.1" />
     <PackageVersion Include="Azure.AI.AgentServer.Responses" Version="1.0.0-beta.1" />
-    <PackageVersion Include="Azure.AI.Projects" Version="2.0.0" />
+    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-alpha.20260417.1" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Azure.Core" Version="1.53.0" />

--- a/dotnet/agent-framework-dotnet.slnx
+++ b/dotnet/agent-framework-dotnet.slnx
@@ -283,6 +283,9 @@
   <Folder Name="/Samples/04-hosting/FoundryHostedAgents/responses/Hosted-McpTools/">
     <Project Path="samples/04-hosting/FoundryHostedAgents/responses/Hosted-McpTools/HostedMcpTools.csproj" />
   </Folder>
+  <Folder Name="/Samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/">
+    <Project Path="samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/HostedToolbox.csproj" />
+  </Folder>
   <Folder Name="/Samples/04-hosting/FoundryHostedAgents/responses/Hosted-TextRag/">
     <Project Path="samples/04-hosting/FoundryHostedAgents/responses/Hosted-TextRag/HostedTextRag.csproj" />
   </Folder>

--- a/dotnet/nuget.config
+++ b/dotnet/nuget.config
@@ -3,10 +3,16 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="azure-sdk-dev" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
       <package pattern="*" />
+    </packageSource>
+    <packageSource key="azure-sdk-dev">
+      <package pattern="Azure.AI.Projects*" />
+      <package pattern="Azure.AI.AgentServer*" />
+      <package pattern="Azure.AI.Extensions.OpenAI*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/HostedToolbox.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/HostedToolbox.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <RootNamespace>HostedToolbox</RootNamespace>
+    <AssemblyName>HostedToolbox</AssemblyName>
+    <NoWarn>$(NoWarn);</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.Projects" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="DotNetEnv" />
+  </ItemGroup>
+
+  <!-- For contributors: uses ProjectReference to build against local source -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
+  </ItemGroup>
+
+  <!-- For end-users: uncomment the PackageReference below and remove the ProjectReference above
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.0.0" />
+  </ItemGroup>
+  -->
+
+</Project>

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/Program.cs
@@ -12,7 +12,7 @@
 //                                       (injected automatically by Foundry platform at runtime)
 //
 // Optional:
-//   FOUNDRY_TOOLSET_NAME              - Name of the toolset to load (default: my-toolset)
+//   FOUNDRY_TOOLBOX_NAME              - Name of the toolset to load (default: my-toolset)
 //   FOUNDRY_AGENT_NAME                - Client name reported to MCP server
 //   FOUNDRY_AGENT_VERSION             - Client version reported to MCP server
 //   FOUNDRY_AGENT_TOOLSET_FEATURES    - Feature flags sent to Foundry proxy via header
@@ -30,7 +30,7 @@ Env.TraversePath().Load();
 string endpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT")
     ?? throw new InvalidOperationException("AZURE_AI_PROJECT_ENDPOINT is not set.");
 string deploymentName = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
-string toolsetName = Environment.GetEnvironmentVariable("FOUNDRY_TOOLSET_NAME") ?? "my-toolset";
+string toolboxName = Environment.GetEnvironmentVariable("FOUNDRY_TOOLBOX_NAME") ?? "my-toolset";
 
 // Use a chained credential: try a temporary dev token first (for local Docker debugging),
 // then fall back to DefaultAzureCredential (for local dev via dotnet run / managed identity in production).
@@ -62,7 +62,7 @@ builder.Services.AddFoundryResponses(agent);
 // The toolset name must match a toolset registered in your Foundry project.
 // When FOUNDRY_AGENT_TOOLSET_ENDPOINT is absent (e.g., in local development without Foundry
 // infrastructure), startup succeeds without error and no toolbox tools are loaded.
-builder.Services.AddFoundryToolboxes(toolsetName);
+builder.Services.AddFoundryToolboxes(toolboxName);
 
 var app = builder.Build();
 app.MapFoundryResponses();

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Toolbox/Program.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+// Foundry Toolbox Agent - A hosted agent that uses Foundry Toolset MCP tools.
+//
+// Demonstrates how to register one or more Foundry toolsets so the agent can
+// call tools provided by the Foundry platform's managed MCP proxy.
+//
+// Required environment variables:
+//   AZURE_AI_PROJECT_ENDPOINT         - Azure AI Foundry project endpoint
+//   AZURE_AI_MODEL_DEPLOYMENT_NAME    - Model deployment name (default: gpt-4o)
+//   FOUNDRY_AGENT_TOOLSET_ENDPOINT    - Foundry Toolsets proxy base URL
+//                                       (injected automatically by Foundry platform at runtime)
+//
+// Optional:
+//   FOUNDRY_TOOLSET_NAME              - Name of the toolset to load (default: my-toolset)
+//   FOUNDRY_AGENT_NAME                - Client name reported to MCP server
+//   FOUNDRY_AGENT_VERSION             - Client version reported to MCP server
+//   FOUNDRY_AGENT_TOOLSET_FEATURES    - Feature flags sent to Foundry proxy via header
+
+using Azure.AI.Projects;
+using Azure.Core;
+using Azure.Identity;
+using DotNetEnv;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry.Hosting;
+
+// Load .env file if present (for local development)
+Env.TraversePath().Load();
+
+string endpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("AZURE_AI_PROJECT_ENDPOINT is not set.");
+string deploymentName = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
+string toolsetName = Environment.GetEnvironmentVariable("FOUNDRY_TOOLSET_NAME") ?? "my-toolset";
+
+// Use a chained credential: try a temporary dev token first (for local Docker debugging),
+// then fall back to DefaultAzureCredential (for local dev via dotnet run / managed identity in production).
+TokenCredential credential = new ChainedTokenCredential(
+    new DevTemporaryTokenCredential(),
+    new DefaultAzureCredential());
+
+// ── Create agent ─────────────────────────────────────────────────────────────
+
+AIAgent agent = new AIProjectClient(new Uri(endpoint), credential)
+    .AsAIAgent(
+        model: deploymentName,
+        instructions: """
+            You are a helpful assistant with access to tools provided by the Foundry Toolset.
+            Use the available tools to answer user questions.
+            If a tool is not available for a request, let the user know clearly.
+            """,
+        name: Environment.GetEnvironmentVariable("AGENT_NAME") ?? "hosted-toolbox-agent",
+        description: "Hosted agent backed by Foundry Toolset MCP tools");
+
+// ── Build the host ────────────────────────────────────────────────────────────
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register the agent and response handler
+builder.Services.AddFoundryResponses(agent);
+
+// Register Foundry Toolbox: connects to the MCP proxy at startup and makes tools available.
+// The toolset name must match a toolset registered in your Foundry project.
+// When FOUNDRY_AGENT_TOOLSET_ENDPOINT is absent (e.g., in local development without Foundry
+// infrastructure), startup succeeds without error and no toolbox tools are loaded.
+builder.Services.AddFoundryToolboxes(toolsetName);
+
+var app = builder.Build();
+app.MapFoundryResponses();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapFoundryResponses("openai/v1");
+}
+
+app.Run();
+
+// ── DevTemporaryTokenCredential ───────────────────────────────────────────────
+
+/// <summary>
+/// A <see cref="TokenCredential"/> for local Docker debugging only.
+/// Reads a pre-fetched bearer token from the <c>AZURE_BEARER_TOKEN</c> environment variable
+/// once at startup. This should NOT be used in production.
+///
+/// Generate a token on your host and pass it to the container:
+///   export AZURE_BEARER_TOKEN=$(az account get-access-token --resource https://ai.azure.com --query accessToken -o tsv)
+///   docker run -e AZURE_BEARER_TOKEN=$AZURE_BEARER_TOKEN ...
+/// </summary>
+internal sealed class DevTemporaryTokenCredential : TokenCredential
+{
+    private const string EnvironmentVariable = "AZURE_BEARER_TOKEN";
+    private readonly string? _token;
+
+    public DevTemporaryTokenCredential()
+    {
+        this._token = Environment.GetEnvironmentVariable(EnvironmentVariable);
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        => this.GetAccessToken();
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        => new(this.GetAccessToken());
+
+    private AccessToken GetAccessToken()
+    {
+        if (string.IsNullOrEmpty(this._token) || this._token == "DefaultAzureCredential")
+        {
+            throw new CredentialUnavailableException($"{EnvironmentVariable} environment variable is not set.");
+        }
+
+        return new AccessToken(this._token, DateTimeOffset.UtcNow.AddHours(1));
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
@@ -119,16 +119,42 @@ public static class FoundryAITool
     /// <param name="toolboxName">The Foundry toolbox name.</param>
     /// <param name="version">Optional pinned toolbox version. When <see langword="null"/>, the project's default version is used.</param>
     /// <returns>An <see cref="AITool"/> marker backed by <see cref="HostedMcpToolboxAITool"/>.</returns>
-    /// <remarks>
-    /// <para>
-    /// Consumers who already hold a <c>ToolboxRecord</c> or <c>ToolboxVersion</c> from
-    /// <c>Azure.AI.Projects.Agents</c> can pass <c>record.Name</c> together with
-    /// <c>record.DefaultVersion</c> (or <c>version.Name</c>/<c>version.Version</c>) to this
-    /// factory.
-    /// </para>
-    /// </remarks>
     public static AITool CreateHostedMcpToolbox(string toolboxName, string? version = null)
         => new HostedMcpToolboxAITool(toolboxName, version);
+
+    /// <summary>
+    /// Creates an <see cref="AITool"/> marker from a <see cref="ToolboxRecord"/> retrieved
+    /// from <c>AIProjectClient</c>. Uses <see cref="ToolboxRecord.Name"/> and
+    /// <see cref="ToolboxRecord.DefaultVersion"/>.
+    /// </summary>
+    /// <param name="toolbox">The toolbox record.</param>
+    /// <returns>An <see cref="AITool"/> marker backed by <see cref="HostedMcpToolboxAITool"/>.</returns>
+    public static AITool CreateHostedMcpToolbox(ToolboxRecord toolbox)
+    {
+        if (toolbox is null)
+        {
+            throw new ArgumentNullException(nameof(toolbox));
+        }
+
+        return new HostedMcpToolboxAITool(toolbox.Name, toolbox.DefaultVersion);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="AITool"/> marker from a specific <see cref="ToolboxVersion"/>
+    /// retrieved from <c>AIProjectClient</c>. Uses <see cref="ToolboxVersion.Name"/> and
+    /// <see cref="ToolboxVersion.Version"/>.
+    /// </summary>
+    /// <param name="toolboxVersion">The toolbox version.</param>
+    /// <returns>An <see cref="AITool"/> marker backed by <see cref="HostedMcpToolboxAITool"/>.</returns>
+    public static AITool CreateHostedMcpToolbox(ToolboxVersion toolboxVersion)
+    {
+        if (toolboxVersion is null)
+        {
+            throw new ArgumentNullException(nameof(toolboxVersion));
+        }
+
+        return new HostedMcpToolboxAITool(toolboxVersion.Name, toolboxVersion.Version);
+    }
 
     // --- OpenAI SDK ResponseTool factories ---
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
@@ -112,6 +112,24 @@ public static class FoundryAITool
     public static AITool CreateA2ATool(Uri baseUri, string? agentCardPath = null)
         => ProjectsAgentTool.CreateA2ATool(baseUri, agentCardPath).AsAITool();
 
+    /// <summary>
+    /// Creates an <see cref="AITool"/> marker that references a Foundry Toolbox by name so
+    /// the hosted server side can resolve and expose its MCP tools for a single request.
+    /// </summary>
+    /// <param name="toolboxName">The Foundry toolbox name.</param>
+    /// <param name="version">Optional pinned toolbox version. When <see langword="null"/>, the project's default version is used.</param>
+    /// <returns>An <see cref="AITool"/> marker backed by <see cref="HostedMcpToolboxAITool"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Consumers who already hold a <c>ToolboxRecord</c> or <c>ToolboxVersion</c> from
+    /// <c>Azure.AI.Projects.Agents</c> can pass <c>record.Name</c> together with
+    /// <c>record.DefaultVersion</c> (or <c>version.Name</c>/<c>version.Version</c>) to this
+    /// factory.
+    /// </para>
+    /// </remarks>
+    public static AITool CreateHostedMcpToolbox(string toolboxName, string? version = null)
+        => new HostedMcpToolboxAITool(toolboxName, version);
+
     // --- OpenAI SDK ResponseTool factories ---
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/HostedMcpToolboxAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/HostedMcpToolboxAITool.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Agents.AI.Foundry;
+
+/// <summary>
+/// A marker <see cref="HostedMcpServerTool"/> that identifies a Foundry Toolbox by name
+/// (and optional version) on the OpenAI Responses <c>mcp</c> wire format.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hosted server recognizes this marker by its <see cref="HostedMcpServerTool.ServerAddress"/>
+/// scheme (<see cref="UriScheme"/>) and resolves it to the set of MCP tools exposed by the
+/// matching toolbox registered in the Foundry project.
+/// </para>
+/// <para>
+/// Callers should not construct this type directly. Use one of the
+/// <c>FoundryAITool.CreateHostedMcpToolbox(...)</c> factory overloads.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+public sealed class HostedMcpToolboxAITool : HostedMcpServerTool
+{
+    /// <summary>
+    /// The URI scheme used to identify Foundry Toolbox markers on the wire.
+    /// </summary>
+    public const string UriScheme = "foundry-toolbox";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostedMcpToolboxAITool"/> class.
+    /// </summary>
+    /// <param name="toolboxName">The Foundry toolbox name.</param>
+    /// <param name="version">Optional pinned toolbox version. When <see langword="null"/>, the project's default version is used.</param>
+    public HostedMcpToolboxAITool(string toolboxName, string? version = null)
+        : base(
+            serverName: NotNullOrWhitespace(toolboxName, nameof(toolboxName)),
+            serverAddress: BuildAddress(toolboxName, version))
+    {
+        this.ToolboxName = toolboxName;
+        this.Version = version;
+    }
+
+    /// <summary>
+    /// Gets the Foundry toolbox name.
+    /// </summary>
+    public string ToolboxName { get; }
+
+    /// <summary>
+    /// Gets the pinned toolbox version, or <see langword="null"/> to use the project's default.
+    /// </summary>
+    public string? Version { get; }
+
+    /// <summary>
+    /// Builds the toolbox marker address: <c>foundry-toolbox://{name}[?version={v}]</c>.
+    /// </summary>
+    public static string BuildAddress(string toolboxName, string? version)
+    {
+        _ = NotNullOrWhitespace(toolboxName, nameof(toolboxName));
+
+        return string.IsNullOrEmpty(version)
+            ? $"{UriScheme}://{toolboxName}"
+            : $"{UriScheme}://{toolboxName}?version={version}";
+    }
+
+    /// <summary>
+    /// Attempts to parse a toolbox marker address into its name and optional version components.
+    /// </summary>
+    /// <param name="address">The <see cref="HostedMcpServerTool.ServerAddress"/> to inspect.</param>
+    /// <param name="toolboxName">When this method returns <see langword="true"/>, the parsed toolbox name.</param>
+    /// <param name="version">When this method returns <see langword="true"/>, the optional version, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="address"/> is a Foundry toolbox marker; otherwise <see langword="false"/>.</returns>
+    public static bool TryParseToolboxAddress(
+        string? address,
+        [NotNullWhen(true)] out string? toolboxName,
+        out string? version)
+    {
+        toolboxName = null;
+        version = null;
+
+        if (string.IsNullOrEmpty(address))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, UriScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // For foundry-toolbox://name, the name appears as Authority (host) with an empty path.
+        // For foundry-toolbox:name (rare), it falls through to PathAndQuery.
+        var name = uri.Host;
+        if (string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(uri.AbsolutePath))
+        {
+            name = uri.AbsolutePath.TrimStart('/');
+        }
+
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        toolboxName = name;
+
+        var query = uri.Query;
+        if (!string.IsNullOrEmpty(query))
+        {
+            // Minimal parser to avoid a HttpUtility dependency on netstandard.
+            foreach (var part in query.TrimStart('?').Split('&'))
+            {
+                var eq = part.IndexOf('=');
+                if (eq <= 0)
+                {
+                    continue;
+                }
+
+                var key = part.Substring(0, eq);
+                if (string.Equals(key, "version", StringComparison.OrdinalIgnoreCase))
+                {
+                    version = Uri.UnescapeDataString(part.Substring(eq + 1));
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static string NotNullOrWhitespace(string value, string paramName)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be empty or whitespace.", paramName);
+        }
+
+        return value;
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
@@ -97,13 +97,77 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         var chatOptions = InputConverter.ConvertToChatOptions(request);
         chatOptions.Instructions = request.Instructions;
 
-        // Inject Foundry Toolbox tools when the toolbox service is available
+        // Inject Foundry Toolbox tools when the toolbox service is available.
+        //
+        // Two sources are considered:
+        //   1. Pre-registered toolboxes (via AddFoundryToolboxes) — always appended.
+        //   2. Per-request markers embedded in request.Tools (HostedMcpToolboxAITool)
+        //      whose ServerAddress scheme is "foundry-toolbox://". Strict mode rejects
+        //      unknown names; otherwise a lazy MCP client is opened and cached.
+        //
+        // Each toolbox's tools are only appended once per request, even if it appears
+        // in both the pre-registered list and the per-request markers.
         if (this._toolboxService is not null)
         {
-            var toolboxTools = this._toolboxService.Tools;
-            if (toolboxTools.Count > 0)
+            List<AITool>? toolsToAdd = null;
+
+            if (this._toolboxService.Tools.Count > 0)
             {
-                chatOptions.Tools = [.. chatOptions.Tools ?? [], .. toolboxTools];
+                toolsToAdd = [.. this._toolboxService.Tools];
+            }
+
+            var markers = InputConverter.ReadMcpToolboxMarkers(request);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string? resolutionError = null;
+
+            foreach (var (name, version) in markers)
+            {
+                if (!seen.Add(name))
+                {
+                    continue;
+                }
+
+                IReadOnlyList<AITool>? toolboxTools = null;
+                try
+                {
+                    toolboxTools = await this._toolboxService
+                        .GetToolboxToolsAsync(name, version, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    if (this._logger.IsEnabled(LogLevel.Warning))
+                    {
+                        this._logger.LogWarning(
+                            ex,
+                            "Foundry toolbox '{ToolboxName}' could not be resolved for response {ResponseId}.",
+                            name,
+                            context.ResponseId);
+                    }
+
+                    resolutionError = ex.Message;
+                    break;
+                }
+
+                toolsToAdd ??= [];
+                foreach (var t in toolboxTools)
+                {
+                    if (!toolsToAdd.Contains(t))
+                    {
+                        toolsToAdd.Add(t);
+                    }
+                }
+            }
+
+            if (resolutionError is not null)
+            {
+                yield return stream.EmitFailed(ResponseErrorCode.ServerError, resolutionError);
+                yield break;
+            }
+
+            if (toolsToAdd?.Count > 0)
+            {
+                chatOptions.Tools = [.. chatOptions.Tools ?? [], .. toolsToAdd];
             }
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
@@ -21,6 +21,7 @@ public class AgentFrameworkResponseHandler : ResponseHandler
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<AgentFrameworkResponseHandler> _logger;
+    private readonly FoundryToolboxService? _toolboxService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentFrameworkResponseHandler"/> class
@@ -28,15 +29,18 @@ public class AgentFrameworkResponseHandler : ResponseHandler
     /// </summary>
     /// <param name="serviceProvider">The service provider for resolving agents.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="toolboxService">Optional Foundry Toolbox service providing MCP tools.</param>
     public AgentFrameworkResponseHandler(
         IServiceProvider serviceProvider,
-        ILogger<AgentFrameworkResponseHandler> logger)
+        ILogger<AgentFrameworkResponseHandler> logger,
+        FoundryToolboxService? toolboxService = null)
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
         ArgumentNullException.ThrowIfNull(logger);
 
         this._serviceProvider = serviceProvider;
         this._logger = logger;
+        this._toolboxService = toolboxService;
     }
 
     /// <inheritdoc/>
@@ -92,14 +96,33 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         // 5. Build chat options
         var chatOptions = InputConverter.ConvertToChatOptions(request);
         chatOptions.Instructions = request.Instructions;
+
+        // Inject Foundry Toolbox tools when the toolbox service is available
+        if (this._toolboxService is not null)
+        {
+            var toolboxTools = this._toolboxService.Tools;
+            if (toolboxTools.Count > 0)
+            {
+                chatOptions.Tools = [.. chatOptions.Tools ?? [], .. toolboxTools];
+            }
+        }
+
         var options = new ChatClientAgentRunOptions(chatOptions);
 
-        // 6. Run the agent and convert output
+        // 6. Set up consent context for -32006 OAuth consent interception.
+        //    We create a linked CTS so the consent-aware tool wrapper can cancel the agent
+        //    run mid-loop when a -32006 error is returned by the proxy. The RequestConsentState
+        //    is a shared mutable object that flows via AsyncLocal to the tool wrapper.
+        using var consentCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var consentState = new RequestConsentState { CancellationSource = consentCts };
+        McpConsentContext.Current.Value = consentState;
+
+        // 7. Run the agent and convert output
         // NOTE: C# forbids 'yield return' inside a try block that has a catch clause,
         // and inside catch blocks. We use a flag to defer the yield to outside the try/catch.
         bool emittedTerminal = false;
         var enumerator = OutputConverter.ConvertUpdatesToEventsAsync(
-            agent.RunStreamingAsync(messages, session, options: options, cancellationToken: cancellationToken),
+            agent.RunStreamingAsync(messages, session, options: options, cancellationToken: consentCts.Token),
             stream,
             cancellationToken).GetAsyncEnumerator(cancellationToken);
         try
@@ -107,6 +130,7 @@ public class AgentFrameworkResponseHandler : ResponseHandler
             while (true)
             {
                 bool shutdownDetected = false;
+                McpConsentInfo? consentInfo = null;
                 ResponseStreamEvent? failedEvent = null;
                 ResponseStreamEvent? evt = null;
                 try
@@ -117,6 +141,11 @@ public class AgentFrameworkResponseHandler : ResponseHandler
                     }
 
                     evt = enumerator.Current;
+                }
+                catch (OperationCanceledException) when (!emittedTerminal && consentState.Pending is not null)
+                {
+                    // -32006 consent error: the tool wrapper cancelled consentCts and stored consent info.
+                    consentInfo = consentState.Pending;
                 }
                 catch (OperationCanceledException) when (context.IsShutdownRequested && !emittedTerminal)
                 {
@@ -135,6 +164,21 @@ public class AgentFrameworkResponseHandler : ResponseHandler
                     failedEvent = stream.EmitFailed(
                         ResponseErrorCode.ServerError,
                         ex.Message);
+                }
+
+                if (consentInfo is not null)
+                {
+                    // Emit mcp_approval_request output item + incomplete for the consent URL.
+                    foreach (var approvalEvent in stream.OutputItemMcpApprovalRequest(
+                        consentInfo.ToolsetName,
+                        consentInfo.ToolName,
+                        consentInfo.ConsentUrl))
+                    {
+                        yield return approvalEvent;
+                    }
+
+                    yield return stream.EmitIncomplete(reason: null);
+                    yield break;
                 }
 
                 if (failedEvent is not null)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/AgentFrameworkResponseHandler.cs
@@ -170,7 +170,7 @@ public class AgentFrameworkResponseHandler : ResponseHandler
                 {
                     // Emit mcp_approval_request output item + incomplete for the consent URL.
                     foreach (var approvalEvent in stream.OutputItemMcpApprovalRequest(
-                        consentInfo.ToolsetName,
+                        consentInfo.ToolboxName,
                         consentInfo.ToolName,
                         consentInfo.ConsentUrl))
                     {

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ConsentAwareMcpClientAIFunction.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ConsentAwareMcpClientAIFunction.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <c>mcp_approval_request</c> output item and marks the response as <c>incomplete</c>.
 /// </para>
 /// </remarks>
-internal sealed class ConsentAwareMcpClientTool : AIFunction
+internal sealed class ConsentAwareMcpClientAIFunction : AIFunction
 {
     private readonly McpClientTool _inner;
-    private readonly string _toolsetName;
+    private readonly string _toolboxName;
 
-    internal ConsentAwareMcpClientTool(McpClientTool inner, string toolsetName)
+    internal ConsentAwareMcpClientAIFunction(McpClientTool inner, string toolboxName)
     {
         this._inner = inner;
-        this._toolsetName = toolsetName;
+        this._toolboxName = toolboxName;
     }
 
     public override string Name => this._inner.Name;
@@ -59,7 +59,7 @@ internal sealed class ConsentAwareMcpClientTool : AIFunction
             var state = McpConsentContext.Current.Value;
             if (state is not null)
             {
-                state.Pending = new McpConsentInfo(this._toolsetName, this._inner.Name, ex.Message);
+                state.Pending = new McpConsentInfo(this._toolboxName, this._inner.Name, ex.Message);
                 state.CancellationSource?.Cancel();
             }
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ConsentAwareMcpClientTool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ConsentAwareMcpClientTool.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// An <see cref="AIFunction"/> wrapper around <see cref="McpClientTool"/> that intercepts
+/// JSON-RPC error -32006 (OAuth consent required) from the Foundry Toolsets proxy and
+/// propagates it back to <see cref="AgentFrameworkResponseHandler"/> via
+/// <see cref="McpConsentContext"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When the proxy returns -32006, the consent URL is stored in <see cref="McpConsentContext.Current"/>
+/// and the per-request <see cref="RequestConsentState.CancellationSource"/> is cancelled. This causes
+/// <see cref="FunctionInvokingChatClient"/> to stop the tool loop (it guards
+/// exceptions with <c>when (!ct.IsCancellationRequested)</c>) and surfaces an
+/// <see cref="System.OperationCanceledException"/> to the handler. The handler then emits the
+/// <c>mcp_approval_request</c> output item and marks the response as <c>incomplete</c>.
+/// </para>
+/// </remarks>
+internal sealed class ConsentAwareMcpClientTool : AIFunction
+{
+    private readonly McpClientTool _inner;
+    private readonly string _toolsetName;
+
+    internal ConsentAwareMcpClientTool(McpClientTool inner, string toolsetName)
+    {
+        this._inner = inner;
+        this._toolsetName = toolsetName;
+    }
+
+    public override string Name => this._inner.Name;
+
+    public override string Description => this._inner.Description;
+
+    public override JsonElement JsonSchema => this._inner.JsonSchema;
+
+    public override JsonElement? ReturnJsonSchema => this._inner.ReturnJsonSchema;
+
+    public override JsonSerializerOptions JsonSerializerOptions => this._inner.JsonSerializerOptions;
+
+    protected override async ValueTask<object?> InvokeCoreAsync(
+        AIFunctionArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await this._inner.InvokeAsync(arguments, cancellationToken).ConfigureAwait(false);
+        }
+        catch (McpProtocolException ex) when ((int)ex.ErrorCode == -32006)
+        {
+            var state = McpConsentContext.Current.Value;
+            if (state is not null)
+            {
+                state.Pending = new McpConsentInfo(this._toolsetName, this._inner.Name, ex.Message);
+                state.CancellationSource?.Cancel();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            throw; // fallback if the CT wasn't cancelled for some reason
+        }
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxBearerTokenHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxBearerTokenHandler.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// An <see cref="DelegatingHandler"/> that:
+/// <list type="bullet">
+///   <item>Acquires a fresh Azure bearer token (scope: <c>https://cognitiveservices.azure.com/.default</c>) per request.</item>
+///   <item>Injects the <c>Foundry-Features</c> header from <c>FOUNDRY_AGENT_TOOLSET_FEATURES</c> when non-empty.</item>
+///   <item>Retries on HTTP 429, 500, 502, and 503 with exponential back-off (max 3 attempts, per spec §7).</item>
+/// </list>
+/// </summary>
+internal sealed class FoundryToolboxBearerTokenHandler : DelegatingHandler
+{
+    private const int MaxRetries = 3;
+    private static readonly TokenRequestContext s_tokenContext =
+        new(["https://cognitiveservices.azure.com/.default"]);
+
+    private readonly TokenCredential _credential;
+    private readonly string? _featuresHeaderValue;
+
+    internal FoundryToolboxBearerTokenHandler(TokenCredential credential, string? featuresHeaderValue)
+    {
+        this._credential = credential;
+        this._featuresHeaderValue = featuresHeaderValue;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var token = await this._credential
+            .GetTokenAsync(s_tokenContext, cancellationToken)
+            .ConfigureAwait(false);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+        if (!string.IsNullOrEmpty(this._featuresHeaderValue))
+        {
+            request.Headers.TryAddWithoutValidation("Foundry-Features", this._featuresHeaderValue);
+        }
+
+        for (int attempt = 0; attempt < MaxRetries; attempt++)
+        {
+            // Clone the request for retries (the original request cannot be sent twice)
+            HttpRequestMessage requestToSend = attempt == 0
+                ? request
+                : await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false);
+
+            var response = await base.SendAsync(requestToSend, cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode is not (HttpStatusCode.TooManyRequests
+                or HttpStatusCode.InternalServerError
+                or HttpStatusCode.BadGateway
+                or HttpStatusCode.ServiceUnavailable))
+            {
+                return response;
+            }
+
+            response.Dispose();
+
+            if (attempt < MaxRetries - 1)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt)), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        // Final attempt after backoff exhausted — return last response (already disposed above, so resend)
+        return await base.SendAsync(
+            await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpRequestMessage> CloneRequestAsync(
+        HttpRequestMessage original,
+        CancellationToken cancellationToken)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri);
+
+        foreach (var header in original.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (original.Content is not null)
+        {
+            var contentBytes = await original.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            clone.Content = new ByteArrayContent(contentBytes);
+
+            foreach (var header in original.Content.Headers)
+            {
+                clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        return clone;
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
@@ -23,6 +23,16 @@ public sealed class FoundryToolboxOptions
     public string ApiVersion { get; set; } = "2025-05-01-preview";
 
     /// <summary>
+    /// Gets or sets a value indicating whether per-request toolbox markers (referenced via
+    /// <c>foundry-toolbox://</c> on the wire) are restricted to toolboxes pre-registered
+    /// via <see cref="ToolboxNames"/>. When <see langword="true"/> (the default), a request
+    /// that references an unknown toolbox is rejected. When <see langword="false"/>, the
+    /// server lazily opens an MCP connection for the referenced toolbox on first use and
+    /// caches it.
+    /// </summary>
+    public bool StrictMode { get; set; } = true;
+
+    /// <summary>
     /// For testing only: overrides <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c>.
     /// Not part of the public API.
     /// </summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 public sealed class FoundryToolboxOptions
 {
     /// <summary>
-    /// Gets the list of toolset names to connect to at startup.
-    /// Each name corresponds to a toolset registered in the Foundry project.
+    /// Gets the list of toolbox names to connect to at startup.
+    /// Each name corresponds to a toolbox registered in the Foundry project.
     /// The platform proxy URL is constructed as:
-    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolsetName}/mcp?api-version={ApiVersion}</c>
+    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolboxName}/mcp?api-version={ApiVersion}</c>
     /// </summary>
-    public IList<string> ToolsetNames { get; } = new List<string>();
+    public IList<string> ToolboxNames { get; } = [];
 
     /// <summary>
     /// Gets or sets the Toolsets API version to use when constructing proxy URLs.

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxOptions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// Options for Foundry Toolbox MCP integration.
+/// </summary>
+public sealed class FoundryToolboxOptions
+{
+    /// <summary>
+    /// Gets the list of toolset names to connect to at startup.
+    /// Each name corresponds to a toolset registered in the Foundry project.
+    /// The platform proxy URL is constructed as:
+    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolsetName}/mcp?api-version={ApiVersion}</c>
+    /// </summary>
+    public IList<string> ToolsetNames { get; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the Toolsets API version to use when constructing proxy URLs.
+    /// </summary>
+    public string ApiVersion { get; set; } = "2025-05-01-preview";
+
+    /// <summary>
+    /// For testing only: overrides <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c>.
+    /// Not part of the public API.
+    /// </summary>
+    internal string? EndpointOverride { get; set; }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
@@ -16,7 +16,7 @@ using ModelContextProtocol.Client;
 namespace Microsoft.Agents.AI.Foundry.Hosting;
 
 /// <summary>
-/// An <see cref="IHostedService"/> that eagerly connects to the Foundry Toolsets MCP proxy at
+/// An <see cref="IHostedService"/> that eagerly connects to the Foundry Toolboxes MCP proxy at
 /// container startup, discovers tools via <c>tools/list</c>, and caches them so they can be
 /// injected into every <see cref="ChatOptions"/> by
 /// <see cref="AgentFrameworkResponseHandler"/>.
@@ -28,7 +28,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// </para>
 /// <para>
 /// Initialization is performed in <see cref="StartAsync"/> so the readiness probe is only satisfied
-/// after all configured toolsets are connected and their tools discovered (spec §3.1 SHOULD).
+/// after all configured toolboxes are connected and their tools discovered (spec §3.1 SHOULD).
 /// </para>
 /// </remarks>
 public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
@@ -41,8 +41,8 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
     private readonly List<HttpClient> _httpClients = [];
 
     /// <summary>
-    /// Gets the cached list of <see cref="AITool"/> instances discovered from all connected toolsets.
-    /// Always non-null after startup; returns an empty list when no toolset endpoint is configured.
+    /// Gets the cached list of <see cref="AITool"/> instances discovered from all connected toolboxes.
+    /// Always non-null after startup; returns an empty list when no toolbox endpoint is configured.
     /// </summary>
     public IReadOnlyList<AITool> Tools { get; private set; } = [];
 
@@ -75,9 +75,9 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
             return;
         }
 
-        if (this._options.ToolsetNames.Count == 0)
+        if (this._options.ToolboxNames.Count == 0)
         {
-            this._logger.LogInformation("No toolset names configured; toolbox support is disabled.");
+            this._logger.LogInformation("No toolbox names configured; toolbox support is disabled.");
             this.Tools = [];
             return;
         }
@@ -88,21 +88,21 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
 
         var allTools = new List<AITool>();
 
-        // Deduplicate toolset names to avoid duplicate MCP clients and ambiguous tool exposure
+        // Deduplicate toolbox names to avoid duplicate MCP clients and ambiguous tool exposure
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var toolsetName in this._options.ToolsetNames)
+        foreach (var toolboxName in this._options.ToolboxNames)
         {
-            if (!seen.Add(toolsetName))
+            if (!seen.Add(toolboxName))
             {
                 continue;
             }
 
-            var proxyUrl = $"{endpoint.TrimEnd('/')}/{toolsetName}/mcp?api-version={this._options.ApiVersion}";
+            var proxyUrl = $"{endpoint.TrimEnd('/')}/{toolboxName}/mcp?api-version={this._options.ApiVersion}";
 
             if (this._logger.IsEnabled(LogLevel.Information))
             {
-                this._logger.LogInformation("Connecting to toolset '{ToolsetName}' at {ProxyUrl}.", toolsetName, proxyUrl);
+                this._logger.LogInformation("Connecting to toolbox '{ToolboxName}' at {ProxyUrl}.", toolboxName, proxyUrl);
             }
 
             try
@@ -118,7 +118,7 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
                 var transportOptions = new HttpClientTransportOptions
                 {
                     Endpoint = new Uri(proxyUrl),
-                    Name = toolsetName,
+                    Name = toolboxName,
                 };
 
                 var transport = new HttpClientTransport(transportOptions, httpClient);
@@ -144,22 +144,22 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
                 if (this._logger.IsEnabled(LogLevel.Information))
                 {
                     this._logger.LogInformation(
-                        "Toolset '{ToolsetName}': discovered {ToolCount} tool(s).",
-                        toolsetName,
+                        "Toolbox '{ToolboxName}': discovered {ToolCount} tool(s).",
+                        toolboxName,
                         tools.Count);
                 }
 
                 foreach (var tool in tools)
                 {
-                    allTools.Add(new ConsentAwareMcpClientTool(tool, toolsetName));
+                    allTools.Add(new ConsentAwareMcpClientAIFunction(tool, toolboxName));
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 this._logger.LogError(
                     ex,
-                    "Failed to connect to toolset '{ToolsetName}'. Tools from this toolset will not be available.",
-                    toolsetName);
+                    "Failed to connect to toolbox '{ToolboxName}'. Tools from this toolbox will not be available.",
+                    toolboxName);
             }
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Client;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// An <see cref="IHostedService"/> that eagerly connects to the Foundry Toolsets MCP proxy at
+/// container startup, discovers tools via <c>tools/list</c>, and caches them so they can be
+/// injected into every <see cref="ChatOptions"/> by
+/// <see cref="AgentFrameworkResponseHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c> is absent the service starts without error and returns
+/// an empty tool list, keeping the container healthy per spec §2.
+/// </para>
+/// <para>
+/// Initialization is performed in <see cref="StartAsync"/> so the readiness probe is only satisfied
+/// after all configured toolsets are connected and their tools discovered (spec §3.1 SHOULD).
+/// </para>
+/// </remarks>
+public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
+{
+    private readonly FoundryToolboxOptions _options;
+    private readonly TokenCredential _credential;
+    private readonly ILogger<FoundryToolboxService> _logger;
+
+    private readonly List<McpClient> _clients = [];
+    private readonly List<HttpClient> _httpClients = [];
+
+    /// <summary>
+    /// Gets the cached list of <see cref="AITool"/> instances discovered from all connected toolsets.
+    /// Always non-null after startup; returns an empty list when no toolset endpoint is configured.
+    /// </summary>
+    public IReadOnlyList<AITool> Tools { get; private set; } = [];
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FoundryToolboxService"/>.
+    /// </summary>
+    public FoundryToolboxService(
+        IOptions<FoundryToolboxOptions> options,
+        TokenCredential credential,
+        ILogger<FoundryToolboxService>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(credential);
+
+        this._options = options.Value;
+        this._credential = credential;
+        this._logger = logger ?? NullLogger<FoundryToolboxService>.Instance;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = this._options.EndpointOverride
+            ?? Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_ENDPOINT");
+
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            this._logger.LogInformation("FOUNDRY_AGENT_TOOLSET_ENDPOINT is not set; toolbox support is disabled.");
+            this.Tools = [];
+            return;
+        }
+
+        if (this._options.ToolsetNames.Count == 0)
+        {
+            this._logger.LogInformation("No toolset names configured; toolbox support is disabled.");
+            this.Tools = [];
+            return;
+        }
+
+        var featuresHeader = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_FEATURES");
+        var agentName = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_NAME") ?? "hosted-agent";
+        var agentVersion = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_VERSION") ?? "1.0.0";
+
+        var allTools = new List<AITool>();
+
+        // Deduplicate toolset names to avoid duplicate MCP clients and ambiguous tool exposure
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var toolsetName in this._options.ToolsetNames)
+        {
+            if (!seen.Add(toolsetName))
+            {
+                continue;
+            }
+
+            var proxyUrl = $"{endpoint.TrimEnd('/')}/{toolsetName}/mcp?api-version={this._options.ApiVersion}";
+
+            if (this._logger.IsEnabled(LogLevel.Information))
+            {
+                this._logger.LogInformation("Connecting to toolset '{ToolsetName}' at {ProxyUrl}.", toolsetName, proxyUrl);
+            }
+
+            try
+            {
+                var handler = new FoundryToolboxBearerTokenHandler(this._credential, featuresHeader)
+                {
+                    InnerHandler = new HttpClientHandler()
+                };
+
+                var httpClient = new HttpClient(handler);
+                this._httpClients.Add(httpClient);
+
+                var transportOptions = new HttpClientTransportOptions
+                {
+                    Endpoint = new Uri(proxyUrl),
+                    Name = toolsetName,
+                };
+
+                var transport = new HttpClientTransport(transportOptions, httpClient);
+
+                var clientOptions = new McpClientOptions
+                {
+                    ClientInfo = new()
+                    {
+                        Name = agentName,
+                        Version = agentVersion
+                    }
+                };
+
+                var client = await McpClient.CreateAsync(
+                    transport,
+                    clientOptions,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                this._clients.Add(client);
+
+                var tools = await client.ListToolsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (this._logger.IsEnabled(LogLevel.Information))
+                {
+                    this._logger.LogInformation(
+                        "Toolset '{ToolsetName}': discovered {ToolCount} tool(s).",
+                        toolsetName,
+                        tools.Count);
+                }
+
+                foreach (var tool in tools)
+                {
+                    allTools.Add(new ConsentAwareMcpClientTool(tool, toolsetName));
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                this._logger.LogError(
+                    ex,
+                    "Failed to connect to toolset '{ToolsetName}'. Tools from this toolset will not be available.",
+                    toolsetName);
+            }
+        }
+
+        this.Tools = allTools;
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var client in this._clients)
+        {
+            await client.DisposeAsync().ConfigureAwait(false);
+        }
+
+        this._clients.Clear();
+
+        foreach (var httpClient in this._httpClients)
+        {
+            httpClient.Dispose();
+        }
+
+        this._httpClients.Clear();
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/FoundryToolboxService.cs
@@ -18,17 +18,19 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <summary>
 /// An <see cref="IHostedService"/> that eagerly connects to the Foundry Toolboxes MCP proxy at
 /// container startup, discovers tools via <c>tools/list</c>, and caches them so they can be
-/// injected into every <see cref="ChatOptions"/> by
-/// <see cref="AgentFrameworkResponseHandler"/>.
+/// injected into every <see cref="ChatOptions"/> by <see cref="AgentFrameworkResponseHandler"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// When <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c> is absent the service starts without error and returns
-/// an empty tool list, keeping the container healthy per spec §2.
+/// When <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c> is absent the service starts without error and
+/// no tools are registered, keeping the container healthy per spec §2.
 /// </para>
 /// <para>
-/// Initialization is performed in <see cref="StartAsync"/> so the readiness probe is only satisfied
-/// after all configured toolboxes are connected and their tools discovered (spec §3.1 SHOULD).
+/// Startup eagerly connects to every name in <see cref="FoundryToolboxOptions.ToolboxNames"/>.
+/// Beyond those, per-request toolbox markers (see <see cref="HostedMcpToolboxAITool"/>) are
+/// resolved at request time through <see cref="GetToolboxToolsAsync"/>. Unknown toolboxes are
+/// rejected when <see cref="FoundryToolboxOptions.StrictMode"/> is <see langword="true"/> and
+/// lazily connected otherwise.
 /// </para>
 /// </remarks>
 public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
@@ -37,12 +39,17 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
     private readonly TokenCredential _credential;
     private readonly ILogger<FoundryToolboxService> _logger;
 
-    private readonly List<McpClient> _clients = [];
-    private readonly List<HttpClient> _httpClients = [];
+    private readonly Dictionary<string, CachedToolbox> _toolboxes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _lazyOpenLock = new(1, 1);
+
+    private string? _resolvedEndpoint;
+    private string? _featuresHeader;
+    private string _agentName = "hosted-agent";
+    private string _agentVersion = "1.0.0";
 
     /// <summary>
-    /// Gets the cached list of <see cref="AITool"/> instances discovered from all connected toolboxes.
-    /// Always non-null after startup; returns an empty list when no toolbox endpoint is configured.
+    /// Gets the cached list of <see cref="AITool"/> instances discovered from all
+    /// pre-registered toolboxes. Always non-null after startup.
     /// </summary>
     public IReadOnlyList<AITool> Tools { get; private set; } = [];
 
@@ -65,30 +72,28 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
     /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var endpoint = this._options.EndpointOverride
+        this._resolvedEndpoint = this._options.EndpointOverride
             ?? Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_ENDPOINT");
 
-        if (string.IsNullOrEmpty(endpoint))
+        if (string.IsNullOrEmpty(this._resolvedEndpoint))
         {
             this._logger.LogInformation("FOUNDRY_AGENT_TOOLSET_ENDPOINT is not set; toolbox support is disabled.");
             this.Tools = [];
             return;
         }
 
+        this._featuresHeader = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_FEATURES");
+        this._agentName = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_NAME") ?? "hosted-agent";
+        this._agentVersion = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_VERSION") ?? "1.0.0";
+
         if (this._options.ToolboxNames.Count == 0)
         {
-            this._logger.LogInformation("No toolbox names configured; toolbox support is disabled.");
+            this._logger.LogInformation("No pre-registered toolbox names configured.");
             this.Tools = [];
             return;
         }
 
-        var featuresHeader = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_FEATURES");
-        var agentName = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_NAME") ?? "hosted-agent";
-        var agentVersion = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_VERSION") ?? "1.0.0";
-
         var allTools = new List<AITool>();
-
-        // Deduplicate toolbox names to avoid duplicate MCP clients and ambiguous tool exposure
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var toolboxName in this._options.ToolboxNames)
@@ -98,61 +103,11 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
                 continue;
             }
 
-            var proxyUrl = $"{endpoint.TrimEnd('/')}/{toolboxName}/mcp?api-version={this._options.ApiVersion}";
-
-            if (this._logger.IsEnabled(LogLevel.Information))
-            {
-                this._logger.LogInformation("Connecting to toolbox '{ToolboxName}' at {ProxyUrl}.", toolboxName, proxyUrl);
-            }
-
             try
             {
-                var handler = new FoundryToolboxBearerTokenHandler(this._credential, featuresHeader)
-                {
-                    InnerHandler = new HttpClientHandler()
-                };
-
-                var httpClient = new HttpClient(handler);
-                this._httpClients.Add(httpClient);
-
-                var transportOptions = new HttpClientTransportOptions
-                {
-                    Endpoint = new Uri(proxyUrl),
-                    Name = toolboxName,
-                };
-
-                var transport = new HttpClientTransport(transportOptions, httpClient);
-
-                var clientOptions = new McpClientOptions
-                {
-                    ClientInfo = new()
-                    {
-                        Name = agentName,
-                        Version = agentVersion
-                    }
-                };
-
-                var client = await McpClient.CreateAsync(
-                    transport,
-                    clientOptions,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                this._clients.Add(client);
-
-                var tools = await client.ListToolsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                if (this._logger.IsEnabled(LogLevel.Information))
-                {
-                    this._logger.LogInformation(
-                        "Toolbox '{ToolboxName}': discovered {ToolCount} tool(s).",
-                        toolboxName,
-                        tools.Count);
-                }
-
-                foreach (var tool in tools)
-                {
-                    allTools.Add(new ConsentAwareMcpClientAIFunction(tool, toolboxName));
-                }
+                var cached = await this.OpenToolboxAsync(toolboxName, version: null, cancellationToken).ConfigureAwait(false);
+                this._toolboxes[toolboxName] = cached;
+                allTools.AddRange(cached.Tools);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -166,24 +121,139 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
         this.Tools = allTools;
     }
 
+    /// <summary>
+    /// Resolves the tools for a per-request toolbox marker. Returns cached tools when the
+    /// toolbox has already been opened; otherwise honors
+    /// <see cref="FoundryToolboxOptions.StrictMode"/> to either reject or lazily open it.
+    /// </summary>
+    /// <param name="toolboxName">The Foundry toolbox name from the marker.</param>
+    /// <param name="version">Optional pinned version; ignored when matching a pre-registered entry.</param>
+    /// <param name="cancellationToken">The request cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the toolbox is not pre-registered and <see cref="FoundryToolboxOptions.StrictMode"/>
+    /// is <see langword="true"/>, or when the toolbox endpoint is not configured.
+    /// </exception>
+    public async ValueTask<IReadOnlyList<AITool>> GetToolboxToolsAsync(
+        string toolboxName,
+        string? version,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolboxName);
+
+        if (this._toolboxes.TryGetValue(toolboxName, out var cached))
+        {
+            return cached.Tools;
+        }
+
+        if (this._options.StrictMode)
+        {
+            throw new InvalidOperationException(
+                $"Toolbox '{toolboxName}' is not pre-registered via AddFoundryToolboxes(...). " +
+                $"Either register it at startup or set {nameof(FoundryToolboxOptions.StrictMode)}=false to allow lazy resolution.");
+        }
+
+        if (string.IsNullOrEmpty(this._resolvedEndpoint))
+        {
+            throw new InvalidOperationException(
+                $"Cannot resolve toolbox '{toolboxName}': FOUNDRY_AGENT_TOOLSET_ENDPOINT is not set.");
+        }
+
+        await this._lazyOpenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Double-check after acquiring the lock to avoid duplicate opens under concurrency.
+            if (this._toolboxes.TryGetValue(toolboxName, out cached))
+            {
+                return cached.Tools;
+            }
+
+            cached = await this.OpenToolboxAsync(toolboxName, version, cancellationToken).ConfigureAwait(false);
+            this._toolboxes[toolboxName] = cached;
+            return cached.Tools;
+        }
+        finally
+        {
+            this._lazyOpenLock.Release();
+        }
+    }
+
+    private async Task<CachedToolbox> OpenToolboxAsync(
+        string toolboxName,
+        string? version,
+        CancellationToken cancellationToken)
+    {
+        var proxyUrl = $"{this._resolvedEndpoint!.TrimEnd('/')}/{toolboxName}/mcp?api-version={this._options.ApiVersion}";
+
+        if (this._logger.IsEnabled(LogLevel.Information))
+        {
+            this._logger.LogInformation("Connecting to toolbox '{ToolboxName}' at {ProxyUrl}.", toolboxName, proxyUrl);
+        }
+
+        var handler = new FoundryToolboxBearerTokenHandler(this._credential, this._featuresHeader)
+        {
+            InnerHandler = new HttpClientHandler()
+        };
+
+        var httpClient = new HttpClient(handler);
+
+        var transportOptions = new HttpClientTransportOptions
+        {
+            Endpoint = new Uri(proxyUrl),
+            Name = toolboxName,
+        };
+
+        var transport = new HttpClientTransport(transportOptions, httpClient);
+
+        var clientOptions = new McpClientOptions
+        {
+            ClientInfo = new()
+            {
+                Name = this._agentName,
+                Version = this._agentVersion
+            }
+        };
+
+        var client = await McpClient.CreateAsync(
+            transport,
+            clientOptions,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var mcpTools = await client.ListToolsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        if (this._logger.IsEnabled(LogLevel.Information))
+        {
+            this._logger.LogInformation(
+                "Toolbox '{ToolboxName}': discovered {ToolCount} tool(s).",
+                toolboxName,
+                mcpTools.Count);
+        }
+
+        var wrapped = new List<AITool>(mcpTools.Count);
+        foreach (var tool in mcpTools)
+        {
+            wrapped.Add(new ConsentAwareMcpClientAIFunction(tool, toolboxName));
+        }
+
+        _ = version; // reserved for future version-specific routing; currently handled server-side by the proxy.
+
+        return new CachedToolbox(client, httpClient, wrapped);
+    }
+
     /// <inheritdoc/>
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        foreach (var client in this._clients)
+        foreach (var cached in this._toolboxes.Values)
         {
-            await client.DisposeAsync().ConfigureAwait(false);
+            await cached.Client.DisposeAsync().ConfigureAwait(false);
+            cached.HttpClient.Dispose();
         }
 
-        this._clients.Clear();
-
-        foreach (var httpClient in this._httpClients)
-        {
-            httpClient.Dispose();
-        }
-
-        this._httpClients.Clear();
+        this._toolboxes.Clear();
+        this._lazyOpenLock.Dispose();
     }
+
+    private sealed record CachedToolbox(McpClient Client, HttpClient HttpClient, IReadOnlyList<AITool> Tools);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/InputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/InputConverter.cs
@@ -97,6 +97,37 @@ internal static class InputConverter
         };
     }
 
+    /// <summary>
+    /// Extracts any Foundry Toolbox markers (<c>foundry-toolbox://</c>) from the request's
+    /// MCP tool entries so the handler can resolve them server-side.
+    /// </summary>
+    /// <param name="request">The create response request.</param>
+    /// <returns>A list of (name, optional version) pairs, one per detected marker. Never <see langword="null"/>.</returns>
+    public static List<(string Name, string? Version)> ReadMcpToolboxMarkers(CreateResponse request)
+    {
+        var markers = new List<(string Name, string? Version)>();
+
+        if (request.Tools is null)
+        {
+            return markers;
+        }
+
+        foreach (var tool in request.Tools)
+        {
+            if (tool is not MCPTool mcp || mcp.ServerUrl is null)
+            {
+                continue;
+            }
+
+            if (HostedMcpToolboxAITool.TryParseToolboxAddress(mcp.ServerUrl.ToString(), out var name, out var version))
+            {
+                markers.Add((name!, version));
+            }
+        }
+
+        return markers;
+    }
+
     private static ChatMessage? ConvertInputItemToMessage(Item item)
     {
         return item switch

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/McpConsentContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/McpConsentContext.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// Carries OAuth consent information for a single tool call that returned JSON-RPC error -32006.
+/// </summary>
+/// <param name="ToolsetName">The toolset name that owns the tool.</param>
+/// <param name="ToolName">Fully-qualified tool name (e.g., <c>logicapps.send_email</c>).</param>
+/// <param name="ConsentUrl">The OAuth consent URL the user must visit.</param>
+internal sealed record McpConsentInfo(string ToolsetName, string ToolName, string ConsentUrl);
+
+/// <summary>
+/// Per-request mutable state shared between <see cref="ConsentAwareMcpClientTool"/> (child context)
+/// and <see cref="AgentFrameworkResponseHandler"/> (parent context) via <see cref="McpConsentContext.Current"/>.
+/// </summary>
+/// <remarks>
+/// Because <see cref="AsyncLocal{T}"/> only flows values DOWN from parent to children,
+/// we use a shared reference type so children can mutate it and the parent observes the mutations.
+/// </remarks>
+internal sealed class RequestConsentState
+{
+    /// <summary>Consent information set by the tool wrapper when -32006 is detected.</summary>
+    internal McpConsentInfo? Pending { get; set; }
+
+    /// <summary>The linked CTS to cancel when consent is required.</summary>
+    internal CancellationTokenSource? CancellationSource { get; set; }
+}
+
+/// <summary>
+/// Thread-static (AsyncLocal) context that enables <see cref="ConsentAwareMcpClientTool"/>
+/// to signal a consent error back to <see cref="AgentFrameworkResponseHandler"/> through the
+/// <see cref="FunctionInvokingChatClient"/> tool loop.
+/// </summary>
+internal static class McpConsentContext
+{
+    /// <summary>
+    /// Holds the shared <see cref="RequestConsentState"/> for the current request.
+    /// Set once by the handler; read and mutated by the tool wrapper.
+    /// </summary>
+    internal static readonly AsyncLocal<RequestConsentState?> Current = new();
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/McpConsentContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/McpConsentContext.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <summary>
 /// Carries OAuth consent information for a single tool call that returned JSON-RPC error -32006.
 /// </summary>
-/// <param name="ToolsetName">The toolset name that owns the tool.</param>
+/// <param name="ToolboxName">The toolbox name that owns the tool.</param>
 /// <param name="ToolName">Fully-qualified tool name (e.g., <c>logicapps.send_email</c>).</param>
 /// <param name="ConsentUrl">The OAuth consent URL the user must visit.</param>
-internal sealed record McpConsentInfo(string ToolsetName, string ToolName, string ConsentUrl);
+internal sealed record McpConsentInfo(string ToolboxName, string ToolName, string ConsentUrl);
 
 /// <summary>
-/// Per-request mutable state shared between <see cref="ConsentAwareMcpClientTool"/> (child context)
+/// Per-request mutable state shared between <see cref="ConsentAwareMcpClientAIFunction"/> (child context)
 /// and <see cref="AgentFrameworkResponseHandler"/> (parent context) via <see cref="McpConsentContext.Current"/>.
 /// </summary>
 /// <remarks>
@@ -31,7 +31,7 @@ internal sealed class RequestConsentState
 }
 
 /// <summary>
-/// Thread-static (AsyncLocal) context that enables <see cref="ConsentAwareMcpClientTool"/>
+/// Thread-static (AsyncLocal) context that enables <see cref="ConsentAwareMcpClientAIFunction"/>
 /// to signal a consent error back to <see cref="AgentFrameworkResponseHandler"/> through the
 /// <see cref="FunctionInvokingChatClient"/> tool loop.
 /// </summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.AI.AgentServer.Responses;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -94,6 +96,59 @@ public static class FoundryHostingExtensions
         services.TryAddSingleton(agentSessionStore);
 
         services.TryAddSingleton<ResponseHandler, AgentFrameworkResponseHandler>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Foundry Toolbox service, which eagerly connects to the Foundry Toolsets
+    /// MCP proxy at startup and provides MCP tools to <see cref="AgentFrameworkResponseHandler"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each string in <paramref name="toolsetNames"/> is a toolset name registered in the Foundry
+    /// project. The proxy URL per toolset is constructed as:
+    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolsetName}/mcp?api-version=2025-05-01-preview</c>
+    /// </para>
+    /// <para>
+    /// When <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c> is absent, startup succeeds without error and
+    /// no tools are loaded (the container remains healthy per spec §2).
+    /// </para>
+    /// <para>
+    /// Example:
+    /// <code>
+    /// builder.Services.AddFoundryToolboxes("my-tools", "another-toolset");
+    /// </code>
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="toolsetNames">Names of the Foundry toolsets to connect to.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFoundryToolboxes(
+        this IServiceCollection services,
+        params string[] toolsetNames)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.Configure<FoundryToolboxOptions>(opt =>
+        {
+            foreach (var name in toolsetNames)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    opt.ToolsetNames.Add(name);
+                }
+            }
+        });
+
+        // Register DefaultAzureCredential as the default TokenCredential if not already registered
+        services.TryAddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
+
+        // Register FoundryToolboxService as a singleton so it can be injected into the handler
+        services.TryAddSingleton<FoundryToolboxService>();
+
+        // Add it as a hosted service so StartAsync is called before the app starts serving requests
+        services.AddHostedService(sp => sp.GetRequiredService<FoundryToolboxService>());
+
         return services;
     }
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
@@ -100,14 +100,14 @@ public static class FoundryHostingExtensions
     }
 
     /// <summary>
-    /// Registers the Foundry Toolbox service, which eagerly connects to the Foundry Toolsets
+    /// Registers the Foundry Toolbox service, which eagerly connects to the Foundry Toolboxes
     /// MCP proxy at startup and provides MCP tools to <see cref="AgentFrameworkResponseHandler"/>.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Each string in <paramref name="toolsetNames"/> is a toolset name registered in the Foundry
-    /// project. The proxy URL per toolset is constructed as:
-    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolsetName}/mcp?api-version=2025-05-01-preview</c>
+    /// Each string in <paramref name="toolboxNames"/> is a toolbox name registered in the Foundry
+    /// project. The proxy URL per toolbox is constructed as:
+    /// <c>{FOUNDRY_AGENT_TOOLSET_ENDPOINT}/{toolboxName}/mcp?api-version=2025-05-01-preview</c>
     /// </para>
     /// <para>
     /// When <c>FOUNDRY_AGENT_TOOLSET_ENDPOINT</c> is absent, startup succeeds without error and
@@ -116,26 +116,26 @@ public static class FoundryHostingExtensions
     /// <para>
     /// Example:
     /// <code>
-    /// builder.Services.AddFoundryToolboxes("my-tools", "another-toolset");
+    /// builder.Services.AddFoundryToolboxes("my-toolbox", "another-toolbox");
     /// </code>
     /// </para>
     /// </remarks>
     /// <param name="services">The service collection.</param>
-    /// <param name="toolsetNames">Names of the Foundry toolsets to connect to.</param>
+    /// <param name="toolboxNames">Names of the Foundry toolboxes to connect to.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddFoundryToolboxes(
         this IServiceCollection services,
-        params string[] toolsetNames)
+        params string[] toolboxNames)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.Configure<FoundryToolboxOptions>(opt =>
         {
-            foreach (var name in toolsetNames)
+            foreach (var name in toolboxNames)
             {
                 if (!string.IsNullOrWhiteSpace(name))
                 {
-                    opt.ToolsetNames.Add(name);
+                    opt.ToolboxNames.Add(name);
                 }
             }
         });

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
@@ -126,6 +126,19 @@ public static class FoundryHostingExtensions
     public static IServiceCollection AddFoundryToolboxes(
         this IServiceCollection services,
         params string[] toolboxNames)
+        => services.AddFoundryToolboxes(configureOptions: null, toolboxNames);
+
+    /// <summary>
+    /// Registers the Foundry Toolbox service with additional options configuration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">Callback to further configure <see cref="FoundryToolboxOptions"/> (e.g. set <see cref="FoundryToolboxOptions.StrictMode"/>).</param>
+    /// <param name="toolboxNames">Names of the Foundry toolboxes to pre-register at startup.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddFoundryToolboxes(
+        this IServiceCollection services,
+        Action<FoundryToolboxOptions>? configureOptions,
+        params string[] toolboxNames)
     {
         ArgumentNullException.ThrowIfNull(services);
 
@@ -138,6 +151,8 @@ public static class FoundryHostingExtensions
                     opt.ToolboxNames.Add(name);
                 }
             }
+
+            configureOptions?.Invoke(opt);
         });
 
         // Register DefaultAzureCredential as the default TokenCredential if not already registered

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
@@ -36,6 +36,8 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Azure.AI.AgentServer.Responses" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/HostedMcpToolboxAIToolTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/HostedMcpToolboxAIToolTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+
+namespace Microsoft.Agents.AI.Foundry.UnitTests;
+
+public class HostedMcpToolboxAIToolTests
+{
+    [Fact]
+    public void Ctor_NameOnly_BuildsMarkerAddress()
+    {
+        var tool = new HostedMcpToolboxAITool("my-toolbox");
+
+        Assert.Equal("my-toolbox", tool.ToolboxName);
+        Assert.Null(tool.Version);
+        Assert.Equal("my-toolbox", tool.ServerName);
+        Assert.Equal("foundry-toolbox://my-toolbox", tool.ServerAddress);
+        Assert.Equal("mcp", tool.Name);
+    }
+
+    [Fact]
+    public void Ctor_WithVersion_IncludesVersionQuery()
+    {
+        var tool = new HostedMcpToolboxAITool("my-toolbox", "v3");
+
+        Assert.Equal("v3", tool.Version);
+        Assert.Equal("foundry-toolbox://my-toolbox?version=v3", tool.ServerAddress);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Ctor_InvalidName_Throws(string? name)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new HostedMcpToolboxAITool(name!));
+    }
+
+    [Fact]
+    public void TryParseToolboxAddress_NameOnly_ReturnsTrue()
+    {
+        var ok = HostedMcpToolboxAITool.TryParseToolboxAddress(
+            "foundry-toolbox://my-toolbox", out var name, out var version);
+
+        Assert.True(ok);
+        Assert.Equal("my-toolbox", name);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void TryParseToolboxAddress_WithVersion_ExtractsVersion()
+    {
+        var ok = HostedMcpToolboxAITool.TryParseToolboxAddress(
+            "foundry-toolbox://my-toolbox?version=v3", out var name, out var version);
+
+        Assert.True(ok);
+        Assert.Equal("my-toolbox", name);
+        Assert.Equal("v3", version);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/mcp")]
+    [InlineData("not-a-url")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParseToolboxAddress_NonMarker_ReturnsFalse(string? address)
+    {
+        var ok = HostedMcpToolboxAITool.TryParseToolboxAddress(address, out var name, out var version);
+
+        Assert.False(ok);
+        Assert.Null(name);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void TryParseToolboxAddress_RoundTripsFromBuild()
+    {
+        var address = HostedMcpToolboxAITool.BuildAddress("box", "2025-06-01");
+
+        var ok = HostedMcpToolboxAITool.TryParseToolboxAddress(address, out var name, out var version);
+
+        Assert.True(ok);
+        Assert.Equal("box", name);
+        Assert.Equal("2025-06-01", version);
+    }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_ReturnsMarker()
+    {
+        var tool = FoundryAITool.CreateHostedMcpToolbox("my-toolbox", "v1");
+
+        var marker = Assert.IsType<HostedMcpToolboxAITool>(tool);
+        Assert.Equal("my-toolbox", marker.ToolboxName);
+        Assert.Equal("v1", marker.Version);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/HostedMcpToolboxAIToolTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/HostedMcpToolboxAIToolTests.cs
@@ -93,4 +93,71 @@ public class HostedMcpToolboxAIToolTests
         Assert.Equal("my-toolbox", marker.ToolboxName);
         Assert.Equal("v1", marker.Version);
     }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_FromToolboxRecord_UsesNameAndDefaultVersion()
+    {
+        var record = Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ToolboxRecord(
+            id: "tbx-123",
+            name: "calendar-tools",
+            defaultVersion: "v2");
+
+        var tool = FoundryAITool.CreateHostedMcpToolbox(record);
+
+        var marker = Assert.IsType<HostedMcpToolboxAITool>(tool);
+        Assert.Equal("calendar-tools", marker.ToolboxName);
+        Assert.Equal("v2", marker.Version);
+        Assert.Equal("foundry-toolbox://calendar-tools?version=v2", marker.ServerAddress);
+    }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_FromToolboxRecord_NullDefaultVersionOmitsQuery()
+    {
+        var record = Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ToolboxRecord(
+            id: "tbx-abc",
+            name: "finance-tools",
+            defaultVersion: null);
+
+        var tool = FoundryAITool.CreateHostedMcpToolbox(record);
+
+        var marker = Assert.IsType<HostedMcpToolboxAITool>(tool);
+        Assert.Equal("finance-tools", marker.ToolboxName);
+        Assert.Null(marker.Version);
+        Assert.Equal("foundry-toolbox://finance-tools", marker.ServerAddress);
+    }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_FromToolboxRecord_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => FoundryAITool.CreateHostedMcpToolbox((Azure.AI.Projects.Agents.ToolboxRecord)null!));
+    }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_FromToolboxVersion_UsesNameAndVersion()
+    {
+        var version = Azure.AI.Projects.Agents.ProjectsAgentsModelFactory.ToolboxVersion(
+            metadata: null,
+            id: "ver-1",
+            name: "hr-tools",
+            version: "2025-09-01",
+            description: "HR toolbox",
+            createdAt: DateTimeOffset.UtcNow,
+            tools: null,
+            policies: null);
+
+        var tool = FoundryAITool.CreateHostedMcpToolbox(version);
+
+        var marker = Assert.IsType<HostedMcpToolboxAITool>(tool);
+        Assert.Equal("hr-tools", marker.ToolboxName);
+        Assert.Equal("2025-09-01", marker.Version);
+        Assert.Equal("foundry-toolbox://hr-tools?version=2025-09-01", marker.ServerAddress);
+    }
+
+    [Fact]
+    public void FoundryAITool_CreateHostedMcpToolbox_FromToolboxVersion_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => FoundryAITool.CreateHostedMcpToolbox((Azure.AI.Projects.Agents.ToolboxVersion)null!));
+    }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/Hosting/FoundryToolboxServiceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/Hosting/FoundryToolboxServiceTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Agents.AI.Foundry.Hosting;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Microsoft.Agents.AI.Foundry.UnitTests.Hosting;
+
+public class FoundryToolboxServiceTests
+{
+    [Fact]
+    public async Task GetToolboxToolsAsync_StrictMode_ThrowsForUnknownToolboxAsync()
+    {
+        var options = new FoundryToolboxOptions { StrictMode = true };
+        var service = new FoundryToolboxService(
+            Options.Create(options),
+            Mock.Of<TokenCredential>());
+
+        // Act + Assert: no StartAsync so Tools is empty; unknown name in strict mode throws.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await service.GetToolboxToolsAsync("missing", version: null, CancellationToken.None));
+
+        Assert.Contains("missing", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("StrictMode", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetToolboxToolsAsync_NonStrictMode_RequiresEndpointAsync()
+    {
+        var options = new FoundryToolboxOptions { StrictMode = false };
+        var service = new FoundryToolboxService(
+            Options.Create(options),
+            Mock.Of<TokenCredential>());
+
+        // Without calling StartAsync, endpoint is not resolved so lazy-open fails clearly.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await service.GetToolboxToolsAsync("missing", version: null, CancellationToken.None));
+
+        Assert.Contains("FOUNDRY_AGENT_TOOLSET_ENDPOINT", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutEndpoint_LeavesToolsEmptyAsync()
+    {
+        // Ensure env var is not set (tests may run in any CI environment)
+        var saved = Environment.GetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_ENDPOINT");
+        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_ENDPOINT", null);
+        try
+        {
+            var options = new FoundryToolboxOptions();
+            options.ToolboxNames.Add("any");
+            var service = new FoundryToolboxService(
+                Options.Create(options),
+                Mock.Of<TokenCredential>());
+
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.Empty(service.Tools);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FOUNDRY_AGENT_TOOLSET_ENDPOINT", saved);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Foundry Toolbox (MCP proxy) integration to `AgentFrameworkResponseHandler` in `Microsoft.Agents.AI.Foundry`, supporting both **host-configured** (eager, startup) and **client-selectable** (per-request, lazy) toolbox injection.

### What this adds

**Phase 1 — Host-configured toolboxes (eager)**

- **Eager initialization** via `IHostedService` — MCP clients connect and discover tools at startup, gating the readiness probe (spec §3.1)
- **Tool injection** — discovered MCP tools are added to `ChatOptions.Tools` on every request
- **OAuth consent interception** — JSON-RPC error `-32006` returned by the Foundry proxy is caught by a per-tool `AIFunction` wrapper, stored in `AsyncLocal` shared state, and propagated back to the handler which emits `mcp_approval_request` + `incomplete` SSE events
- **Retry/backoff** — `FoundryToolboxBearerTokenHandler` retries up to 3x with exponential backoff on 429/5xx (spec §7)
- **Graceful degradation** — when `FOUNDRY_AGENT_TOOLSET_ENDPOINT` is absent the container starts healthy with no tools (spec §2)

**Phase 2 — Client-selectable toolboxes (per-request)**

- **`HostedMcpToolboxAITool`** — new public (experimental) marker type subclassing `HostedMcpServerTool`. Rides the OpenAI Responses `mcp` wire format using a synthetic `foundry-toolbox://<name>?version=<v>` URI so toolbox selection survives client → server serialization without a new wire type.
- **`FoundryAITool.CreateHostedMcpToolbox(...)`** — factory overloads so consumers can attach a toolbox marker from (a) a plain `name [+ version]`, (b) a `ToolboxRecord` (uses `Name` + `DefaultVersion`), or (c) a specific `ToolboxVersion` (uses `Name` + `Version`) retrieved from `AIProjectClient`.
- **Per-request parsing & merge** — handler parses marker tools from the incoming request, resolves them via `FoundryToolboxService`, and merges with any host-configured toolbox tools. Markers are deduped by name per request.
- **Lazy toolbox open** — toolboxes requested by the client that weren't pre-registered are opened on demand and cached (double-checked `SemaphoreSlim`). Cached toolboxes are reused across requests.
- **`StrictMode` option** (default `true`) — when a client-requested toolbox fails to resolve, the handler emits a failed response with a clear error. Set `StrictMode = false` to silently skip unresolvable toolboxes.

### Files changed

**New**
- `HostedMcpToolboxAITool.cs` — marker tool, `UriScheme = "foundry-toolbox"`, `BuildAddress`/`TryParseToolboxAddress`
- `FoundryToolboxOptions.cs` — toolbox name list, API version, `StrictMode`
- `FoundryToolboxBearerTokenHandler.cs` — `DelegatingHandler`: Bearer token, `Foundry-Features` header, 3x backoff
- `McpConsentContext.cs` — `AsyncLocal` per-request consent state
- `ConsentAwareMcpClientAIFunction.cs` — `AIFunction` wrapper catching `-32006`, cancels linked CTS to escape `FunctionInvokingChatClient` tool loop
- `FoundryToolboxService.cs` — `IHostedService` + `IAsyncDisposable`: eager MCP client per toolbox at startup, plus `GetToolboxToolsAsync(name, version?, ct)` for lazy open
- `InputConverter.ReadMcpToolboxMarkers` — parses `MCPTool` entries with the `foundry-toolbox://` scheme
- Unit tests: `HostedMcpToolboxAIToolTests`, `Hosting/FoundryToolboxServiceTests`
- `Hosted-Toolbox/` sample — minimal hosted agent using `AddFoundryToolboxes`

**Modified**
- `AgentFrameworkResponseHandler.cs` — per-request marker parse + merge, linked CTS consent path, `mcp_approval_request` emission, `EmitFailed` on strict-mode resolution failures
- `FoundryAITool.cs` — `CreateHostedMcpToolbox(string, string?)`, `CreateHostedMcpToolbox(ToolboxRecord)`, `CreateHostedMcpToolbox(ToolboxVersion)` factories
- `ServiceCollectionExtensions.cs` — `AddFoundryToolboxes(params string[])` and `AddFoundryToolboxes(configureOptions, params string[])` overloads
- `Microsoft.Agents.AI.Foundry.csproj` — `ModelContextProtocol` + `Azure.Identity` under `.NETCoreApp` condition

### Usage

**Host configured (eager at startup):**

```csharp
builder.Services.AddFoundryResponses(agent);
builder.Services.AddFoundryToolboxes("my-toolbox", "another-toolbox");
```

**Client selected (per request) — discover via `AIProjectClient`:**

```csharp
// Discover a toolbox via the Foundry project
var project = new AIProjectClient(endpoint, credential);
ToolboxRecord toolbox = await project.GetAgentToolboxesClient().GetToolboxAsync("calendar-tools");

// Attach as a per-request tool (uses record.Name + record.DefaultVersion)
var response = await agent.RunAsync(
    "Book a meeting with the team next Tuesday.",
    new ChatClientAgentRunOptions
    {
        ChatOptions = new() { Tools = [FoundryAITool.CreateHostedMcpToolbox(toolbox)] }
    });

// Or pin a specific version
ToolboxVersion version = await project.GetAgentToolboxesClient().GetToolboxVersionAsync("calendar-tools", "v2");
var toolWithVersion = FoundryAITool.CreateHostedMcpToolbox(version);

// Or pass the name/version explicitly
var toolByName = FoundryAITool.CreateHostedMcpToolbox("calendar-tools", version: "v2");
```

**Combined** — host-configured toolboxes are always injected; client markers additionally lazy-open any toolbox the server hasn't pre-registered.

### Environment variables

| Variable | Required | Description |
|---|---|---|
| `FOUNDRY_AGENT_TOOLSET_ENDPOINT` | No (absent = healthy, no tools) | Foundry Toolsets proxy base URL |
| `FOUNDRY_AGENT_TOOLSET_FEATURES` | No | Feature flags sent via `Foundry-Features` header |
| `FOUNDRY_AGENT_NAME` | No | MCP client info name (default: `hosted-agent`) |
| `FOUNDRY_AGENT_VERSION` | No | MCP client info version (default: `1.0.0`) |

> **WIP** — needs integration testing against a live Foundry Toolsets proxy.
