### PR TITLE
.NET: Send A2A session task id as message taskId

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
@@ -345,9 +345,8 @@ public sealed class A2AAgent : AIAgent
         // See: https://github.com/a2aproject/A2A/blob/main/docs/topics/life-of-a-task.md#group-related-interactions
         a2aMessage.ContextId = typedSession.ContextId;
 
-        // Link the message as a follow-up to an existing task, if any.
-        // See: https://github.com/a2aproject/A2A/blob/main/docs/topics/life-of-a-task.md#task-refinements
-        a2aMessage.ReferenceTaskIds = typedSession.TaskId is null ? null : [typedSession.TaskId];
+        // Continue the current task, if any.
+        a2aMessage.TaskId = typedSession.TaskId;
 
         return a2aMessage;
     }

--- a/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
@@ -465,7 +465,7 @@ public sealed class A2AAgentTests : IDisposable
     }
 
     [Fact]
-    public async Task RunAsync_WithTaskInSessionAndMessage_AddTaskAsReferencesToMessageAsync()
+    public async Task RunAsync_WithTaskInSessionAndMessage_SetsTaskIdOnMessageAsync()
     {
         // Arrange
         this._handler.ResponseToReturn = new SendMessageResponse
@@ -478,8 +478,7 @@ public sealed class A2AAgentTests : IDisposable
             }
         };
 
-        var session = (A2AAgentSession)await this._agent.CreateSessionAsync();
-        session.TaskId = "task-123";
+        var session = await this._agent.CreateSessionAsync("context-123", "task-123");
 
         var inputMessage = new ChatMessage(ChatRole.User, "Please make the background transparent");
 
@@ -488,9 +487,9 @@ public sealed class A2AAgentTests : IDisposable
 
         // Assert
         var message = this._handler.CapturedSendMessageRequest?.Message;
-        Assert.Null(message?.TaskId);
-        Assert.NotNull(message?.ReferenceTaskIds);
-        Assert.Contains("task-123", message.ReferenceTaskIds);
+        Assert.Equal("context-123", message?.ContextId);
+        Assert.Equal("task-123", message?.TaskId);
+        Assert.Null(message?.ReferenceTaskIds);
     }
 
     [Fact]
@@ -813,7 +812,7 @@ public sealed class A2AAgentTests : IDisposable
     }
 
     [Fact]
-    public async Task RunStreamingAsync_WithTaskInSessionAndMessage_AddTaskAsReferencesToMessageAsync()
+    public async Task RunStreamingAsync_WithTaskInSessionAndMessage_SetsTaskIdOnMessageAsync()
     {
         // Arrange
         this._handler.StreamingResponseToReturn = new StreamResponse
@@ -826,8 +825,7 @@ public sealed class A2AAgentTests : IDisposable
             }
         };
 
-        var session = (A2AAgentSession)await this._agent.CreateSessionAsync();
-        session.TaskId = "task-123";
+        var session = await this._agent.CreateSessionAsync("context-123", "task-123");
 
         // Act
         await foreach (var _ in this._agent.RunStreamingAsync("Please make the background transparent", session))
@@ -837,9 +835,9 @@ public sealed class A2AAgentTests : IDisposable
 
         // Assert
         var message = this._handler.CapturedSendMessageRequest?.Message;
-        Assert.Null(message?.TaskId);
-        Assert.NotNull(message?.ReferenceTaskIds);
-        Assert.Contains("task-123", message.ReferenceTaskIds);
+        Assert.Equal("context-123", message?.ContextId);
+        Assert.Equal("task-123", message?.TaskId);
+        Assert.Null(message?.ReferenceTaskIds);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation and Context

Fixes #5417.

`A2AAgent` sessions can carry both a `contextId` and a `taskId` through `CreateSessionAsync(contextId, taskId)`, but outbound messages were copying the session task id into `ReferenceTaskIds` instead of `TaskId`. For an in-progress A2A task, the next client message needs `taskId` set so the remote agent can update that task. With the current payload, callers cannot resume that task-specific interaction through the framework path.

### Description

- Set outbound A2A `Message.TaskId` from `A2AAgentSession.TaskId`.
- Stop treating the session task id as `ReferenceTaskIds`.
- Update the `RunAsync` and `RunStreamingAsync` regression tests to use the public `CreateSessionAsync(contextId, taskId)` path and assert that both `contextId` and `taskId` are sent.

This is safe because it uses the existing session task id and does not add a new public API or change the session serialization shape. It aligns the wire payload with the existing overload name and with the A2A task continuation field.

### Validation

- `dotnet test --project tests/Microsoft.Agents.AI.A2A.UnitTests/Microsoft.Agents.AI.A2A.UnitTests.csproj` (`net8.0`, `net9.0`, `net10.0`; 351 passed)
- `dotnet format agent-framework-dotnet.slnx --verify-no-changes --no-restore --include src/Microsoft.Agents.AI.A2A/A2AAgent.cs tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs`
- `git diff --check`

### Remaining risk / follow-up

This does not add a separate public `ReferenceTaskIds` session API. If callers need to start a new task while explicitly referencing earlier tasks, that should be handled as a follow-up API discussion.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
