### PR TITLE
Python: Add /liveness endpoint for Kubernetes liveness probe

### DIFF
--- a/python/scripts/local_mcp_streamable_http_server.py
+++ b/python/scripts/local_mcp_streamable_http_server.py
@@ -52,6 +52,12 @@ def create_server(*, host: str, port: int, mount_path: str) -> FastMCP:
             }
         )
 
+    @server.custom_route("/liveness", methods=["GET"], include_in_schema=False)
+    async def liveness(_request: Request) -> Response:
+        """Return a simple liveness response for Kubernetes liveness probes."""
+        await asyncio.sleep(0)
+        return JSONResponse({"status": "alive"})
+
     @server.tool(
         name="search_agent_framework_docs",
         description="Return deterministic Agent Framework documentation text for MCP integration tests.",


### PR DESCRIPTION
Good day

Found that the service has a /readiness endpoint but is missing /liveness, causing Kubernetes liveness probes to receive 404 responses.

This PR adds the /liveness endpoint returning {"status": "alive"} following the same pattern as /readiness.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithRoof

Reference: #5441