### PR TITLE
Python: test(core): regression test for __version__ clobbered by connector packages (#5590)

### DIFF
--- a/python/packages/core/tests/core/test_package_init.py
+++ b/python/packages/core/tests/core/test_package_init.py
@@ -11,7 +11,8 @@ import agent_framework
 
 
 def test_version_is_importable() -> None:
-    assert hasattr(agent_framework, "__version__"), (
+    version = getattr(agent_framework, "__version__", None)
+    assert version is not None, (
         "agent_framework.__version__ is missing — another installed package likely "
         "overwrote agent_framework/__init__.py with an empty file"
     )

--- a/python/packages/core/tests/core/test_package_init.py
+++ b/python/packages/core/tests/core/test_package_init.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Regression test for https://github.com/microsoft/agent-framework/issues/5590.
+
+agent-framework-azure-ai-search==0.0.0a1 shipped an empty agent_framework/__init__.py
+that overwrote core's version on install, breaking every import that touches
+observability.py (which does `from . import __version__`).
+"""
+
+import agent_framework
+
+
+def test_version_is_importable() -> None:
+    assert hasattr(agent_framework, "__version__"), (
+        "agent_framework.__version__ is missing — another installed package likely "
+        "overwrote agent_framework/__init__.py with an empty file"
+    )
+
+
+def test_version_is_a_non_empty_string() -> None:
+    assert isinstance(agent_framework.__version__, str)
+    assert agent_framework.__version__

--- a/python/packages/core/tests/core/test_package_init.py
+++ b/python/packages/core/tests/core/test_package_init.py
@@ -11,13 +11,11 @@ import agent_framework
 
 
 def test_version_is_importable() -> None:
+def test_version_is_present_and_a_non_empty_string() -> None:
     version = getattr(agent_framework, "__version__", None)
-    assert version is not None, (
+
+    assert isinstance(version, str), (
         "agent_framework.__version__ is missing — another installed package likely "
         "overwrote agent_framework/__init__.py with an empty file"
     )
-
-
-def test_version_is_a_non_empty_string() -> None:
-    assert isinstance(agent_framework.__version__, str)
-    assert agent_framework.__version__
+    assert version


### PR DESCRIPTION
## Root cause (found while reproducing #5590)

`agent-framework-azure-ai-search==0.0.0a1` shipped an **empty** `agent_framework/__init__.py` (0 bytes). pip/uv install order is not guaranteed, so when azure-ai-search installed after core it overwrote core's `agent_framework/__init__.py` — removing `__version__` and every public export.

The downstream failure is in `observability.py`:

```python
from . import __version__ as version_info  # ImportError if __init__.py is empty
```

which is imported by `_tools.py` → `_clients.py` → every connector package, making the entire framework unusable after a fresh install.

**Verified against installed packages:**

```
agent_framework_core-1.2.2.dist-info/RECORD:
  agent_framework/__init__.py  sha256=9S6...  11645  ✅

agent_framework_azure_ai_search-0.0.0a1.dist-info/RECORD:
  agent_framework/__init__.py  sha256=47D...  0      ❌  (empty — clobbers core)
```

The fix in the source already removed the stray file from `azure-ai-search`. This PR adds a regression test so it can't ship broken again.

## Changes

- `python/packages/core/tests/core/test_package_init.py` — two tests asserting `agent_framework.__version__` exists and is a non-empty string. These would have failed in CI before the 1.2.2 release and caught the issue.

Closes #5590