### PR TITLE
.NET: Bump OpenTelemetry packages to 1.15.3

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -61,10 +61,10 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <!-- Microsoft.AspNetCore.* -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -56,11 +56,11 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Net.Security" Version="4.3.2" />
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/invocations/Hosted-Invocations-EchoAgent/Hosted-Invocations-EchoAgent.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/invocations/Hosted-Invocations-EchoAgent/Hosted-Invocations-EchoAgent.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.AI.AgentServer.Invocations" />
     <PackageReference Include="DotNetEnv" />
+    <PackageReference Include="OpenTelemetry.Api" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
   <!-- For contributors: uses ProjectReference to build against local source -->

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/Microsoft.Agents.AI.Foundry.Hosting.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/Microsoft.Agents.AI.Foundry.Hosting.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Azure.AI.Projects" VersionOverride="2.1.0-beta.1" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context

The CI build is failing with `NU1902` (Warning As Error) due to known moderate severity vulnerabilities in OpenTelemetry packages at version 1.15.0:

- [`GHSA-g94r-2vxg-569j`](https://github.com/advisories/GHSA-g94r-2vxg-569j) — `OpenTelemetry.Api` 1.15.0
- [`GHSA-mr8r-92fq-pj8p`](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) — `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.0
- [`GHSA-q834-8qmm-v933`](https://github.com/advisories/GHSA-q834-8qmm-v933) — `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.0

### Description

#### Bump OpenTelemetry core packages from 1.15.0 → 1.15.3

In `Directory.Packages.props`:
- `OpenTelemetry` 1.15.0 → 1.15.3
- `OpenTelemetry.Api` 1.15.0 → 1.15.3
- `OpenTelemetry.Exporter.Console` 1.15.0 → 1.15.3
- `OpenTelemetry.Exporter.InMemory` 1.15.0 → 1.15.3
- `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.0 → 1.15.3

#### Align Extensions and Instrumentation packages to 1.15.x

To keep the full OpenTelemetry package set aligned and avoid version skew:
- `OpenTelemetry.Extensions.Hosting` 1.14.0 → 1.15.3
- `OpenTelemetry.Instrumentation.AspNetCore` 1.14.0 → 1.15.2
- `OpenTelemetry.Instrumentation.Http` 1.14.0 → 1.15.1
- `OpenTelemetry.Instrumentation.Runtime` 1.14.0 → 1.15.1

#### Pin transitive dependencies in projects with disabled central pinning

`Microsoft.Agents.AI.Foundry.Hosting.csproj` and `Hosted-Invocations-EchoAgent.csproj` set `CentralPackageTransitivePinningEnabled=false`, which prevents the centrally managed 1.15.3 version from overriding the transitive `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.15.0 pulled in by `Azure.AI.AgentServer.Core`. Added explicit `PackageReference` entries to force the patched versions:

- `Microsoft.Agents.AI.Foundry.Hosting.csproj` — added `OpenTelemetry.Exporter.OpenTelemetryProtocol` (flows to 8 hosted agent sample projects via `ProjectReference`)
- `Hosted-Invocations-EchoAgent.csproj` — added `OpenTelemetry.Api` and `OpenTelemetry.Exporter.OpenTelemetryProtocol`