### PR TITLE
Propagate integration-test model credentials to issue-triage repro

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 concurrency:
   group: issue-triage-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
@@ -88,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: team_check
     if: ${{ needs.team_check.outputs.is_team_member == 'false' }}
+    environment: integration
     timeout-minutes: 60
 
     steps:
@@ -125,6 +127,13 @@ jobs:
         working-directory: ${{ env.DEVFLOW_PATH }}
         run: uv sync --frozen
 
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Classify issue relevance
         id: spam
         working-directory: ${{ env.DEVFLOW_PATH }}
@@ -161,6 +170,28 @@ jobs:
           AGENT_REPO_PATH: ${{ env.TARGET_REPO_PATH }}
           ISSUE_REPO: ${{ needs.team_check.outputs.repo }}
           ISSUE_NUMBER: ${{ needs.team_check.outputs.issue_number }}
+          # Model-provider settings for generated repro code. Never enter the
+          # agent prompt; consumed by SDK constructors via os.environ. Azure
+          # OpenAI and Foundry auth via AAD from the azure/login step above.
+          OPENAI_API_KEY: ${{ secrets.OPENAI__APIKEY }}
+          OPENAI_CHAT_COMPLETION_MODEL: ${{ vars.OPENAI__CHATMODELID }}
+          OPENAI_CHAT_MODEL: ${{ vars.OPENAI__RESPONSESMODELID }}
+          OPENAI_MODEL: ${{ vars.OPENAI__RESPONSESMODELID }}
+          OPENAI_EMBEDDING_MODEL: ${{ vars.OPENAI_EMBEDDING_MODEL_ID }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZUREOPENAI__ENDPOINT }}
+          AZURE_OPENAI_CHAT_COMPLETION_MODEL: ${{ vars.AZUREOPENAI__CHATDEPLOYMENTNAME }}
+          AZURE_OPENAI_CHAT_MODEL: ${{ vars.AZUREOPENAI__RESPONSESDEPLOYMENTNAME }}
+          AZURE_OPENAI_MODEL: ${{ vars.AZUREOPENAI__RESPONSESDEPLOYMENTNAME }}
+          AZURE_OPENAI_EMBEDDING_MODEL: ${{ vars.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME }}
+          FOUNDRY_PROJECT_ENDPOINT: ${{ vars.FOUNDRY_PROJECT_ENDPOINT }}
+          FOUNDRY_MODEL: ${{ vars.FOUNDRY_MODEL }}
+          FOUNDRY_AGENT_NAME: ${{ vars.FOUNDRY_AGENT_NAME }}
+          FOUNDRY_AGENT_VERSION: ${{ vars.FOUNDRY_AGENT_VERSION }}
+          FOUNDRY_MODELS_ENDPOINT: ${{ vars.FOUNDRY_MODELS_ENDPOINT || '' }}
+          FOUNDRY_MODELS_API_KEY: ${{ secrets.FOUNDRY_MODELS_API_KEY || '' }}
+          FOUNDRY_EMBEDDING_MODEL: ${{ vars.FOUNDRY_EMBEDDING_MODEL || '' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_CHAT_MODEL: ${{ vars.ANTHROPIC_CHAT_MODEL_ID }}
         run: |
           uv run python scripts/trigger_issue_repro.py \
             --repo "$ISSUE_REPO" \


### PR DESCRIPTION
## Summary

Extends the `Issue Triage` workflow so the reproduce step can execute generated Python that calls a real language model, using the same credentials already proven in the integration test workflow — without those secrets ever entering the agent prompt.

- Scope the `triage` job to the `integration` GitHub Environment and add `id-token: write` permission.
- Add an `azure/login@v2` OIDC step to establish an AAD session for Azure OpenAI and Foundry callers (`DefaultAzureCredential` picks this up automatically — no API key to leak).
- On the `Reproduce reported issue` step only, inject the OpenAI / Azure OpenAI / Foundry / Anthropic env vars (keys from `secrets`, model ids/endpoints from `vars`) that mirror `python-integration-tests.yml`. The spam-gate step keeps its minimal environment.

A companion change in `moonbox3/agent-dashboard@main` updates `repro_instructions` so the agent must construct clients from env-based constructors and must never print/log secrets or inline credentials as literals.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` against a known-good bug issue and confirm the `integration` environment's reviewer gate appears before execution.
- [ ] Verify `Azure CLI Login` step succeeds and the `Reproduce reported issue` job has the expected env vars.
- [ ] Confirm the agent's generated repro code constructs an Azure OpenAI / OpenAI / Foundry client without any hardcoded credential literals and the call against the real provider succeeds.
- [ ] Inspect job logs for any accidental secret exposure; GH masking should catch exact matches.