### PR TITLE
Net: Bump Preview Foundry Hosted Agents

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -3,21 +3,17 @@
     <!-- Central version prefix - applies to all nuget packages. -->
     <VersionPrefix>0.0.1</VersionPrefix>
     <RCNumber>1</RCNumber>
-    <PackageVersion Condition="'$(IsReleaseCandidate)' == 'true'">$(VersionPrefix)-rc$(RCNumber)</PackageVersion>
-    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix).260417.1</PackageVersion>
-    <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' == ''">$(VersionPrefix)-preview.260417.1</PackageVersion>
-    <PackageVersion Condition="'$(IsReleased)' == 'true'">$(VersionPrefix)</PackageVersion>
+    <!-- Preview-only branch: all publishable packages ship as 0.0.1-preview.260417.2 regardless of IsReleaseCandidate/VersionSuffix. -->
+    <PackageVersion>$(VersionPrefix)-preview.260417.2</PackageVersion>
     <GitTag>0.0.1</GitTag>
 
     <Configurations>Debug;Release;Publish</Configurations>
-    <!-- IsPackable intentionally NOT set to true here. Packaging is opt-in per project for this branch. -->
-    <!-- The repo default in dotnet/Directory.Build.props keeps IsPackable=false. -->
-    <!-- Only the Foundry preview set explicitly overrides IsPackable=true in their csproj. -->
+    <!-- Override the repo-wide IsPackable=false default from Directory.Build.props. Projects that want to stay non-packable (e.g. Mem0) set IsPackable=false AFTER importing this file. -->
+    <IsPackable>true</IsPackable>
 
     <!-- Package validation. Baseline Version should be the latest version available on NuGet. -->
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
-    <!-- Enable validation for GA packages -->
-    <EnablePackageValidation Condition="'$(IsReleased)' == 'true'">true</EnablePackageValidation>
+    <!-- Preview-only branch: package validation disabled entirely. -->
     <!-- Validate assembly attributes only for Publish builds -->
     <NoWarn Condition="'$(Configuration)' != 'Publish'">$(NoWarn);CP0003</NoWarn>
     <!-- Do not validate reference assemblies -->

--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/Microsoft.Agents.AI.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Agents.AI</RootNamespace>
     <NoWarn>$(NoWarn);MEAI001</NoWarn>
-    <IsReleased>false</IsReleased>
+    <IsReleased>true</IsReleased>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,11 +19,6 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-
-  <!-- Foundry preview release: opt back in to packaging. -->
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
@@ -1,18 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>false</IsReleased>
+    <IsReleased>true</IsReleased>
     <InjectSharedThrow>true</InjectSharedThrow>
     <NoWarn>$(NoWarn);OPENAI001;MEAI001;NU1903</NoWarn>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-
-  <!-- Foundry preview release: opt back in to packaging. -->
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
 
   <!-- Disable package validation baseline until the first release under the new package name -->
   <PropertyGroup>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Microsoft.Agents.AI.Workflows.Generators.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Microsoft.Agents.AI.Workflows.Generators.csproj
@@ -29,15 +29,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsReleased>false</IsReleased>
+    <IsReleased>true</IsReleased>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-
-  <!-- Foundry preview release: opt back in to packaging. -->
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Microsoft.Agents.AI.Workflows.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Microsoft.Agents.AI.Workflows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>false</IsReleased>
+    <IsReleased>true</IsReleased>
     <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
@@ -13,11 +13,6 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-
-  <!-- Foundry preview release: opt back in to packaging. -->
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
 
   <PropertyGroup>
     <!-- NuGet Package Settings -->

--- a/dotnet/src/Microsoft.Agents.AI/Microsoft.Agents.AI.csproj
+++ b/dotnet/src/Microsoft.Agents.AI/Microsoft.Agents.AI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleased>false</IsReleased>
+    <IsReleased>true</IsReleased>
     <NoWarn>$(NoWarn);MEAI001;MAAI001</NoWarn>
   </PropertyGroup>
 
@@ -16,11 +16,6 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
-
-  <!-- Foundry preview release: opt back in to packaging. -->
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Agents.AI.Abstractions\Microsoft.Agents.AI.Abstractions.csproj" />


### PR DESCRIPTION
Revises the Foundry pre-release approach from PR #5336 to publish **all** normally packable src projects as preview packages stamped `0.0.1-preview.260417.2`, including projects previously flagged `IsReleased=true` or with a non-default `VersionSuffix` (rc/alpha).

## Why

PR #5336 was opt-in: only 5 Foundry-set packages were packed, and only they were stamped preview. For this branch we want every publishable package shipped retroactively under the same `0.0.1-preview.260417.2` label so nothing in the set reports a stable or `-rc`/`-alpha` version.

## Changes

**`dotnet/nuget/nuget-package.props`**
- Collapse the four conditional `PackageVersion` expressions (`IsReleaseCandidate`, `VersionSuffix`, default preview, `IsReleased` stable) into a single unconditional `0.0.1-preview.260417.2`.
- Restore the global `<IsPackable>true</IsPackable>` default (offsetting the repo-wide `IsPackable=false` in `Directory.Build.props`). Projects that opt out (Mem0, Declarative) already set `IsPackable=false` **after** importing this file so they remain non-packable.
- Remove the `IsReleased`-gated `EnablePackageValidation` line. Validation does not apply to a 0.0.1 preview.

**csproj reverts** (Abstractions, Agents.AI, Workflows, Workflows.Generators, Foundry)
- Revert the `IsPackable=true` opt-in block introduced in PR #5336 (now redundant since the props default is true again).
- Restore `IsReleased=true` to its pre-PR value. The setting is now a no-op because the props no longer branches on it.

## Verified locally

- `dotnet build dotnet/agent-framework-dotnet.slnx -c Debug --tl:off --warnaserror` → green
- `dotnet pack dotnet/agent-framework-dotnet.slnx -c Debug --tl:off` → 26 nupkgs all stamped `0.0.1-preview.260417.2`

Packages produced:
- Microsoft.Agents.AI
- Microsoft.Agents.AI.A2A
- Microsoft.Agents.AI.Abstractions
- Microsoft.Agents.AI.AGUI
- Microsoft.Agents.AI.Anthropic
- Microsoft.Agents.AI.AzureAI.Persistent
- Microsoft.Agents.AI.CopilotStudio
- Microsoft.Agents.AI.CosmosNoSql
- Microsoft.Agents.AI.Declarative
- Microsoft.Agents.AI.DevUI
- Microsoft.Agents.AI.DurableTask
- Microsoft.Agents.AI.Foundry
- Microsoft.Agents.AI.GitHub.Copilot
- Microsoft.Agents.AI.Hosting
- Microsoft.Agents.AI.Hosting.A2A
- Microsoft.Agents.AI.Hosting.A2A.AspNetCore
- Microsoft.Agents.AI.Hosting.AGUI.AspNetCore
- Microsoft.Agents.AI.Hosting.AzureFunctions
- Microsoft.Agents.AI.Hosting.OpenAI
- Microsoft.Agents.AI.OpenAI
- Microsoft.Agents.AI.Purview
- Microsoft.Agents.AI.Workflows
- Microsoft.Agents.AI.Workflows.Declarative
- Microsoft.Agents.AI.Workflows.Declarative.Foundry
- Microsoft.Agents.AI.Workflows.Declarative.Mcp
- Microsoft.Agents.AI.Workflows.Generators

`Microsoft.Agents.AI.Foundry` nuspec verified: all internal cross-references stamped `0.0.1-preview.260417.2`; `Azure.AI.AgentServer.Responses` dependency pinned to `1.0.0-beta.1` (the only version on nuget.org).

## Not for merge to main

Target branch is `feature/responses-hosting`. This branch is intended only for retroactive preview publishing.
