### PR TITLE
Python: Fix hosted MCP replay producing orphan function_call_output

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -806,6 +806,18 @@ def _item_to_message(item: Item) -> Message:
     if item.type == "custom_tool_call_output":
         cto = cast(ItemCustomToolCallOutput, item)
         output = cto.output if isinstance(cto.output, str) else str(cto.output)
+        # Hosted-MCP results land here because the host writes them via
+        # `aoutput_item_custom_tool_call_output` (see `_to_outputs` for
+        # `mcp_server_tool_result`). The persisted `call_id` keeps its
+        # `mcp_*` prefix; on read, route those back to a hosted-MCP result
+        # Content so the chat-client serialize layer can coalesce them
+        # onto a single `mcp_call` input item with `output` populated.
+        # Issue #5546.
+        if cto.call_id and cto.call_id.startswith("mcp_"):
+            return Message(
+                role="tool",
+                contents=[Content.from_mcp_server_tool_result(call_id=cto.call_id, output=output)],
+            )
         return Message(
             role="tool",
             contents=[Content.from_function_result(cto.call_id, result=output)],
@@ -1054,6 +1066,16 @@ def _output_item_to_message(item: OutputItem) -> Message:
     if item.type == "custom_tool_call_output":
         cto = cast(OutputItemCustomToolCallOutput, item)
         output = cto.output if isinstance(cto.output, str) else str(cto.output)
+        # Hosted-MCP results land here because the host writes them via
+        # `aoutput_item_custom_tool_call_output`. Route `mcp_*` call_ids
+        # back to a hosted-MCP result Content so the chat-client serialize
+        # layer can coalesce onto the matching `mcp_call` input item.
+        # Issue #5546.
+        if cto.call_id and cto.call_id.startswith("mcp_"):
+            return Message(
+                role="tool",
+                contents=[Content.from_mcp_server_tool_result(call_id=cto.call_id, output=output)],
+            )
         return Message(
             role="tool",
             contents=[Content.from_function_result(cto.call_id, result=output)],

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -879,6 +879,30 @@ class TestOutputItemToMessage:
         assert msg.contents[0].type == "function_result"
         assert msg.contents[0].result == "result text"
 
+    def test_custom_tool_call_output_with_mcp_call_id_routes_to_mcp_server_tool_result(self) -> None:
+        """When the host wrote a hosted-MCP result via
+        `aoutput_item_custom_tool_call_output`, the persisted call_id keeps
+        its `mcp_*` prefix. On read, that result must reconstruct as a
+        `mcp_server_tool_result` Content (not `function_result`), so the
+        chat-client serialize layer treats it as a hosted-MCP result and
+        does not produce an orphan `function_call_output`.
+        """
+        from azure.ai.agentserver.responses.models import OutputItemCustomToolCallOutput
+
+        item = OutputItemCustomToolCallOutput({
+            "type": "custom_tool_call_output",
+            "call_id": "mcp_06b686e11f118cf40169f0e5badb3081979842929d5cf04920",
+            "output": "found 10 cats",
+        })
+        msg = _output_item_to_message(item)
+        assert msg.role == "tool"
+        assert len(msg.contents) == 1
+        c = msg.contents[0]
+        assert c.type == "mcp_server_tool_result", (
+            f"expected mcp_server_tool_result for mcp_-prefixed call_id; got {c.type}"
+        )
+        assert c.call_id == "mcp_06b686e11f118cf40169f0e5badb3081979842929d5cf04920"
+
     def test_apply_patch_call(self) -> None:
         from azure.ai.agentserver.responses.models import ApplyPatchUpdateFileOperation, OutputItemApplyPatchToolCall
 
@@ -1328,6 +1352,32 @@ class TestItemToMessage:
         msg = _item_to_message(item)
         assert msg is not None
         assert msg.contents[0].result == "123"
+
+    def test_custom_tool_call_output_with_mcp_call_id_routes_to_mcp_server_tool_result(self) -> None:
+        """Issue #5546: input items carrying a hosted-MCP result (from a
+        prior turn that the framework wrote via
+        `aoutput_item_custom_tool_call_output`) must reconstruct as a
+        `mcp_server_tool_result` Content, not `function_result`. Otherwise
+        the chat-client serialize layer turns it into an orphan
+        `function_call_output` with `mcp_*` call_id and the Responses API
+        rejects the next turn.
+        """
+        from azure.ai.agentserver.responses.models import ItemCustomToolCallOutput
+
+        item = ItemCustomToolCallOutput({
+            "type": "custom_tool_call_output",
+            "call_id": "mcp_06b686e11f118cf40169f0e5badb3081979842929d5cf04920",
+            "output": "found 10 cats",
+        })
+        msg = _item_to_message(item)
+        assert msg is not None
+        assert msg.role == "tool"
+        assert len(msg.contents) == 1
+        c = msg.contents[0]
+        assert c.type == "mcp_server_tool_result", (
+            f"expected mcp_server_tool_result for mcp_-prefixed call_id; got {c.type}"
+        )
+        assert c.call_id == "mcp_06b686e11f118cf40169f0e5badb3081979842929d5cf04920"
 
     def test_apply_patch_call(self) -> None:
         from azure.ai.agentserver.responses.models import ApplyPatchToolCallItemParam, ApplyPatchUpdateFileOperation

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1748,7 +1748,7 @@ class RawOpenAIChatClient(  # type: ignore[misc]
             return output
         if isinstance(output, Sequence) and not isinstance(output, (str, bytes, bytearray)):
             parts: list[str] = []
-            for entry in output:
+            for entry in cast(Sequence[Any], output):
                 text = getattr(entry, "text", None)
                 if isinstance(text, str):
                     parts.append(text)
@@ -1764,8 +1764,8 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         See `_AF_MCP_PENDING_OUTPUT_KEY`. The Responses API expects a single
         `mcp_call` input item carrying both `arguments` and `output`, so a
         result Content cannot be its own input item. Any unmatched markers
-        are dropped (debug-logged) — surfacing them as standalone items
-        would produce the orphan `function_call_output`/`mcp_call_output`
+        are dropped (debug-logged); surfacing them as standalone items
+        would produce the orphan `function_call_output` / `mcp_call_output`
         the API rejects.
         """
         out: list[dict[str, Any]] = []

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1750,8 +1750,11 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         if isinstance(output, str):
             return output
         if isinstance(output, Sequence) and not isinstance(output, (str, bytes, bytearray)):
+            # cast is for pyright (reportUnknownVariableType); mypy considers
+            # it redundant after the isinstance narrowing.
+            entries = cast(Sequence[Any], output)  # type: ignore[redundant-cast]
             parts: list[str] = []
-            for entry in cast(Sequence[Any], output):
+            for entry in entries:
                 if isinstance(entry, str):
                     parts.append(entry)
                     continue

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1740,7 +1740,10 @@ class RawOpenAIChatClient(  # type: ignore[misc]
 
         Accepts a string, a list of text-bearing Content objects (the form
         the chat client produces when parsing an `mcp_call` Responses item),
-        or any other value (best-effort `str()`).
+        or any other value. List entries that are dicts with the canonical
+        MCP text-content shape (`{"text": "..."}`) are unwrapped to their
+        text. Anything else falls back to JSON encoding rather than Python
+        `repr`, so the wire payload stays parseable for downstream callers.
         """
         if output is None:
             return ""
@@ -1749,13 +1752,21 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         if isinstance(output, Sequence) and not isinstance(output, (str, bytes, bytearray)):
             parts: list[str] = []
             for entry in cast(Sequence[Any], output):
+                if isinstance(entry, str):
+                    parts.append(entry)
+                    continue
                 text = getattr(entry, "text", None)
                 if isinstance(text, str):
                     parts.append(text)
-                else:
-                    parts.append(str(entry))
+                    continue
+                if isinstance(entry, Mapping):
+                    mapping_text = cast(Any, entry).get("text")
+                    if isinstance(mapping_text, str):
+                        parts.append(mapping_text)
+                        continue
+                parts.append(json.dumps(entry, default=str))
             return "".join(parts)
-        return str(output)
+        return json.dumps(output, default=str)
 
     @staticmethod
     def _coalesce_pending_mcp_results(items: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -121,6 +121,14 @@ OPENAI_LOCAL_SHELL_COMMAND_PARTS_KEY = "openai.local_shell_command_parts"
 OPENAI_SHELL_OUTPUT_TYPE_SHELL_CALL = "shell_call_output"
 OPENAI_SHELL_OUTPUT_TYPE_LOCAL_SHELL_CALL = "local_shell_call_output"
 
+# Internal marker emitted by `_prepare_content_for_openai` for an
+# `mcp_server_tool_result` Content. The Responses API expects an `mcp_call`
+# input item to carry both arguments and output as one item, so result
+# Contents cannot be serialized standalone. `_prepare_messages_for_openai`
+# coalesces these markers into the most recent matching `mcp_call` input
+# item before returning, dropping any that are unmatched.
+_AF_MCP_PENDING_OUTPUT_KEY = "__af_pending_mcp_result__"
+
 
 class OpenAIContinuationToken(ContinuationToken):
     """Continuation token for OpenAI Responses API background operations."""
@@ -1363,7 +1371,10 @@ class RawOpenAIChatClient(  # type: ignore[misc]
             for message in chat_messages
         ]
         # Flatten the list of lists into a single list
-        return list(chain.from_iterable(list_of_list))
+        flat = list(chain.from_iterable(list_of_list))
+        # Coalesce hosted-MCP result markers onto matching mcp_call input
+        # items (drop unmatched). See `_AF_MCP_PENDING_OUTPUT_KEY`.
+        return self._coalesce_pending_mcp_results(flat)
 
     def _prepare_message_for_openai(
         self,
@@ -1428,6 +1439,18 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     )
                     if prepared:
                         all_messages.append(prepared)
+                case "mcp_server_tool_call" | "mcp_server_tool_result":
+                    # Hosted MCP call/result contents serialize as a single
+                    # top-level mcp_call input item; the result side emits an
+                    # internal marker that `_prepare_messages_for_openai`
+                    # coalesces onto the matching call (or drops if unmatched).
+                    prepared_mcp = self._prepare_content_for_openai(
+                        message.role,
+                        content,
+                        replays_local_storage=replays_local_storage,
+                    )
+                    if prepared_mcp:
+                        all_messages.append(prepared_mcp)
                 case _:
                     prepared_content = self._prepare_content_for_openai(
                         message.role,
@@ -1606,6 +1629,24 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     "approval_request_id": content.id,
                     "approve": content.approved,
                 }
+            case "mcp_server_tool_call":
+                if not content.call_id:
+                    return {}
+                return {
+                    "type": "mcp_call",
+                    "id": content.call_id,
+                    "server_label": content.server_name or "",
+                    "name": content.tool_name or "",
+                    "arguments": self._stringify_mcp_arguments(content.arguments),
+                }
+            case "mcp_server_tool_result":
+                if not content.call_id:
+                    return {}
+                return {
+                    _AF_MCP_PENDING_OUTPUT_KEY: True,
+                    "call_id": content.call_id,
+                    "output": self._stringify_mcp_output(content.output),
+                }
             case "hosted_file":
                 # `input_file` is an input-only content type in the Responses API and is rejected
                 # inside an assistant message. Hosted-file content on an assistant message
@@ -1680,6 +1721,77 @@ class RawOpenAIChatClient(  # type: ignore[misc]
     def _join_shell_commands(commands: Sequence[str]) -> str:
         """Join shell commands into a single executable command string."""
         return "\n".join(command for command in commands if command).strip()
+
+    @staticmethod
+    def _stringify_mcp_arguments(arguments: Any) -> str:
+        """Render hosted-MCP tool-call arguments as a JSON string for the Responses API."""
+        if arguments is None:
+            return ""
+        if isinstance(arguments, str):
+            return arguments
+        try:
+            return json.dumps(arguments)
+        except (TypeError, ValueError):
+            return str(arguments)
+
+    @staticmethod
+    def _stringify_mcp_output(output: Any) -> str:
+        """Render a hosted-MCP tool-call result into the string `mcp_call.output` field.
+
+        Accepts a string, a list of text-bearing Content objects (the form
+        the chat client produces when parsing an `mcp_call` Responses item),
+        or any other value (best-effort `str()`).
+        """
+        if output is None:
+            return ""
+        if isinstance(output, str):
+            return output
+        if isinstance(output, Sequence) and not isinstance(output, (str, bytes, bytearray)):
+            parts: list[str] = []
+            for entry in output:
+                text = getattr(entry, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+                else:
+                    parts.append(str(entry))
+            return "".join(parts)
+        return str(output)
+
+    @staticmethod
+    def _coalesce_pending_mcp_results(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Merge pending hosted-MCP result markers onto matching mcp_call input items.
+
+        See `_AF_MCP_PENDING_OUTPUT_KEY`. The Responses API expects a single
+        `mcp_call` input item carrying both `arguments` and `output`, so a
+        result Content cannot be its own input item. Any unmatched markers
+        are dropped (debug-logged) — surfacing them as standalone items
+        would produce the orphan `function_call_output`/`mcp_call_output`
+        the API rejects.
+        """
+        out: list[dict[str, Any]] = []
+        for item in items:
+            if item.get(_AF_MCP_PENDING_OUTPUT_KEY):
+                target_call_id = item.get("call_id")
+                target = next(
+                    (
+                        existing
+                        for existing in reversed(out)
+                        if existing.get("type") == "mcp_call" and existing.get("id") == target_call_id
+                    ),
+                    None,
+                )
+                if target is not None:
+                    if target.get("output") is None:
+                        target["output"] = item.get("output")
+                else:
+                    logger.debug(
+                        "Dropping orphan mcp_server_tool_result for call_id=%s; "
+                        "no matching mcp_call appeared in input.",
+                        target_call_id,
+                    )
+                continue
+            out.append(item)
+        return out
 
     @staticmethod
     def _serialize_provider_payload(value: Any) -> Any:

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -5216,7 +5216,7 @@ def test_prepare_messages_for_openai_coalesces_mcp_call_and_result_into_single_i
 
 def test_prepare_messages_for_openai_drops_orphan_mcp_server_tool_result() -> None:
     """When an mcp_server_tool_result has no matching mcp_server_tool_call in
-    the message list, it must be dropped — NOT serialized as a
+    the message list, it must be dropped, NOT serialized as a
     function_call_output. An orphan function_call_output is what triggers the
     Responses API 400 reported in #5546.
     """

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -5133,4 +5133,116 @@ def test_prepare_messages_for_openai_filters_none_fc_id() -> None:
     assert fc_item["id"].startswith("fc_")
 
 
+# region: hosted MCP round-trip (issue #5546)
+
+
+def test_prepare_messages_for_openai_serializes_mcp_server_tool_call_as_mcp_call_input_item() -> None:
+    """A Message containing only an mcp_server_tool_call Content should produce
+    a top-level mcp_call input item, not be silently dropped (which today's
+    _prepare_content_for_openai default branch does).
+    """
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_mcp_server_tool_call(
+                    call_id="mcp_abc123",
+                    tool_name="search",
+                    server_name="api_specs",
+                    arguments='{"q": "cats"}',
+                )
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages)
+
+    mcp_items = [item for item in result if isinstance(item, dict) and item.get("type") == "mcp_call"]
+    assert len(mcp_items) == 1, f"expected exactly one mcp_call item; got result={result}"
+    item = mcp_items[0]
+    assert item["id"] == "mcp_abc123"
+    assert item["server_label"] == "api_specs"
+    assert item["name"] == "search"
+    assert item["arguments"] == '{"q": "cats"}'
+    assert "output" not in item or item["output"] is None
+
+
+def test_prepare_messages_for_openai_coalesces_mcp_call_and_result_into_single_item() -> None:
+    """An mcp_server_tool_call followed by an mcp_server_tool_result with the
+    same call_id (in same or separate Messages) must produce ONE mcp_call
+    input item carrying both arguments and output. Two items would let the
+    Responses API see an orphaned output and reject the request.
+    """
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_mcp_server_tool_call(
+                    call_id="mcp_abc123",
+                    tool_name="search",
+                    server_name="api_specs",
+                    arguments='{"q": "cats"}',
+                )
+            ],
+        ),
+        Message(
+            role="tool",
+            contents=[
+                Content.from_mcp_server_tool_result(
+                    call_id="mcp_abc123",
+                    output=[Content.from_text(text="found 10 cats")],
+                )
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages)
+
+    mcp_items = [item for item in result if isinstance(item, dict) and item.get("type") == "mcp_call"]
+    assert len(mcp_items) == 1, f"expected one coalesced mcp_call item carrying both arguments and output; got {result}"
+    item = mcp_items[0]
+    assert item["id"] == "mcp_abc123"
+    assert item["arguments"] == '{"q": "cats"}'
+    assert item.get("output") == "found 10 cats"
+
+    # And no orphaned function_call_output should appear anywhere in the input.
+    fco_items = [item for item in result if isinstance(item, dict) and item.get("type") == "function_call_output"]
+    assert fco_items == [], f"unexpected orphan function_call_output items: {fco_items}"
+
+
+def test_prepare_messages_for_openai_drops_orphan_mcp_server_tool_result() -> None:
+    """When an mcp_server_tool_result has no matching mcp_server_tool_call in
+    the message list, it must be dropped — NOT serialized as a
+    function_call_output. An orphan function_call_output is what triggers the
+    Responses API 400 reported in #5546.
+    """
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="tool",
+            contents=[
+                Content.from_mcp_server_tool_result(
+                    call_id="mcp_orphan_id",
+                    output=[Content.from_text(text="dangling output")],
+                )
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages)
+
+    fco_items = [item for item in result if isinstance(item, dict) and item.get("type") == "function_call_output"]
+    assert fco_items == [], f"orphan mcp_server_tool_result must not serialize as function_call_output; got {fco_items}"
+    mcp_items = [item for item in result if isinstance(item, dict) and item.get("type") == "mcp_call"]
+    assert mcp_items == [], f"orphan mcp_server_tool_result must not synthesize a stand-alone mcp_call; got {mcp_items}"
+
+
+# endregion
+
+
 # endregion

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -5242,6 +5242,27 @@ def test_prepare_messages_for_openai_drops_orphan_mcp_server_tool_result() -> No
     assert mcp_items == [], f"orphan mcp_server_tool_result must not synthesize a stand-alone mcp_call; got {mcp_items}"
 
 
+def test_stringify_mcp_output_extracts_text_from_dict_entries() -> None:
+    """A list of dicts in the canonical MCP text-content shape
+    (`{"type": "text", "text": "..."}`, e.g. from raw-JSON-decoded MCP
+    responses) must unwrap to plain text rather than Python `repr`.
+    """
+    result = OpenAIChatClient._stringify_mcp_output([{"type": "text", "text": "found 10 cats"}])
+    assert result == "found 10 cats"
+
+
+def test_stringify_mcp_output_falls_back_to_json_for_non_text_dict_entries() -> None:
+    """Dict entries that are not in the canonical text-content shape must
+    serialize as JSON, not Python `repr`. Python `repr` for a dict uses
+    single quotes and would not round-trip through any JSON-aware consumer.
+    """
+    result = OpenAIChatClient._stringify_mcp_output([{"type": "image", "url": "https://example.com/x"}])
+    # Valid JSON: starts with `{`, contains the keys, no Python-repr single quotes.
+    assert result.startswith("{")
+    assert '"url"' in result
+    assert "'" not in result
+
+
 # endregion
 
 


### PR DESCRIPTION
### Motivation and Context

Resolves part of #5546. Customer-facing symptom:

> openai.BadRequestError: 400 - 'No tool call found for function call output with call_id mcp_06b...'

Hit on the third turn of any conversation that ran a hosted MCP / Foundry-toolbox-MCP tool on a prior turn. The replayed `input` array contained a `function_call_output` whose `mcp_*` call_id had no matching `function_call`, and the Responses API rejected it.

Root cause is multi-layer (full breakdown in the #5546 thread). Two layers ship here, items (2) and (3) from that thread:

- Chat-client serialize layer had no cases for `mcp_server_tool_call` / `mcp_server_tool_result` Contents, so on replay they fell through to the `function_result` path and serialized as orphan `function_call_output`.
- Host read layer mapped every `custom_tool_call_output` item to `function_result` Content, including ones whose `mcp_*` call_id meant they were actually hosted-MCP results.

Items (1) agentserver SDK additions and (4) host write-side single-item emission remain tracked on the issue and depend on an SDK release. The fixes here are sufficient to remove the customer-visible 400.

### Description

`packages/openai/agent_framework_openai/_chat_client.py`

- Adds explicit cases for `mcp_server_tool_call` and `mcp_server_tool_result` in `_prepare_message_for_openai`'s outer match, and in `_prepare_content_for_openai`. `mcp_server_tool_call` serializes as a top-level `mcp_call` input item. `mcp_server_tool_result` emits an internal pending-output marker keyed by the new module-level constant `_AF_MCP_PENDING_OUTPUT_KEY`.
- `_prepare_messages_for_openai` runs a coalesce post-pass (`_coalesce_pending_mcp_results`) that merges pending markers onto the most recent matching `mcp_call` input item, so the API receives one item carrying both `arguments` and `output`. Unmatched markers are dropped (debug-logged) instead of emitted, which is what removes the orphan path.
- Adds static helpers `_stringify_mcp_arguments` and `_stringify_mcp_output` to normalize argument/output shapes (string, dict, or list of text-bearing Contents) into the wire types `mcp_call` expects.

`packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py`

- In both `_item_to_message` and `_output_item_to_message`, route `custom_tool_call_output` whose `call_id.startswith("mcp_")` to `Content.from_mcp_server_tool_result`. Non-`mcp_` call_ids continue to produce `Content.from_function_result` (preserved behavior). Symmetric with the write-side choice MAF already makes for hosted-MCP results.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] Is this a breaking change? No.