### PR TITLE
Python: samples: add Synap context provider example

### DIFF
--- a/python/samples/02-agents/context_providers/synap/README.md
+++ b/python/samples/02-agents/context_providers/synap/README.md
@@ -44,3 +44,4 @@ python synap_basic.py
 - [Microsoft Agent Framework Integration Guide](https://docs.maximem.ai/integrations/microsoft-agent)
 - [Dashboard](https://synap.maximem.ai)
 - [PyPI: maximem-synap-microsoft-agent](https://pypi.org/project/maximem-synap-microsoft-agent/)
+- [Open source integration package](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations)

--- a/python/samples/02-agents/context_providers/synap/README.md
+++ b/python/samples/02-agents/context_providers/synap/README.md
@@ -5,18 +5,32 @@ Demonstrates [SynapContextProvider](https://docs.maximem.ai/integrations/microso
 ## How It Works
 
 `SynapContextProvider` implements two lifecycle hooks:
-- **`before_run`**: fetches Synap context relevant to the user's input and appends it to the agent's instructions via `context.extend_instructions(...)`
+- **`before_run`**: fetches Synap context relevant to the user's input and appends it to the agent's instructions
 - **`after_run`**: records input and response messages to Synap via `sdk.conversation.record_message(...)` for future retrieval
 
-Read failures degrade gracefully — a Synap outage never breaks the agent run. Write failures are logged but not re-raised.
+Read failures degrade gracefully. Write failures are logged but never re-raised.
 
 ## Setup
 
+**1. Install dependencies**
+
 ```bash
-pip install maximem-synap-microsoft-agent
+pip install maximem-synap-microsoft-agent azure-identity python-dotenv
 ```
 
-Set `SYNAP_API_KEY` (get one at [synap.maximem.ai](https://synap.maximem.ai)).
+**2. Configure Azure credentials**
+
+This sample uses [Azure AI Foundry](https://ai.azure.com) as the model provider. Run `az login` to authenticate, or replace `AzureCliCredential` with your preferred credential.
+
+Set the following in a `.env` file or as environment variables:
+
+```
+AZURE_AI_FOUNDRY_PROJECT_ENDPOINT=<your-foundry-endpoint>
+```
+
+**3. Get a Synap API key**
+
+Sign up at [synap.maximem.ai](https://synap.maximem.ai) and set `SYNAP_API_KEY` in your `.env`, or pass it directly to `MaximemSynapSDK(api_key=...)`.
 
 ## Run
 

--- a/python/samples/02-agents/context_providers/synap/README.md
+++ b/python/samples/02-agents/context_providers/synap/README.md
@@ -1,0 +1,32 @@
+# Synap Context Provider Sample
+
+Demonstrates [SynapContextProvider](https://docs.maximem.ai/integrations/microsoft-agent) — a Microsoft Agent Framework `ContextProvider` backed by [Synap](https://maximem.ai), a managed memory layer for AI agents.
+
+## How It Works
+
+`SynapContextProvider` implements two lifecycle hooks:
+- **`before_run`**: fetches Synap context relevant to the user's input and appends it to the agent's instructions via `context.extend_instructions(...)`
+- **`after_run`**: records input and response messages to Synap via `sdk.conversation.record_message(...)` for future retrieval
+
+Read failures degrade gracefully — a Synap outage never breaks the agent run. Write failures are logged but not re-raised.
+
+## Setup
+
+```bash
+pip install maximem-synap-microsoft-agent
+```
+
+Set `SYNAP_API_KEY` (get one at [synap.maximem.ai](https://synap.maximem.ai)).
+
+## Run
+
+```bash
+python synap_basic.py
+```
+
+## More Resources
+
+- [Synap Documentation](https://docs.maximem.ai)
+- [Microsoft Agent Framework Integration Guide](https://docs.maximem.ai/integrations/microsoft-agent)
+- [Dashboard](https://synap.maximem.ai)
+- [PyPI: maximem-synap-microsoft-agent](https://pypi.org/project/maximem-synap-microsoft-agent/)

--- a/python/samples/02-agents/context_providers/synap/synap_basic.py
+++ b/python/samples/02-agents/context_providers/synap/synap_basic.py
@@ -1,44 +1,64 @@
 # Copyright (c) Microsoft. All rights reserved.
-# Demonstrates SynapContextProvider with Microsoft Agent Framework.
-# Install: pip install maximem-synap-microsoft-agent
-# Get API key at synap.maximem.ai
 
 import asyncio
-import os
+import uuid
 
 from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
 from maximem_synap import MaximemSynapSDK
 from synap_microsoft_agent import SynapContextProvider
 
+# Load environment variables from .env file
+load_dotenv()
+
 
 async def main() -> None:
-    """Example: SynapContextProvider for persistent cross-session memory."""
-    sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
+    """Example of persistent cross-session memory with SynapContextProvider."""
+    print("=== Synap Context Provider Example ===")
 
-    user_id = "demo-user-001"
+    # Use a stable user_id so memories persist across runs.
+    # In production, derive this from the authenticated user's identity.
+    user_id = str(uuid.uuid4())
 
-    provider = SynapContextProvider(
-        sdk=sdk,
-        user_id=user_id,
-        customer_id="acme_corp",
-    )
+    sdk = MaximemSynapSDK(api_key="your-synap-api-key")  # or set SYNAP_API_KEY env var
 
-    async with Agent(
-        name="MemoryAssistant",
-        instructions="You are a helpful assistant with long-term memory.",
-        context_providers=[provider],
-    ) as agent:
+    # For Azure authentication, run `az login` or replace AzureCliCredential with
+    # your preferred authentication option.
+    async with (
+        AzureCliCredential() as credential,
+        Agent(
+            client=FoundryChatClient(credential=credential),
+            name="MemoryAssistant",
+            instructions="You are a helpful assistant with long-term memory.",
+            context_providers=[
+                SynapContextProvider(
+                    sdk=sdk,
+                    user_id=user_id,
+                    customer_id="acme_corp",
+                )
+            ],
+        ) as agent,
+    ):
         # First turn — teach the agent something about the user
         query = "I always prefer concise answers and I'm a software engineer."
         print(f"User: {query}")
         result = await agent.run(query)
         print(f"Agent: {result}\n")
 
-        # Second turn — the agent recalls from Synap
+        # Synap stores memories asynchronously. Allow time for processing
+        # before querying in a new session — the agent should recall preferences.
+        print("Waiting for Synap to process memories...")
+        await asyncio.sleep(5)
+
+        # Second turn in a new session — agent recalls from Synap
+        print("Request within a new session:")
+        session = agent.create_session()
         query = "How should you answer my questions?"
         print(f"User: {query}")
-        result = await agent.run(query)
-        print(f"Agent: {result}\n")
+        result = await agent.run(query, session=session)
+        print(f"Agent: {result}")
 
 
 if __name__ == "__main__":

--- a/python/samples/02-agents/context_providers/synap/synap_basic.py
+++ b/python/samples/02-agents/context_providers/synap/synap_basic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
-import uuid
+import os
 
 from agent_framework import Agent
 from agent_framework.foundry import FoundryChatClient
@@ -18,11 +18,11 @@ async def main() -> None:
     """Example of persistent cross-session memory with SynapContextProvider."""
     print("=== Synap Context Provider Example ===")
 
-    # Use a stable user_id so memories persist across runs.
+    # Stable user_id so memories persist across runs.
     # In production, derive this from the authenticated user's identity.
-    user_id = str(uuid.uuid4())
+    user_id = "demo-user-001"
 
-    sdk = MaximemSynapSDK(api_key="your-synap-api-key")  # or set SYNAP_API_KEY env var
+    sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
 
     # For Azure authentication, run `az login` or replace AzureCliCredential with
     # your preferred authentication option.

--- a/python/samples/02-agents/context_providers/synap/synap_basic.py
+++ b/python/samples/02-agents/context_providers/synap/synap_basic.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Demonstrates SynapContextProvider with Microsoft Agent Framework.
+# Install: pip install maximem-synap-microsoft-agent
+# Get API key at synap.maximem.ai
+
+import asyncio
+import os
+
+from agent_framework import Agent
+from maximem_synap import MaximemSynapSDK
+from synap_microsoft_agent import SynapContextProvider
+
+
+async def main() -> None:
+    """Example: SynapContextProvider for persistent cross-session memory."""
+    sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
+
+    user_id = "demo-user-001"
+
+    provider = SynapContextProvider(
+        sdk=sdk,
+        user_id=user_id,
+        customer_id="acme_corp",
+    )
+
+    async with Agent(
+        name="MemoryAssistant",
+        instructions="You are a helpful assistant with long-term memory.",
+        context_providers=[provider],
+    ) as agent:
+        # First turn — teach the agent something about the user
+        query = "I always prefer concise answers and I'm a software engineer."
+        print(f"User: {query}")
+        result = await agent.run(query)
+        print(f"Agent: {result}\n")
+
+        # Second turn — the agent recalls from Synap
+        query = "How should you answer my questions?"
+        print(f"User: {query}")
+        result = await agent.run(query)
+        print(f"Agent: {result}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds a sample demonstrating `SynapContextProvider` — a Microsoft Agent Framework `ContextProvider` backed by [Synap](https://maximem.ai), a managed memory layer for AI agents.

## What's included

- `python/samples/02-agents/context_providers/synap/synap_basic.py` — basic usage showing context injection and turn recording
- `python/samples/02-agents/context_providers/synap/README.md` — setup and run instructions

## How SynapContextProvider works

- **`before_run`**: fetches Synap context relevant to the user's input and appends it to the agent's instructions via `context.extend_instructions(...)`
- **`after_run`**: records input and response messages to Synap via `sdk.conversation.record_message(...)` for future retrieval

Read failures degrade gracefully (log + skip). Write failures are logged but never re-raised — the agent run always completes. This matches the contract established by `Mem0ContextProvider`.

Memory is scoped to `user_id` and `customer_id`, ensuring strict isolation in multi-tenant applications.

**Install:** `pip install maximem-synap-microsoft-agent`
**PyPI:** https://pypi.org/project/maximem-synap-microsoft-agent/
**Docs:** https://docs.maximem.ai/integrations/microsoft-agent
**Open source:** Integration package source at [`maximem-ai/maximem_synap_sdk`](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations) — contributions welcome