### PR TITLE
Python: Clarify allowed types for deserialization

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
@@ -10,9 +10,9 @@ This hybrid approach provides:
 When ``allowed_types`` is supplied to :func:`decode_checkpoint_value`, a
 ``RestrictedUnpickler`` is used that limits which classes may be instantiated
 during deserialization.  The default built-in safe set covers common Python
-value types (primitives, datetime, uuid, ...), all ``agent_framework`` internal
-types, and all ``openai.types`` types.  Callers can extend the set by passing
-additional ``"module:qualname"`` strings.
+value types (primitives, datetime, uuid, ...). Callers MUST extend the set by 
+passing additional ``"module:qualname"`` strings for any framework or custom 
+types they wish to deserialize safely.
 """
 
 from __future__ import annotations
@@ -33,12 +33,6 @@ _TYPE_MARKER = "__type__"
 
 # Types that are natively JSON-serializable and don't need pickling
 _JSON_NATIVE_TYPES = (str, int, float, bool, type(None))
-
-# Module prefix for framework-internal types that are always allowed
-_FRAMEWORK_MODULE_PREFIX = "agent_framework."
-
-# Module prefix for OpenAI SDK types that are always allowed
-_OPENAI_MODULE_PREFIX = "openai.types."
 
 # Built-in types considered safe for checkpoint deserialization.
 # Each entry is a ``module:qualname`` string matching the format produced by
@@ -87,9 +81,8 @@ class _RestrictedUnpickler(pickle.Unpickler):  # noqa: S301
     """Unpickler that restricts which classes may be instantiated.
 
     Only classes whose ``module:qualname`` key appears in the combined allow
-    set (built-in safe types + framework types + OpenAI SDK types +
-    caller-specified extras) are permitted.  All other classes raise
-    :class:`pickle.UnpicklingError`.
+    set (built-in safe types + caller-specified extras) are permitted.  All 
+    other classes raise :class:`pickle.UnpicklingError`.
     """
 
     def __init__(self, data: bytes, allowed_types: frozenset[str]) -> None:
@@ -99,11 +92,11 @@ class _RestrictedUnpickler(pickle.Unpickler):  # noqa: S301
     def find_class(self, module: str, name: str) -> type:
         type_key = f"{module}:{name}"
 
+        # SECURITY FIX: Over-broad module.startswith() checks have been removed.
+        # Instantiation must strictly adhere to the explicit whitelists.
         if (
             type_key in _BUILTIN_ALLOWED_TYPE_KEYS
             or type_key in self._allowed_types
-            or module.startswith(_FRAMEWORK_MODULE_PREFIX)
-            or module.startswith(_OPENAI_MODULE_PREFIX)
         ):
             return super().find_class(module, name)  # type: ignore[no-any-return]  # nosec
 
@@ -142,7 +135,7 @@ def decode_checkpoint_value(value: Any, *, allowed_types: frozenset[str] | None 
     Args:
         value: A JSON-deserialized value from checkpoint storage.
         allowed_types: If not ``None``, restrict pickle deserialization to the
-            built-in safe set, framework types, and the types listed here.
+            built-in safe set and the types listed here.
             Each entry should use ``"module:qualname"`` format — that is, the
             dotted module path followed by a colon and the class
             ``__qualname__``.  For example, given a user-defined class::
@@ -261,8 +254,7 @@ def _base64_to_unpickle(encoded: str, *, allowed_types: frozenset[str] | None = 
     Args:
         encoded: Base64-encoded pickle data.
         allowed_types: If not ``None``, use restricted unpickling that only
-            permits built-in safe types, framework types, and the specified
-            extra types.
+            permits built-in safe types and the specified extra types.
 
     Raises:
         WorkflowCheckpointException: If the base64 data is corrupted, the pickle


### PR DESCRIPTION
1. Why is this change required?
The previous implementation of _RestrictedUnpickler contained a critical security flaw that allowed Remote Code Execution (RCE). It whitelisted entire module namespaces (agent_framework.* and openai.types.*), which is inherently unsafe in Python's pickle deserialization.

2. What problem does it solve?
It prevents "gadget" attacks. By whitelisting a whole namespace, an attacker could use any class within the framework that has side effects during initialization (e.g., executing commands, opening files) to compromise the host. This change enforces a strict, explicit whitelist policy.

3. What scenario does it contribute to?
Secure handling of Durable Workflows and Checkpoints. It ensures that when agents load state from potentially untrusted sources (shared storage, databases, or user uploads), the system remains protected against malicious payloads.

4. If it fixes an open issue, please link to the issue here.
Security vulnerability identified via independent audit (MSRC report pending).

Description
This PR hardens the _RestrictedUnpickler in _checkpoint_encoding.py by:

Removing over-broad whitelists: Deleted the logic that automatically allowed any module starting with agent_framework. or openai.types..

Enforcing Explicit Whitelisting: The unpickler now strictly only allows types defined in _BUILTIN_ALLOWED_TYPE_KEYS or those explicitly provided by the user via the allowed_checkpoint_types parameter.

Updating Documentation: Updated the module and method docstrings to clearly state that callers are now responsible for explicitly whitelisting any framework or custom classes they intend to deserialize.

Contribution Checklist
[x] The code builds clean without any errors or warnings

[x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)

[x] All unit tests pass, and I have added new tests where possible

[x] Is this a breaking change? Yes. [BREAKING] (Callers must now explicitly whitelist framework types they use in checkpoints).