### PR TITLE
Python: Fix OpenAI Responses streaming to propagate `created_at` from final `response.completed` event

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -2028,6 +2028,7 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         local_shell_tool_name = self._get_local_shell_tool_name(options.get("tools"))
         conversation_id: str | None = None
         response_id: str | None = None
+        created_at: str | None = None
         continuation_token: OpenAIContinuationToken | None = None
         model = self.model
         match event.type:
@@ -2209,6 +2210,9 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                 response_id = event.response.id
                 conversation_id = self._get_conversation_id(event.response, options.get("store"))
                 model = event.response.model
+                created_at = datetime.fromtimestamp(event.response.created_at, tz=timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
                 if event.response.usage:
                     usage = self._parse_usage_from_openai(event.response.usage)
                     if usage:
@@ -2589,6 +2593,7 @@ class RawOpenAIChatClient(  # type: ignore[misc]
             response_id=response_id,
             role="assistant",
             model=model,
+            created_at=created_at,
             continuation_token=continuation_token,
             additional_properties=metadata,
             raw_representation=event,

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -2192,6 +2192,7 @@ def test_streaming_chunk_with_usage_only() -> None:
     mock_event.response.id = "resp_usage"
     mock_event.response.model = "test-model"
     mock_event.response.conversation = None
+    mock_event.response.created_at = 1000000000.0
     mock_event.response.usage = MagicMock()
     mock_event.response.usage.input_tokens = 50
     mock_event.response.usage.output_tokens = 25
@@ -4438,11 +4439,34 @@ def test_streaming_response_completed_no_continuation_token() -> None:
     mock_event.response.conversation = MagicMock()
     mock_event.response.conversation.id = "conv_done"
     mock_event.response.model = "test-model"
+    mock_event.response.created_at = 1000000000.0
     mock_event.response.usage = None
 
     update = client._parse_chunk_from_openai(mock_event, chat_options, function_call_ids)
 
     assert update.continuation_token is None
+
+
+def test_streaming_response_completed_sets_created_at() -> None:
+    """Test that response.completed sets created_at on the ChatResponseUpdate."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+    chat_options: dict[str, Any] = {}
+    function_call_ids: dict[int, tuple[str, str]] = {}
+
+    mock_event = MagicMock()
+    mock_event.type = "response.completed"
+    mock_event.response = MagicMock()
+    mock_event.response.id = "resp_created"
+    mock_event.response.conversation = MagicMock()
+    mock_event.response.conversation.id = "conv_created"
+    mock_event.response.model = "test-model"
+    mock_event.response.created_at = 1000000000.0
+    mock_event.response.usage = None
+
+    update = client._parse_chunk_from_openai(mock_event, chat_options, function_call_ids)
+
+    assert update.created_at is not None
+    assert update.created_at == "2001-09-09T01:46:40.000000Z"
 
 
 def test_map_chat_to_agent_update_preserves_continuation_token() -> None:

--- a/python/samples/02-agents/conversations/file_history_provider.py
+++ b/python/samples/02-agents/conversations/file_history_provider.py
@@ -21,7 +21,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 try:
-    import orjson  # type: ignore[import-not-found]
+    import orjson  # pyright: ignore[reportMissingImports]
 except ImportError:
     orjson = None
 

--- a/python/samples/02-agents/conversations/file_history_provider.py
+++ b/python/samples/02-agents/conversations/file_history_provider.py
@@ -21,7 +21,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 try:
-    import orjson
+    import orjson  # type: ignore[import-not-found]
 except ImportError:
     orjson = None
 

--- a/python/samples/02-agents/conversations/file_history_provider_conversation_persistence.py
+++ b/python/samples/02-agents/conversations/file_history_provider_conversation_persistence.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 try:
-    import orjson
+    import orjson  # type: ignore[import-not-found]
 except ImportError:
     orjson = None
 

--- a/python/samples/02-agents/conversations/file_history_provider_conversation_persistence.py
+++ b/python/samples/02-agents/conversations/file_history_provider_conversation_persistence.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 try:
-    import orjson  # type: ignore[import-not-found]
+    import orjson  # pyright: ignore[reportMissingImports]
 except ImportError:
     orjson = None
 


### PR DESCRIPTION
### Motivation and Context

When using `OpenAIChatClient` with `stream=True`, the final streamed response had `created_at=None` even though the raw `response.completed` event contains a valid timestamp. This caused noisy warnings in durabletask persistence and incorrect metadata on streamed responses.

Fixes #5347

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

The root cause was that `_parse_chunk_from_openai` extracted `response_id`, `conversation_id`, and `model` from the `response.completed` event but never read `created_at`. The fix adds extraction of `event.response.created_at` (a Unix timestamp), formats it as an ISO 8601 UTC string, and passes it through to the returned `ChatResponseUpdate`. A dedicated unit test verifies the timestamp is correctly propagated and formatted.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by moonbox3's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5347,"repo":"microsoft/agent-framework","rid":"7214534f066a44cc9b98948a7de7c65e","rt":"fix","sf":"pr","ts":"2026-04-21T03:27:36.679017+00:00","u":"moonbox3","v":1}
-->
