### PR TITLE
.NET: Disable flaky AzureAIAgentsPersistent integration tests

### DIFF
--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
@@ -12,13 +12,13 @@ public class AzureAIAgentsChatClientAgentRunStreamingTests() : ChatClientAgentRu
 
     public override Task RunWithInstructionsAndNoMessageReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithInstructionsAndNoMessageReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunStreamingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
@@ -7,4 +8,17 @@ namespace AzureAIAgentsPersistent.IntegrationTests;
 [Trait("Category", "Integration")]
 public class AzureAIAgentsChatClientAgentRunStreamingTests() : ChatClientAgentRunStreamingTests<AzureAIAgentsPersistentFixture>(() => new())
 {
+    private const string SkipReason = "Flaky integration test";
+
+    public override Task RunWithInstructionsAndNoMessageReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithInstructionsAndNoMessageReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync();
+    }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
@@ -7,4 +8,17 @@ namespace AzureAIAgentsPersistent.IntegrationTests;
 [Trait("Category", "Integration")]
 public class AzureAIAgentsChatClientAgentRunTests() : ChatClientAgentRunTests<AzureAIAgentsPersistentFixture>(() => new())
 {
+    private const string SkipReason = "Flaky integration test";
+
+    public override Task RunWithInstructionsAndNoMessageReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithInstructionsAndNoMessageReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync();
+    }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsChatClientAgentRunTests.cs
@@ -12,13 +12,13 @@ public class AzureAIAgentsChatClientAgentRunTests() : ChatClientAgentRunTests<Az
 
     public override Task RunWithInstructionsAndNoMessageReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithInstructionsAndNoMessageReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithFunctionsInvokesFunctionsAndReturnsExpectedResultsAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
@@ -17,11 +17,12 @@ namespace AzureAIAgentsPersistent.IntegrationTests;
 [Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentCreateTests
 {
+    private const string SkipFlakyReason = "Flaky integration test";
     private const string SkipCodeInterpreterReason = "Azure AI Code Interpreter intermittently fails to execute uploaded files in CI";
 
     private readonly PersistentAgentsClient _persistentAgentsClient = new(TestConfiguration.GetRequiredValue(TestSettings.AzureAIProjectEndpoint), TestAzureCliCredentials.CreateAzureCliCredential());
 
-    [Theory(Skip = "Flaky integration test")]
+    [Theory(Skip = SkipFlakyReason)]
     [InlineData("CreateWithChatClientAgentOptionsAsync")]
     [InlineData("CreateWithFoundryOptionsAsync")]
     public async Task CreateAgent_CreatesAgentWithCorrectMetadataAsync(string createMechanism)
@@ -203,7 +204,7 @@ public class AzureAIAgentsPersistentCreateTests
         }
     }
 
-    [Theory(Skip = "Flaky integration test")]
+    [Theory(Skip = SkipFlakyReason)]
     [InlineData("CreateWithChatClientAgentOptionsAsync")]
     public async Task CreateAgent_CreatesAgentWithAIFunctionToolsAsync(string createMechanism)
     {

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentCreateTests.cs
@@ -21,7 +21,7 @@ public class AzureAIAgentsPersistentCreateTests
 
     private readonly PersistentAgentsClient _persistentAgentsClient = new(TestConfiguration.GetRequiredValue(TestSettings.AzureAIProjectEndpoint), TestAzureCliCredentials.CreateAzureCliCredential());
 
-    [Theory]
+    [Theory(Skip = "Flaky integration test")]
     [InlineData("CreateWithChatClientAgentOptionsAsync")]
     [InlineData("CreateWithFoundryOptionsAsync")]
     public async Task CreateAgent_CreatesAgentWithCorrectMetadataAsync(string createMechanism)
@@ -203,7 +203,7 @@ public class AzureAIAgentsPersistentCreateTests
         }
     }
 
-    [Theory]
+    [Theory(Skip = "Flaky integration test")]
     [InlineData("CreateWithChatClientAgentOptionsAsync")]
     public async Task CreateAgent_CreatesAgentWithAIFunctionToolsAsync(string createMechanism)
     {

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
@@ -12,31 +12,31 @@ public class AzureAIAgentsPersistentRunStreamingTests() : RunStreamingTests<Azur
 
     public override Task RunWithNoMessageDoesNotFailAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithNoMessageDoesNotFailAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithStringReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithStringReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithChatMessageReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithChatMessageReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithChatMessagesReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithChatMessagesReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task SessionMaintainsHistoryAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.SessionMaintainsHistoryAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunStreamingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
@@ -7,4 +8,35 @@ namespace AzureAIAgentsPersistent.IntegrationTests;
 [Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentRunStreamingTests() : RunStreamingTests<AzureAIAgentsPersistentFixture>(() => new())
 {
+    private const string SkipReason = "Flaky integration test";
+
+    public override Task RunWithNoMessageDoesNotFailAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithNoMessageDoesNotFailAsync();
+    }
+
+    public override Task RunWithStringReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithStringReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithChatMessageReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithChatMessageReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithChatMessagesReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithChatMessagesReturnsExpectedResultAsync();
+    }
+
+    public override Task SessionMaintainsHistoryAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.SessionMaintainsHistoryAsync();
+    }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using AgentConformance.IntegrationTests;
 
 namespace AzureAIAgentsPersistent.IntegrationTests;
@@ -7,4 +8,35 @@ namespace AzureAIAgentsPersistent.IntegrationTests;
 [Trait("Category", "Integration")]
 public class AzureAIAgentsPersistentRunTests() : RunTests<AzureAIAgentsPersistentFixture>(() => new())
 {
+    private const string SkipReason = "Flaky integration test";
+
+    public override Task RunWithNoMessageDoesNotFailAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithNoMessageDoesNotFailAsync();
+    }
+
+    public override Task RunWithStringReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithStringReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithChatMessageReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithChatMessageReturnsExpectedResultAsync();
+    }
+
+    public override Task RunWithChatMessagesReturnsExpectedResultAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.RunWithChatMessagesReturnsExpectedResultAsync();
+    }
+
+    public override Task SessionMaintainsHistoryAsync()
+    {
+        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
+        return base.SessionMaintainsHistoryAsync();
+    }
 }

--- a/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
+++ b/dotnet/tests/AzureAIAgentsPersistent.IntegrationTests/AzureAIAgentsPersistentRunTests.cs
@@ -12,31 +12,31 @@ public class AzureAIAgentsPersistentRunTests() : RunTests<AzureAIAgentsPersisten
 
     public override Task RunWithNoMessageDoesNotFailAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithNoMessageDoesNotFailAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithStringReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithStringReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithChatMessageReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithChatMessageReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task RunWithChatMessagesReturnsExpectedResultAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.RunWithChatMessagesReturnsExpectedResultAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 
     public override Task SessionMaintainsHistoryAsync()
     {
-        Assert.SkipWhen(SkipReason is not null, SkipReason ?? string.Empty);
-        return base.SessionMaintainsHistoryAsync();
+        Assert.Skip(SkipReason);
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
All integration tests in AzureAIAgentsPersistent.IntegrationTests are now skipped due to flakiness. Uses the existing Assert.SkipWhen pattern for inherited test methods and Skip attribute for Theory methods.