### PR TITLE
.NET: Refactor harness console to be more extensible and easy to understand with better UX

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -136,6 +136,8 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <!-- Redis -->
     <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
+    <!-- Console UX -->
+    <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <!-- Test -->
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.22" />

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ICommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ICommandHandler.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Agents.AI;
+
+namespace Harness.Shared.Console.Commands;
+
+/// <summary>
+/// Handles a console command (e.g., /todos, /mode). Command handlers are checked
+/// in order before user input is sent to the agent. The first handler that
+/// accepts the input prevents further handlers from being checked.
+/// </summary>
+public interface ICommandHandler
+{
+    /// <summary>
+    /// Gets the help text for this command, displayed in the console header.
+    /// Returns <see langword="null"/> if the command is not currently available.
+    /// </summary>
+    /// <returns>Help text like <c>"/todos (show todo list)"</c>, or <see langword="null"/>.</returns>
+    string? GetHelpText();
+
+    /// <summary>
+    /// Attempts to handle the given user input.
+    /// </summary>
+    /// <param name="input">The raw user input string.</param>
+    /// <param name="session">The current agent session.</param>
+    /// <returns><see langword="true"/> if this handler handled the input; <see langword="false"/> otherwise.</returns>
+    bool TryHandle(string input, AgentSession session);
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ICommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ICommandHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Agents.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Agents.AI;
+
+namespace Harness.Shared.Console.Commands;
+
+/// <summary>
+/// Handles the <c>/mode</c> command to display or switch the current agent mode.
+/// </summary>
+internal sealed class ModeCommandHandler : ICommandHandler
+{
+    private readonly AgentModeProvider? _modeProvider;
+    private readonly IReadOnlyDictionary<string, ConsoleColor>? _modeColors;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModeCommandHandler"/> class.
+    /// </summary>
+    /// <param name="modeProvider">The mode provider, or <see langword="null"/> if not available.</param>
+    /// <param name="modeColors">Optional mapping of mode names to console colors.</param>
+    public ModeCommandHandler(AgentModeProvider? modeProvider, IReadOnlyDictionary<string, ConsoleColor>? modeColors = null)
+    {
+        this._modeProvider = modeProvider;
+        this._modeColors = modeColors;
+    }
+
+    /// <inheritdoc/>
+    public string? GetHelpText() => this._modeProvider is not null ? "/mode [plan|execute] (show or switch mode)" : null;
+
+    /// <inheritdoc/>
+    public bool TryHandle(string input, AgentSession session)
+    {
+        if (!input.StartsWith("/mode ", StringComparison.OrdinalIgnoreCase) && !input.Equals("/mode", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (this._modeProvider is null)
+        {
+            System.Console.WriteLine("AgentModeProvider is not available.");
+            return true;
+        }
+
+        string[] parts = input.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 2)
+        {
+            string current = this._modeProvider.GetMode(session);
+            System.Console.WriteLine($"\n  Current mode: {current}\n");
+            return true;
+        }
+
+        string newMode = parts[1];
+
+        try
+        {
+            this._modeProvider.SetMode(session, newMode);
+            System.Console.ForegroundColor = ConsoleWriter.GetModeColor(newMode, this._modeColors);
+            System.Console.WriteLine($"\n  Switched to {newMode} mode.\n");
+            System.Console.ResetColor();
+        }
+        catch (ArgumentException ex)
+        {
+            System.Console.ForegroundColor = ConsoleColor.Red;
+            System.Console.WriteLine($"\n  {ex}\n");
+            System.Console.ResetColor();
+        }
+
+        return true;
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Agents.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/TodoCommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/TodoCommandHandler.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Agents.AI;
+
+namespace Harness.Shared.Console.Commands;
+
+/// <summary>
+/// Handles the <c>/todos</c> command to display the current todo list.
+/// </summary>
+internal sealed class TodoCommandHandler : ICommandHandler
+{
+    private readonly TodoProvider? _todoProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TodoCommandHandler"/> class.
+    /// </summary>
+    /// <param name="todoProvider">The todo provider, or <see langword="null"/> if not available.</param>
+    public TodoCommandHandler(TodoProvider? todoProvider)
+    {
+        this._todoProvider = todoProvider;
+    }
+
+    /// <inheritdoc/>
+    public string? GetHelpText() => this._todoProvider is not null ? "/todos (show todo list)" : null;
+
+    /// <inheritdoc/>
+    public bool TryHandle(string input, AgentSession session)
+    {
+        if (!input.Equals("/todos", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (this._todoProvider is null)
+        {
+            System.Console.WriteLine("TodoProvider is not available.");
+            return true;
+        }
+
+        var todos = this._todoProvider.GetAllTodos(session);
+        if (todos.Count == 0)
+        {
+            System.Console.WriteLine("\n  No todos yet.\n");
+            return true;
+        }
+
+        System.Console.WriteLine();
+        System.Console.WriteLine("  ── Todo List ──");
+        foreach (var item in todos)
+        {
+            string status = item.IsComplete ? "✓" : "○";
+            System.Console.ForegroundColor = item.IsComplete ? ConsoleColor.DarkGray : ConsoleColor.White;
+            System.Console.Write($"  [{status}] #{item.Id} {item.Title}");
+            if (!string.IsNullOrWhiteSpace(item.Description))
+            {
+                System.Console.Write($" — {item.Description}");
+            }
+
+            System.Console.WriteLine();
+        }
+
+        System.Console.ResetColor();
+        System.Console.WriteLine();
+        return true;
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/TodoCommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/TodoCommandHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Agents.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
@@ -208,11 +208,11 @@ public sealed class ConsoleWriter : IDisposable
     /// <summary>
     /// Writes the stream-complete footer (handles "no text response" fallback, resets color).
     /// </summary>
-    public async Task WriteStreamFooterAsync(bool hasApprovalRequests)
+    public async Task WriteStreamFooterAsync(bool hasFollowUpMessages)
     {
         await this._spinner.StopAsync();
 
-        if (!this._hasReceivedAnyText && !hasApprovalRequests)
+        if (!this._hasReceivedAnyText && !hasFollowUpMessages)
         {
             System.Console.ForegroundColor = ConsoleColor.DarkYellow;
             System.Console.Write("\n  (no text response from agent)");

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
@@ -79,10 +79,7 @@ public sealed class ConsoleWriter : IDisposable
         string prefix = this._lastWasText ? "\n\n  " : "  ";
         this._lastWasText = false;
 
-        if (color.HasValue)
-        {
-            System.Console.ForegroundColor = color.Value;
-        }
+        System.Console.ForegroundColor = color ?? GetModeColor(this.CurrentMode, this._modeColors);
 
         if (newLine)
         {
@@ -93,10 +90,7 @@ public sealed class ConsoleWriter : IDisposable
             System.Console.Write(prefix + text);
         }
 
-        if (color.HasValue)
-        {
-            System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
-        }
+        System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
 
         this._spinner.Start();
     }
@@ -186,7 +180,6 @@ public sealed class ConsoleWriter : IDisposable
     {
         await this._spinner.StopAsync();
 
-        System.Console.WriteLine();
         AnsiConsole.Write(this.CreateModeRule());
 
         const string FreeformOption = "✏️  Type a custom response...";
@@ -226,7 +219,6 @@ public sealed class ConsoleWriter : IDisposable
         }
 
         System.Console.ResetColor();
-        System.Console.WriteLine();
         System.Console.WriteLine();
     }
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Spectre.Console;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/ConsoleWriter.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Spectre.Console;
+
+namespace Harness.Shared.Console;
+
+/// <summary>
+/// Centralizes all console output and spinner management for the harness console.
+/// Observers write through this class so the spinner is automatically paused before output.
+/// </summary>
+public sealed class ConsoleWriter : IDisposable
+{
+    private readonly Spinner _spinner = new();
+    private readonly IReadOnlyDictionary<string, ConsoleColor>? _modeColors;
+
+    private bool _lastWasText;
+    private bool _hasReceivedAnyText;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsoleWriter"/> class.
+    /// </summary>
+    /// <param name="modeColors">Optional mapping of mode names to console colors.</param>
+    public ConsoleWriter(IReadOnlyDictionary<string, ConsoleColor>? modeColors = null)
+    {
+        this._modeColors = modeColors;
+    }
+
+    /// <summary>
+    /// Gets or sets the current agent mode (e.g., "plan", "execute").
+    /// Used to determine the console color for mode-prefixed output.
+    /// </summary>
+    public string? CurrentMode { get; set; }
+
+    /// <summary>
+    /// Writes the agent response header (e.g., "[plan] Agent: ") and starts the spinner.
+    /// </summary>
+    public void WriteResponseHeader()
+    {
+        if (this.CurrentMode is not null)
+        {
+            System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
+            System.Console.Write($"\n[{this.CurrentMode}] Agent: ");
+        }
+        else
+        {
+            System.Console.Write("\nAgent: ");
+        }
+
+        this._lastWasText = true;
+        this._hasReceivedAnyText = false;
+        this._spinner.Start();
+    }
+
+    /// <summary>
+    /// Writes informational output with automatic prefix spacing, without a trailing newline.
+    /// Use when continuation content will be appended on the same line.
+    /// </summary>
+    /// <param name="text">The informational text to write (without leading newline/indent — added automatically).</param>
+    /// <param name="color">Optional console color for the text.</param>
+    public async Task WriteInfoAsync(string text, ConsoleColor? color = null)
+    {
+        await this.WriteInfoCoreAsync(text, color, newLine: false);
+    }
+
+    /// <summary>
+    /// Writes informational output with automatic prefix spacing, followed by a newline.
+    /// </summary>
+    /// <param name="text">The informational text to write (without leading newline/indent — added automatically).</param>
+    /// <param name="color">Optional console color for the text.</param>
+    public async Task WriteInfoLineAsync(string text, ConsoleColor? color = null)
+    {
+        await this.WriteInfoCoreAsync(text, color, newLine: true);
+    }
+
+    private async Task WriteInfoCoreAsync(string text, ConsoleColor? color, bool newLine)
+    {
+        await this._spinner.StopAsync();
+
+        string prefix = this._lastWasText ? "\n\n  " : "  ";
+        this._lastWasText = false;
+
+        if (color.HasValue)
+        {
+            System.Console.ForegroundColor = color.Value;
+        }
+
+        if (newLine)
+        {
+            System.Console.WriteLine(prefix + text);
+        }
+        else
+        {
+            System.Console.Write(prefix + text);
+        }
+
+        if (color.HasValue)
+        {
+            System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
+        }
+
+        this._spinner.Start();
+    }
+
+    /// <summary>
+    /// Writes text output from the agent, managing line break state.
+    /// Ensures a newline is written before the first text output.
+    /// </summary>
+    /// <param name="text">The text to write.</param>
+    /// <param name="color">Optional console color override for this text.</param>
+    public async Task WriteTextAsync(string text, ConsoleColor? color = null)
+    {
+        await this._spinner.StopAsync();
+
+        if (!this._lastWasText)
+        {
+            System.Console.Write("\n");
+            this._lastWasText = true;
+        }
+
+        this._hasReceivedAnyText = true;
+
+        if (color.HasValue)
+        {
+            System.Console.ForegroundColor = color.Value;
+        }
+
+        System.Console.Write(text);
+
+        if (color.HasValue)
+        {
+            System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
+        }
+
+        this._spinner.Start();
+    }
+
+    /// <summary>
+    /// Reads a line of input from the console, pausing the spinner while waiting for input.
+    /// Optionally displays a prompt before reading. The prompt is rendered between
+    /// two horizontal rules for visual clarity.
+    /// </summary>
+    /// <param name="prompt">Optional prompt text to display before reading input.</param>
+    /// <param name="promptColor">Optional console color for the prompt text.</param>
+    /// <returns>The line read from the console, or <c>null</c> if no input is available.</returns>
+    public async Task<string?> ReadLineAsync(string? prompt = null, ConsoleColor? promptColor = null)
+    {
+        await this._spinner.StopAsync();
+
+        if (prompt is not null)
+        {
+            System.Console.WriteLine();
+            AnsiConsole.Write(this.CreateModeRule());
+
+            if (promptColor.HasValue)
+            {
+                System.Console.ForegroundColor = promptColor.Value;
+            }
+
+            System.Console.Write($"  {prompt}");
+
+            if (promptColor.HasValue)
+            {
+                System.Console.ForegroundColor = GetModeColor(this.CurrentMode, this._modeColors);
+            }
+        }
+
+        string? input = System.Console.ReadLine();
+
+        if (prompt is not null)
+        {
+            AnsiConsole.Write(this.CreateModeRule());
+        }
+
+        this._lastWasText = false;
+        return input;
+    }
+
+    /// <summary>
+    /// Presents a selection prompt with the given choices, plus an option to type a custom response.
+    /// Uses Spectre.Console <see cref="SelectionPrompt{T}"/> for interactive arrow-key selection.
+    /// </summary>
+    /// <param name="title">The title/question displayed above the selection list.</param>
+    /// <param name="choices">The list of choices to present.</param>
+    /// <returns>The selected choice text, or the custom-typed response.</returns>
+    public async Task<string> ReadSelectionAsync(string title, IList<string> choices)
+    {
+        await this._spinner.StopAsync();
+
+        System.Console.WriteLine();
+        AnsiConsole.Write(this.CreateModeRule());
+
+        const string FreeformOption = "✏️  Type a custom response...";
+        var allChoices = choices.Concat([FreeformOption]).ToList();
+
+        var prompt = new SelectionPrompt<string>()
+            .Title($"  [bold]{Markup.Escape(title)}[/]")
+            .PageSize(10)
+            .AddChoices(allChoices);
+
+        string selection = AnsiConsole.Prompt(prompt);
+
+        if (selection == FreeformOption)
+        {
+            var textPrompt = new TextPrompt<string>("  [grey]Response:[/]");
+            selection = AnsiConsole.Prompt(textPrompt);
+        }
+
+        AnsiConsole.MarkupLine($"  [dim]→ {Markup.Escape(selection)}[/]");
+        AnsiConsole.Write(this.CreateModeRule());
+
+        this._lastWasText = false;
+        return selection;
+    }
+
+    /// <summary>
+    /// Writes the stream-complete footer (handles "no text response" fallback, resets color).
+    /// </summary>
+    public async Task WriteStreamFooterAsync(bool hasApprovalRequests)
+    {
+        await this._spinner.StopAsync();
+
+        if (!this._hasReceivedAnyText && !hasApprovalRequests)
+        {
+            System.Console.ForegroundColor = ConsoleColor.DarkYellow;
+            System.Console.Write("\n  (no text response from agent)");
+        }
+
+        System.Console.ResetColor();
+        System.Console.WriteLine();
+        System.Console.WriteLine();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        this._spinner.Dispose();
+    }
+
+    /// <summary>
+    /// Gets the console color associated with a mode name, using the provided color map.
+    /// </summary>
+    internal static ConsoleColor GetModeColor(string? mode, IReadOnlyDictionary<string, ConsoleColor>? modeColors = null)
+    {
+        if (mode is null)
+        {
+            return ConsoleColor.Gray;
+        }
+
+        if (modeColors is not null && modeColors.TryGetValue(mode, out var color))
+        {
+            return color;
+        }
+
+        return ConsoleColor.Gray;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Rule"/> styled with the current mode color.
+    /// </summary>
+    internal Rule CreateModeRule()
+    {
+        var spectreColor = ToSpectreColor(GetModeColor(this.CurrentMode, this._modeColors));
+        return new Rule().RuleStyle(new Style(spectreColor));
+    }
+
+    internal static Color ToSpectreColor(ConsoleColor consoleColor) => consoleColor switch
+    {
+        ConsoleColor.Black => Color.Black,
+        ConsoleColor.DarkBlue => Color.Blue,
+        ConsoleColor.DarkGreen => Color.Green,
+        ConsoleColor.DarkCyan => Color.Teal,
+        ConsoleColor.DarkRed => Color.Red,
+        ConsoleColor.DarkMagenta => Color.Purple,
+        ConsoleColor.DarkYellow => Color.Olive,
+        ConsoleColor.Gray => Color.Silver,
+        ConsoleColor.DarkGray => Color.Grey,
+        ConsoleColor.Blue => Color.Blue1,
+        ConsoleColor.Green => Color.Green1,
+        ConsoleColor.Cyan => Color.Aqua,
+        ConsoleColor.Red => Color.Red1,
+        ConsoleColor.Magenta => Color.Fuchsia,
+        ConsoleColor.Yellow => Color.Yellow,
+        ConsoleColor.White => Color.White,
+        _ => Color.Silver,
+    };
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
@@ -26,6 +26,14 @@ public static class HarnessConsole
     {
         options ??= new();
 
+        if (options.EnablePlanningUx
+            && (string.IsNullOrWhiteSpace(options.PlanningModeName) || string.IsNullOrWhiteSpace(options.ExecutionModeName)))
+        {
+            throw new ArgumentException(
+                "When EnablePlanningUx is true, both PlanningModeName and ExecutionModeName must be configured.",
+                nameof(options));
+        }
+
         System.Console.WriteLine($"=== {title} ===");
         System.Console.WriteLine(userPrompt);
 
@@ -162,7 +170,7 @@ public static class HarnessConsole
                 }
             }
 
-            await writer.WriteStreamFooterAsync(hasApprovalRequests: hasObserverMessages);
+            await writer.WriteStreamFooterAsync(hasFollowUpMessages: hasObserverMessages);
             nextMessages = combinedMessages.Count > 0 ? combinedMessages : null;
         }
     }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Agents.AI;
-using Microsoft.Extensions.AI;
 using Harness.Shared.Console.Commands;
 using Harness.Shared.Console.Observers;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 
 namespace Harness.Shared.Console;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
@@ -2,408 +2,205 @@
 
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using Harness.Shared.Console.Commands;
+using Harness.Shared.Console.Observers;
 
 namespace Harness.Shared.Console;
 
 /// <summary>
 /// Provides a reusable interactive console loop for running an <see cref="AIAgent"/>
-/// with streaming output, tool call display, spinner, and mode-aware prompts.
+/// with streaming output, extensible observers, and mode-aware interaction strategies.
 /// </summary>
 public static class HarnessConsole
 {
     /// <summary>
     /// Runs an interactive console session with the specified agent.
     /// Supports streaming output, tool call display, spinner animation,
-    /// and the <c>/todos</c> command.
+    /// optional planning UX with structured output, and the <c>/todos</c> command.
     /// </summary>
     /// <param name="agent">The agent to interact with.</param>
     /// <param name="title">The title displayed in the console header.</param>
     /// <param name="userPrompt">A short prompt to the user, displayed below the title.</param>
-    /// <param name="maxContextWindowTokens">Optional max context window size in tokens. When set, usage is displayed as a percentage.</param>
-    /// <param name="maxOutputTokens">Optional max output tokens. Used with <paramref name="maxContextWindowTokens"/> to show input/output budget breakdown.</param>
-    public static async Task RunAgentAsync(AIAgent agent, string title, string userPrompt, int? maxContextWindowTokens = null, int? maxOutputTokens = null)
+    /// <param name="options">Optional configuration options for the console session.</param>
+    public static async Task RunAgentAsync(AIAgent agent, string title, string userPrompt, HarnessConsoleOptions? options = null)
     {
-        var todoProvider = agent.GetService<TodoProvider>();
-        var modeProvider = agent.GetService<AgentModeProvider>();
+        options ??= new();
 
         System.Console.WriteLine($"=== {title} ===");
         System.Console.WriteLine(userPrompt);
 
-        var commands = new List<string>();
-        if (todoProvider is not null)
-        {
-            commands.Add("/todos (show todo list)");
-        }
+        var todoProvider = agent.GetService<TodoProvider>();
+        var modeProvider = agent.GetService<AgentModeProvider>();
 
-        if (modeProvider is not null)
+        // Build command handlers.
+        var commandHandlers = new List<ICommandHandler>
         {
-            commands.Add("/mode [plan|execute] (show or switch mode)");
-        }
+            new TodoCommandHandler(todoProvider),
+            new ModeCommandHandler(modeProvider, options.ModeColors),
+        };
 
-        commands.Add("exit (quit)");
+        var commands = commandHandlers
+            .Select(h => h.GetHelpText())
+            .Where(t => t is not null)
+            .Append("exit (quit)");
+
         System.Console.WriteLine($"Commands: {string.Join(", ", commands)}");
         System.Console.WriteLine();
 
         AgentSession session = await agent.CreateSessionAsync();
+        using var writer = new ConsoleWriter(options.ModeColors);
+        writer.CurrentMode = modeProvider?.GetMode(session);
 
-        WritePrompt(modeProvider, session);
-        string? userInput = System.Console.ReadLine();
+        string prompt = BuildUserPrompt(modeProvider, session);
+        string? userInput = await writer.ReadLineAsync(prompt);
 
+        // Main loop to run a command or agent and get the next user command/input.
         while (!string.IsNullOrWhiteSpace(userInput) && !userInput.Equals("exit", StringComparison.OrdinalIgnoreCase))
         {
-            if (userInput.Equals("/todos", StringComparison.OrdinalIgnoreCase))
+            // Check command handlers first — first one to handle wins.
+            bool handled = false;
+            foreach (var handler in commandHandlers)
             {
-                PrintTodos(todoProvider, session);
-            }
-            else if (userInput.StartsWith("/mode", StringComparison.OrdinalIgnoreCase))
-            {
-                HandleModeCommand(modeProvider, session, userInput);
-            }
-            else
-            {
-                await StreamAgentResponseAsync(agent, session, modeProvider, userInput, maxContextWindowTokens, maxOutputTokens);
+                if (handler.TryHandle(userInput, session))
+                {
+                    handled = true;
+                    break;
+                }
             }
 
-            WritePrompt(modeProvider, session);
-            userInput = System.Console.ReadLine();
+            if (!handled)
+            {
+                await RunAgentTurnAsync(agent, session, modeProvider, options, writer, userInput);
+            }
+
+            writer.CurrentMode = modeProvider?.GetMode(session);
+            prompt = BuildUserPrompt(modeProvider, session);
+            userInput = await writer.ReadLineAsync(prompt);
         }
 
         System.Console.ResetColor();
         System.Console.WriteLine("Goodbye!");
     }
 
-    private static async Task StreamAgentResponseAsync(AIAgent agent, AgentSession session, AgentModeProvider? modeProvider, string userInput, int? maxContextWindowTokens, int? maxOutputTokens)
+    /// <summary>
+    /// Runs one or more agent invocations for a single user turn, using the current
+    /// observers. Re-invokes automatically for tool approvals and mode-driven follow-ups
+    /// (e.g., planning clarification loops).
+    /// </summary>
+    private static async Task RunAgentTurnAsync(
+        AIAgent agent,
+        AgentSession session,
+        AgentModeProvider? modeProvider,
+        HarnessConsoleOptions options,
+        ConsoleWriter writer,
+        string userInput)
     {
-        // Initial user input
-        var approvalRequests = await StreamAndCollectApprovalsAsync(agent.RunStreamingAsync(userInput, session), modeProvider, session, maxContextWindowTokens, maxOutputTokens);
-        var messagesToSend = PromptForApprovals(approvalRequests);
+        IList<ChatMessage>? nextMessages = [new ChatMessage(ChatRole.User, userInput)];
 
-        // Loop while there are approval responses to send back
-        while (messagesToSend is not null)
+        while (nextMessages is not null)
         {
-            approvalRequests = await StreamAndCollectApprovalsAsync(agent.RunStreamingAsync(messagesToSend, session), modeProvider, session, maxContextWindowTokens, maxOutputTokens);
-            messagesToSend = PromptForApprovals(approvalRequests);
+            // Build observers for this invocation (may change between iterations due to mode changes).
+            var observers = CreateObservers(options, modeProvider, session);
+
+            // Build run options — observers may inject ResponseFormat, etc.
+            var runOptions = new AgentRunOptions();
+            foreach (var observer in observers)
+            {
+                observer.ConfigureRunOptions(runOptions);
+            }
+
+            // Stream the response, fanning out to all observers.
+            writer.CurrentMode = modeProvider?.GetMode(session);
+            writer.WriteResponseHeader();
+
+            try
+            {
+                await foreach (var update in agent.RunStreamingAsync(nextMessages, session, runOptions))
+                {
+                    // Update mode color if the mode changed during streaming.
+                    if (modeProvider is not null)
+                    {
+                        string currentMode = modeProvider.GetMode(session);
+                        if (currentMode != writer.CurrentMode)
+                        {
+                            writer.CurrentMode = currentMode;
+                        }
+                    }
+
+                    foreach (var content in update.Contents)
+                    {
+                        foreach (var observer in observers)
+                        {
+                            await observer.OnContentAsync(writer, content);
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(update.Text))
+                    {
+                        foreach (var observer in observers)
+                        {
+                            await observer.OnTextAsync(writer, update.Text);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                await writer.WriteInfoLineAsync($"❌ Stream error: {ex.GetType().Name}:\n{ex}", ConsoleColor.Red);
+            }
+
+            // Collect messages from all observers.
+            var combinedMessages = new List<ChatMessage>();
+            bool hasObserverMessages = false;
+            foreach (var observer in observers)
+            {
+                var messages = await observer.OnStreamCompleteAsync(writer, agent, session, options);
+                if (messages is { Count: > 0 })
+                {
+                    combinedMessages.AddRange(messages);
+                    hasObserverMessages = true;
+                }
+            }
+
+            await writer.WriteStreamFooterAsync(hasApprovalRequests: hasObserverMessages);
+            nextMessages = combinedMessages.Count > 0 ? combinedMessages : null;
         }
     }
 
-    private static async Task<List<ToolApprovalRequestContent>> StreamAndCollectApprovalsAsync(IAsyncEnumerable<AgentResponseUpdate> updates, AgentModeProvider? modeProvider, AgentSession session, int? maxContextWindowTokens, int? maxOutputTokens)
+    private static List<ConsoleObserver> CreateObservers(HarnessConsoleOptions options, AgentModeProvider? modeProvider, AgentSession session)
     {
-        var approvalRequests = new List<ToolApprovalRequestContent>();
-        string? mode = modeProvider is not null ? modeProvider.GetMode(session) : null;
-        if (mode is not null)
+        var observers = new List<ConsoleObserver>
         {
-            System.Console.ForegroundColor = GetModeColor(mode);
-            System.Console.Write($"\n[{mode}] Agent: ");
+            new ToolCallDisplayObserver(),
+            new ToolApprovalObserver(),
+            new ErrorDisplayObserver(),
+            new ReasoningDisplayObserver(),
+            new UsageDisplayObserver(options.MaxContextWindowTokens, options.MaxOutputTokens),
+        };
+
+        // Add the appropriate output observer based on the current mode.
+        if (options.EnablePlanningUx
+            && modeProvider is not null
+            && string.Equals(modeProvider.GetMode(session), options.PlanningModeName, StringComparison.OrdinalIgnoreCase))
+        {
+            observers.Add(new PlanningOutputObserver(modeProvider));
         }
         else
         {
-            System.Console.Write("\nAgent: ");
+            observers.Add(new TextOutputObserver());
         }
 
-        var spinner = new Spinner();
-        spinner.Start();
-        bool hasTextOutput = false;
-        bool hasReceivedAnyText = false;
-
-        try
-        {
-            await foreach (var update in updates)
-            {
-                foreach (var content in update.Contents)
-                {
-                    if (content is FunctionCallContent functionCall)
-                    {
-                        await spinner.StopAsync();
-                        System.Console.ForegroundColor = ConsoleColor.DarkYellow;
-                        System.Console.Write(hasTextOutput ? "\n\n  🔧 Calling tool: " : "\n  🔧 Calling tool: ");
-                        System.Console.Write($"{ToolCallFormatter.Format(functionCall)}...");
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                        hasTextOutput = false;
-                        spinner.Start();
-                    }
-                    else if (content is ToolCallContent toolCall)
-                    {
-                        await spinner.StopAsync();
-                        System.Console.ForegroundColor = ConsoleColor.DarkYellow;
-                        System.Console.Write(hasTextOutput ? "\n\n  🔧 Calling tool: " : "\n  🔧 Calling tool: ");
-                        System.Console.Write($"{toolCall}...");
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                        hasTextOutput = false;
-                        spinner.Start();
-                    }
-                    else if (content is ToolApprovalRequestContent approvalRequest)
-                    {
-                        await spinner.StopAsync();
-                        approvalRequests.Add(approvalRequest);
-                        string toolName = approvalRequest.ToolCall is FunctionCallContent fc ? ToolCallFormatter.Format(fc) : approvalRequest.ToolCall?.ToString() ?? "unknown";
-                        System.Console.ForegroundColor = ConsoleColor.Yellow;
-                        System.Console.Write(hasTextOutput ? "\n\n  ⚠️ Approval needed: " : "\n  ⚠️ Approval needed: ");
-                        System.Console.Write(toolName);
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                        hasTextOutput = false;
-                    }
-                    else if (content is ErrorContent errorContent)
-                    {
-                        await spinner.StopAsync();
-                        System.Console.ForegroundColor = ConsoleColor.Red;
-                        System.Console.Write($"\n  ❌ Error: {errorContent.Message}");
-                        if (errorContent.ErrorCode is not null)
-                        {
-                            System.Console.Write($" (code: {errorContent.ErrorCode})");
-                        }
-
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                    }
-                    else if (content is TextReasoningContent reasoning && !string.IsNullOrEmpty(reasoning.Text))
-                    {
-                        await spinner.StopAsync();
-
-                        if (!hasTextOutput)
-                        {
-                            System.Console.Write("\n");
-                            hasTextOutput = true;
-                            hasReceivedAnyText = true;
-                        }
-
-                        System.Console.ForegroundColor = ConsoleColor.DarkMagenta;
-                        System.Console.Write(reasoning.Text);
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                    }
-                    else if (content is UsageContent usage)
-                    {
-                        await spinner.StopAsync();
-                        System.Console.ForegroundColor = ConsoleColor.DarkGray;
-                        System.Console.Write("\n\n  📊 Tokens");
-                        if (usage.Details is not null)
-                        {
-                            WriteUsageBreakdown(usage.Details, maxContextWindowTokens, maxOutputTokens);
-                        }
-                        else
-                        {
-                            System.Console.Write(" —");
-                        }
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                        hasTextOutput = false;
-                    }
-                }
-
-                if (string.IsNullOrEmpty(update.Text))
-                {
-                    continue;
-                }
-
-                await spinner.StopAsync();
-
-                if (!hasTextOutput)
-                {
-                    System.Console.Write("\n");
-                    hasTextOutput = true;
-                    hasReceivedAnyText = true;
-                }
-
-                if (modeProvider is not null)
-                {
-                    string currentMode = modeProvider.GetMode(session);
-                    if (currentMode != mode)
-                    {
-                        mode = currentMode;
-                        System.Console.ForegroundColor = GetModeColor(mode);
-                    }
-                }
-
-                System.Console.Write(update.Text);
-            }
-        }
-        catch (Exception ex)
-        {
-            await spinner.StopAsync();
-            System.Console.ForegroundColor = ConsoleColor.Red;
-            System.Console.Write($"\n  ❌ Stream error: {ex.GetType().Name}:\n{ex}");
-        }
-
-        await spinner.StopAsync();
-
-        if (!hasReceivedAnyText && approvalRequests.Count == 0)
-        {
-            System.Console.ForegroundColor = ConsoleColor.DarkYellow;
-            System.Console.Write("\n  (no text response from agent)");
-        }
-
-        System.Console.ResetColor();
-        System.Console.WriteLine();
-        System.Console.WriteLine();
-
-        return approvalRequests;
+        return observers;
     }
 
-    /// <summary>
-    /// Prompts the user for approval of each tool approval request.
-    /// Returns a list of messages to send back to the agent, or <see langword="null"/> if there are no requests.
-    /// </summary>
-    private static List<ChatMessage>? PromptForApprovals(List<ToolApprovalRequestContent> approvalRequests)
-    {
-        if (approvalRequests.Count == 0)
-        {
-            return null;
-        }
-
-        var responses = new List<AIContent>();
-        foreach (var request in approvalRequests)
-        {
-            string toolName = request.ToolCall is FunctionCallContent fc ? ToolCallFormatter.Format(fc) : request.ToolCall?.ToString() ?? "unknown";
-
-            System.Console.ForegroundColor = ConsoleColor.Yellow;
-            System.Console.WriteLine($"\n  🔐 Tool approval required: {toolName}");
-            System.Console.ResetColor();
-            System.Console.WriteLine("     1) Approve this call");
-            System.Console.WriteLine("     2) Always approve this tool (any arguments)");
-            System.Console.WriteLine("     3) Always approve this tool with these arguments");
-            System.Console.WriteLine("     4) Deny");
-            System.Console.Write("     Choice [1-4]: ");
-
-            string? choice = System.Console.ReadLine()?.Trim();
-            AIContent response = choice switch
-            {
-                "2" => request.CreateAlwaysApproveToolResponse("User chose to always approve this tool"),
-                "3" => request.CreateAlwaysApproveToolWithArgumentsResponse("User chose to always approve this tool with these arguments"),
-                "4" => request.CreateResponse(approved: false, reason: "User denied"),
-                _ => request.CreateResponse(approved: true, reason: "User approved"),
-            };
-
-            string action = choice switch
-            {
-                "2" => "✅ Always approved (any args)",
-                "3" => "✅ Always approved (these args)",
-                "4" => "❌ Denied",
-                _ => "✅ Approved",
-            };
-            System.Console.ForegroundColor = ConsoleColor.DarkGray;
-            System.Console.WriteLine($"     {action}");
-            System.Console.ResetColor();
-
-            responses.Add(response);
-        }
-
-        return [new ChatMessage(ChatRole.User, responses)];
-    }
-
-    private static void HandleModeCommand(AgentModeProvider? modeProvider, AgentSession session, string input)
-    {
-        if (modeProvider is null)
-        {
-            System.Console.WriteLine("AgentModeProvider is not available.");
-            return;
-        }
-
-        string[] parts = input.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (parts.Length < 2)
-        {
-            string current = modeProvider.GetMode(session);
-            System.Console.WriteLine($"\n  Current mode: {current}\n");
-            return;
-        }
-
-        string newMode = parts[1];
-
-        try
-        {
-            modeProvider.SetMode(session, newMode);
-            System.Console.ForegroundColor = GetModeColor(newMode);
-            System.Console.WriteLine($"\n  Switched to {newMode} mode.\n");
-            System.Console.ResetColor();
-        }
-        catch (ArgumentException ex)
-        {
-            System.Console.ForegroundColor = ConsoleColor.Red;
-            System.Console.WriteLine($"\n  {ex}\n");
-            System.Console.ResetColor();
-        }
-    }
-
-    private static void WritePrompt(AgentModeProvider? modeProvider, AgentSession session)
+    private static string BuildUserPrompt(AgentModeProvider? modeProvider, AgentSession session)
     {
         if (modeProvider is not null)
         {
             string mode = modeProvider.GetMode(session);
-            System.Console.ForegroundColor = GetModeColor(mode);
-            System.Console.Write($"[{mode}] ");
+            return $"[{mode}] You: ";
         }
 
-        System.Console.Write("You: ");
-        System.Console.ResetColor();
+        return "You: ";
     }
-
-    private static void PrintTodos(TodoProvider? todoProvider, AgentSession session)
-    {
-        if (todoProvider is null)
-        {
-            System.Console.WriteLine("TodoProvider is not available.");
-            return;
-        }
-
-        var todos = todoProvider.GetAllTodos(session);
-        if (todos.Count == 0)
-        {
-            System.Console.WriteLine("\n  No todos yet.\n");
-            return;
-        }
-
-        System.Console.WriteLine();
-        System.Console.WriteLine("  ── Todo List ──");
-        foreach (var item in todos)
-        {
-            string status = item.IsComplete ? "✓" : "○";
-            System.Console.ForegroundColor = item.IsComplete ? ConsoleColor.DarkGray : ConsoleColor.White;
-            System.Console.Write($"  [{status}] #{item.Id} {item.Title}");
-            if (!string.IsNullOrWhiteSpace(item.Description))
-            {
-                System.Console.Write($" — {item.Description}");
-            }
-
-            System.Console.WriteLine();
-        }
-
-        System.Console.ResetColor();
-        System.Console.WriteLine();
-    }
-
-    private static void WriteUsageBreakdown(UsageDetails details, int? maxContextWindowTokens, int? maxOutputTokens)
-    {
-        int? inputBudget = (maxContextWindowTokens is not null && maxOutputTokens is not null)
-            ? maxContextWindowTokens.Value - maxOutputTokens.Value
-            : null;
-
-        System.Console.Write(" — input: ");
-        WriteTokenCount(details.InputTokenCount, inputBudget);
-
-        System.Console.Write(" | output: ");
-        WriteTokenCount(details.OutputTokenCount, maxOutputTokens);
-
-        System.Console.Write(" | total: ");
-        WriteTokenCount(details.TotalTokenCount, maxContextWindowTokens);
-    }
-
-    private static void WriteTokenCount(long? count, int? budget)
-    {
-        if (count is null)
-        {
-            System.Console.Write("—");
-            return;
-        }
-
-        System.Console.Write($"{count.Value:N0}");
-        if (budget is not null && budget.Value > 0)
-        {
-            double pct = (double)count.Value / budget.Value * 100;
-            System.Console.Write($"/{budget.Value:N0} ({pct:F1}%)");
-        }
-    }
-
-    private static ConsoleColor GetModeColor(string? mode) => mode switch
-    {
-        "plan" => ConsoleColor.Cyan,
-        "execute" => ConsoleColor.Green,
-        null => ConsoleColor.Gray,
-        _ => ConsoleColor.Gray,
-    };
 }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Harness.Shared.Console;
+
+/// <summary>
+/// Configuration options for <see cref="HarnessConsole"/>.
+/// </summary>
+public class HarnessConsoleOptions
+{
+    /// <summary>
+    /// Gets or sets the optional maximum context window size in tokens.
+    /// When set, token usage is displayed as a percentage of the budget.
+    /// </summary>
+    public int? MaxContextWindowTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional maximum output tokens.
+    /// Used with <see cref="MaxContextWindowTokens"/> to show input/output budget breakdown.
+    /// </summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the planning UX is enabled.
+    /// When <see langword="true"/> and the agent is in the mode specified by <see cref="PlanningModeName"/>,
+    /// the console uses structured output to present clarification questions and approval requests
+    /// instead of streaming free-form text.
+    /// </summary>
+    /// <value>Defaults to <see langword="false"/>.</value>
+    public bool EnablePlanningUx { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the agent mode that activates the planning UX.
+    /// Must be set when <see cref="EnablePlanningUx"/> is <see langword="true"/>.
+    /// </summary>
+    public string? PlanningModeName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the agent mode to switch to when the user approves a plan.
+    /// Must be set when <see cref="EnablePlanningUx"/> is <see langword="true"/>.
+    /// </summary>
+    public string? ExecutionModeName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a mapping of agent mode names to console colors.
+    /// When a mode is not found in this dictionary, the default color (<see cref="ConsoleColor.Gray"/>) is used.
+    /// </summary>
+    public Dictionary<string, ConsoleColor> ModeColors { get; set; } = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["plan"] = ConsoleColor.Cyan,
+        ["execute"] = ConsoleColor.Green,
+    };
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 namespace Harness.Shared.Console;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Harness_Shared_Console.csproj
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Harness_Shared_Console.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Spectre.Console" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Abstract base class for console observers that participate in the agent response
+/// streaming lifecycle. Observers can configure run options, observe streamed content,
+/// and return messages to re-invoke the agent after the stream completes.
+/// All methods have default no-op implementations so subclasses only override what they need.
+/// </summary>
+public abstract class ConsoleObserver
+{
+    /// <summary>
+    /// Configures <see cref="AgentRunOptions"/> before the agent is invoked.
+    /// Override to set options such as <see cref="AgentRunOptions.ResponseFormat"/>.
+    /// </summary>
+    /// <param name="options">The run options to configure.</param>
+    public virtual void ConfigureRunOptions(AgentRunOptions options)
+    {
+    }
+
+    /// <summary>
+    /// Called for each <see cref="AIContent"/> item in the response stream.
+    /// </summary>
+    /// <param name="writer">The console writer for rendering output.</param>
+    /// <param name="content">The content item from the stream.</param>
+    public virtual Task OnContentAsync(ConsoleWriter writer, AIContent content) => Task.CompletedTask;
+
+    /// <summary>
+    /// Called for each text update in the response stream.
+    /// </summary>
+    /// <param name="writer">The console writer for rendering output.</param>
+    /// <param name="text">The text from the update.</param>
+    public virtual Task OnTextAsync(ConsoleWriter writer, string text) => Task.CompletedTask;
+
+    /// <summary>
+    /// Called after the response stream completes. Returns messages to include in the
+    /// next agent invocation, or <see langword="null"/> if no re-invocation is needed.
+    /// </summary>
+    /// <param name="writer">The console writer for rendering output.</param>
+    /// <param name="agent">The agent being interacted with.</param>
+    /// <param name="session">The current agent session.</param>
+    /// <param name="options">The console options.</param>
+    /// <returns>Messages to send to the agent, or <see langword="null"/> if no action is needed.</returns>
+    public virtual Task<IList<ChatMessage>?> OnStreamCompleteAsync(
+        ConsoleWriter writer,
+        AIAgent agent,
+        AgentSession session,
+        HarnessConsoleOptions options) => Task.FromResult<IList<ChatMessage>?>(null);
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Extensions.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
@@ -22,7 +22,7 @@ internal sealed class ErrorDisplayObserver : ConsoleObserver
 
             if (!string.IsNullOrWhiteSpace(errorContent.Details))
             {
-                errorText += $" details: {errorContent.Details})";
+                errorText += $" details: {errorContent.Details}";
             }
 
             await writer.WriteInfoLineAsync(errorText, ConsoleColor.Red);

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ErrorDisplayObserver.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Displays error content (❌) from the response stream.
+/// </summary>
+internal sealed class ErrorDisplayObserver : ConsoleObserver
+{
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(ConsoleWriter writer, AIContent content)
+    {
+        if (content is ErrorContent errorContent)
+        {
+            string errorText = $"❌ Error: {errorContent.Message}";
+            if (!string.IsNullOrWhiteSpace(errorContent.ErrorCode))
+            {
+                errorText += $" (code: {errorContent.ErrorCode})";
+            }
+
+            if (!string.IsNullOrWhiteSpace(errorContent.Details))
+            {
+                errorText += $" details: {errorContent.Details})";
+            }
+
+            await writer.WriteInfoLineAsync(errorText, ConsoleColor.Red);
+        }
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text;
 using System.Text.Json;
@@ -78,12 +78,19 @@ internal sealed class PlanningOutputObserver : ConsoleObserver
         // Render based on response type.
         if (planningResponse.Type == PlanningResponseType.Clarification)
         {
-            return AsUserMessages(await this.RenderClarificationAndCollectResponseAsync(writer, planningResponse));
+            return AsUserMessages(await this.RenderClarificationsAndCollectResponsesAsync(writer, planningResponse));
         }
 
         if (planningResponse.Type == PlanningResponseType.Approval)
         {
-            string response = await this.RenderApprovalAndCollectResponseAsync(writer, planningResponse, options);
+            var question = planningResponse.Questions.FirstOrDefault();
+            if (question is null)
+            {
+                await writer.WriteInfoLineAsync("(approval response had no content)", ConsoleColor.DarkYellow);
+                return null;
+            }
+
+            string response = await this.RenderApprovalAndCollectResponseAsync(writer, question, options);
             if (response == "Approved")
             {
                 this._modeProvider.SetMode(session, options.ExecutionModeName!);
@@ -102,24 +109,39 @@ internal sealed class PlanningOutputObserver : ConsoleObserver
     private static IList<ChatMessage>? AsUserMessages(string? text) =>
         text is not null ? [new ChatMessage(ChatRole.User, text)] : null;
 
-    private async Task<string?> RenderClarificationAndCollectResponseAsync(ConsoleWriter writer, PlanningResponse response)
+    private async Task<string?> RenderClarificationsAndCollectResponsesAsync(ConsoleWriter writer, PlanningResponse response)
     {
-        await writer.WriteInfoLineAsync(response.Message ?? string.Empty);
+        var answers = new List<string>();
 
-        if (response.Choices is { Count: > 0 })
+        foreach (var question in response.Questions)
         {
-            return await writer.ReadSelectionAsync(
-                "Choose an option:",
-                response.Choices);
+            await writer.WriteInfoLineAsync(string.Empty);
+            await writer.WriteInfoLineAsync(question.Message);
+
+            string? answer;
+            if (question.Choices is { Count: > 0 })
+            {
+                answer = await writer.ReadSelectionAsync(
+                    "Choose an option:",
+                    question.Choices);
+            }
+            else
+            {
+                answer = (await writer.ReadLineAsync("Response: "))?.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(answer))
+            {
+                answers.Add($"Q: {question.Message}\nA: {answer}");
+            }
         }
 
-        string? input = (await writer.ReadLineAsync("Response: "))?.Trim();
-        return string.IsNullOrWhiteSpace(input) ? null : input;
+        return answers.Count > 0 ? string.Join("\n\n", answers) : null;
     }
 
-    private async Task<string> RenderApprovalAndCollectResponseAsync(ConsoleWriter writer, PlanningResponse response, HarnessConsoleOptions options)
+    private async Task<string> RenderApprovalAndCollectResponseAsync(ConsoleWriter writer, PlanningQuestion question, HarnessConsoleOptions options)
     {
-        await writer.WriteInfoLineAsync(response.Message ?? string.Empty);
+        await writer.WriteInfoLineAsync(question.Message);
 
         var choices = new List<string>
         {

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -161,7 +161,14 @@ internal sealed class PlanningOutputObserver : ConsoleObserver
             string? feedback = await writer.ReadLineAsync(
                 "Your feedback: ",
                 ConsoleWriter.GetModeColor(options.PlanningModeName, options.ModeColors));
-            return string.IsNullOrWhiteSpace(feedback) ? "Approved" : feedback;
+
+            if (string.IsNullOrWhiteSpace(feedback))
+            {
+                // Treat empty feedback as no changes — re-prompt the agent with the plan.
+                return "No changes suggested. Please re-present the plan for approval.";
+            }
+
+            return feedback;
         }
 
         // Custom freeform input — treat as suggested changes.

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Planning observer that configures structured output, collects streamed text,
+/// and deserializes it as a <see cref="PlanningResponse"/>. Renders clarification
+/// questions and approval prompts, and manages mode switching when the user approves a plan.
+/// </summary>
+internal sealed class PlanningOutputObserver : ConsoleObserver
+{
+    private readonly StringBuilder _textCollector = new();
+    private readonly AgentModeProvider _modeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlanningOutputObserver"/> class.
+    /// </summary>
+    /// <param name="modeProvider">The mode provider for switching modes on approval.</param>
+    public PlanningOutputObserver(AgentModeProvider modeProvider)
+    {
+        this._modeProvider = modeProvider;
+    }
+
+    /// <inheritdoc/>
+    public override void ConfigureRunOptions(AgentRunOptions options)
+    {
+        options.ResponseFormat = ChatResponseFormat.ForJsonSchema<PlanningResponse>();
+    }
+
+    /// <inheritdoc/>
+    public override Task OnTextAsync(ConsoleWriter writer, string text)
+    {
+        // Collect text silently instead of displaying it.
+        this._textCollector.Append(text);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IList<ChatMessage>?> OnStreamCompleteAsync(
+        ConsoleWriter writer,
+        AIAgent agent,
+        AgentSession session,
+        HarnessConsoleOptions options)
+    {
+        // Read collected text from our stream observation.
+        string collectedText = this._textCollector.ToString();
+        this._textCollector.Clear();
+
+        if (string.IsNullOrWhiteSpace(collectedText))
+        {
+            return null;
+        }
+
+        // Deserialize the structured response.
+        PlanningResponse? planningResponse;
+        try
+        {
+            planningResponse = JsonSerializer.Deserialize<PlanningResponse>(collectedText);
+        }
+        catch (JsonException ex)
+        {
+            await writer.WriteInfoLineAsync($"❌ Failed to parse planning response: {ex.Message}", ConsoleColor.Red);
+            await writer.WriteInfoLineAsync($"(raw response) {collectedText}", ConsoleColor.DarkYellow);
+            return null;
+        }
+
+        if (planningResponse is null)
+        {
+            await writer.WriteInfoLineAsync("(no structured response from agent)", ConsoleColor.DarkYellow);
+            return null;
+        }
+
+        // Render based on response type.
+        if (planningResponse.Type == PlanningResponseType.Clarification)
+        {
+            return AsUserMessages(await this.RenderClarificationAndCollectResponseAsync(writer, planningResponse));
+        }
+
+        if (planningResponse.Type == PlanningResponseType.Approval)
+        {
+            string response = await this.RenderApprovalAndCollectResponseAsync(writer, planningResponse, options);
+            if (response == "Approved")
+            {
+                this._modeProvider.SetMode(session, options.ExecutionModeName!);
+
+                await writer.WriteInfoLineAsync($"✅ Switched to {options.ExecutionModeName} mode.",
+                    ConsoleWriter.GetModeColor(options.ExecutionModeName, options.ModeColors));
+            }
+
+            return AsUserMessages(response);
+        }
+
+        await writer.WriteInfoLineAsync($"(unexpected response type: {planningResponse.Type})", ConsoleColor.DarkYellow);
+        return null;
+    }
+
+    private static IList<ChatMessage>? AsUserMessages(string? text) =>
+        text is not null ? [new ChatMessage(ChatRole.User, text)] : null;
+
+    private async Task<string?> RenderClarificationAndCollectResponseAsync(ConsoleWriter writer, PlanningResponse response)
+    {
+        await writer.WriteInfoLineAsync(response.Message ?? string.Empty);
+
+        if (response.Choices is { Count: > 0 })
+        {
+            return await writer.ReadSelectionAsync(
+                "Choose an option:",
+                response.Choices);
+        }
+
+        string? input = (await writer.ReadLineAsync("Response: "))?.Trim();
+        return string.IsNullOrWhiteSpace(input) ? null : input;
+    }
+
+    private async Task<string> RenderApprovalAndCollectResponseAsync(ConsoleWriter writer, PlanningResponse response, HarnessConsoleOptions options)
+    {
+        await writer.WriteInfoLineAsync(response.Message ?? string.Empty);
+
+        var choices = new List<string>
+        {
+            "Approve and switch to execute mode",
+            "Suggest changes",
+        };
+
+        string selection = await writer.ReadSelectionAsync("What would you like to do?", choices);
+
+        if (selection == choices[0])
+        {
+            return "Approved";
+        }
+
+        if (selection == choices[1])
+        {
+            string? feedback = await writer.ReadLineAsync(
+                "Your feedback: ",
+                ConsoleWriter.GetModeColor(options.PlanningModeName, options.ModeColors));
+            return string.IsNullOrWhiteSpace(feedback) ? "Approved" : feedback;
+        }
+
+        // Custom freeform input — treat as suggested changes.
+        return selection;
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponse.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponse.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Represents a structured response from the agent while in planning mode.
+/// Used with structured output to enable consistent rendering of clarification
+/// questions and approval requests in the console.
+/// </summary>
+public class PlanningResponse
+{
+    /// <summary>
+    /// Gets or sets the type of planning response.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required PlanningResponseType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message to display to the user.
+    /// For clarification, this is the question. For approval, this is a summary of what the agent plans to do.
+    /// </summary>
+    [JsonPropertyName("message")]
+    [Description("For clarifications, this has the question that needs to be clarified with the user. For approvals, this would contain a summary of the execution plan that the user needs to approve.")]
+    public required string Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of choices for the user to pick from.
+    /// Only used when <see cref="Type"/> is <see cref="PlanningResponseType.Clarification"/>.
+    /// </summary>
+    [JsonPropertyName("choices")]
+    [Description("For clarifications, this has a list of options that the user can choose from. null for approvals.")]
+    public List<string>? Choices { get; set; }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponse.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponse.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel;
 using System.Text.Json.Serialization;
@@ -19,8 +19,23 @@ public class PlanningResponse
     public required PlanningResponseType Type { get; set; }
 
     /// <summary>
+    /// Gets or sets the list of questions or items to present to the user.
+    /// For clarification, this contains one or more questions (each with choices).
+    /// For approval, this contains exactly one item with the plan summary.
+    /// </summary>
+    [JsonPropertyName("questions")]
+    [Description("For clarifications, this has one or more questions to ask the user (each with choices). For approvals, this has exactly one item containing the plan summary for the user to approve.")]
+    public required List<PlanningQuestion> Questions { get; set; }
+}
+
+/// <summary>
+/// Represents a single question or item within a <see cref="PlanningResponse"/>.
+/// </summary>
+public class PlanningQuestion
+{
+    /// <summary>
     /// Gets or sets the message to display to the user.
-    /// For clarification, this is the question. For approval, this is a summary of what the agent plans to do.
+    /// For clarification, this is the question. For approval, this is the plan summary.
     /// </summary>
     [JsonPropertyName("message")]
     [Description("For clarifications, this has the question that needs to be clarified with the user. For approvals, this would contain a summary of the execution plan that the user needs to approve.")]
@@ -28,7 +43,7 @@ public class PlanningResponse
 
     /// <summary>
     /// Gets or sets the list of choices for the user to pick from.
-    /// Only used when <see cref="Type"/> is <see cref="PlanningResponseType.Clarification"/>.
+    /// Only used for clarification questions. Null when no predefined choices are offered.
     /// </summary>
     [JsonPropertyName("choices")]
     [Description("For clarifications, this has a list of options that the user can choose from. null for approvals.")]

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponseType.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponseType.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Specifies the type of planning response from the agent.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PlanningResponseType>))]
+public enum PlanningResponseType
+{
+    /// <summary>
+    /// The agent needs clarification and presents options for the user to choose from.
+    /// </summary>
+    [Description("Use this type when you need clarification around the user request and you want to present the user with options to choose from.")]
+    Clarification,
+
+    /// <summary>
+    /// The agent is seeking approval to proceed with execution.
+    /// </summary>
+    [Description("Use this type when you are ready to start execution, but need approval to start executing.")]
+    Approval,
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponseType.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningResponseType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.ComponentModel;
 using System.Text.Json.Serialization;

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ReasoningDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ReasoningDisplayObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Extensions.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ReasoningDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ReasoningDisplayObserver.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Displays reasoning content in dark magenta from the response stream.
+/// </summary>
+internal sealed class ReasoningDisplayObserver : ConsoleObserver
+{
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(ConsoleWriter writer, AIContent content)
+    {
+        if (content is TextReasoningContent reasoning && !string.IsNullOrEmpty(reasoning.Text))
+        {
+            await writer.WriteTextAsync(reasoning.Text, ConsoleColor.DarkMagenta);
+        }
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/TextOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/TextOutputObserver.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Streams agent text output directly to the console.
+/// Used in normal (non-planning) mode.
+/// </summary>
+internal sealed class TextOutputObserver : ConsoleObserver
+{
+    /// <inheritdoc/>
+    public override async Task OnTextAsync(ConsoleWriter writer, string text)
+    {
+        await writer.WriteTextAsync(text);
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/TextOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/TextOutputObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 namespace Harness.Shared.Console.Observers;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolApprovalObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolApprovalObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolApprovalObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolApprovalObserver.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Collects <see cref="ToolApprovalRequestContent"/> items during the response stream,
+/// displays approval-needed notifications inline, and prompts the user for approval
+/// decisions after the stream completes.
+/// </summary>
+internal sealed class ToolApprovalObserver : ConsoleObserver
+{
+    private readonly List<ToolApprovalRequestContent> _approvalRequests = [];
+
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(ConsoleWriter writer, AIContent content)
+    {
+        if (content is ToolApprovalRequestContent approvalRequest)
+        {
+            this._approvalRequests.Add(approvalRequest);
+            string toolName = approvalRequest.ToolCall is FunctionCallContent fc
+                ? ToolCallFormatter.Format(fc)
+                : approvalRequest.ToolCall?.ToString() ?? "unknown";
+            await writer.WriteInfoLineAsync($"⚠️ Approval needed: {toolName}", ConsoleColor.Yellow);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IList<ChatMessage>?> OnStreamCompleteAsync(
+        ConsoleWriter writer,
+        AIAgent agent,
+        AgentSession session,
+        HarnessConsoleOptions options)
+    {
+        if (this._approvalRequests.Count == 0)
+        {
+            return null;
+        }
+
+        var messages = await PromptForApprovalsAsync(writer, this._approvalRequests);
+        this._approvalRequests.Clear();
+        return messages;
+    }
+
+    private static async Task<List<ChatMessage>?> PromptForApprovalsAsync(ConsoleWriter writer, List<ToolApprovalRequestContent> approvalRequests)
+    {
+        if (approvalRequests.Count == 0)
+        {
+            return null;
+        }
+
+        var responses = new List<AIContent>();
+        foreach (var request in approvalRequests)
+        {
+            string toolName = request.ToolCall is FunctionCallContent fc
+                ? ToolCallFormatter.Format(fc)
+                : request.ToolCall?.ToString() ?? "unknown";
+
+            var choices = new List<string>
+            {
+                "Approve this call",
+                "Always approve this tool (any arguments)",
+                "Always approve this tool with these arguments",
+                "Deny",
+            };
+
+            string selection = await writer.ReadSelectionAsync($"🔐 Tool approval: {toolName}", choices);
+            AIContent response = selection switch
+            {
+                "Always approve this tool (any arguments)" => request.CreateAlwaysApproveToolResponse("User chose to always approve this tool"),
+                "Always approve this tool with these arguments" => request.CreateAlwaysApproveToolWithArgumentsResponse("User chose to always approve this tool with these arguments"),
+                "Deny" => request.CreateResponse(approved: false, reason: "User denied"),
+                _ => request.CreateResponse(approved: true, reason: "User approved"),
+            };
+
+            string action = selection switch
+            {
+                "Always approve this tool (any arguments)" => "✅ Always approved (any args)",
+                "Always approve this tool with these arguments" => "✅ Always approved (these args)",
+                "Deny" => "❌ Denied",
+                _ => "✅ Approved",
+            };
+            await writer.WriteInfoLineAsync($"   {action}", ConsoleColor.DarkGray);
+
+            responses.Add(response);
+        }
+
+        return [new ChatMessage(ChatRole.User, responses)];
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Extensions.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Displays tool call notifications (🔧) for <see cref="FunctionCallContent"/>
+/// and <see cref="ToolCallContent"/> items in the response stream.
+/// </summary>
+internal sealed class ToolCallDisplayObserver : ConsoleObserver
+{
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(ConsoleWriter writer, AIContent content)
+    {
+        if (content is FunctionCallContent functionCall)
+        {
+            await writer.WriteInfoLineAsync($"🔧 Calling tool: {ToolCallFormatter.Format(functionCall)}...", ConsoleColor.DarkYellow);
+        }
+        else if (content is ToolCallContent toolCall)
+        {
+            await writer.WriteInfoLineAsync($"🔧 Calling tool: {toolCall}...", ConsoleColor.DarkYellow);
+        }
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallFormatter.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallFormatter.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 
-namespace Harness.Shared.Console;
+namespace Harness.Shared.Console.Observers;
 
 /// <summary>
 /// Formats <see cref="FunctionCallContent"/> instances into human-readable strings

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/UsageDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/UsageDisplayObserver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Extensions.AI;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/UsageDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/UsageDisplayObserver.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+
+namespace Harness.Shared.Console.Observers;
+
+/// <summary>
+/// Displays token usage statistics (📊) from the response stream.
+/// </summary>
+internal sealed class UsageDisplayObserver : ConsoleObserver
+{
+    private readonly int? _maxContextWindowTokens;
+    private readonly int? _maxOutputTokens;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UsageDisplayObserver"/> class.
+    /// </summary>
+    /// <param name="maxContextWindowTokens">Optional max context window size in tokens.</param>
+    /// <param name="maxOutputTokens">Optional max output tokens.</param>
+    public UsageDisplayObserver(int? maxContextWindowTokens, int? maxOutputTokens)
+    {
+        this._maxContextWindowTokens = maxContextWindowTokens;
+        this._maxOutputTokens = maxOutputTokens;
+    }
+
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(ConsoleWriter writer, AIContent content)
+    {
+        if (content is UsageContent usage)
+        {
+            if (usage.Details is not null)
+            {
+                await writer.WriteInfoLineAsync(this.FormatUsageBreakdown(usage.Details), ConsoleColor.DarkGray);
+            }
+            else
+            {
+                await writer.WriteInfoLineAsync("📊 Tokens —", ConsoleColor.DarkGray);
+            }
+        }
+    }
+
+    private string FormatUsageBreakdown(UsageDetails details)
+    {
+        int? inputBudget = (this._maxContextWindowTokens is not null && this._maxOutputTokens is not null)
+            ? this._maxContextWindowTokens.Value - this._maxOutputTokens.Value
+            : null;
+
+        return $"📊 Tokens — input: {FormatTokenCount(details.InputTokenCount, inputBudget)}"
+            + $" | output: {FormatTokenCount(details.OutputTokenCount, this._maxOutputTokens)}"
+            + $" | total: {FormatTokenCount(details.TotalTokenCount, this._maxContextWindowTokens)}";
+    }
+
+    private static string FormatTokenCount(long? count, int? budget)
+    {
+        if (count is null)
+        {
+            return "—";
+        }
+
+        if (budget is not null && budget.Value > 0)
+        {
+            double pct = (double)count.Value / budget.Value * 100;
+            return $"{count.Value:N0}/{budget.Value:N0} ({pct:F1}%)";
+        }
+
+        return $"{count.Value:N0}";
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -43,15 +43,17 @@ var instructions =
 
     *Plan Mode*
 
-    1. Analyze the request.
-    2. Ask for clarifications where needed.
-      1. When asking for clarification and you have specific options in mind, present them to the user with numbers, so they can respond with the number instead of having to retype the entire response.
-      2. Always also allow the user to respond with free-form text in case they want to provide information or context that you didn't specifically ask for.
-    3. Create one or more todo items.
-    4. Write the plan to a memory file, so that it is retained even if compaction happens. Make sure to update the plan file if the user requests changes.
-    5. Present the plan to the user.
-    6. Ask for approval to switch to execute mode and process the plan.
-    7. When approval is granted, always switch to execute mode (using the `AgentMode_Set` tool), and follow the steps for *Execute mode*.
+    1. Analyze the request with the purpose of building a research plan.
+    2. Create a list of todo items.
+    3. If needed, use the provided tools do some exploratory checks to help build a plan and determine what clarifying questions you may need from the user.
+    4. Ask for clarifications from the user where needed.
+      1. Ask each clarification one by one.
+      2. When asking for clarification and you have specific options in mind, present them to the user, so they can choose the option instead of having to retype the entire response.
+      3. Do not proceed until you have received all the needed clarifications.
+      4. Do short exploratory research if it helps with being able to ask sensible clarifications from the user.
+    5. Write the plan to a memory file, so that it is retained even if compaction happens. Make sure to update the plan file if the user requests changes.
+    6. Present the plan to the user and ask for approval to switch to execute mode and process the plan.
+    76. When approval is granted, always switch to execute mode (using the `AgentMode_Set` tool), and follow the steps for *Execute mode*.
 
     *Execute Mode*
 
@@ -174,4 +176,15 @@ AIAgent agent =
     .Build();
 
 // Run the interactive console session using the shared HarnessConsole helper.
-await HarnessConsole.RunAgentAsync(agent, title: "Research Assistant", userPrompt: "Enter a research topic to get started.", maxContextWindowTokens: MaxContextWindowTokens, maxOutputTokens: MaxOutputTokens);
+await HarnessConsole.RunAgentAsync(
+    agent,
+    title: "Research Assistant",
+    userPrompt: "Enter a research topic to get started.",
+    new HarnessConsoleOptions
+    {
+        MaxContextWindowTokens = MaxContextWindowTokens,
+        MaxOutputTokens = MaxOutputTokens,
+        EnablePlanningUx = true,
+        PlanningModeName = "plan",
+        ExecutionModeName = "execute"
+    });

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -45,7 +45,7 @@ var instructions =
 
     1. Analyze the request with the purpose of building a research plan.
     2. Create a list of todo items.
-    3. If needed, use the provided tools do some exploratory checks to help build a plan and determine what clarifying questions you may need from the user.
+    3. If needed, use the provided tools to do some exploratory checks to help build a plan and determine what clarifying questions you may need from the user.
     4. Ask for clarifications from the user where needed.
       1. Ask each clarification one by one.
       2. When asking for clarification and you have specific options in mind, present them to the user, so they can choose the option instead of having to retype the entire response.
@@ -53,7 +53,7 @@ var instructions =
       4. Do short exploratory research if it helps with being able to ask sensible clarifications from the user.
     5. Write the plan to a memory file, so that it is retained even if compaction happens. Make sure to update the plan file if the user requests changes.
     6. Present the plan to the user and ask for approval to switch to execute mode and process the plan.
-    76. When approval is granted, always switch to execute mode (using the `AgentMode_Set` tool), and follow the steps for *Execute mode*.
+    7. When approval is granted, always switch to execute mode (using the `AgentMode_Set` tool), and follow the steps for *Execute mode*.
 
     *Execute Mode*
 


### PR DESCRIPTION
### Motivation and Context

The harness console code was hard to understand and a bit spaghetti-ish, so refactoring so that it is more structured and easier to understand and extend.

### Description

- Separated out most code into Observers which can take action based on the agent output.
- Main loop stays in HarnessConsole.
- Ensured that ConsoleWriter is responsible for dealing with the spinner and line breaks, so other code doesn't have to.
- Introduced better UX with pickers for option selection
- Introduced a planning mode observer that uses structured output to require the agent to provide either follow up questions or ask for approval.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.