### PR TITLE
.NET: Fix declarative resume edge predicates to recognize both direct and PortableValue-wrapped forms after checkpoint restore

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Kit/ActionExecutorResult.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Kit/ActionExecutorResult.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Agents.AI.Workflows.Declarative.Extensions;
+
 namespace Microsoft.Agents.AI.Workflows.Declarative.Kit;
 
 /// <summary>
@@ -25,6 +27,11 @@ public sealed record class ActionExecutorResult
 
     internal static ActionExecutorResult ThrowIfNot(object? message)
     {
+        if (message is PortableValue portableValue && portableValue.IsType(out ActionExecutorResult? unwrapped))
+        {
+            return unwrapped;
+        }
+
         if (message is not ActionExecutorResult executorMessage)
         {
             throw new DeclarativeActionException($"Unexpected message type: {message?.GetType().Name ?? "(null)"} (Expected: {nameof(ActionExecutorResult)})");

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeAzureAgentExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeAzureAgentExecutor.cs
@@ -27,9 +27,11 @@ internal sealed class InvokeAzureAgentExecutor(InvokeAzureAgent model, ResponseA
         public static string Resume(string id) => $"{id}_{nameof(Resume)}";
     }
 
-    public static bool RequiresInput(object? message) => message is ExternalInputRequest;
+    public static bool RequiresInput(object? message) =>
+        message is ExternalInputRequest || (message is PortableValue pv && pv.IsType(out ExternalInputRequest? _));
 
-    public static bool RequiresNothing(object? message) => message is ActionExecutorResult;
+    public static bool RequiresNothing(object? message) =>
+        message is ActionExecutorResult || (message is PortableValue pv && pv.IsType(out ActionExecutorResult? _));
 
     private AzureAgentUsage AgentUsage => Throw.IfNull(this.Model.Agent, $"{nameof(this.Model)}.{nameof(this.Model.Agent)}");
     private AzureAgentInput? AgentInput => this.Model.Input;

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeMcpToolExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeMcpToolExecutor.cs
@@ -46,12 +46,14 @@ internal sealed class InvokeMcpToolExecutor(
     /// <summary>
     /// Determines if the message indicates external input is required.
     /// </summary>
-    public static bool RequiresInput(object? message) => message is ExternalInputRequest;
+    public static bool RequiresInput(object? message) =>
+        message is ExternalInputRequest || (message is PortableValue pv && pv.IsType(out ExternalInputRequest? _));
 
     /// <summary>
     /// Determines if the message indicates no external input is required.
     /// </summary>
-    public static bool RequiresNothing(object? message) => message is ActionExecutorResult;
+    public static bool RequiresNothing(object? message) =>
+        message is ActionExecutorResult || (message is PortableValue pv && pv.IsType(out ActionExecutorResult? _));
 
     /// <inheritdoc/>
     protected override bool EmitResultEvent => false;

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
@@ -16,7 +16,7 @@ public sealed class PortableValuePredicateTests
     #region ActionExecutorResult.ThrowIfNot
 
     [Fact]
-    public void ThrowIfNot_WithDirectActionExecutorResult_ReturnsResult()
+    public void ActionExecutorResult_ThrowIfNot_WithDirectActionExecutorResult_ReturnsResult()
     {
         // Arrange
         ActionExecutorResult result = new("test-executor");
@@ -29,7 +29,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void ThrowIfNot_WithPortableValueWrappedActionExecutorResult_Unwraps()
+    public void ActionExecutorResult_ThrowIfNot_WithPortableValueWrappedActionExecutorResult_Unwraps()
     {
         // Arrange
         ActionExecutorResult result = new("test-executor");
@@ -43,7 +43,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void ThrowIfNot_WithNonActionExecutorResult_Throws()
+    public void ActionExecutorResult_ThrowIfNot_WithNonActionExecutorResult_Throws()
     {
         // Arrange
         object message = "not an ActionExecutorResult";
@@ -53,14 +53,14 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void ThrowIfNot_WithNull_Throws()
+    public void ActionExecutorResult_ThrowIfNot_WithNull_Throws()
     {
         // Act & Assert
         Assert.Throws<DeclarativeActionException>(() => ActionExecutorResult.ThrowIfNot(null));
     }
 
     [Fact]
-    public void ThrowIfNot_WithPortableValueWrappedNonResult_Throws()
+    public void ActionExecutorResult_ThrowIfNot_WithPortableValueWrappedNonResult_Throws()
     {
         // Arrange
         PortableValue wrapped = new("not an ActionExecutorResult");
@@ -74,7 +74,7 @@ public sealed class PortableValuePredicateTests
     #region InvokeAzureAgentExecutor Predicates
 
     [Fact]
-    public void RequiresInput_WithDirectExternalInputRequest_ReturnsTrue()
+    public void InvokeAzureAgentExecutor_RequiresInput_WithDirectExternalInputRequest_ReturnsTrue()
     {
         // Arrange
         ExternalInputRequest request = new("test prompt");
@@ -84,7 +84,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void RequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
+    public void InvokeAzureAgentExecutor_RequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
     {
         // Arrange
         ExternalInputRequest request = new("test prompt");
@@ -95,7 +95,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void RequiresInput_WithActionExecutorResult_ReturnsFalse()
+    public void InvokeAzureAgentExecutor_RequiresInput_WithActionExecutorResult_ReturnsFalse()
     {
         // Arrange
         ActionExecutorResult result = new("test");
@@ -105,7 +105,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void RequiresNothing_WithDirectActionExecutorResult_ReturnsTrue()
+    public void InvokeAzureAgentExecutor_RequiresNothing_WithDirectActionExecutorResult_ReturnsTrue()
     {
         // Arrange
         ActionExecutorResult result = new("test");
@@ -115,7 +115,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void RequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
+    public void InvokeAzureAgentExecutor_RequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
     {
         // Arrange
         ActionExecutorResult result = new("test");
@@ -126,7 +126,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void RequiresNothing_WithExternalInputRequest_ReturnsFalse()
+    public void InvokeAzureAgentExecutor_RequiresNothing_WithExternalInputRequest_ReturnsFalse()
     {
         // Arrange
         ExternalInputRequest request = new("test prompt");
@@ -140,7 +140,7 @@ public sealed class PortableValuePredicateTests
     #region InvokeMcpToolExecutor Predicates
 
     [Fact]
-    public void McpRequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
+    public void InvokeMcpToolExecutor_McpRequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
     {
         // Arrange
         ExternalInputRequest request = new("test prompt");
@@ -151,7 +151,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void McpRequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
+    public void InvokeMcpToolExecutor_McpRequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
     {
         // Arrange
         ActionExecutorResult result = new("test");
@@ -166,7 +166,7 @@ public sealed class PortableValuePredicateTests
     #region QuestionExecutor.IsComplete
 
     [Fact]
-    public void IsComplete_WithPortableValueWrappedResult_NullResult_ReturnsTrue()
+    public void QuestionExecutor_IsComplete_WithPortableValueWrappedResult_NullResult_ReturnsTrue()
     {
         // Arrange - result with null Result property means "complete"
         ActionExecutorResult result = new("test", result: null);
@@ -177,7 +177,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void IsComplete_WithPortableValueWrappedResult_NonNullResult_ReturnsFalse()
+    public void QuestionExecutor_IsComplete_WithPortableValueWrappedResult_NonNullResult_ReturnsFalse()
     {
         // Arrange - result with non-null Result property means "not complete"
         ActionExecutorResult result = new("test", result: true);

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Declarative.Events;
+using Microsoft.Agents.AI.Workflows.Declarative.Kit;
+using Microsoft.Agents.AI.Workflows.Declarative.ObjectModel;
+
+namespace Microsoft.Agents.AI.Workflows.Declarative.UnitTests.Kit;
+
+/// <summary>
+/// Tests that edge predicates correctly handle PortableValue-wrapped messages,
+/// which occur after checkpoint restore (JSON round-trip).
+/// </summary>
+public sealed class PortableValuePredicateTests
+{
+    #region ActionExecutorResult.ThrowIfNot
+
+    [Fact]
+    public void ThrowIfNot_WithDirectActionExecutorResult_ReturnsResult()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test-executor");
+
+        // Act
+        ActionExecutorResult actual = ActionExecutorResult.ThrowIfNot(result);
+
+        // Assert
+        actual.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public void ThrowIfNot_WithPortableValueWrappedActionExecutorResult_Unwraps()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test-executor");
+        PortableValue wrapped = new(result);
+
+        // Act
+        ActionExecutorResult actual = ActionExecutorResult.ThrowIfNot(wrapped);
+
+        // Assert
+        actual.ExecutorId.Should().Be("test-executor");
+    }
+
+    [Fact]
+    public void ThrowIfNot_WithNonActionExecutorResult_Throws()
+    {
+        // Arrange
+        object message = "not an ActionExecutorResult";
+
+        // Act & Assert
+        Assert.Throws<DeclarativeActionException>(() => ActionExecutorResult.ThrowIfNot(message));
+    }
+
+    [Fact]
+    public void ThrowIfNot_WithNull_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<DeclarativeActionException>(() => ActionExecutorResult.ThrowIfNot(null));
+    }
+
+    [Fact]
+    public void ThrowIfNot_WithPortableValueWrappedNonResult_Throws()
+    {
+        // Arrange
+        PortableValue wrapped = new("not an ActionExecutorResult");
+
+        // Act & Assert
+        Assert.Throws<DeclarativeActionException>(() => ActionExecutorResult.ThrowIfNot(wrapped));
+    }
+
+    #endregion
+
+    #region InvokeAzureAgentExecutor Predicates
+
+    [Fact]
+    public void RequiresInput_WithDirectExternalInputRequest_ReturnsTrue()
+    {
+        // Arrange
+        ExternalInputRequest request = new("test prompt");
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresInput(request).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
+    {
+        // Arrange
+        ExternalInputRequest request = new("test prompt");
+        PortableValue wrapped = new(request);
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresInput(wrapped).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequiresInput_WithActionExecutorResult_ReturnsFalse()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test");
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresInput(result).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RequiresNothing_WithDirectActionExecutorResult_ReturnsTrue()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test");
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresNothing(result).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test");
+        PortableValue wrapped = new(result);
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresNothing(wrapped).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequiresNothing_WithExternalInputRequest_ReturnsFalse()
+    {
+        // Arrange
+        ExternalInputRequest request = new("test prompt");
+
+        // Act & Assert
+        InvokeAzureAgentExecutor.RequiresNothing(request).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region InvokeMcpToolExecutor Predicates
+
+    [Fact]
+    public void McpRequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
+    {
+        // Arrange
+        ExternalInputRequest request = new("test prompt");
+        PortableValue wrapped = new(request);
+
+        // Act & Assert
+        InvokeMcpToolExecutor.RequiresInput(wrapped).Should().BeTrue();
+    }
+
+    [Fact]
+    public void McpRequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
+    {
+        // Arrange
+        ActionExecutorResult result = new("test");
+        PortableValue wrapped = new(result);
+
+        // Act & Assert
+        InvokeMcpToolExecutor.RequiresNothing(wrapped).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region QuestionExecutor.IsComplete
+
+    [Fact]
+    public void IsComplete_WithPortableValueWrappedResult_NullResult_ReturnsTrue()
+    {
+        // Arrange - result with null Result property means "complete"
+        ActionExecutorResult result = new("test", result: null);
+        PortableValue wrapped = new(result);
+
+        // Act & Assert
+        QuestionExecutor.IsComplete(wrapped).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsComplete_WithPortableValueWrappedResult_NonNullResult_ReturnsFalse()
+    {
+        // Arrange - result with non-null Result property means "not complete"
+        ActionExecutorResult result = new("test", result: true);
+        PortableValue wrapped = new(result);
+
+        // Act & Assert
+        QuestionExecutor.IsComplete(wrapped).Should().BeFalse();
+    }
+
+    #endregion
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
@@ -140,7 +140,7 @@ public sealed class PortableValuePredicateTests
     #region InvokeMcpToolExecutor Predicates
 
     [Fact]
-    public void InvokeMcpToolExecutor_McpRequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
+    public void InvokeMcpToolExecutor_RequiresInput_WithPortableValueWrappedRequest_ReturnsTrue()
     {
         // Arrange
         ExternalInputRequest request = new("test prompt");

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Kit/PortableValuePredicateTests.cs
@@ -151,7 +151,7 @@ public sealed class PortableValuePredicateTests
     }
 
     [Fact]
-    public void InvokeMcpToolExecutor_McpRequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
+    public void InvokeMcpToolExecutor_RequiresNothing_WithPortableValueWrappedResult_ReturnsTrue()
     {
         // Arrange
         ActionExecutorResult result = new("test");


### PR DESCRIPTION
### Motivation and Context

After a JSON checkpoint round-trip, queued messages are restored as `PortableValue` wrappers. Edge predicates in evaluate `Message` directly, so predicates like `RequiresInput` and `RequiresNothing` fail to match path.

Fixes #5307 

### Description

- Update impacted declarative edge predicates to handle `PortableValue`. Also harden `ActionExecutorResult` to unwrap `PortableValue` as a second line of defense once a message reaches the target executor path.
- Added relevant unit tests.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.