### PR TITLE
Python: fix(foundry-hosting): emit oauth_consent_request and function_approval_request

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -1258,6 +1258,22 @@ async def _to_outputs(stream: ResponseEventStream, content: Content) -> AsyncIte
             max_output_length=content.max_output_length,
         ):
             yield event
+    elif content.type == "oauth_consent_request" and content.consent_link:
+        label = (content.additional_properties or {}).get("server_label", "")
+        text = f"OAuth consent required for MCP server '{label}'. Please visit:\n{content.consent_link}"
+        async for event in stream.aoutput_item_message(text):
+            yield event
+    elif content.type == "function_approval_request" and content.function_call is not None:
+        fn = content.function_call
+        label = (content.additional_properties or {}).get("server_label", "")
+        text = (
+            f"Approval required for MCP tool '{fn.name or 'unknown'}'"
+            + (f" on server '{label}'" if label else "")
+            + f" (request id: {content.id}).\n"
+            + f"Arguments: {_arguments_to_str(fn.arguments)}"
+        )
+        async for event in stream.aoutput_item_message(text):
+            yield event
     else:
         # Log a warning for unsupported content types instead of raising an error to avoid breaking the response stream.
         logger.warning(f"Content type '{content.type}' is not supported yet. This is usually safe to ignore.")

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -25,13 +25,15 @@ from agent_framework import (
     RawAgent,
     ResponseStream,
 )
-from azure.ai.agentserver.responses import InMemoryResponseProvider
+from azure.ai.agentserver.responses import InMemoryResponseProvider, ResponseEventStream
+from azure.ai.agentserver.responses.models import ResponseStreamEvent
 from typing_extensions import Any
 
 from agent_framework_foundry_hosting import ResponsesHostServer
 from agent_framework_foundry_hosting._responses import (
     _item_to_message,  # pyright: ignore[reportPrivateUsage]
     _output_item_to_message,  # pyright: ignore[reportPrivateUsage]
+    _to_outputs,  # pyright: ignore[reportPrivateUsage]
 )
 
 # region Helpers
@@ -132,6 +134,11 @@ def _parse_sse_events(body: str) -> list[dict[str, Any]]:
 def _sse_event_types(events: list[dict[str, Any]]) -> list[str]:
     """Extract event type strings from parsed SSE events."""
     return [e["event"] for e in events]
+
+
+async def _empty_response_events(*args: Any, **kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+    if False:
+        yield MagicMock()
 
 
 # endregion
@@ -558,6 +565,56 @@ class TestStreaming:
         assert types[-1] == "response.completed"
         assert "response.output_item.added" in types
         assert "response.output_item.done" in types
+
+
+# endregion
+
+
+# region _to_outputs conversion
+
+
+class TestToOutputs:
+    """Tests for _to_outputs covering streaming Content to ResponseStreamEvent conversion."""
+
+    async def test_oauth_consent_request_emits_consent_link_message(self, caplog: pytest.LogCaptureFixture) -> None:
+        stream = MagicMock(spec=ResponseEventStream)
+        stream.aoutput_item_message.side_effect = _empty_response_events
+        content = Content.from_oauth_consent_request(
+            "https://example.com/consent",
+            additional_properties={"server_label": "github"},
+        )
+
+        async for _ in _to_outputs(stream, content):
+            pass
+
+        stream.aoutput_item_message.assert_called_once()
+        text = stream.aoutput_item_message.call_args.args[0]
+        assert "OAuth consent required" in text
+        assert "github" in text
+        assert "https://example.com/consent" in text
+        assert "not supported yet" not in caplog.text
+
+    async def test_function_approval_request_emits_approval_message(self, caplog: pytest.LogCaptureFixture) -> None:
+        stream = MagicMock(spec=ResponseEventStream)
+        stream.aoutput_item_message.side_effect = _empty_response_events
+        function_call = Content.from_function_call("call-1", "my_tool", arguments='{"x": 1}')
+        content = Content.from_function_approval_request(
+            "req-123",
+            function_call,
+            additional_properties={"server_label": "github"},
+        )
+
+        async for _ in _to_outputs(stream, content):
+            pass
+
+        stream.aoutput_item_message.assert_called_once()
+        text = stream.aoutput_item_message.call_args.args[0]
+        assert "Approval required" in text
+        assert "my_tool" in text
+        assert "github" in text
+        assert "req-123" in text
+        assert '{"x": 1}' in text
+        assert "not supported yet" not in caplog.text
 
 
 # endregion


### PR DESCRIPTION
### Motivation and Context

Fixes #5535.

When `ResponsesHostServer` receives streaming Content of type `oauth_consent_request` or `function_approval_request` from a Foundry MCP toolbox, the SSE stream returns `output: []` and the consent link / approval prompt is silently dropped with a warning:

```
WARNING:agent_framework_foundry_hosting._responses:Content type 'oauth_consent_request' is not supported yet. This is usually safe to ignore.
```

PR #5070 fixed the streaming chunk parser so these content types now surface from the Responses API into the agent framework. The remaining gap was in the hosting layer's SSE emission: `_to_outputs()` in `agent_framework_foundry_hosting._responses` had no handler for either type, so they fell through to the warning branch.

### Description

Adds two `elif` branches to `_to_outputs` (right before the final `else` warning), both using the existing `aoutput_item_message` SSE helper:

1. `oauth_consent_request` emits a text message containing the consent URL and the MCP server label (from `additional_properties.server_label`).
2. `function_approval_request` emits a text message describing the function name, server label, request id, and arguments. The Content carries a nested `function_call` with `name`/`arguments`, which we surface via the existing `_arguments_to_str` helper.

No SSE wire-format changes. No new dependencies. The reporter's monkey-patch workaround in the issue body is replaced by upstream support so users do not have to patch.

Adds unit coverage in `test_responses.py` for both new branches: each test calls `_to_outputs(stream, content)` directly with a mocked stream and asserts the emitted text contains the consent link / function name.

Verified locally:
- `pytest packages/foundry_hosting/tests/test_responses.py` — 90 passed
- `ruff check` — clean
- `ruff format --check` — clean

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No.