### PR TITLE
.NET: Guard SharedStateAgent empty-streams with state-shape check

### DIFF
--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/SharedState/SharedStateAgent.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/SharedState/SharedStateAgent.cs
@@ -31,8 +31,16 @@ internal sealed class SharedStateAgent : DelegatingAIAgent
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (options is not ChatClientAgentRunOptions { ChatOptions.AdditionalProperties: { } properties } chatRunOptions ||
-            !properties.TryGetValue("ag_ui_state", out JsonElement state))
+            !properties.TryGetValue("ag_ui_state", out JsonElement state) ||
+            state.ValueKind != JsonValueKind.Object ||
+            !HasAnyProperties(state))
         {
+            // No state, non-object state, or empty state ({}): pass through to the inner agent.
+            // Without this guard, the two-pass structured-output flow below would force a JSON
+            // schema response format that the model cannot satisfy when the client sends an empty
+            // state (common on first chat turn before the UI has hydrated). TryDeserialize then
+            // fails and the method hits `yield break`, emitting no text, no tool calls, no data —
+            // causing a silent chat surface.
             await foreach (var update in this.InnerAgent.RunStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
             {
                 yield return update;
@@ -102,6 +110,21 @@ internal sealed class SharedStateAgent : DelegatingAIAgent
         {
             yield return update;
         }
+    }
+
+    private static bool HasAnyProperties(JsonElement state)
+    {
+        if (state.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        foreach (JsonProperty _ in state.EnumerateObject())
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static bool TryDeserialize<T>(string json, JsonSerializerOptions jsonSerializerOptions, out T structuredOutput)


### PR DESCRIPTION
When ChatOptions.AdditionalProperties contains ag_ui_state but the payload is empty `{}` or lacks schema-matching content, the two-pass structured-output flow's TryDeserialize fails and the method emits zero content updates. UI sees a completely silent response on agentic-chat demos that forward shared state even when empty.

Guard RunCoreStreamingAsync: when ag_ui_state is absent, non-object, or an empty object, pass through to the inner agent instead of taking the schema-constrained path. Mirror the fix pattern already in the sibling Step05_StateManagement sample.

Helper HasAnyProperties includes a defensive ValueKind != Object early return so it remains safe under future callers that drop the caller-side guard.

Verified via standalone xUnit repro (3 failing -> 3 passing on empty `{}`, non-object state, missing key; plus HasAnyProperties unit tests across Array / String / Number / Null / Undefined / Bool / EmptyObject / NonEmptyObject). Test harness excluded from repo (net10.0 SDK installed locally in .dotnet/, not upstream).

Related: downstream CopilotKit PR #4083 commit 9227bc27d worked around this by adding the guard to showcase/packages/ms-agent-dotnet/agent/SharedStateAgent.cs.
