### PR TITLE
.NET: Bump preview version to 260420.1 and fix AgentServer package deps

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="$(AspireAppHostSdkVersion)" />
     <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="13.0.0" />
     <!-- Azure.* -->
-    <PackageVersion Include="Azure.AI.AgentServer.Core" Version="1.0.0-beta.21" />
+    <PackageVersion Include="Azure.AI.AgentServer.Core" Version="1.0.0-beta.22" />
     <PackageVersion Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.1" />
-    <PackageVersion Include="Azure.AI.AgentServer.Responses" Version="1.0.0-beta.1" />
+    <PackageVersion Include="Azure.AI.AgentServer.Responses" Version="1.0.0-beta.3" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.0.0" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />

--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -4,7 +4,7 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <RCNumber>1</RCNumber>
     <!-- Preview-only branch: all publishable packages ship as 0.0.1-preview.260417.2 regardless of IsReleaseCandidate/VersionSuffix. -->
-    <PackageVersion>$(VersionPrefix)-preview.260417.2</PackageVersion>
+    <PackageVersion>$(VersionPrefix)-preview.260420.1</PackageVersion>
     <GitTag>0.0.1</GitTag>
 
     <Configurations>Debug;Release;Publish</Configurations>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Hosting/ServiceCollectionExtensions.cs
@@ -118,6 +118,13 @@ public static class FoundryHostingExtensions
     }
 
     /// <summary>
+    /// The ActivitySource name for the Responses hosting pipeline.
+    /// Matches the value previously exposed by <c>AgentHostTelemetry.ResponsesSourceName</c>
+    /// in <c>Azure.AI.AgentServer.Core</c>.
+    /// </summary>
+    private const string ResponsesSourceName = "Azure.AI.AgentServer.Responses";
+
+    /// <summary>
     /// Wraps <paramref name="agent"/> with <see cref="OpenTelemetryAgent"/> instrumentation
     /// so that agent invocations emit spans into the pipeline registered by
     /// <c>Azure.AI.AgentServer.Core</c>'s <c>AddAgentHostTelemetry()</c>.
@@ -131,7 +138,7 @@ public static class FoundryHostingExtensions
         }
 
         return agent.AsBuilder()
-                    .UseOpenTelemetry(sourceName: AgentHostTelemetry.ResponsesSourceName)
+                    .UseOpenTelemetry(sourceName: ResponsesSourceName)
                     .Build();
     }
 


### PR DESCRIPTION
- Bump PackageVersion to 0.0.1-preview.260420.1
- Bump Azure.AI.AgentServer.Core beta.21 -> beta.22 (required by Azure.AI.AgentServer.Responses beta.3)
- Replace AgentHostTelemetry.ResponsesSourceName with local constant (type made internal in AgentServer.Core beta.22)

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.