### PR TITLE
 Net: Prepare Foundry Preview Release

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>0.0.1</VersionPrefix>
     <RCNumber>1</RCNumber>
     <PackageVersion Condition="'$(IsReleaseCandidate)' == 'true'">$(VersionPrefix)-rc$(RCNumber)</PackageVersion>
     <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix).260417.1</PackageVersion>
     <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' == ''">$(VersionPrefix)-preview.260417.1</PackageVersion>
     <PackageVersion Condition="'$(IsReleased)' == 'true'">$(VersionPrefix)</PackageVersion>
-    <GitTag>1.2.0</GitTag>
+    <GitTag>0.0.1</GitTag>
 
     <Configurations>Debug;Release;Publish</Configurations>
     <!-- IsPackable intentionally NOT set to true here. Packaging is opt-in per project for this branch. -->

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,16 +1,18 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <RCNumber>1</RCNumber>
     <PackageVersion Condition="'$(IsReleaseCandidate)' == 'true'">$(VersionPrefix)-rc$(RCNumber)</PackageVersion>
-    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix).260410.1</PackageVersion>
-    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' == ''">$(VersionPrefix)-preview.260410.1</PackageVersion>
+    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix).260417.1</PackageVersion>
+    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' == ''">$(VersionPrefix)-preview.260417.1</PackageVersion>
     <PackageVersion Condition="'$(IsReleased)' == 'true'">$(VersionPrefix)</PackageVersion>
-    <GitTag>1.1.0</GitTag>
+    <GitTag>1.2.0</GitTag>
 
     <Configurations>Debug;Release;Publish</Configurations>
-    <IsPackable>true</IsPackable>
+    <!-- IsPackable intentionally NOT set to true here. Packaging is opt-in per project for this branch. -->
+    <!-- The repo default in dotnet/Directory.Build.props keeps IsPackable=false. -->
+    <!-- Only the Foundry preview set explicitly overrides IsPackable=true in their csproj. -->
 
     <!-- Package validation. Baseline Version should be the latest version available on NuGet. -->
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
@@ -70,7 +72,7 @@
     <None Include="$(RepoRoot)/dotnet/nuget/NUGET.md" Link="NUGET.md" Pack="true" PackagePath="." />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND '$(IsPackable)' == 'true' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Agents.AI</RootNamespace>
     <NoWarn>$(NoWarn);MEAI001</NoWarn>
-    <IsReleased>true</IsReleased>
+    <IsReleased>false</IsReleased>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,6 +19,11 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Foundry preview release: opt back in to packaging. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>true</IsReleased>
+    <IsReleased>false</IsReleased>
     <InjectSharedThrow>true</InjectSharedThrow>
     <NoWarn>$(NoWarn);OPENAI001;MEAI001;NU1903</NoWarn>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Foundry preview release: opt back in to packaging. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <!-- Disable package validation baseline until the first release under the new package name -->
   <PropertyGroup>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Microsoft.Agents.AI.Workflows.Generators.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Microsoft.Agents.AI.Workflows.Generators.csproj
@@ -29,10 +29,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsReleased>true</IsReleased>
+    <IsReleased>false</IsReleased>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Foundry preview release: opt back in to packaging. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Microsoft.Agents.AI.Workflows.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Microsoft.Agents.AI.Workflows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>true</IsReleased>
+    <IsReleased>false</IsReleased>
     <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
@@ -13,6 +13,11 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Foundry preview release: opt back in to packaging. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI/Microsoft.Agents.AI.csproj
+++ b/dotnet/src/Microsoft.Agents.AI/Microsoft.Agents.AI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>true</IsReleased>
+    <IsReleased>false</IsReleased>
     <NoWarn>$(NoWarn);MEAI001;MAAI001</NoWarn>
   </PropertyGroup>
 
@@ -16,6 +16,11 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Foundry preview release: opt back in to packaging. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Agents.AI.Abstractions\Microsoft.Agents.AI.Abstractions.csproj" />


### PR DESCRIPTION
## Summary

Prepares this branch to publish preview NuGet packages for `Microsoft.Agents.AI.Foundry` and its direct dependencies at version `0.0.1-preview.260417.1` (retroactive preview publish, pre-1.0).

## Changes

- `dotnet/nuget/nuget-package.props`
  - Set `VersionPrefix` and `GitTag` to `0.0.1`.
  - Set the preview stamp to `260417.1`.
  - Remove the global `<IsPackable>true</IsPackable>` so the repo-level default (`false`) in `dotnet/Directory.Build.props` applies by default.
  - Gate `GeneratePackageOnBuild` on `IsPackable=true` to avoid pack errors in Release.
- The 5 csproj files below opt back in with `<IsPackable>true</IsPackable>` and flip `<IsReleased>` to `false` so they emit the `-preview.YYMMDD.N` suffix:
  - `Microsoft.Agents.AI.Abstractions`
  - `Microsoft.Agents.AI`
  - `Microsoft.Agents.AI.Workflows`
  - `Microsoft.Agents.AI.Workflows.Generators`
  - `Microsoft.Agents.AI.Foundry`

All other packable `src/` projects stop producing `.nupkg` files from this branch.

## Verification

- `dotnet build dotnet/agent-framework-dotnet.slnx -c Debug --tl:off --warnaserror` - green.
- `dotnet pack -c Debug` - produced exactly the 5 expected packages:
  - `Microsoft.Agents.AI.Abstractions.0.0.1-preview.260417.1.nupkg`
  - `Microsoft.Agents.AI.0.0.1-preview.260417.1.nupkg`
  - `Microsoft.Agents.AI.Workflows.0.0.1-preview.260417.1.nupkg`
  - `Microsoft.Agents.AI.Workflows.Generators.0.0.1-preview.260417.1.nupkg`
  - `Microsoft.Agents.AI.Foundry.0.0.1-preview.260417.1.nupkg`
- Inspected nuspec contents: internal cross-references across all TFMs (net10.0, net9.0, net8.0, net472, netstandard2.0) are correctly pinned to `0.0.1-preview.260417.1`. `Workflows.Generators` ships analyzer-only (no `lib/`, no dependencies), as expected for a Roslyn source generator with `DevelopmentDependency=true`.
- `Azure.AI.AgentServer.Responses` stays at `1.0.0-beta.1` (the only version published on NuGet.org at this time).
- CI-parity `dotnet format --verify-no-changes` (WSL2 + Docker, `mcr.microsoft.com/dotnet/sdk:10.0`) on the 5 touched projects - green.
