### PR TITLE
Python: fix FoundryChatClient/FoundryAgent dropping default_headers

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -198,7 +198,10 @@ class RawFoundryAgentChatClient(  # type: ignore[misc]
             self._should_close_client = True
 
         # Get OpenAI client from project
-        async_client = self.project_client.get_openai_client()
+        openai_client_kwargs: dict[str, Any] = {}
+        if default_headers:
+            openai_client_kwargs["default_headers"] = dict(default_headers)
+        async_client = self.project_client.get_openai_client(**openai_client_kwargs)
 
         super().__init__(
             async_client=async_client,

--- a/python/packages/foundry/agent_framework_foundry/_chat_client.py
+++ b/python/packages/foundry/agent_framework_foundry/_chat_client.py
@@ -204,9 +204,13 @@ class RawFoundryChatClient(  # type: ignore[misc]
                 project_client_kwargs["allow_preview"] = allow_preview
             project_client = AIProjectClient(**project_client_kwargs)
 
+        openai_client_kwargs: dict[str, Any] = {}
+        if default_headers:
+            openai_client_kwargs["default_headers"] = dict(default_headers)
+
         super().__init__(
             model=resolved_model,
-            async_client=project_client.get_openai_client(),
+            async_client=project_client.get_openai_client(**openai_client_kwargs),
             default_headers=default_headers,
             instruction_role=instruction_role,
             compaction_strategy=compaction_strategy,

--- a/python/packages/foundry/tests/foundry/test_foundry_chat_client.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_chat_client.py
@@ -180,6 +180,43 @@ def test_init_with_default_header() -> None:
         assert client.default_headers[key] == value
 
 
+def test_default_headers_forwarded_to_openai_client() -> None:
+    """Regression: ``default_headers`` must be forwarded to the underlying AsyncOpenAI client.
+
+    Previously, ``FoundryChatClient(default_headers=...)`` stored the headers on the instance
+    but called ``project_client.get_openai_client()`` without forwarding them, so the headers
+    never reached outbound HTTP requests.
+    """
+    default_headers = {"x-custom-header": "repro-value"}
+    mock_openai_client = _make_mock_openai_client()
+    project_client = MagicMock()
+    project_client.get_openai_client.return_value = mock_openai_client
+
+    FoundryChatClient(
+        project_client=project_client,
+        model=_TEST_FOUNDRY_MODEL,
+        default_headers=default_headers,
+    )
+
+    project_client.get_openai_client.assert_called_once()
+    forwarded = project_client.get_openai_client.call_args.kwargs.get("default_headers")
+    assert forwarded is not None
+    for key, value in default_headers.items():
+        assert forwarded.get(key) == value
+
+
+def test_get_openai_client_not_called_with_headers_kwarg_when_unset() -> None:
+    """When ``default_headers`` is not passed, don't inject an empty dict into the Azure call."""
+    mock_openai_client = _make_mock_openai_client()
+    project_client = MagicMock()
+    project_client.get_openai_client.return_value = mock_openai_client
+
+    FoundryChatClient(project_client=project_client, model=_TEST_FOUNDRY_MODEL)
+
+    project_client.get_openai_client.assert_called_once()
+    assert "default_headers" not in project_client.get_openai_client.call_args.kwargs
+
+
 def test_init_with_project_endpoint_creates_project_client() -> None:
     credential = MagicMock()
     mock_openai_client = _make_mock_openai_client()


### PR DESCRIPTION
### Motivation and Context

Fixes #5416.

`FoundryChatClient(default_headers=...)` and `FoundryAgent(default_headers=...)` are documented to set additional HTTP headers on outbound requests. The constructor accepted the parameter, stored it on `self.default_headers`, and then forgot about it — the underlying `AsyncOpenAI` client was obtained via `project_client.get_openai_client()` without forwarding the headers, so custom headers never reached the wire.

This is a silent failure: the parameter looks wired up, existing unit test (`test_init_with_default_header`) even asserts the stored attribute is populated, but the reporter still spent hours tracking down why their header wasn't appearing in requests.

### Description

`AIProjectClient.get_openai_client(**kwargs)` already forwards `default_headers` (and friends) to `AsyncOpenAI`, so the fix is just to pass them through from the two Foundry entry points:

- `agent_framework_foundry/_chat_client.py` (`RawFoundryChatClient.__init__`)
- `agent_framework_foundry/_agent.py` (`FoundryAgent.__init__`)

I deliberately didn't touch `load_openai_service_settings` in the shared `openai` package — while that is where the headers are dropped for the pre-built-client path, the reported bug is Foundry-specific and going through `get_openai_client` is the Azure-native way. The existing `self.default_headers` storage on the instance is kept intact for serialization/reflection.

#### Tests

- `test_default_headers_forwarded_to_openai_client` — regression test: asserts the headers actually land on the `get_openai_client` call.
- `test_get_openai_client_not_called_with_headers_kwarg_when_unset` — don't inject an empty dict when the user didn't ask for headers.
- Existing `test_init_with_default_header` still passes (storage attribute behavior unchanged).

Full foundry test suite: `102 passed, 14 skipped` (skips are the integration tests needing a real endpoint).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No.