### PR TITLE
Python: (foundry): stop emitting [TOOLBOXES] warning for every FoundryChatClient call

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -34,7 +34,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-from ._tools import sanitize_foundry_response_tool
+from ._tools import _sanitize_foundry_response_tool
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar  # type: ignore # pragma: no cover
@@ -321,7 +321,7 @@ class RawFoundryAgentChatClient(  # type: ignore[misc]
         surface.
         """
         response_tools = super()._prepare_tools_for_openai(tools)
-        return [sanitize_foundry_response_tool(tool_item) for tool_item in response_tools]
+        return [_sanitize_foundry_response_tool(tool_item) for tool_item in response_tools]
 
     def _prepare_messages_for_azure_ai(self, messages: Sequence[Message]) -> tuple[list[Message], str | None]:
         """Extract system/developer messages as instructions for Azure AI.

--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -34,7 +34,7 @@ from azure.ai.projects.aio import AIProjectClient
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-from ._tools import _sanitize_foundry_response_tool
+from ._tools import _sanitize_foundry_response_tool  # pyright: ignore[reportPrivateUsage]
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar  # type: ignore # pragma: no cover

--- a/python/packages/foundry/agent_framework_foundry/_chat_client.py
+++ b/python/packages/foundry/agent_framework_foundry/_chat_client.py
@@ -33,7 +33,7 @@ from azure.ai.projects.models import MCPTool as FoundryMCPTool
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-from ._tools import fetch_toolbox, sanitize_foundry_response_tool
+from ._tools import _sanitize_foundry_response_tool, fetch_toolbox
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar  # type: ignore # pragma: no cover
@@ -235,7 +235,7 @@ class RawFoundryChatClient(  # type: ignore[misc]
         them downstream.
         """
         response_tools = super()._prepare_tools_for_openai(tools)
-        return [sanitize_foundry_response_tool(tool_item) for tool_item in response_tools]
+        return [_sanitize_foundry_response_tool(tool_item) for tool_item in response_tools]
 
     async def configure_azure_monitor(
         self,

--- a/python/packages/foundry/agent_framework_foundry/_chat_client.py
+++ b/python/packages/foundry/agent_framework_foundry/_chat_client.py
@@ -33,7 +33,7 @@ from azure.ai.projects.models import MCPTool as FoundryMCPTool
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-from ._tools import _sanitize_foundry_response_tool, fetch_toolbox
+from ._tools import _sanitize_foundry_response_tool, fetch_toolbox  # pyright: ignore[reportPrivateUsage]
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar  # type: ignore # pragma: no cover

--- a/python/packages/foundry/agent_framework_foundry/_tools.py
+++ b/python/packages/foundry/agent_framework_foundry/_tools.py
@@ -155,8 +155,7 @@ def _validate_hosted_tool_payload(sanitized: Mapping[str, Any]) -> None:
         )
 
 
-@experimental(feature_id=ExperimentalFeature.TOOLBOXES)
-def sanitize_foundry_response_tool(tool_item: Any) -> Any:
+def _sanitize_foundry_response_tool(tool_item: Any) -> Any:
     """Return a Responses-API-safe tool payload for Foundry hosted tools.
 
     Reconciles known mismatches between toolbox reads and the Responses API:

--- a/python/packages/foundry/agent_framework_foundry/_tools.py
+++ b/python/packages/foundry/agent_framework_foundry/_tools.py
@@ -155,7 +155,7 @@ def _validate_hosted_tool_payload(sanitized: Mapping[str, Any]) -> None:
         )
 
 
-def _sanitize_foundry_response_tool(tool_item: Any) -> Any:
+def _sanitize_foundry_response_tool(tool_item: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
     """Return a Responses-API-safe tool payload for Foundry hosted tools.
 
     Reconciles known mismatches between toolbox reads and the Responses API:


### PR DESCRIPTION
### Motivation and Context

`FoundryChatClient` emits a `[TOOLBOXES] sanitize_foundry_response_tool is experimental ...` warning on every call, even when the caller never touches a toolbox. `sanitize_foundry_response_tool` runs unconditionally inside `_prepare_tools_for_openai` for every tool payload, so its `@experimental(TOOLBOXES)` decorator fires for plain function tools too — misleading users into thinking they're using an experimental feature when they aren't.

### Description

Rename `sanitize_foundry_response_tool` → `_sanitize_foundry_response_tool` and drop the `@experimental` decorator. It's a pure internal Responses-API payload sanitizer — not in `__all__`, no external callers — so the toolbox feature gate doesn't belong on it. The genuinely toolbox-facing public helpers (`fetch_toolbox`, `get_toolbox_tool_name`, `get_toolbox_tool_type`, `select_toolbox_tools`) stay `@experimental(TOOLBOXES)`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?**