### PR TITLE
.NET: Fix YAML block scalar parsing for file skills

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
@@ -233,7 +233,9 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
         foreach (Match kvMatch in s_yamlKeyValueRegex.Matches(yamlContent))
         {
             string key = kvMatch.Groups[1].Value;
-            string value = kvMatch.Groups[2].Success ? kvMatch.Groups[2].Value : kvMatch.Groups[3].Value;
+            string value = kvMatch.Groups[2].Success
+                ? kvMatch.Groups[2].Value
+                : ParseYamlScalarValue(yamlContent, kvMatch);
 
             if (string.Equals(key, "name", StringComparison.OrdinalIgnoreCase))
             {
@@ -538,6 +540,62 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
         }
 
         return false;
+    }
+
+    private static string ParseYamlScalarValue(string yamlContent, Match kvMatch)
+    {
+        string value = kvMatch.Groups[3].Value;
+
+        if (value.Length == 0 || value[0] is not ('|' or '>'))
+        {
+            return value;
+        }
+
+        char scalarStyle = value[0];
+
+        int nextLineStart = yamlContent.IndexOf('\n', kvMatch.Index + kvMatch.Length);
+        if (nextLineStart < 0)
+        {
+            return value;
+        }
+
+        nextLineStart++;
+
+        var lines = yamlContent.Substring(nextLineStart).Split('\n');
+        var blockLines = new List<string>();
+
+        foreach (string line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                blockLines.Add(string.Empty);
+                continue;
+            }
+
+            if (line[0] != ' ' && line[0] != '\t')
+            {
+                break;
+            }
+
+            blockLines.Add(line);
+        }
+
+        if (blockLines.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        int commonIndent = blockLines
+            .Where(line => line.Length > 0)
+            .Min(line => line.TakeWhile(ch => ch == ' ' || ch == '\t').Count());
+
+        string[] normalizedLines = blockLines
+            .Select(line => line.Length == 0 ? string.Empty : line.Substring(Math.Min(commonIndent, line.Length)))
+            .ToArray();
+
+        return scalarStyle == '|'
+            ? string.Join("\n", normalizedLines)
+            : string.Join(" ", normalizedLines.Where(line => line.Length > 0));
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
@@ -552,6 +552,7 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
         }
 
         char scalarStyle = value[0];
+        bool keepTrailingNewline = value.Length > 1 && value[1] == '+';
 
         int nextLineStart = yamlContent.IndexOf('\n', kvMatch.Index + kvMatch.Length);
         if (nextLineStart < 0)
@@ -561,10 +562,11 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
 
         nextLineStart++;
 
-        var lines = yamlContent.Substring(nextLineStart).Split('\n');
         var blockLines = new List<string>();
+        using var reader = new StringReader(yamlContent.Substring(nextLineStart));
 
-        foreach (string line in lines)
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
         {
             if (string.IsNullOrWhiteSpace(line))
             {
@@ -593,9 +595,11 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
             .Select(line => line.Length == 0 ? string.Empty : line.Substring(Math.Min(commonIndent, line.Length)))
             .ToArray();
 
-        return scalarStyle == '|'
+        string parsedValue = scalarStyle == '|'
             ? string.Join("\n", normalizedLines)
             : string.Join(" ", normalizedLines.Where(line => line.Length > 0));
+
+        return keepTrailingNewline ? parsedValue + "\n" : parsedValue;
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
@@ -108,11 +108,11 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
     }
 
     [Theory]
-    [InlineData("|-")]
-    [InlineData("|+")]
-    [InlineData(">-")]
-    [InlineData(">+")]
-    public async Task GetSkillsAsync_ScalarDescriptionWithChompingIndicator_ParsesValueAsync(string indicator)
+    [InlineData("|-", "This is a multiline\ndescription for the skill.")]
+    [InlineData("|+", "This is a multiline\ndescription for the skill.\n")]
+    [InlineData(">-", "This is a multiline description for the skill.")]
+    [InlineData(">+", "This is a multiline description for the skill.\n")]
+    public async Task GetSkillsAsync_ScalarDescriptionWithChompingIndicator_ParsesValueAsync(string indicator, string expectedDescription)
     {
         // Arrange
         string chomping = indicator[1] == '+' ? "keep" : "strip";
@@ -129,7 +129,7 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
 
         // Assert
         Assert.Single(skills);
-        Assert.StartsWith("This is a multiline", skills[0].Frontmatter.Description, StringComparison.Ordinal);
+        Assert.Equal(expectedDescription, skills[0].Frontmatter.Description);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
@@ -70,6 +70,69 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSkillsAsync_BlockScalarDescription_ParsesMultilineValueAsync()
+    {
+        // Arrange
+        string skillDir = Path.Combine(this._testRoot, "block-scalar-skill");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(
+            Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: block-scalar-skill\ndescription: |\n  This is a multiline\n  description for the skill.\n---\nBody text.");
+        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
+
+        // Act
+        var skills = await source.GetSkillsAsync();
+
+        // Assert
+        Assert.Single(skills);
+        Assert.Equal("This is a multiline\ndescription for the skill.", skills[0].Frontmatter.Description);
+    }
+
+    [Fact]
+    public async Task GetSkillsAsync_FoldedScalarDescription_ParsesMultilineValueAsync()
+    {
+        // Arrange
+        string skillDir = Path.Combine(this._testRoot, "folded-scalar-skill");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(
+            Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: folded-scalar-skill\ndescription: >\n  This is a multiline\n  description for the skill.\n---\nBody text.");
+        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
+
+        // Act
+        var skills = await source.GetSkillsAsync();
+
+        // Assert
+        Assert.Single(skills);
+        Assert.Equal("This is a multiline description for the skill.", skills[0].Frontmatter.Description);
+    }
+
+    [Theory]
+    [InlineData("|-")]
+    [InlineData("|+")]
+    [InlineData(">-")]
+    [InlineData(">+")]
+    public async Task GetSkillsAsync_ScalarDescriptionWithChompingIndicator_ParsesValueAsync(string indicator)
+    {
+        // Arrange
+        string chomping = indicator[1] == '+' ? "keep" : "strip";
+        string skillName = "chomping-scalar-skill-" + (indicator[0] == '|' ? "literal-" : "folded-") + chomping;
+        string skillDir = Path.Combine(this._testRoot, skillName);
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(
+            Path.Combine(skillDir, "SKILL.md"),
+            $"---\nname: {skillName}\ndescription: {indicator}\n  This is a multiline\n  description for the skill.\n---\nBody text.");
+        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
+
+        // Act
+        var skills = await source.GetSkillsAsync();
+
+        // Assert
+        Assert.Single(skills);
+        Assert.StartsWith("This is a multiline", skills[0].Frontmatter.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task GetSkillsAsync_MissingFrontmatter_ExcludesSkillAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation and Context

Fixes the .NET file skill loader portion of #5586.

`SKILL.md` frontmatter currently parses YAML block scalar values like `description: |` or `description: >` as only the scalar indicator (`|` / `>`) instead of the multiline content.

### Description

This PR updates the .NET file skill loader to parse YAML block scalar values in frontmatter.

Changes:
- Supports literal scalars: `|`, `|-`, `|+`
- Supports folded scalars: `>`, `>-`, `>+`
- Strips common indentation from block content
- Preserves newlines for literal scalars
- Folds lines with spaces for folded scalars
- Adds regression coverage in `FileAgentSkillLoaderTests`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the Contributing Guidelines
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No

Validation:
- `dotnet build ./dotnet/tests/Microsoft.Agents.AI.UnitTests/Microsoft.Agents.AI.UnitTests.csproj`
- `FileAgentSkillLoaderTests`: 79/79 passed
- `Microsoft.Agents.AI.UnitTests` net10.0 assembly: 1459/1459 passed