### PR TITLE
Python: Improve the handling of intermediate outputs for workflows and orchestrations

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **agent-framework-foundry-hosting**: Add hosted Durable Workflow support — propagate full conversation history to workflow agents and wire `Workflow.as_agent()` end-to-end via the foundry hosting layer ([#5531](https://github.com/microsoft/agent-framework/pull/5531))
 
 ### Changed
-- **agent-framework-orchestrations**: [BREAKING] Standardize orchestration terminal outputs as `AgentResponse` so `Workflow.as_agent()` returns the final answer only; aligns sequential-approval (`with_request_info`) and concurrent (`intermediate_outputs=True`) flows on the same output contract ([#5301](https://github.com/microsoft/agent-framework/pull/5301))
+- **agent-framework-orchestrations**: [BREAKING] Standardize orchestration terminal outputs as `AgentResponse` so `Workflow.as_agent()` returns the final answer only; aligns sequential-approval (`with_request_info`) and concurrent participant output designation flows on the same output contract ([#5301](https://github.com/microsoft/agent-framework/pull/5301))
 - **agent-framework-core**, **agent-framework-declarative**: Preserve `Workflow.run()` shared state across calls so multi-turn `WorkflowAgent` invocations retain context, accept `list[Message]` input in the declarative start executor, and coerce `Enum` values when serializing PowerFx symbols ([#5531](https://github.com/microsoft/agent-framework/pull/5531))
 - **dependencies**: Update workspace package dependencies and preserve `mcp[ws]` / `uvicorn[standard]` extras through override-dependencies in `/python` ([#5555](https://github.com/microsoft/agent-framework/pull/5555))
 

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 import azure.durable_functions as df
 import azure.functions as func
 from agent_framework import AgentExecutor, SupportsAgentRun, Workflow, WorkflowEvent
+from agent_framework._workflows._runner_context import YieldOutputEventType
 from agent_framework_durabletask import (
     DEFAULT_MAX_POLL_RETRIES,
     DEFAULT_POLL_INTERVAL_SECONDS,
@@ -307,6 +308,18 @@ class AgentFunctionApp(DFAppBase):
             async def run() -> dict[str, Any]:
                 # Create runner context and shared state
                 runner_context = CapturingRunnerContext()
+                workflow = self.workflow
+
+                def classify_yielded_output(executor_id: str) -> YieldOutputEventType | None:
+                    if workflow is None:
+                        return "output"
+                    if workflow.is_terminal_executor(executor_id):
+                        return "output"
+                    if workflow.is_intermediate_executor(executor_id):
+                        return "intermediate"
+                    return None
+
+                runner_context.set_yield_output_classifier(classify_yielded_output)
                 shared_state = State()
 
                 # Deserialize shared state values to reconstruct dataclasses/Pydantic models

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_context.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_context.py
@@ -19,6 +19,7 @@ from agent_framework import (
     WorkflowEvent,
     WorkflowMessage,
 )
+from agent_framework._workflows._runner_context import YieldOutputClassifier, YieldOutputEventType
 from agent_framework._workflows._state import State
 
 
@@ -41,6 +42,7 @@ class CapturingRunnerContext(RunnerContext):
         self._pending_request_info_events: dict[str, WorkflowEvent[Any]] = {}
         self._workflow_id: str | None = None
         self._streaming: bool = False
+        self._yield_output_classifier: YieldOutputClassifier = lambda _executor_id: "output"
 
     # region Messaging
 
@@ -143,6 +145,14 @@ class CapturingRunnerContext(RunnerContext):
     def is_streaming(self) -> bool:
         """Check if streaming mode is enabled (always False in activity context)."""
         return self._streaming
+
+    def set_yield_output_classifier(self, classifier: YieldOutputClassifier) -> None:
+        """Set the classifier used by WorkflowContext.yield_output()."""
+        self._yield_output_classifier = classifier
+
+    def classify_yielded_output(self, executor_id: str) -> YieldOutputEventType | None:
+        """Classify an executor's yield_output payload as output, intermediate, or hidden."""
+        return self._yield_output_classifier(executor_id)
 
     # endregion Workflow Configuration
 

--- a/python/packages/azurefunctions/tests/test_func_utils.py
+++ b/python/packages/azurefunctions/tests/test_func_utils.py
@@ -107,7 +107,7 @@ class TestCapturingRunnerContext:
     @pytest.mark.asyncio
     async def test_add_event_queues_event(self, context: CapturingRunnerContext) -> None:
         """Test that add_event queues events correctly."""
-        event = WorkflowEvent.output(executor_id="exec_1", data="output")
+        event = WorkflowEvent("output", executor_id="exec_1", data="output")
 
         await context.add_event(event)
 
@@ -120,7 +120,7 @@ class TestCapturingRunnerContext:
     @pytest.mark.asyncio
     async def test_drain_events_clears_queue(self, context: CapturingRunnerContext) -> None:
         """Test that drain_events clears the event queue."""
-        await context.add_event(WorkflowEvent.output(executor_id="e", data="test"))
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="test"))
 
         await context.drain_events()  # First drain
         events = await context.drain_events()  # Second drain
@@ -132,14 +132,14 @@ class TestCapturingRunnerContext:
         """Test has_events returns correct boolean."""
         assert await context.has_events() is False
 
-        await context.add_event(WorkflowEvent.output(executor_id="e", data="test"))
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="test"))
 
         assert await context.has_events() is True
 
     @pytest.mark.asyncio
     async def test_next_event_waits_for_event(self, context: CapturingRunnerContext) -> None:
         """Test that next_event returns queued events."""
-        event = WorkflowEvent.output(executor_id="e", data="waited")
+        event = WorkflowEvent("output", executor_id="e", data="waited")
         await context.add_event(event)
 
         result = await context.next_event()
@@ -171,7 +171,7 @@ class TestCapturingRunnerContext:
     async def test_reset_for_new_run_clears_state(self, context: CapturingRunnerContext) -> None:
         """Test that reset_for_new_run clears all state."""
         await context.send_message(WorkflowMessage(data="test", target_id="t", source_id="s"))
-        await context.add_event(WorkflowEvent.output(executor_id="e", data="event"))
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="event"))
         context.set_streaming(True)
 
         context.reset_for_new_run()

--- a/python/packages/core/AGENTS.md
+++ b/python/packages/core/AGENTS.md
@@ -77,7 +77,10 @@ agent_framework/
 ### Workflows (`_workflows/`)
 
 - **`Workflow`** - Graph-based workflow definition
-- **`WorkflowBuilder`** - Fluent API for building workflows
+- **`WorkflowBuilder`** - Fluent API for building workflows, including explicit
+  `output_executors` / `intermediate_executors` designation for caller-facing emissions
+- **`WorkflowRunResult`** - Non-streaming workflow result with terminal `get_outputs()`
+  and intermediate `get_intermediate_outputs()` accessors
 - **Orchestrators**: `SequentialOrchestrator`, `ConcurrentOrchestrator`, `GroupChatOrchestrator`, `MagenticOrchestrator`, `HandoffOrchestrator`
 
 ## Built-in Providers

--- a/python/packages/core/AGENTS.md
+++ b/python/packages/core/AGENTS.md
@@ -78,9 +78,13 @@ agent_framework/
 
 - **`Workflow`** - Graph-based workflow definition
 - **`WorkflowBuilder`** - Fluent API for building workflows, including explicit
-  `output_from` / `intermediate_output_from` selection for caller-facing emissions
-- **`WorkflowRunResult`** - Non-streaming workflow result with terminal `get_outputs()`
-  and intermediate `get_intermediate_outputs()` accessors
+  `output_from` / `intermediate_output_from` selection for caller-facing emissions. `output_from`
+  is an allow-list for **Workflow Output**; unselected executor payloads are hidden unless
+  `intermediate_output_from` selects them as **Intermediate Output**. Use `output_from="all"` for
+  explicit all-output behavior and `intermediate_output_from="all_other"` for visible progress from
+  every output-capable executor not selected by `output_from`.
+- **`WorkflowRunResult`** - Non-streaming workflow result with Workflow Output `get_outputs()`
+  and Intermediate Output `get_intermediate_outputs()` accessors
 - **Orchestrators**: `SequentialOrchestrator`, `ConcurrentOrchestrator`, `GroupChatOrchestrator`, `MagenticOrchestrator`, `HandoffOrchestrator`
 
 ## Built-in Providers

--- a/python/packages/core/AGENTS.md
+++ b/python/packages/core/AGENTS.md
@@ -78,7 +78,7 @@ agent_framework/
 
 - **`Workflow`** - Graph-based workflow definition
 - **`WorkflowBuilder`** - Fluent API for building workflows, including explicit
-  `output_executors` / `intermediate_executors` designation for caller-facing emissions
+  `output_from` / `intermediate_output_from` selection for caller-facing emissions
 - **`WorkflowRunResult`** - Non-streaming workflow result with terminal `get_outputs()`
   and intermediate `get_intermediate_outputs()` accessors
 - **Orchestrators**: `SequentialOrchestrator`, `ConcurrentOrchestrator`, `GroupChatOrchestrator`, `MagenticOrchestrator`, `HandoffOrchestrator`

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -32,6 +32,7 @@ from .._types import (
 from ..exceptions import AgentInvalidRequestException, AgentInvalidResponseException
 from ._checkpoint import CheckpointStorage
 from ._events import (
+    _LIFECYCLE_EVENT_TYPES,
     WorkflowEvent,
 )
 from ._message_utils import normalize_messages_input
@@ -46,6 +47,26 @@ if TYPE_CHECKING:
     from ._workflow import Workflow
 
 logger = logging.getLogger(__name__)
+
+
+def _to_text_reasoning(contents: Sequence[Content]) -> list[Content]:
+    """Rewrite text items as text_reasoning; non-text content passes through unchanged."""
+    rewritten: list[Content] = []
+    for c in contents:
+        if c.type == "text":
+            rewritten.append(
+                Content.from_text_reasoning(
+                    id=c.id,
+                    text=c.text,
+                    protected_data=c.protected_data,
+                    annotations=c.annotations,
+                    additional_properties=c.additional_properties,
+                    raw_representation=c.raw_representation,
+                )
+            )
+        else:
+            rewritten.append(c)
+    return rewritten
 
 
 class WorkflowAgent(BaseAgent):
@@ -300,7 +321,7 @@ class WorkflowAgent(BaseAgent):
             function_invocation_kwargs=function_invocation_kwargs,
             client_kwargs=client_kwargs,
         ):
-            if event.type == "output" or event.type == "request_info":
+            if event.type not in _LIFECYCLE_EVENT_TYPES:
                 output_events.append(event)
 
         result = self._convert_workflow_events_to_agent_response(response_id, output_events)
@@ -514,7 +535,14 @@ class WorkflowAgent(BaseAgent):
         response_id: str,
         output_events: list[WorkflowEvent[Any]],
     ) -> AgentResponse:
-        """Convert a list of workflow output events to an AgentResponse."""
+        """Convert a list of workflow events to an AgentResponse.
+
+        Terminal events (``type='output'``) keep their text content as ``text``.
+        Intermediate events (``type='intermediate'`` and the legacy/orchestration
+        variants) have their text content rewritten to ``text_reasoning`` so
+        ``response.text`` returns terminal-only by virtue of the existing
+        ``Message.text`` filter.
+        """
         messages: list[Message] = []
         raw_representations: list[object] = []
         merged_usage: UsageDetails | None = None
@@ -535,18 +563,31 @@ class WorkflowAgent(BaseAgent):
                 raw_representations.append(output_event)
             else:
                 data = output_event.data
+                # Anything that isn't `output` is intermediate — this branch only sees
+                # events that already passed the lifecycle filter and weren't request_info.
+                is_intermediate = output_event.type != "output"
+
+                def _mark_msg(msg: Message) -> Message:
+                    return Message(
+                        contents=_to_text_reasoning(msg.contents),
+                        role=msg.role,
+                        author_name=msg.author_name,
+                        message_id=msg.message_id,
+                        additional_properties=msg.additional_properties,
+                        raw_representation=msg.raw_representation,
+                    )
 
                 if isinstance(data, AgentResponseUpdate):
-                    # We cannot support AgentResponseUpdate in non-streaming mode. This is because the message
-                    # sequence cannot be guaranteed when there are streaming updates in between non-streaming
-                    # responses.
+                    # AgentResponseUpdate in non-streaming mode would break message ordering
+                    # if interleaved with non-streaming AgentResponses.
                     raise AgentInvalidRequestException(
                         "Output event with AgentResponseUpdate data cannot be emitted in non-streaming mode. "
                         "Please ensure executors emit AgentResponse for non-streaming workflows."
                     )
 
                 if isinstance(data, AgentResponse):
-                    messages.extend(data.messages)
+                    inner_msgs = [_mark_msg(m) for m in data.messages] if is_intermediate else list(data.messages)
+                    messages.extend(inner_msgs)
                     raw_representations.append(data.raw_representation)
                     merged_usage = add_usage_details(merged_usage, data.usage_details)
                     latest_created_at = (
@@ -557,16 +598,19 @@ class WorkflowAgent(BaseAgent):
                         else latest_created_at
                     )
                 elif isinstance(data, Message):
-                    messages.append(data)
+                    messages.append(_mark_msg(data) if is_intermediate else data)
                     raw_representations.append(data.raw_representation)
                 elif is_instance_of(data, list[Message]):
                     chat_messages = cast(list[Message], data)
-                    messages.extend(chat_messages)
+                    inner_msgs = [_mark_msg(m) for m in chat_messages] if is_intermediate else list(chat_messages)
+                    messages.extend(inner_msgs)
                     raw_representations.append(data)
                 else:
                     contents = self._extract_contents(data)
                     if not contents:
                         continue
+                    if is_intermediate:
+                        contents = _to_text_reasoning(contents)
 
                     messages.append(
                         Message(
@@ -626,25 +670,35 @@ class WorkflowAgent(BaseAgent):
     ) -> list[AgentResponseUpdate]:
         """Convert a workflow event to a list of AgentResponseUpdate objects.
 
-        Events with type='output' and type='request_info' are processed.
-        Other workflow events are ignored as they are workflow-internal.
+        Forwarding rule:
 
-        For 'output' events, AgentExecutor yields AgentResponseUpdate for streaming updates
-        via ctx.yield_output(). This method converts those to agent response updates.
-
-        Returns:
-            A list of AgentResponseUpdate objects. Empty list if the event is not relevant.
+        - ``type='output'`` — terminal user-facing emission. Forwarded as-is.
+        - ``type='request_info'`` — request-info translation (unchanged).
+        - Any other typed event (``intermediate``, the deprecated ``data``,
+          orchestration-specific types) — forwarded as intermediate. Text payloads
+          are rewritten to ``text_reasoning`` content; non-text content types
+          (function_call, function_result, data, uri, …) pass through unchanged
+          since their ``Content.type`` already discriminates them.
+        - Lifecycle / diagnostic events (``started``/``status``/``failed``/
+          ``warning``/``error``/``superstep_*``/``executor_*``) are dropped.
         """
-        if event.type == "output":
+        if event.type in _LIFECYCLE_EVENT_TYPES:
+            return []
+
+        if event.type != "request_info":
             data = event.data
             executor_id = event.executor_id
+            is_intermediate = event.type != "output"
+
+            def _maybe_mark(contents: list[Content]) -> list[Content]:
+                return _to_text_reasoning(contents) if is_intermediate else contents
 
             if isinstance(data, AgentResponseUpdate):
                 # Construct a fresh AgentResponseUpdate so we don't mutate a payload
                 # that AgentExecutor still holds a reference to in its `updates` list.
                 return [
                     AgentResponseUpdate(
-                        contents=list(data.contents),
+                        contents=_maybe_mark(list(data.contents)),
                         role=data.role,
                         author_name=data.author_name or executor_id,
                         response_id=data.response_id,
@@ -659,7 +713,7 @@ class WorkflowAgent(BaseAgent):
                 for msg in data.messages:
                     updates.append(
                         AgentResponseUpdate(
-                            contents=list(msg.contents),
+                            contents=_maybe_mark(list(msg.contents)),
                             role=msg.role,
                             author_name=msg.author_name or executor_id,
                             response_id=data.response_id or response_id,
@@ -673,7 +727,7 @@ class WorkflowAgent(BaseAgent):
             if isinstance(data, Message):
                 return [
                     AgentResponseUpdate(
-                        contents=list(data.contents),
+                        contents=_maybe_mark(list(data.contents)),
                         role=data.role,
                         author_name=data.author_name or executor_id,
                         response_id=response_id,
@@ -689,7 +743,7 @@ class WorkflowAgent(BaseAgent):
                 for msg in chat_messages:
                     updates.append(
                         AgentResponseUpdate(
-                            contents=list(msg.contents),
+                            contents=_maybe_mark(list(msg.contents)),
                             role=msg.role,
                             author_name=msg.author_name or executor_id,
                             response_id=response_id,
@@ -702,6 +756,10 @@ class WorkflowAgent(BaseAgent):
             contents = self._extract_contents(data)
             if not contents:
                 return []
+            if is_intermediate:
+                # _extract_contents returned text content for fallback str()-coercion of
+                # arbitrary payloads; reroute to text_reasoning for intermediate events.
+                contents = _maybe_mark(contents)
             return [
                 AgentResponseUpdate(
                     contents=contents,

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -32,7 +32,7 @@ from .._types import (
 from ..exceptions import AgentInvalidRequestException, AgentInvalidResponseException
 from ._checkpoint import CheckpointStorage
 from ._events import (
-    _LIFECYCLE_EVENT_TYPES,
+    _AGENT_FORWARDED_EVENT_TYPES,
     WorkflowEvent,
 )
 from ._message_utils import normalize_messages_input
@@ -321,7 +321,7 @@ class WorkflowAgent(BaseAgent):
             function_invocation_kwargs=function_invocation_kwargs,
             client_kwargs=client_kwargs,
         ):
-            if event.type not in _LIFECYCLE_EVENT_TYPES:
+            if event.type in _AGENT_FORWARDED_EVENT_TYPES:
                 output_events.append(event)
 
         result = self._convert_workflow_events_to_agent_response(response_id, output_events)
@@ -578,12 +578,27 @@ class WorkflowAgent(BaseAgent):
                     )
 
                 if isinstance(data, AgentResponseUpdate):
-                    # AgentResponseUpdate in non-streaming mode would break message ordering
-                    # if interleaved with non-streaming AgentResponses.
-                    raise AgentInvalidRequestException(
-                        "Output event with AgentResponseUpdate data cannot be emitted in non-streaming mode. "
-                        "Please ensure executors emit AgentResponse for non-streaming workflows."
+                    if not is_intermediate:
+                        # Terminal AgentResponseUpdate in non-streaming mode would break
+                        # message ordering if interleaved with non-streaming AgentResponses.
+                        raise AgentInvalidRequestException(
+                            "Output event with AgentResponseUpdate data cannot be emitted in non-streaming mode. "
+                            "Please ensure executors emit AgentResponse for non-streaming workflows."
+                        )
+                    # Intermediate updates surface as reasoning content on a synthesized
+                    # Message; this preserves the partial signal without altering the
+                    # terminal response shape.
+                    messages.append(
+                        Message(
+                            contents=_to_text_reasoning(list(data.contents)),
+                            role=data.role or "assistant",
+                            author_name=data.author_name or output_event.executor_id,
+                            message_id=data.message_id or str(uuid.uuid4()),
+                            raw_representation=data.raw_representation,
+                        )
                     )
+                    raw_representations.append(data.raw_representation)
+                    continue
 
                 if isinstance(data, AgentResponse):
                     inner_msgs = [_mark_msg(m) for m in data.messages] if is_intermediate else list(data.messages)
@@ -673,16 +688,17 @@ class WorkflowAgent(BaseAgent):
         Forwarding rule:
 
         - ``type='output'`` — terminal user-facing emission. Forwarded as-is.
+        - ``type='intermediate'`` (and the deprecated ``type='data'``) — forwarded
+          as intermediate. Text payloads are rewritten to ``text_reasoning`` content;
+          non-text content types (function_call, function_result, data, uri, …)
+          pass through unchanged since their ``Content.type`` already discriminates
+          them.
         - ``type='request_info'`` — request-info translation (unchanged).
-        - Any other typed event (``intermediate``, the deprecated ``data``,
-          orchestration-specific types) — forwarded as intermediate. Text payloads
-          are rewritten to ``text_reasoning`` content; non-text content types
-          (function_call, function_result, data, uri, …) pass through unchanged
-          since their ``Content.type`` already discriminates them.
-        - Lifecycle / diagnostic events (``started``/``status``/``failed``/
-          ``warning``/``error``/``superstep_*``/``executor_*``) are dropped.
+        - Everything else (lifecycle, diagnostics, executor bookkeeping,
+          orchestration-internal events like ``group_chat``/``handoff_sent``/
+          ``magentic_orchestrator``) is dropped.
         """
-        if event.type in _LIFECYCLE_EVENT_TYPES:
+        if event.type not in _AGENT_FORWARDED_EVENT_TYPES:
             return []
 
         if event.type != "request_info":

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -578,27 +578,15 @@ class WorkflowAgent(BaseAgent):
                     )
 
                 if isinstance(data, AgentResponseUpdate):
-                    if not is_intermediate:
-                        # Terminal AgentResponseUpdate in non-streaming mode would break
-                        # message ordering if interleaved with non-streaming AgentResponses.
-                        raise AgentInvalidRequestException(
-                            "Output event with AgentResponseUpdate data cannot be emitted in non-streaming mode. "
-                            "Please ensure executors emit AgentResponse for non-streaming workflows."
-                        )
-                    # Intermediate updates surface as reasoning content on a synthesized
-                    # Message; this preserves the partial signal without altering the
-                    # terminal response shape.
-                    messages.append(
-                        Message(
-                            contents=_to_text_reasoning(list(data.contents)),
-                            role=data.role or "assistant",
-                            author_name=data.author_name or output_event.executor_id,
-                            message_id=data.message_id or str(uuid.uuid4()),
-                            raw_representation=data.raw_representation,
-                        )
+                    # AgentResponseUpdate is a streaming-only payload. Accepting it
+                    # in non-streaming runs would make message ordering depend on
+                    # partial chunks for both terminal and intermediate events.
+                    event_label = "Intermediate" if is_intermediate else "Output"
+                    raise AgentInvalidRequestException(
+                        f"{event_label} event with AgentResponseUpdate data cannot be emitted "
+                        "in non-streaming mode. Please ensure executors emit AgentResponse "
+                        "for non-streaming workflows."
                     )
-                    raw_representations.append(data.raw_representation)
-                    continue
 
                 if isinstance(data, AgentResponse):
                     inner_msgs = [_mark_msg(m) for m in data.messages] if is_intermediate else list(data.messages)

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -32,7 +32,7 @@ from .._types import (
 from ..exceptions import AgentInvalidRequestException, AgentInvalidResponseException
 from ._checkpoint import CheckpointStorage
 from ._events import (
-    _AGENT_FORWARDED_EVENT_TYPES,
+    AGENT_FORWARDED_EVENT_TYPES,
     WorkflowEvent,
 )
 from ._message_utils import normalize_messages_input
@@ -321,7 +321,7 @@ class WorkflowAgent(BaseAgent):
             function_invocation_kwargs=function_invocation_kwargs,
             client_kwargs=client_kwargs,
         ):
-            if event.type in _AGENT_FORWARDED_EVENT_TYPES:
+            if event.type in AGENT_FORWARDED_EVENT_TYPES:
                 output_events.append(event)
 
         result = self._convert_workflow_events_to_agent_response(response_id, output_events)
@@ -686,7 +686,7 @@ class WorkflowAgent(BaseAgent):
           orchestration-internal events like ``group_chat``/``handoff_sent``/
           ``magentic_orchestrator``) is dropped.
         """
-        if event.type not in _AGENT_FORWARDED_EVENT_TYPES:
+        if event.type not in AGENT_FORWARDED_EVENT_TYPES:
             return []
 
         if event.type != "request_info":

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -125,7 +125,7 @@ class WorkflowAgent(BaseAgent):
         Note:
             Only output events (type='output') and request_info events (type='request_info') from
             the workflow are considered and converted to agent responses of the WorkflowAgent.
-            Other workflow events are ignored. Use `with_output_from` in WorkflowBuilder to control
+            Other workflow events are ignored. Use `output_from` in WorkflowBuilder to control
             which executors' outputs are surfaced as agent responses.
         """
         if id is None:

--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -49,26 +49,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _to_text_reasoning(contents: Sequence[Content]) -> list[Content]:
-    """Rewrite text items as text_reasoning; non-text content passes through unchanged."""
-    rewritten: list[Content] = []
-    for c in contents:
-        if c.type == "text":
-            rewritten.append(
-                Content.from_text_reasoning(
-                    id=c.id,
-                    text=c.text,
-                    protected_data=c.protected_data,
-                    annotations=c.annotations,
-                    additional_properties=c.additional_properties,
-                    raw_representation=c.raw_representation,
-                )
-            )
-        else:
-            rewritten.append(c)
-    return rewritten
-
-
 class WorkflowAgent(BaseAgent):
     """An `Agent` subclass that wraps a workflow and exposes it as an agent."""
 
@@ -537,11 +517,8 @@ class WorkflowAgent(BaseAgent):
     ) -> AgentResponse:
         """Convert a list of workflow events to an AgentResponse.
 
-        Terminal events (``type='output'``) keep their text content as ``text``.
-        Intermediate events (``type='intermediate'`` and the legacy/orchestration
-        variants) have their text content rewritten to ``text_reasoning`` so
-        ``response.text`` returns terminal-only by virtue of the existing
-        ``Message.text`` filter.
+        Caller-facing workflow events are forwarded as agent messages. Terminal and
+        intermediate event payloads keep their original content types.
         """
         messages: list[Message] = []
         raw_representations: list[object] = []
@@ -567,16 +544,6 @@ class WorkflowAgent(BaseAgent):
                 # events that already passed the lifecycle filter and weren't request_info.
                 is_intermediate = output_event.type != "output"
 
-                def _mark_msg(msg: Message) -> Message:
-                    return Message(
-                        contents=_to_text_reasoning(msg.contents),
-                        role=msg.role,
-                        author_name=msg.author_name,
-                        message_id=msg.message_id,
-                        additional_properties=msg.additional_properties,
-                        raw_representation=msg.raw_representation,
-                    )
-
                 if isinstance(data, AgentResponseUpdate):
                     # AgentResponseUpdate is a streaming-only payload. Accepting it
                     # in non-streaming runs would make message ordering depend on
@@ -589,8 +556,7 @@ class WorkflowAgent(BaseAgent):
                     )
 
                 if isinstance(data, AgentResponse):
-                    inner_msgs = [_mark_msg(m) for m in data.messages] if is_intermediate else list(data.messages)
-                    messages.extend(inner_msgs)
+                    messages.extend(data.messages)
                     raw_representations.append(data.raw_representation)
                     merged_usage = add_usage_details(merged_usage, data.usage_details)
                     latest_created_at = (
@@ -601,19 +567,16 @@ class WorkflowAgent(BaseAgent):
                         else latest_created_at
                     )
                 elif isinstance(data, Message):
-                    messages.append(_mark_msg(data) if is_intermediate else data)
+                    messages.append(data)
                     raw_representations.append(data.raw_representation)
                 elif is_instance_of(data, list[Message]):
                     chat_messages = cast(list[Message], data)
-                    inner_msgs = [_mark_msg(m) for m in chat_messages] if is_intermediate else list(chat_messages)
-                    messages.extend(inner_msgs)
+                    messages.extend(chat_messages)
                     raw_representations.append(data)
                 else:
                     contents = self._extract_contents(data)
                     if not contents:
                         continue
-                    if is_intermediate:
-                        contents = _to_text_reasoning(contents)
 
                     messages.append(
                         Message(
@@ -677,32 +640,26 @@ class WorkflowAgent(BaseAgent):
 
         - ``type='output'`` — terminal user-facing emission. Forwarded as-is.
         - ``type='intermediate'`` (and the deprecated ``type='data'``) — forwarded
-          as intermediate. Text payloads are rewritten to ``text_reasoning`` content;
-          non-text content types (function_call, function_result, data, uri, …)
-          pass through unchanged since their ``Content.type`` already discriminates
-          them.
+          as-is.
         - ``type='request_info'`` — request-info translation (unchanged).
         - Everything else (lifecycle, diagnostics, executor bookkeeping,
           orchestration-internal events like ``group_chat``/``handoff_sent``/
           ``magentic_orchestrator``) is dropped.
         """
+        # TODO(evmattso): https://github.com/microsoft/agent-framework/issues/5885
         if event.type not in AGENT_FORWARDED_EVENT_TYPES:
             return []
 
         if event.type != "request_info":
             data = event.data
             executor_id = event.executor_id
-            is_intermediate = event.type != "output"
-
-            def _maybe_mark(contents: list[Content]) -> list[Content]:
-                return _to_text_reasoning(contents) if is_intermediate else contents
 
             if isinstance(data, AgentResponseUpdate):
                 # Construct a fresh AgentResponseUpdate so we don't mutate a payload
                 # that AgentExecutor still holds a reference to in its `updates` list.
                 return [
                     AgentResponseUpdate(
-                        contents=_maybe_mark(list(data.contents)),
+                        contents=list(data.contents),
                         role=data.role,
                         author_name=data.author_name or executor_id,
                         response_id=data.response_id,
@@ -717,7 +674,7 @@ class WorkflowAgent(BaseAgent):
                 for msg in data.messages:
                     updates.append(
                         AgentResponseUpdate(
-                            contents=_maybe_mark(list(msg.contents)),
+                            contents=list(msg.contents),
                             role=msg.role,
                             author_name=msg.author_name or executor_id,
                             response_id=data.response_id or response_id,
@@ -731,7 +688,7 @@ class WorkflowAgent(BaseAgent):
             if isinstance(data, Message):
                 return [
                     AgentResponseUpdate(
-                        contents=_maybe_mark(list(data.contents)),
+                        contents=list(data.contents),
                         role=data.role,
                         author_name=data.author_name or executor_id,
                         response_id=response_id,
@@ -747,7 +704,7 @@ class WorkflowAgent(BaseAgent):
                 for msg in chat_messages:
                     updates.append(
                         AgentResponseUpdate(
-                            contents=_maybe_mark(list(msg.contents)),
+                            contents=list(msg.contents),
                             role=msg.role,
                             author_name=msg.author_name or executor_id,
                             response_id=response_id,
@@ -760,10 +717,6 @@ class WorkflowAgent(BaseAgent):
             contents = self._extract_contents(data)
             if not contents:
                 return []
-            if is_intermediate:
-                # _extract_contents returned text content for fallback str()-coercion of
-                # arbitrary payloads; reroute to text_reasoning for intermediate events.
-                contents = _maybe_mark(contents)
             return [
                 AgentResponseUpdate(
                     contents=contents,

--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -478,7 +478,7 @@ class AgentExecutor(Executor):
 
         # Prefer stream finalization when available so result hooks run
         # (e.g., thread conversation updates). Fall back to reconstructing from updates
-        # for legacy/custom agents that return a plain async iterable.
+        # for compatibility/custom agents that return a plain async iterable.
         # TODO(evmattso): Integrate workflow agent run handling around ResponseStream so
         # AgentExecutor does not need this conditional stream-finalization branch.
         maybe_get_final_response = getattr(stream, "get_final_response", None)

--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -123,7 +123,7 @@ class AgentExecutor(Executor):
     - run(stream=True): Emits incremental output events (type='output') as the agent produces tokens
     - run(): Emits a single output event (type='output') containing the complete response
 
-    Use `with_output_from` in WorkflowBuilder to control whether the AgentResponse
+    Use `output_from` in WorkflowBuilder to control whether the AgentResponse
     or AgentResponseUpdate objects are yielded as workflow outputs.
 
     Messages sent to downstream executors will always be the complete AgentResponse. In

--- a/python/packages/core/agent_framework/_workflows/_edge_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_edge_runner.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..observability import EdgeGroupDeliveryStatus, OtelAttr, create_edge_group_processing_span
 from ._edge import (
@@ -20,6 +20,9 @@ from ._edge import (
 from ._executor import Executor
 from ._runner_context import RunnerContext, WorkflowMessage
 from ._state import State
+
+if TYPE_CHECKING:
+    from ._workflow import OutputDesignation
 
 logger = logging.getLogger(__name__)
 
@@ -38,13 +41,21 @@ class EdgeRunner(ABC):
         self._executors = executors
 
     @abstractmethod
-    async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+    async def send_message(
+        self,
+        message: WorkflowMessage,
+        state: State,
+        ctx: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
+    ) -> bool:
         """Send a message through the edge group.
 
         Args:
             message: The message to send.
             state: The workflow state.
             ctx: The context for the runner.
+            output_designation: Snapshot of the workflow's output designation policy. Defaults
+                to legacy mode (every yield is type='output') for direct callers.
 
         Returns:
             bool: True if the message was processed successfully,
@@ -65,6 +76,7 @@ class EdgeRunner(ABC):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
     ) -> None:
         """Execute a message on a target executor with trace context."""
         if target_id not in self._executors:
@@ -78,6 +90,7 @@ class EdgeRunner(ABC):
             source_ids,  # source_executor_ids
             state,  # state
             ctx,  # runner_context
+            output_designation=output_designation,
             trace_contexts=message.trace_contexts,  # Pass trace contexts
             source_span_ids=message.source_span_ids,  # Pass source span IDs for linking
         )
@@ -90,7 +103,13 @@ class SingleEdgeRunner(EdgeRunner):
         super().__init__(edge_group, executors)
         self._edge = edge_group.edges[0]
 
-    async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+    async def send_message(
+        self,
+        message: WorkflowMessage,
+        state: State,
+        ctx: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
+    ) -> bool:
         """Send a message through the single edge."""
         should_execute = False
         target_id: str | None = None
@@ -144,7 +163,7 @@ class SingleEdgeRunner(EdgeRunner):
 
         # Execute outside the span
         if should_execute and target_id and source_id:
-            await self._execute_on_target(target_id, [source_id], message, state, ctx)
+            await self._execute_on_target(target_id, [source_id], message, state, ctx, output_designation)
             return True
 
         return False
@@ -162,7 +181,13 @@ class FanOutEdgeRunner(EdgeRunner):
             Callable[[Any, list[str]], list[str]] | None, getattr(edge_group, "selection_func", None)
         )
 
-    async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+    async def send_message(
+        self,
+        message: WorkflowMessage,
+        state: State,
+        ctx: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
+    ) -> bool:
         """Send a message through all edges in the fan-out edge group."""
         deliverable_edges: list[Edge] = []
         single_target_edge: Edge | None = None
@@ -253,14 +278,19 @@ class FanOutEdgeRunner(EdgeRunner):
         # Execute outside the span
         if single_target_edge:
             await self._execute_on_target(
-                single_target_edge.target_id, [single_target_edge.source_id], message, state, ctx
+                single_target_edge.target_id,
+                [single_target_edge.source_id],
+                message,
+                state,
+                ctx,
+                output_designation,
             )
             return True
 
         if deliverable_edges:
 
             async def send_to_edge(edge: Edge) -> bool:
-                await self._execute_on_target(edge.target_id, [edge.source_id], message, state, ctx)
+                await self._execute_on_target(edge.target_id, [edge.source_id], message, state, ctx, output_designation)
                 return True
 
             tasks = [send_to_edge(edge) for edge in deliverable_edges]
@@ -285,7 +315,13 @@ class FanInEdgeRunner(EdgeRunner):
         # Key is the source executor ID, value is a list of messages
         self._buffer: dict[str, list[WorkflowMessage]] = defaultdict(list)
 
-    async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+    async def send_message(
+        self,
+        message: WorkflowMessage,
+        state: State,
+        ctx: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
+    ) -> bool:
         """Send a message through all edges in the fan-in edge group."""
         execution_data: dict[str, Any] | None = None
         with create_edge_group_processing_span(
@@ -362,7 +398,12 @@ class FanInEdgeRunner(EdgeRunner):
         # Execute outside the span if needed
         if execution_data:
             await self._execute_on_target(
-                execution_data["target_id"], execution_data["source_ids"], execution_data["message"], state, ctx
+                execution_data["target_id"],
+                execution_data["source_ids"],
+                execution_data["message"],
+                state,
+                ctx,
+                output_designation,
             )
             return True
 

--- a/python/packages/core/agent_framework/_workflows/_edge_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_edge_runner.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from ..observability import EdgeGroupDeliveryStatus, OtelAttr, create_edge_group_processing_span
 from ._edge import (
@@ -20,9 +20,6 @@ from ._edge import (
 from ._executor import Executor
 from ._runner_context import RunnerContext, WorkflowMessage
 from ._state import State
-
-if TYPE_CHECKING:
-    from ._workflow import OutputDesignation
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +43,6 @@ class EdgeRunner(ABC):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
     ) -> bool:
         """Send a message through the edge group.
 
@@ -54,8 +50,6 @@ class EdgeRunner(ABC):
             message: The message to send.
             state: The workflow state.
             ctx: The context for the runner.
-            output_designation: Snapshot of the workflow's output designation policy. Defaults
-                to legacy mode (every yield is type='output') for direct callers.
 
         Returns:
             bool: True if the message was processed successfully,
@@ -76,7 +70,6 @@ class EdgeRunner(ABC):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
     ) -> None:
         """Execute a message on a target executor with trace context."""
         if target_id not in self._executors:
@@ -90,7 +83,6 @@ class EdgeRunner(ABC):
             source_ids,  # source_executor_ids
             state,  # state
             ctx,  # runner_context
-            output_designation=output_designation,
             trace_contexts=message.trace_contexts,  # Pass trace contexts
             source_span_ids=message.source_span_ids,  # Pass source span IDs for linking
         )
@@ -108,7 +100,6 @@ class SingleEdgeRunner(EdgeRunner):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
     ) -> bool:
         """Send a message through the single edge."""
         should_execute = False
@@ -163,7 +154,7 @@ class SingleEdgeRunner(EdgeRunner):
 
         # Execute outside the span
         if should_execute and target_id and source_id:
-            await self._execute_on_target(target_id, [source_id], message, state, ctx, output_designation)
+            await self._execute_on_target(target_id, [source_id], message, state, ctx)
             return True
 
         return False
@@ -186,7 +177,6 @@ class FanOutEdgeRunner(EdgeRunner):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
     ) -> bool:
         """Send a message through all edges in the fan-out edge group."""
         deliverable_edges: list[Edge] = []
@@ -283,14 +273,13 @@ class FanOutEdgeRunner(EdgeRunner):
                 message,
                 state,
                 ctx,
-                output_designation,
             )
             return True
 
         if deliverable_edges:
 
             async def send_to_edge(edge: Edge) -> bool:
-                await self._execute_on_target(edge.target_id, [edge.source_id], message, state, ctx, output_designation)
+                await self._execute_on_target(edge.target_id, [edge.source_id], message, state, ctx)
                 return True
 
             tasks = [send_to_edge(edge) for edge in deliverable_edges]
@@ -320,7 +309,6 @@ class FanInEdgeRunner(EdgeRunner):
         message: WorkflowMessage,
         state: State,
         ctx: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
     ) -> bool:
         """Send a message through all edges in the fan-in edge group."""
         execution_data: dict[str, Any] | None = None
@@ -403,7 +391,6 @@ class FanInEdgeRunner(EdgeRunner):
                 execution_data["message"],
                 state,
                 ctx,
-                output_designation,
             )
             return True
 

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import sys
 import traceback as _traceback
+import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -106,8 +107,9 @@ WorkflowEventType = Literal[
     "status",  # Workflow state changed (use .state)
     "failed",  # Workflow terminated with error (use .details)
     # Data events
-    "output",  # Executor yielded final output (use .executor_id, .data)
-    "data",  # Executor emitted data during execution (use .executor_id, .data)
+    "output",  # Executor yielded final terminal output (use .executor_id, .data)
+    "intermediate",  # Executor emitted intermediate (non-terminal) output (use .executor_id, .data)
+    "data",  # DEPRECATED — legacy alias for intermediate emissions; use type='intermediate' instead.
     # Request events (human-in-the-loop)
     "request_info",  # Executor requests external info (use .request_id, .source_executor_id)
     # Diagnostic events (warnings/errors from user code)
@@ -128,6 +130,24 @@ WorkflowEventType = Literal[
 ]
 
 
+# Framework-managed event types — workflow lifecycle, diagnostics, and executor bookkeeping
+# — that carry no user-facing payload and are not forwarded through the
+# ``workflow.as_agent()`` boundary. Internal to the ``_workflows`` package.
+_LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset({
+    "started",
+    "status",
+    "failed",
+    "warning",
+    "error",
+    "superstep_started",
+    "superstep_completed",
+    "executor_invoked",
+    "executor_completed",
+    "executor_failed",
+    "executor_bypassed",
+})
+
+
 class WorkflowEvent(Generic[DataT]):
     """Unified event for all workflow emissions.
 
@@ -141,8 +161,8 @@ class WorkflowEvent(Generic[DataT]):
     - `WorkflowEvent.failed(details)` - workflow terminated with error
     - `WorkflowEvent.warning(message)` - warning from user code
     - `WorkflowEvent.error(exception)` - error from user code
-    - `WorkflowEvent.output(executor_id, data)` - executor yielded final output
-    - `WorkflowEvent.data(executor_id, data)` - executor emitted data (e.g., AgentResponse)
+    - `WorkflowEvent.output(executor_id, data)` - executor yielded final terminal output
+    - `WorkflowEvent.intermediate(executor_id, data)` - executor emitted intermediate (non-terminal) data
     - `WorkflowEvent.request_info(...)` - executor requests external info
     - `WorkflowEvent.superstep_started(iteration)` - superstep began
     - `WorkflowEvent.superstep_completed(iteration)` - superstep ended
@@ -265,16 +285,33 @@ class WorkflowEvent(Generic[DataT]):
 
     @classmethod
     def output(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
-        """Create an 'output' event when an executor yields final output."""
+        """Create an 'output' event when an executor yields final terminal output."""
         return cls("output", executor_id=executor_id, data=data)
 
     @classmethod
-    def emit(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
-        """Create a 'data' event when an executor emits data during execution.
+    def intermediate(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
+        """Create an 'intermediate' event for a non-terminal emission.
 
-        This is the primary method for executors to emit typed data
-        (e.g., AgentResponse, AgentResponseUpdate, custom data).
+        The runner labels yields automatically based on the workflow's ``output_executors``;
+        this factory exists for cases that need to construct events directly.
         """
+        return cls("intermediate", executor_id=executor_id, data=data)
+
+    @classmethod
+    def emit(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
+        """Create a 'data' event (deprecated alias for intermediate emissions).
+
+        .. deprecated::
+            Use :meth:`WorkflowEvent.intermediate` instead. Will be removed in a future
+            major release along with the ``type='data'`` event variant.
+        """
+        warnings.warn(
+            "WorkflowEvent.emit() / type='data' are deprecated; use WorkflowEvent.intermediate() "
+            "(or ctx.yield_output() from a non-designated executor). Will be removed in a future "
+            "major release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return cls("data", executor_id=executor_id, data=data)
 
     @classmethod

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -130,21 +130,16 @@ WorkflowEventType = Literal[
 ]
 
 
-# Framework-managed event types — workflow lifecycle, diagnostics, and executor bookkeeping
-# — that carry no user-facing payload and are not forwarded through the
-# ``workflow.as_agent()`` boundary. Internal to the ``_workflows`` package.
-_LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset({
-    "started",
-    "status",
-    "failed",
-    "warning",
-    "error",
-    "superstep_started",
-    "superstep_completed",
-    "executor_invoked",
-    "executor_completed",
-    "executor_failed",
-    "executor_bypassed",
+# Event types forwarded across the ``workflow.as_agent()`` boundary. Anything not
+# in this set — lifecycle events, diagnostics, executor bookkeeping, and
+# orchestration-internal events (``group_chat``, ``handoff_sent``,
+# ``magentic_orchestrator``) — stays inside the workflow and is not surfaced to
+# agent callers. Internal to the ``_workflows`` package.
+_AGENT_FORWARDED_EVENT_TYPES: frozenset[str] = frozenset({
+    "output",
+    "intermediate",
+    "data",  # deprecated alias for intermediate; retained for backward compat
+    "request_info",
 })
 
 

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -109,7 +109,7 @@ WorkflowEventType = Literal[
     # Data events
     "output",  # Executor yielded final terminal output (use .executor_id, .data)
     "intermediate",  # Executor emitted intermediate (non-terminal) output (use .executor_id, .data)
-    "data",  # DEPRECATED — legacy alias for intermediate emissions; use type='intermediate' instead.
+    "data",  # DEPRECATED — compatibility alias for intermediate emissions; use type='intermediate' instead.
     # Request events (human-in-the-loop)
     "request_info",  # Executor requests external info (use .request_id, .source_executor_id)
     # Diagnostic events (warnings/errors from user code)
@@ -149,15 +149,15 @@ class WorkflowEvent(Generic[DataT]):
     This single generic class handles all workflow events through a `type` discriminator,
     following the same pattern as the `Content` class.
 
-    Use factory methods for convenient construction:
+    Use factory methods for convenient construction of lifecycle, diagnostic, request,
+    and executor bookkeeping events. Workflow ``output`` and ``intermediate`` events
+    are emitted by ``ctx.yield_output(...)`` based on workflow output selection.
 
     - `WorkflowEvent.started()` - workflow run began
     - `WorkflowEvent.status(state)` - workflow state changed
     - `WorkflowEvent.failed(details)` - workflow terminated with error
     - `WorkflowEvent.warning(message)` - warning from user code
     - `WorkflowEvent.error(exception)` - error from user code
-    - `WorkflowEvent.output(executor_id, data)` - executor yielded final terminal output
-    - `WorkflowEvent.intermediate(executor_id, data)` - executor emitted intermediate (non-terminal) data
     - `WorkflowEvent.request_info(...)` - executor requests external info
     - `WorkflowEvent.superstep_started(iteration)` - superstep began
     - `WorkflowEvent.superstep_completed(iteration)` - superstep ended
@@ -173,14 +173,13 @@ class WorkflowEvent(Generic[DataT]):
     Examples:
         .. code-block:: python
 
-            # Create events via factory methods
+            # Create lifecycle events via factory methods
             started = WorkflowEvent.started()
             status = WorkflowEvent.status(WorkflowRunState.IN_PROGRESS)
-            output = WorkflowEvent.output("agent1", result_data)
 
-            # Emit typed data from executor
-            event: WorkflowEvent[AgentResponse] = WorkflowEvent.data("agent1", response)
-            data: AgentResponse = event.data  # Type-safe access
+            # Type-safe access to event data
+            event: WorkflowEvent[AgentResponse] = WorkflowEvent("data", executor_id="agent1", data=response)
+            data: AgentResponse = event.data
 
             # Check event type
             if event.type == "status":
@@ -279,35 +278,16 @@ class WorkflowEvent(Generic[DataT]):
         return WorkflowEvent("error", data=exception)
 
     @classmethod
-    def output(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
-        """Create an 'output' event for a final terminal emission.
-
-        The runner labels yields automatically based on the workflow's output/intermediate
-        designation; this factory exists for cases that need to construct events directly.
-        """
-        return cls("output", executor_id=executor_id, data=data)
-
-    @classmethod
-    def intermediate(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
-        """Create an 'intermediate' event for a non-terminal emission.
-
-        The runner labels yields automatically based on the workflow's output/intermediate
-        designation; this factory exists for cases that need to construct events directly.
-        """
-        return cls("intermediate", executor_id=executor_id, data=data)
-
-    @classmethod
     def emit(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
         """Create a 'data' event (deprecated alias for intermediate emissions).
 
         .. deprecated::
-            Use :meth:`WorkflowEvent.intermediate` instead. Will be removed in a future
-            major release along with the ``type='data'`` event variant.
+            Use ``ctx.yield_output(...)`` and configure ``intermediate_output_from`` instead.
+            Will be removed in a future major release along with the ``type='data'`` event variant.
         """
         warnings.warn(
-            "WorkflowEvent.emit() / type='data' are deprecated; use WorkflowEvent.intermediate() "
-            "(or ctx.yield_output() from an intermediate-designated executor). Will be removed "
-            "in a future major release.",
+            "WorkflowEvent.emit() / type='data' are deprecated; use ctx.yield_output() from an "
+            "intermediate-designated executor. Will be removed in a future major release.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -287,8 +287,8 @@ class WorkflowEvent(Generic[DataT]):
     def intermediate(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
         """Create an 'intermediate' event for a non-terminal emission.
 
-        The runner labels yields automatically based on the workflow's ``output_executors``;
-        this factory exists for cases that need to construct events directly.
+        The runner labels yields automatically based on the workflow's output/intermediate
+        designation; this factory exists for cases that need to construct events directly.
         """
         return cls("intermediate", executor_id=executor_id, data=data)
 
@@ -302,8 +302,8 @@ class WorkflowEvent(Generic[DataT]):
         """
         warnings.warn(
             "WorkflowEvent.emit() / type='data' are deprecated; use WorkflowEvent.intermediate() "
-            "(or ctx.yield_output() from a non-designated executor). Will be removed in a future "
-            "major release.",
+            "(or ctx.yield_output() from an intermediate-designated executor). Will be removed "
+            "in a future major release.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -280,7 +280,11 @@ class WorkflowEvent(Generic[DataT]):
 
     @classmethod
     def output(cls, executor_id: str, data: DataT) -> WorkflowEvent[DataT]:
-        """Create an 'output' event when an executor yields final terminal output."""
+        """Create an 'output' event for a final terminal emission.
+
+        The runner labels yields automatically based on the workflow's output/intermediate
+        designation; this factory exists for cases that need to construct events directly.
+        """
         return cls("output", executor_id=executor_id, data=data)
 
     @classmethod

--- a/python/packages/core/agent_framework/_workflows/_events.py
+++ b/python/packages/core/agent_framework/_workflows/_events.py
@@ -135,7 +135,7 @@ WorkflowEventType = Literal[
 # orchestration-internal events (``group_chat``, ``handoff_sent``,
 # ``magentic_orchestrator``) — stays inside the workflow and is not surfaced to
 # agent callers. Internal to the ``_workflows`` package.
-_AGENT_FORWARDED_EVENT_TYPES: frozenset[str] = frozenset({
+AGENT_FORWARDED_EVENT_TYPES: frozenset[str] = frozenset({
     "output",
     "intermediate",
     "data",  # deprecated alias for intermediate; retained for backward compat

--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -8,7 +8,10 @@ import logging
 import types
 import typing
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+if TYPE_CHECKING:
+    from ._workflow import OutputDesignation
 
 from ..observability import create_processing_span
 from ._events import (
@@ -222,6 +225,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
     ) -> None:
@@ -235,6 +239,8 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids: The IDs of the source executors that sent messages to this executor.
             state: The state for the workflow.
             runner_context: The runner context that provides methods to send messages and events.
+            output_designation: Snapshot of the workflow's output designation policy used to label
+                yields as terminal vs intermediate.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking.
 
@@ -263,6 +269,7 @@ class Executor(RequestInfoMixin, DictConvertible):
                 source_executor_ids=source_executor_ids,
                 state=state,
                 runner_context=runner_context,
+                output_designation=output_designation,
                 trace_contexts=trace_contexts,
                 source_span_ids=source_span_ids,
                 request_id=original_message.original_request_info_event.request_id
@@ -298,6 +305,7 @@ class Executor(RequestInfoMixin, DictConvertible):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
+        output_designation: "OutputDesignation | None" = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
         request_id: str | None = None,
@@ -308,6 +316,8 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids: The IDs of the source executors that sent messages to this executor.
             state: The state for the workflow.
             runner_context: The runner context that provides methods to send messages and events.
+            output_designation: Snapshot of the workflow's output designation policy passed to
+                the WorkflowContext for yield labeling.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking.
             request_id: Optional request ID if this context is for a `handle_response` handler.
@@ -321,6 +331,7 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids=source_executor_ids,
             state=state,
             runner_context=runner_context,
+            output_designation=output_designation,
             trace_contexts=trace_contexts,
             source_span_ids=source_span_ids,
             request_id=request_id,

--- a/python/packages/core/agent_framework/_workflows/_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_executor.py
@@ -8,10 +8,7 @@ import logging
 import types
 import typing
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, TypeVar, overload
-
-if TYPE_CHECKING:
-    from ._workflow import OutputDesignation
+from typing import Any, TypeVar, overload
 
 from ..observability import create_processing_span
 from ._events import (
@@ -225,7 +222,6 @@ class Executor(RequestInfoMixin, DictConvertible):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
     ) -> None:
@@ -239,8 +235,6 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids: The IDs of the source executors that sent messages to this executor.
             state: The state for the workflow.
             runner_context: The runner context that provides methods to send messages and events.
-            output_designation: Snapshot of the workflow's output designation policy used to label
-                yields as terminal vs intermediate.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking.
 
@@ -269,7 +263,6 @@ class Executor(RequestInfoMixin, DictConvertible):
                 source_executor_ids=source_executor_ids,
                 state=state,
                 runner_context=runner_context,
-                output_designation=output_designation,
                 trace_contexts=trace_contexts,
                 source_span_ids=source_span_ids,
                 request_id=original_message.original_request_info_event.request_id
@@ -305,7 +298,6 @@ class Executor(RequestInfoMixin, DictConvertible):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
-        output_designation: "OutputDesignation | None" = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
         request_id: str | None = None,
@@ -316,8 +308,6 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids: The IDs of the source executors that sent messages to this executor.
             state: The state for the workflow.
             runner_context: The runner context that provides methods to send messages and events.
-            output_designation: Snapshot of the workflow's output designation policy passed to
-                the WorkflowContext for yield labeling.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking.
             request_id: Optional request ID if this context is for a `handle_response` handler.
@@ -331,7 +321,6 @@ class Executor(RequestInfoMixin, DictConvertible):
             source_executor_ids=source_executor_ids,
             state=state,
             runner_context=runner_context,
-            output_designation=output_designation,
             trace_contexts=trace_contexts,
             source_span_ids=source_span_ids,
             request_id=request_id,

--- a/python/packages/core/agent_framework/_workflows/_functional.py
+++ b/python/packages/core/agent_framework/_workflows/_functional.py
@@ -982,7 +982,8 @@ class FunctionalWorkflow:
 
                 # Emit the return value as the workflow output.
                 if return_value is not None:
-                    await ctx.add_event(WorkflowEvent.output(self.name, return_value))
+                    with _framework_event_origin():
+                        await ctx.add_event(WorkflowEvent("output", executor_id=self.name, data=return_value))
 
                 # Persist step cache for response-only replay
                 self._last_step_cache = dict(ctx._step_cache)

--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..exceptions import (
     WorkflowCheckpointException,
@@ -24,6 +24,9 @@ from ._runner_context import (
 )
 from ._state import State
 
+if TYPE_CHECKING:
+    from ._workflow import OutputDesignation
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,6 +41,7 @@ class Runner:
         ctx: RunnerContext,
         workflow_name: str,
         graph_signature_hash: str,
+        output_designation: "OutputDesignation | None" = None,
         max_iterations: int = 100,
     ) -> None:
         """Initialize the runner with edges, state, and context.
@@ -49,8 +53,13 @@ class Runner:
             ctx: The runner context for the workflow.
             workflow_name: The name of the workflow, used for checkpoint labeling.
             graph_signature_hash: A hash representing the workflow graph topology for checkpoint validation.
+            output_designation: Snapshot of the workflow's output designation policy. Threaded
+                through edge runners to executors so yields are labeled correctly. Defaults to
+                legacy mode (every yield is type='output') for direct ``Runner`` callers.
             max_iterations: The maximum number of iterations to run.
         """
+        from ._workflow import OutputDesignation
+
         # Workflow instance related attributes
         self._executors = executors
         self._edge_runners = [create_edge_runner(group, executors) for group in edge_groups]
@@ -58,6 +67,7 @@ class Runner:
         self._ctx = ctx
         self._workflow_name = workflow_name
         self._graph_signature_hash = graph_signature_hash
+        self._output_designation: OutputDesignation = output_designation or OutputDesignation()
 
         # Runner state related attributes
         self._iteration = 0
@@ -184,7 +194,7 @@ class Runner:
 
             async def _deliver_message_inner(edge_runner: EdgeRunner, message: WorkflowMessage) -> bool:
                 """Inner loop to deliver a single message through an edge runner."""
-                return await edge_runner.send_message(message, self._state, self._ctx)
+                return await edge_runner.send_message(message, self._state, self._ctx, self._output_designation)
 
             async def _deliver_messages_for_edge_runner(edge_runner: EdgeRunner) -> None:
                 # Preserve message order per edge runner (and therefore per routed target path)

--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ..exceptions import (
     WorkflowCheckpointException,
@@ -24,9 +24,6 @@ from ._runner_context import (
 )
 from ._state import State
 
-if TYPE_CHECKING:
-    from ._workflow import OutputDesignation
-
 logger = logging.getLogger(__name__)
 
 
@@ -41,7 +38,6 @@ class Runner:
         ctx: RunnerContext,
         workflow_name: str,
         graph_signature_hash: str,
-        output_designation: "OutputDesignation | None" = None,
         max_iterations: int = 100,
     ) -> None:
         """Initialize the runner with edges, state, and context.
@@ -53,13 +49,8 @@ class Runner:
             ctx: The runner context for the workflow.
             workflow_name: The name of the workflow, used for checkpoint labeling.
             graph_signature_hash: A hash representing the workflow graph topology for checkpoint validation.
-            output_designation: Snapshot of the workflow's output designation policy. Threaded
-                through edge runners to executors so yields are labeled correctly. Defaults to
-                legacy mode (every yield is type='output') for direct ``Runner`` callers.
             max_iterations: The maximum number of iterations to run.
         """
-        from ._workflow import OutputDesignation
-
         # Workflow instance related attributes
         self._executors = executors
         self._edge_runners = [create_edge_runner(group, executors) for group in edge_groups]
@@ -67,7 +58,6 @@ class Runner:
         self._ctx = ctx
         self._workflow_name = workflow_name
         self._graph_signature_hash = graph_signature_hash
-        self._output_designation: OutputDesignation = output_designation or OutputDesignation()
 
         # Runner state related attributes
         self._iteration = 0
@@ -194,7 +184,7 @@ class Runner:
 
             async def _deliver_message_inner(edge_runner: EdgeRunner, message: WorkflowMessage) -> bool:
                 """Inner loop to deliver a single message through an edge runner."""
-                return await edge_runner.send_message(message, self._state, self._ctx, self._output_designation)
+                return await edge_runner.send_message(message, self._state, self._ctx)
 
             async def _deliver_messages_for_edge_runner(edge_runner: EdgeRunner) -> None:
                 # Preserve message order per edge runner (and therefore per routed target path)

--- a/python/packages/core/agent_framework/_workflows/_runner_context.py
+++ b/python/packages/core/agent_framework/_workflows/_runner_context.py
@@ -7,7 +7,10 @@ import logging
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
+
+if TYPE_CHECKING:
+    from ._workflow import Workflow
 
 from ._checkpoint import CheckpointID, CheckpointStorage, WorkflowCheckpoint
 from ._const import INTERNAL_SOURCE_ID
@@ -192,6 +195,19 @@ class RunnerContext(Protocol):
         """
         ...
 
+    def should_label_as_intermediate(self, executor_id: str) -> bool:
+        """Whether yields from ``executor_id`` should be labeled type='intermediate'.
+
+        Returns True only when the workflow was built with explicit ``output_executors``
+        AND ``executor_id`` is not in that designated set. In legacy mode (no explicit
+        ``output_executors``), always returns False — every yield is type='output'.
+
+        RunnerContext subclasses that don't support intermediate labeling may inherit the
+        Protocol's no-op default body, which returns ``None`` (falsy) — yielding legacy
+        behavior automatically.
+        """
+        ...
+
     async def create_checkpoint(
         self,
         workflow_name: str,
@@ -286,6 +302,12 @@ class InProcRunnerContext:
 
         # Streaming flag - set by workflow's run(..., stream=True) vs run(..., stream=False)
         self._streaming: bool = False
+
+        # Back-reference to the Workflow this context serves; assigned once by
+        # WorkflowBuilder.build() after both objects exist (chicken-and-egg: the workflow
+        # needs the context for its Runner). The runner consults the Workflow as the
+        # single source of truth for output designation rather than caching a copy.
+        self._workflow: Workflow | None = None
 
     # region Messaging and Events
     async def send_message(self, message: WorkflowMessage) -> None:
@@ -430,6 +452,11 @@ class InProcRunnerContext:
             True if streaming mode is enabled, False otherwise.
         """
         return self._streaming
+
+    def should_label_as_intermediate(self, executor_id: str) -> bool:
+        if self._workflow is None or self._workflow._output_executors is None:
+            return False  # not yet bound, or legacy mode
+        return executor_id not in self._workflow._output_executors
 
     async def add_request_info_event(self, event: WorkflowEvent[Any]) -> None:
         """Add a request_info event to the context and track it for correlation.

--- a/python/packages/core/agent_framework/_workflows/_runner_context.py
+++ b/python/packages/core/agent_framework/_workflows/_runner_context.py
@@ -7,10 +7,7 @@ import logging
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
-
-if TYPE_CHECKING:
-    from ._workflow import Workflow
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from ._checkpoint import CheckpointID, CheckpointStorage, WorkflowCheckpoint
 from ._const import INTERNAL_SOURCE_ID
@@ -195,19 +192,6 @@ class RunnerContext(Protocol):
         """
         ...
 
-    def should_label_as_intermediate(self, executor_id: str) -> bool:
-        """Whether yields from ``executor_id`` should be labeled type='intermediate'.
-
-        Returns True only when the workflow was built with explicit ``output_executors``
-        AND ``executor_id`` is not in that designated set. In legacy mode (no explicit
-        ``output_executors``), always returns False — every yield is type='output'.
-
-        RunnerContext subclasses that don't support intermediate labeling may inherit the
-        Protocol's no-op default body, which returns ``None`` (falsy) — yielding legacy
-        behavior automatically.
-        """
-        ...
-
     async def create_checkpoint(
         self,
         workflow_name: str,
@@ -302,12 +286,6 @@ class InProcRunnerContext:
 
         # Streaming flag - set by workflow's run(..., stream=True) vs run(..., stream=False)
         self._streaming: bool = False
-
-        # Back-reference to the Workflow this context serves; assigned once by
-        # WorkflowBuilder.build() after both objects exist (chicken-and-egg: the workflow
-        # needs the context for its Runner). The runner consults the Workflow as the
-        # single source of truth for output designation rather than caching a copy.
-        self._workflow: Workflow | None = None
 
     # region Messaging and Events
     async def send_message(self, message: WorkflowMessage) -> None:
@@ -452,11 +430,6 @@ class InProcRunnerContext:
             True if streaming mode is enabled, False otherwise.
         """
         return self._streaming
-
-    def should_label_as_intermediate(self, executor_id: str) -> bool:
-        if self._workflow is None or self._workflow._output_executors is None:
-            return False  # not yet bound, or legacy mode
-        return executor_id not in self._workflow._output_executors
 
     async def add_request_info_event(self, event: WorkflowEvent[Any]) -> None:
         """Add a request_info event to the context and track it for correlation.

--- a/python/packages/core/agent_framework/_workflows/_runner_context.py
+++ b/python/packages/core/agent_framework/_workflows/_runner_context.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Literal, Protocol, TypeVar, runtime_checkable
 
 from ._checkpoint import CheckpointID, CheckpointStorage, WorkflowCheckpoint
 from ._const import INTERNAL_SOURCE_ID
@@ -18,6 +19,8 @@ from ._typing_utils import is_instance_of
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+YieldOutputEventType = Literal["output", "intermediate"]
+YieldOutputClassifier = Callable[[str], YieldOutputEventType | None]
 
 
 class MessageType(Enum):
@@ -263,6 +266,14 @@ class RunnerContext(Protocol):
         """
         ...
 
+    def set_yield_output_classifier(self, classifier: YieldOutputClassifier) -> None:
+        """Set the classifier used by WorkflowContext.yield_output()."""
+        ...
+
+    def classify_yielded_output(self, executor_id: str) -> YieldOutputEventType | None:
+        """Classify an executor's yield_output payload as output, intermediate, or hidden."""
+        ...
+
 
 class InProcRunnerContext:
     """In-process execution context for local execution and optional checkpointing."""
@@ -286,6 +297,7 @@ class InProcRunnerContext:
 
         # Streaming flag - set by workflow's run(..., stream=True) vs run(..., stream=False)
         self._streaming: bool = False
+        self._yield_output_classifier: YieldOutputClassifier = lambda _executor_id: "output"
 
     # region Messaging and Events
     async def send_message(self, message: WorkflowMessage) -> None:
@@ -480,3 +492,11 @@ class InProcRunnerContext:
             A dictionary mapping request IDs to their corresponding WorkflowEvent (type='request_info').
         """
         return dict(self._pending_request_info_events)
+
+    def set_yield_output_classifier(self, classifier: YieldOutputClassifier) -> None:
+        """Set the classifier used by WorkflowContext.yield_output()."""
+        self._yield_output_classifier = classifier
+
+    def classify_yielded_output(self, executor_id: str) -> YieldOutputEventType | None:
+        """Classify an executor's yield_output payload as output, intermediate, or hidden."""
+        return self._yield_output_classifier(executor_id)

--- a/python/packages/core/agent_framework/_workflows/_validation.py
+++ b/python/packages/core/agent_framework/_workflows/_validation.py
@@ -104,6 +104,7 @@ class WorkflowGraphValidator:
         executors: dict[str, Executor],
         start_executor: Executor,
         output_executors: list[str],
+        intermediate_executors: list[str] | None = None,
     ) -> None:
         """Validate the entire workflow graph.
 
@@ -112,6 +113,7 @@ class WorkflowGraphValidator:
             executors: Map of executor IDs to executor instances
             start_executor: The starting executor
             output_executors: List of output executor IDs
+            intermediate_executors: List of intermediate executor IDs
 
         Raises:
             WorkflowValidationError: If any validation fails
@@ -158,7 +160,7 @@ class WorkflowGraphValidator:
         self._validate_graph_connectivity(start_executor.id)
         self._validate_self_loops()
         self._validate_dead_ends()
-        self._output_validation(output_executors)
+        self._output_validation(output_executors, intermediate_executors or [])
 
     def _validate_handler_output_annotations(self) -> None:
         """Validate that each handler's ctx parameter is annotated with WorkflowContext[T].
@@ -356,8 +358,15 @@ class WorkflowGraphValidator:
 
     # region Output Validation
 
-    def _output_validation(self, output_executors: list[str]) -> None:
-        """Validate that output executors exist in the workflow and have the correct workflow context annotations."""
+    def _output_validation(self, output_executors: list[str], intermediate_executors: list[str]) -> None:
+        """Validate that designated executors exist and have workflow output annotations."""
+        overlap = sorted(set(output_executors).intersection(intermediate_executors))
+        if overlap:
+            raise WorkflowValidationError(
+                f"Executors cannot be both output and intermediate designated: {overlap}",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            )
+
         for output_id in output_executors:
             if output_id not in self._executors:
                 raise WorkflowValidationError(
@@ -369,6 +378,20 @@ class WorkflowGraphValidator:
             if not output_executor.workflow_output_types:
                 raise WorkflowValidationError(
                     f"Output executor '{output_id}' must have output type annotations defined.",
+                    validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+                )
+
+        for intermediate_id in intermediate_executors:
+            if intermediate_id not in self._executors:
+                raise WorkflowValidationError(
+                    f"Intermediate executor '{intermediate_id}' is not present in the workflow graph",
+                    validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+                )
+
+            intermediate_executor = self._executors[intermediate_id]
+            if not intermediate_executor.workflow_output_types:
+                raise WorkflowValidationError(
+                    f"Intermediate executor '{intermediate_id}' must have output type annotations defined.",
                     validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
                 )
 
@@ -415,6 +438,7 @@ def validate_workflow_graph(
     executors: dict[str, Executor],
     start_executor: Executor,
     output_executors: list[str],
+    intermediate_executors: list[str] | None = None,
 ) -> None:
     """Convenience function to validate a workflow graph.
 
@@ -423,6 +447,7 @@ def validate_workflow_graph(
         executors: Map of executor IDs to executor instances
         start_executor: The starting executor instance
         output_executors: List of output executor IDs
+        intermediate_executors: List of intermediate executor IDs
 
     Raises:
         WorkflowValidationError: If any validation fails
@@ -433,4 +458,5 @@ def validate_workflow_graph(
         executors,
         start_executor,
         output_executors,
+        intermediate_executors,
     )

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -198,8 +198,10 @@ class Workflow(DictConvertible):
                 better observability and management.
             description: Optional description of what the workflow does. If the workflow is built using
                 WorkflowBuilder, this will be the description of the builder.
-            output_executors: Optional list of executor IDs whose outputs will be considered workflow outputs.
-                              If None or empty, all executor outputs are treated as workflow outputs.
+            output_executors: List of executor IDs designated as terminal outputs, or
+                ``None`` for legacy mode (every yield is ``type='output'``). Any list
+                (including ``[]``) opts into strict mode where only designated yields are
+                ``type='output'``; see ``WorkflowBuilder`` for the canonical contract.
         """
         self.edge_groups = list(edge_groups)
         self.executors = dict(executors)
@@ -215,9 +217,10 @@ class Workflow(DictConvertible):
         self.graph_signature = self._compute_graph_signature()
         self.graph_signature_hash = self._hash_graph_signature(self.graph_signature)
 
-        # Output events (WorkflowEvent with type='output') from these executors are treated as workflow outputs.
-        # If None or empty, all executor outputs are considered workflow outputs.
-        self._output_executors = list(output_executors) if output_executors else list(self.executors.keys())
+        # Stored as the original nullable shape so legacy (None) and strict-no-terminals ([])
+        # are distinguishable; consumed by `_should_yield_output_event` and the runner's
+        # labeling check.
+        self._output_executors: list[str] | None = list(output_executors) if output_executors is not None else None
 
         # Store non-serializable runtime objects as private attributes
         self._runner_context = runner_context
@@ -289,7 +292,13 @@ class Workflow(DictConvertible):
         return self.executors[self.start_executor_id]
 
     def get_output_executors(self) -> list[Executor]:
-        """Get the list of output executors in the workflow."""
+        """Get the list of output executors in the workflow.
+
+        In legacy mode (no explicit ``output_executors``), returns every executor in the
+        workflow. In strict mode, returns only the designated output executors.
+        """
+        if self._output_executors is None:
+            return list(self.executors.values())
         return [self.executors[executor_id] for executor_id in self._output_executors]
 
     def get_executors_list(self) -> list[Executor]:
@@ -834,11 +843,10 @@ class Workflow(DictConvertible):
         Returns:
             True if the event should be yielded as a workflow output, False otherwise.
         """
-        # If no specific output executors are defined, yield all outputs
-        if not self._output_executors:
+        # Legacy mode: every yield is treated as a workflow output.
+        if self._output_executors is None:
             return True
-
-        # Check if the event's source executor is in the list of output executors
+        # Strict mode: only yields from designated executors are workflow outputs.
         return event.executor_id in self._output_executors
 
     # Graph signature helpers

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -11,6 +11,7 @@ import logging
 import types
 import uuid
 from collections.abc import AsyncIterable, Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from .._sessions import ContextProvider
@@ -100,6 +101,24 @@ class WorkflowRunResult(list[WorkflowEvent]):
 
 
 # region Workflow
+
+
+@dataclass(frozen=True)
+class OutputDesignation:
+    """Immutable rule for labeling executor yields as terminal vs intermediate outputs.
+
+    ``designated`` is ``None`` in legacy mode (every yield is terminal) and a
+    ``frozenset[str]`` of executor IDs in strict mode (only those yields are terminal).
+    Package-internal value type owned by ``Workflow``; not exported from ``agent_framework``.
+    """
+
+    designated: frozenset[str] | None = field(default=None)
+
+    def is_terminal(self, executor_id: str) -> bool:
+        """Return True when ``executor_id``'s yields should be labeled type='output'."""
+        if self.designated is None:
+            return True
+        return executor_id in self.designated
 
 
 class Workflow(DictConvertible):
@@ -217,10 +236,11 @@ class Workflow(DictConvertible):
         self.graph_signature = self._compute_graph_signature()
         self.graph_signature_hash = self._hash_graph_signature(self.graph_signature)
 
-        # Stored as the original nullable shape so legacy (None) and strict-no-terminals ([])
-        # are distinguishable; consumed by `_should_yield_output_event` and the runner's
-        # labeling check.
-        self._output_executors: list[str] | None = list(output_executors) if output_executors is not None else None
+        # Single value type encodes legacy (None) vs strict (frozenset, possibly empty)
+        # output-designation policy; threaded as a parameter into executor invocations.
+        self._output_designation: OutputDesignation = OutputDesignation(
+            designated=frozenset(output_executors) if output_executors is not None else None,
+        )
 
         # Store non-serializable runtime objects as private attributes
         self._runner_context = runner_context
@@ -232,6 +252,7 @@ class Workflow(DictConvertible):
             runner_context,
             self.name,
             self.graph_signature_hash,
+            self._output_designation,
             max_iterations=max_iterations,
         )
 
@@ -257,7 +278,9 @@ class Workflow(DictConvertible):
             "max_iterations": self.max_iterations,
             "edge_groups": [group.to_dict() for group in self.edge_groups],
             "executors": {executor_id: executor.to_dict() for executor_id, executor in self.executors.items()},
-            "output_executors": self._output_executors,
+            "output_executors": (
+                sorted(self._output_designation.designated) if self._output_designation.designated is not None else None
+            ),
         }
 
         if self.description is not None:
@@ -297,9 +320,19 @@ class Workflow(DictConvertible):
         In legacy mode (no explicit ``output_executors``), returns every executor in the
         workflow. In strict mode, returns only the designated output executors.
         """
-        if self._output_executors is None:
+        designated = self._output_designation.designated
+        if designated is None:
             return list(self.executors.values())
-        return [self.executors[executor_id] for executor_id in self._output_executors]
+        return [self.executors[executor_id] for executor_id in designated if executor_id in self.executors]
+
+    def is_terminal_executor(self, executor_id: str) -> bool:
+        """Return True when ``executor_id``'s yields are labeled type='output'.
+
+        Public read-only predicate over the workflow's output designation. External
+        observers (e.g., orchestration tests, DevUI mappers) should consult this rather
+        than re-encoding the rule as a set-membership check.
+        """
+        return self._output_designation.is_terminal(executor_id)
 
     def get_executors_list(self) -> list[Executor]:
         """Get the list of executors in the workflow."""
@@ -489,6 +522,7 @@ class Workflow(DictConvertible):
                 [self.__class__.__name__],
                 self._state,
                 self._runner.context,
+                output_designation=self._output_designation,
                 trace_contexts=None,
                 source_span_ids=None,
             )
@@ -640,7 +674,11 @@ class Workflow(DictConvertible):
             function_invocation_kwargs=function_invocation_kwargs,
             client_kwargs=client_kwargs,
         ):
-            if event.type == "output" and not self._should_yield_output_event(event):
+            if (
+                event.type == "output"
+                and event.executor_id is not None
+                and not self._output_designation.is_terminal(event.executor_id)
+            ):
                 continue
             if event.type == "request_info" and event.request_id in (responses or {}):
                 # Don't yield request_info events for which we have responses to send -
@@ -833,21 +871,6 @@ class Workflow(DictConvertible):
             param_name,
         )
         return {GLOBAL_KWARGS_KEY: dict(kwargs)}
-
-    def _should_yield_output_event(self, event: WorkflowEvent[Any]) -> bool:
-        """Determine if an output event should be yielded as a workflow output.
-
-        Args:
-            event: The WorkflowEvent with type='output' to evaluate.
-
-        Returns:
-            True if the event should be yielded as a workflow output, False otherwise.
-        """
-        # Legacy mode: every yield is treated as a workflow output.
-        if self._output_executors is None:
-            return True
-        # Strict mode: only yields from designated executors are workflow outputs.
-        return event.executor_id in self._output_executors
 
     # Graph signature helpers
 

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -36,6 +36,7 @@ from ._runner import Runner
 from ._runner_context import RunnerContext
 from ._state import State
 from ._typing_utils import is_instance_of, try_coerce_to_type
+from ._validation import ValidationTypeEnum, WorkflowValidationError
 
 if TYPE_CHECKING:
     from ._agent import WorkflowAgent
@@ -71,7 +72,6 @@ def _coalesce_renamed_kwarg(old_name: str, old_value: Any, new_name: str, new_va
 def _coalesce_output_from_kwarg(
     output_from: Any,
     output_executors: Any,
-    final_output_from: Any,
 ) -> Any:
     """Resolve output-selection aliases to canonical ``output_from``."""
     supplied = [
@@ -79,7 +79,6 @@ def _coalesce_output_from_kwarg(
         for name, value in (
             ("output_from", output_from),
             ("output_executors", output_executors),
-            ("final_output_from", final_output_from),
         )
         if value is not _MISSING
     ]
@@ -94,13 +93,6 @@ def _coalesce_output_from_kwarg(
             stacklevel=3,
         )
         return output_executors
-    if final_output_from is not _MISSING:
-        warnings.warn(
-            "`final_output_from` is deprecated and will be removed in a future version; use `output_from` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return final_output_from
     if output_from is not _MISSING:
         return output_from
     return None
@@ -179,7 +171,7 @@ class WorkflowRunResult(list[WorkflowEvent]):
 class OutputDesignation:
     """Immutable rule for labeling executor yields as terminal, intermediate, or hidden outputs.
 
-    ``outputs`` is ``None`` in legacy mode (every yield is terminal). In explicit mode,
+    ``outputs`` is ``None`` in omitted-selection compatibility mode (every yield is terminal). In explicit mode,
     ``outputs`` and ``intermediates`` are disjoint executor ID sets; unlisted executor
     yields are hidden from caller-facing output/intermediate events.
     Package-internal value type owned by ``Workflow``; not exported from ``agent_framework``.
@@ -295,7 +287,6 @@ class Workflow(DictConvertible):
         intermediate_output_from: list[str] | None = _MISSING,
         *,
         output_executors: list[str] | None = _MISSING,
-        final_output_from: list[str] | None = _MISSING,
         intermediate_executors: list[str] | None = _MISSING,
     ):
         """Initialize the workflow with a list of edges.
@@ -313,18 +304,17 @@ class Workflow(DictConvertible):
             description: Optional description of what the workflow does. If the workflow is built using
                 WorkflowBuilder, this will be the description of the builder.
             output_from: List of executor IDs designated as workflow outputs, or
-                ``None`` for legacy mode when ``intermediate_output_from`` is also ``None``.
+                ``None`` for omitted-selection compatibility behavior when ``intermediate_output_from`` is also
+                ``None``.
             intermediate_output_from: List of executor IDs designated as intermediate outputs.
                 In explicit designation mode, unlisted executor yields are hidden from
                 caller-facing output/intermediate events.
             output_executors: Deprecated alias for ``output_from``. Will be removed
                 in a future version.
-            final_output_from: Deprecated alias for ``output_from``. Will be removed
-                in a future version.
             intermediate_executors: Deprecated alias for ``intermediate_output_from``. Will be
                 removed in a future version.
         """
-        output_from = _coalesce_output_from_kwarg(output_from, output_executors, final_output_from)
+        output_from = _coalesce_output_from_kwarg(output_from, output_executors)
         intermediate_output_from = _coalesce_renamed_kwarg(
             "intermediate_executors", intermediate_executors, "intermediate_output_from", intermediate_output_from
         )
@@ -342,8 +332,7 @@ class Workflow(DictConvertible):
         self.graph_signature = self._compute_graph_signature()
         self.graph_signature_hash = self._hash_graph_signature(self.graph_signature)
 
-        # Single value type encodes legacy vs explicit output-designation policy;
-        # threaded as a parameter into executor invocations.
+        # Single value type encodes omitted-selection compatibility vs explicit output-designation policy.
         output_designation_ids = (
             frozenset(output_from)
             if output_from is not None
@@ -356,6 +345,7 @@ class Workflow(DictConvertible):
 
         # Store non-serializable runtime objects as private attributes
         self._runner_context = runner_context
+        self._runner_context.set_yield_output_classifier(self._output_designation.classify)
         self._state = State()
         self._runner: Runner = Runner(
             self.edge_groups,
@@ -364,7 +354,6 @@ class Workflow(DictConvertible):
             runner_context,
             self.name,
             self.graph_signature_hash,
-            self._output_designation,
             max_iterations=max_iterations,
         )
 
@@ -432,21 +421,29 @@ class Workflow(DictConvertible):
     def get_output_executors(self) -> list[Executor]:
         """Get the list of output executors in the workflow.
 
-        In legacy mode (no explicit ``output_from``), returns every executor in the
-        workflow. In strict mode, returns only the designated output executors.
+        In omitted-selection compatibility mode (no explicit ``output_from``), returns every
+        executor in the workflow. In explicit mode, returns only the designated output executors.
         """
         designated = self._output_designation.outputs
         if designated is None:
             return list(self.executors.values())
-        return [self.executors[executor_id] for executor_id in designated if executor_id in self.executors]
+        return [self._get_designated_executor(executor_id, kind="Output") for executor_id in designated]
 
     def get_intermediate_executors(self) -> list[Executor]:
         """Get the list of intermediate executors in the workflow."""
         return [
-            self.executors[executor_id]
+            self._get_designated_executor(executor_id, kind="Intermediate")
             for executor_id in self._output_designation.intermediates
-            if executor_id in self.executors
         ]
+
+    def _get_designated_executor(self, executor_id: str, *, kind: str) -> Executor:
+        try:
+            return self.executors[executor_id]
+        except KeyError as exc:
+            raise WorkflowValidationError(
+                f"{kind} executor '{executor_id}' is not present in the workflow graph",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            ) from exc
 
     def is_terminal_executor(self, executor_id: str) -> bool:
         """Return True when ``executor_id``'s yields are labeled type='output'.
@@ -649,7 +646,6 @@ class Workflow(DictConvertible):
                 [self.__class__.__name__],
                 self._state,
                 self._runner.context,
-                output_designation=self._output_designation,
                 trace_contexts=None,
                 source_span_ids=None,
             )
@@ -801,12 +797,6 @@ class Workflow(DictConvertible):
             function_invocation_kwargs=function_invocation_kwargs,
             client_kwargs=client_kwargs,
         ):
-            if (
-                event.type == "output"
-                and event.executor_id is not None
-                and not self._output_designation.is_terminal(event.executor_id)
-            ):
-                continue
             if event.type == "request_info" and event.request_id in (responses or {}):
                 # Don't yield request_info events for which we have responses to send -
                 # these are considered "handled". This prevents the caller from seeing

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -10,6 +10,7 @@ import json
 import logging
 import types
 import uuid
+import warnings
 from collections.abc import AsyncIterable, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -40,6 +41,31 @@ if TYPE_CHECKING:
     from ._agent import WorkflowAgent
 
 logger = logging.getLogger(__name__)
+
+
+_MISSING: Any = object()
+
+
+def _coalesce_renamed_kwarg(old_name: str, old_value: Any, new_name: str, new_value: Any) -> Any:
+    """Resolve a renamed keyword argument while keeping the deprecated name working.
+
+    Pass ``_MISSING`` (not ``None``) for the value that was not supplied — ``None`` is
+    a legitimate user-supplied value for these kwargs.
+    """
+    old_supplied = old_value is not _MISSING
+    new_supplied = new_value is not _MISSING
+    if old_supplied and new_supplied:
+        raise TypeError(f"Cannot pass both `{old_name}` (deprecated) and `{new_name}`; use `{new_name}` only.")
+    if old_supplied:
+        warnings.warn(
+            f"`{old_name}` is deprecated and will be removed in a future version; use `{new_name}` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return old_value
+    if new_supplied:
+        return new_value
+    return None
 
 
 class WorkflowRunResult(list[WorkflowEvent]):
@@ -227,8 +253,11 @@ class Workflow(DictConvertible):
         name: str,
         description: str | None = None,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
-        output_executors: list[str] | None = None,
-        intermediate_executors: list[str] | None = None,
+        final_output_from: list[str] | None = _MISSING,
+        intermediate_output_from: list[str] | None = _MISSING,
+        *,
+        output_executors: list[str] | None = _MISSING,
+        intermediate_executors: list[str] | None = _MISSING,
     ):
         """Initialize the workflow with a list of edges.
 
@@ -244,12 +273,22 @@ class Workflow(DictConvertible):
                 better observability and management.
             description: Optional description of what the workflow does. If the workflow is built using
                 WorkflowBuilder, this will be the description of the builder.
-            output_executors: List of executor IDs designated as terminal outputs, or
-                ``None`` for legacy mode when ``intermediate_executors`` is also ``None``.
-            intermediate_executors: List of executor IDs designated as intermediate outputs.
+            final_output_from: List of executor IDs designated as terminal outputs, or
+                ``None`` for legacy mode when ``intermediate_output_from`` is also ``None``.
+            intermediate_output_from: List of executor IDs designated as intermediate outputs.
                 In explicit designation mode, unlisted executor yields are hidden from
                 caller-facing output/intermediate events.
+            output_executors: Deprecated alias for ``final_output_from``. Will be removed
+                in a future version.
+            intermediate_executors: Deprecated alias for ``intermediate_output_from``. Will be
+                removed in a future version.
         """
+        final_output_from = _coalesce_renamed_kwarg(
+            "output_executors", output_executors, "final_output_from", final_output_from
+        )
+        intermediate_output_from = _coalesce_renamed_kwarg(
+            "intermediate_executors", intermediate_executors, "intermediate_output_from", intermediate_output_from
+        )
         self.edge_groups = list(edge_groups)
         self.executors = dict(executors)
         self.start_executor_id = start_executor.id
@@ -267,13 +306,13 @@ class Workflow(DictConvertible):
         # Single value type encodes legacy vs explicit output-designation policy;
         # threaded as a parameter into executor invocations.
         output_designation_ids = (
-            frozenset(output_executors)
-            if output_executors is not None
-            else (frozenset[str]() if intermediate_executors is not None else None)
+            frozenset(final_output_from)
+            if final_output_from is not None
+            else (frozenset[str]() if intermediate_output_from is not None else None)
         )
         self._output_designation: OutputDesignation = OutputDesignation(
             outputs=output_designation_ids,
-            intermediates=frozenset(intermediate_executors or []),
+            intermediates=frozenset(intermediate_output_from or []),
         )
 
         # Store non-serializable runtime objects as private attributes

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -74,6 +74,14 @@ class WorkflowRunResult(list[WorkflowEvent]):
         """
         return [event.data for event in self if event.type == "output"]
 
+    def get_intermediate_outputs(self) -> list[Any]:
+        """Get all intermediate outputs from the workflow run result.
+
+        Returns:
+            A list of intermediate outputs produced by the workflow during its execution.
+        """
+        return [event.data for event in self if event.type == "intermediate"]
+
     def get_request_info_events(self) -> list[WorkflowEvent[Any]]:
         """Get all request info events from the workflow run result.
 
@@ -105,20 +113,38 @@ class WorkflowRunResult(list[WorkflowEvent]):
 
 @dataclass(frozen=True)
 class OutputDesignation:
-    """Immutable rule for labeling executor yields as terminal vs intermediate outputs.
+    """Immutable rule for labeling executor yields as terminal, intermediate, or hidden outputs.
 
-    ``designated`` is ``None`` in legacy mode (every yield is terminal) and a
-    ``frozenset[str]`` of executor IDs in strict mode (only those yields are terminal).
+    ``outputs`` is ``None`` in legacy mode (every yield is terminal). In explicit mode,
+    ``outputs`` and ``intermediates`` are disjoint executor ID sets; unlisted executor
+    yields are hidden from caller-facing output/intermediate events.
     Package-internal value type owned by ``Workflow``; not exported from ``agent_framework``.
     """
 
-    designated: frozenset[str] | None = field(default=None)
+    outputs: frozenset[str] | None = field(default=None)
+    intermediates: frozenset[str] = field(default_factory=lambda: frozenset[str]())
 
     def is_terminal(self, executor_id: str) -> bool:
         """Return True when ``executor_id``'s yields should be labeled type='output'."""
-        if self.designated is None:
+        if self.outputs is None:
             return True
-        return executor_id in self.designated
+        return executor_id in self.outputs
+
+    def is_intermediate(self, executor_id: str) -> bool:
+        """Return True when ``executor_id``'s yields should be labeled type='intermediate'."""
+        if self.outputs is None:
+            return False
+        return executor_id in self.intermediates
+
+    def classify(self, executor_id: str) -> Literal["output", "intermediate"] | None:
+        """Return the workflow event type for this executor's yield, or None when hidden."""
+        if self.outputs is None:
+            return "output"
+        if executor_id in self.outputs:
+            return "output"
+        if executor_id in self.intermediates:
+            return "intermediate"
+        return None
 
 
 class Workflow(DictConvertible):
@@ -202,6 +228,7 @@ class Workflow(DictConvertible):
         description: str | None = None,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
         output_executors: list[str] | None = None,
+        intermediate_executors: list[str] | None = None,
     ):
         """Initialize the workflow with a list of edges.
 
@@ -218,9 +245,10 @@ class Workflow(DictConvertible):
             description: Optional description of what the workflow does. If the workflow is built using
                 WorkflowBuilder, this will be the description of the builder.
             output_executors: List of executor IDs designated as terminal outputs, or
-                ``None`` for legacy mode (every yield is ``type='output'``). Any list
-                (including ``[]``) opts into strict mode where only designated yields are
-                ``type='output'``; see ``WorkflowBuilder`` for the canonical contract.
+                ``None`` for legacy mode when ``intermediate_executors`` is also ``None``.
+            intermediate_executors: List of executor IDs designated as intermediate outputs.
+                In explicit designation mode, unlisted executor yields are hidden from
+                caller-facing output/intermediate events.
         """
         self.edge_groups = list(edge_groups)
         self.executors = dict(executors)
@@ -236,10 +264,16 @@ class Workflow(DictConvertible):
         self.graph_signature = self._compute_graph_signature()
         self.graph_signature_hash = self._hash_graph_signature(self.graph_signature)
 
-        # Single value type encodes legacy (None) vs strict (frozenset, possibly empty)
-        # output-designation policy; threaded as a parameter into executor invocations.
+        # Single value type encodes legacy vs explicit output-designation policy;
+        # threaded as a parameter into executor invocations.
+        output_designation_ids = (
+            frozenset(output_executors)
+            if output_executors is not None
+            else (frozenset[str]() if intermediate_executors is not None else None)
+        )
         self._output_designation: OutputDesignation = OutputDesignation(
-            designated=frozenset(output_executors) if output_executors is not None else None,
+            outputs=output_designation_ids,
+            intermediates=frozenset(intermediate_executors or []),
         )
 
         # Store non-serializable runtime objects as private attributes
@@ -279,7 +313,10 @@ class Workflow(DictConvertible):
             "edge_groups": [group.to_dict() for group in self.edge_groups],
             "executors": {executor_id: executor.to_dict() for executor_id, executor in self.executors.items()},
             "output_executors": (
-                sorted(self._output_designation.designated) if self._output_designation.designated is not None else None
+                sorted(self._output_designation.outputs) if self._output_designation.outputs is not None else None
+            ),
+            "intermediate_executors": (
+                sorted(self._output_designation.intermediates) if self._output_designation.outputs is not None else None
             ),
         }
 
@@ -320,10 +357,18 @@ class Workflow(DictConvertible):
         In legacy mode (no explicit ``output_executors``), returns every executor in the
         workflow. In strict mode, returns only the designated output executors.
         """
-        designated = self._output_designation.designated
+        designated = self._output_designation.outputs
         if designated is None:
             return list(self.executors.values())
         return [self.executors[executor_id] for executor_id in designated if executor_id in self.executors]
+
+    def get_intermediate_executors(self) -> list[Executor]:
+        """Get the list of intermediate executors in the workflow."""
+        return [
+            self.executors[executor_id]
+            for executor_id in self._output_designation.intermediates
+            if executor_id in self.executors
+        ]
 
     def is_terminal_executor(self, executor_id: str) -> bool:
         """Return True when ``executor_id``'s yields are labeled type='output'.
@@ -333,6 +378,10 @@ class Workflow(DictConvertible):
         than re-encoding the rule as a set-membership check.
         """
         return self._output_designation.is_terminal(executor_id)
+
+    def is_intermediate_executor(self, executor_id: str) -> bool:
+        """Return True when ``executor_id``'s yields are labeled type='intermediate'."""
+        return self._output_designation.is_intermediate(executor_id)
 
     def get_executors_list(self) -> list[Executor]:
         """Get the list of executors in the workflow."""

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -68,6 +68,44 @@ def _coalesce_renamed_kwarg(old_name: str, old_value: Any, new_name: str, new_va
     return None
 
 
+def _coalesce_output_from_kwarg(
+    output_from: Any,
+    output_executors: Any,
+    final_output_from: Any,
+) -> Any:
+    """Resolve output-selection aliases to canonical ``output_from``."""
+    supplied = [
+        name
+        for name, value in (
+            ("output_from", output_from),
+            ("output_executors", output_executors),
+            ("final_output_from", final_output_from),
+        )
+        if value is not _MISSING
+    ]
+    if len(supplied) > 1:
+        formatted = ", ".join(f"`{name}`" for name in supplied)
+        raise TypeError(f"Cannot pass multiple workflow output selection parameters ({formatted}); use `output_from`.")
+
+    if output_executors is not _MISSING:
+        warnings.warn(
+            "`output_executors` is deprecated and will be removed in a future version; use `output_from` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return output_executors
+    if final_output_from is not _MISSING:
+        warnings.warn(
+            "`final_output_from` is deprecated and will be removed in a future version; use `output_from` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return final_output_from
+    if output_from is not _MISSING:
+        return output_from
+    return None
+
+
 class WorkflowRunResult(list[WorkflowEvent]):
     """Container for events generated during non-streaming workflow execution.
 
@@ -253,10 +291,11 @@ class Workflow(DictConvertible):
         name: str,
         description: str | None = None,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
-        final_output_from: list[str] | None = _MISSING,
+        output_from: list[str] | None = _MISSING,
         intermediate_output_from: list[str] | None = _MISSING,
         *,
         output_executors: list[str] | None = _MISSING,
+        final_output_from: list[str] | None = _MISSING,
         intermediate_executors: list[str] | None = _MISSING,
     ):
         """Initialize the workflow with a list of edges.
@@ -273,19 +312,19 @@ class Workflow(DictConvertible):
                 better observability and management.
             description: Optional description of what the workflow does. If the workflow is built using
                 WorkflowBuilder, this will be the description of the builder.
-            final_output_from: List of executor IDs designated as terminal outputs, or
+            output_from: List of executor IDs designated as workflow outputs, or
                 ``None`` for legacy mode when ``intermediate_output_from`` is also ``None``.
             intermediate_output_from: List of executor IDs designated as intermediate outputs.
                 In explicit designation mode, unlisted executor yields are hidden from
                 caller-facing output/intermediate events.
-            output_executors: Deprecated alias for ``final_output_from``. Will be removed
+            output_executors: Deprecated alias for ``output_from``. Will be removed
+                in a future version.
+            final_output_from: Deprecated alias for ``output_from``. Will be removed
                 in a future version.
             intermediate_executors: Deprecated alias for ``intermediate_output_from``. Will be
                 removed in a future version.
         """
-        final_output_from = _coalesce_renamed_kwarg(
-            "output_executors", output_executors, "final_output_from", final_output_from
-        )
+        output_from = _coalesce_output_from_kwarg(output_from, output_executors, final_output_from)
         intermediate_output_from = _coalesce_renamed_kwarg(
             "intermediate_executors", intermediate_executors, "intermediate_output_from", intermediate_output_from
         )
@@ -306,8 +345,8 @@ class Workflow(DictConvertible):
         # Single value type encodes legacy vs explicit output-designation policy;
         # threaded as a parameter into executor invocations.
         output_designation_ids = (
-            frozenset(final_output_from)
-            if final_output_from is not None
+            frozenset(output_from)
+            if output_from is not None
             else (frozenset[str]() if intermediate_output_from is not None else None)
         )
         self._output_designation: OutputDesignation = OutputDesignation(
@@ -393,7 +432,7 @@ class Workflow(DictConvertible):
     def get_output_executors(self) -> list[Executor]:
         """Get the list of output executors in the workflow.
 
-        In legacy mode (no explicit ``output_executors``), returns every executor in the
+        In legacy mode (no explicit ``output_from``), returns every executor in the
         workflow. In strict mode, returns only the designated output executors.
         """
         designated = self._output_designation.outputs

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import uuid
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -98,8 +99,15 @@ class WorkflowBuilder:
             start_executor: The starting executor for the workflow. Can be an Executor instance
                 or SupportsAgentRun instance.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_executors: Optional list of executors whose outputs should be collected.
-                If not provided, outputs from all executors are collected.
+            output_executors: Designates which executors emit terminal output (``type='output'``
+                workflow events). Three-state contract:
+
+                - **Unset (default):** legacy mode. Every ``yield_output`` produces ``type='output'``.
+                  A ``DeprecationWarning`` is raised at ``build()`` recommending explicit designation.
+                - **``[]`` (explicit empty list):** strict mode with no terminals. Every ``yield_output``
+                  produces ``type='intermediate'``. ``WorkflowRunResult.get_outputs()`` returns ``[]``.
+                - **``[X, ...]`` (explicit list):** strict mode. Yields from designated executors
+                  produce ``type='output'``; all other yields produce ``type='intermediate'``.
         """
         self._edge_groups: list[EdgeGroup] = []
         self._executors: dict[str, Executor] = {}
@@ -113,8 +121,12 @@ class WorkflowBuilder:
         # being created for the same agent.
         self._agent_wrappers: dict[str, Executor] = {}
 
-        # Output executors filter; if set, only outputs from these executors are yielded
-        self._output_executors: list[Executor | SupportsAgentRun] = output_executors if output_executors else []
+        # Output executors filter. ``None`` means legacy mode (every yield_output produces
+        # type='output'). Any list (including ``[]``) opts into strict mode — designated
+        # executors emit type='output', all other executors emit type='intermediate'.
+        self._output_executors: list[Executor | SupportsAgentRun] | None = (
+            list(output_executors) if output_executors is not None else None
+        )
 
         # Set the start executor
         self._set_start_executor(start_executor)
@@ -637,19 +649,39 @@ class WorkflowBuilder:
                         "Starting executor must be set via the start_executor constructor parameter before building."
                     )
 
+                if self._output_executors is None:
+                    warnings.warn(
+                        "WorkflowBuilder built without explicit output_executors; every yield_output "
+                        "produces type='output' (legacy default). Pass output_executors=[...] to opt "
+                        "into the strict contract — explicit designation will be required in a future "
+                        "major release.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+
                 start_executor = self._start_executor
                 executors = self._executors
                 edge_groups = self._edge_groups
-                output_executors = [ex.id for ex in self._output_executors if isinstance(ex, Executor)] + [
-                    resolve_agent_id(agent) for agent in self._output_executors if isinstance(agent, SupportsAgentRun)
-                ]
+                # Resolve designated executor ids when output_executors was passed explicitly.
+                # Legacy mode (None) and strict mode (any list) are distinguished here once;
+                # both the runner context and the Workflow receive a single shape.
+                output_executors_for_workflow: list[str] | None = (
+                    [ex.id for ex in self._output_executors if isinstance(ex, Executor)]
+                    + [
+                        resolve_agent_id(agent)
+                        for agent in self._output_executors
+                        if isinstance(agent, SupportsAgentRun)
+                    ]
+                    if self._output_executors is not None
+                    else None
+                )
 
                 # Perform validation before creating the workflow
                 validate_workflow_graph(
                     edge_groups,
                     executors,
                     start_executor,
-                    output_executors,
+                    output_executors_for_workflow or [],
                 )
 
                 # Add validation completed event
@@ -666,8 +698,13 @@ class WorkflowBuilder:
                     self._name,
                     description=self._description,
                     max_iterations=self._max_iterations,
-                    output_executors=output_executors,
+                    output_executors=output_executors_for_workflow,
                 )
+                # Bind the runner context to the workflow so the runner can consult it as
+                # the single source of truth for output-event labeling. Both objects must
+                # exist first (the workflow needs the context for its Runner), so the
+                # back-reference is assigned here as the last step of build().
+                context._workflow = workflow
                 build_attributes: dict[str, Any] = {
                     OtelAttr.WORKFLOW_BUILDER_NAME: self._name,
                     OtelAttr.WORKFLOW_ID: workflow.id,

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -700,11 +700,6 @@ class WorkflowBuilder:
                     max_iterations=self._max_iterations,
                     output_executors=output_executors_for_workflow,
                 )
-                # Bind the runner context to the workflow so the runner can consult it as
-                # the single source of truth for output-event labeling. Both objects must
-                # exist first (the workflow needs the context for its Runner), so the
-                # back-reference is assigned here as the last step of build().
-                context._workflow = workflow
                 build_attributes: dict[str, Any] = {
                     OtelAttr.WORKFLOW_BUILDER_NAME: self._name,
                     OtelAttr.WORKFLOW_ID: workflow.id,

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -32,7 +32,7 @@ from ._validation import ValidationTypeEnum, WorkflowValidationError, validate_w
 from ._workflow import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     Workflow,
-    _coalesce_renamed_kwarg,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from_kwarg,  # pyright: ignore[reportPrivateUsage]
 )
 
 if sys.version_info >= (3, 11):
@@ -88,10 +88,10 @@ class WorkflowBuilder:
         *,
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
-        final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
+        output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
         intermediate_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
         output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
-        intermediate_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
+        final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
     ):
         """Initialize the WorkflowBuilder.
 
@@ -106,25 +106,22 @@ class WorkflowBuilder:
             start_executor: The starting executor for the workflow. Can be an Executor instance
                 or SupportsAgentRun instance.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            final_output_from: Designates which executors emit terminal output
+            output_from: Designates which executors emit workflow output
                 (``type='output'`` workflow events).
             intermediate_output_from: Designates which executors emit intermediate output
-                (``type='intermediate'`` workflow events). If neither ``final_output_from`` nor
+                (``type='intermediate'`` workflow events). If neither ``output_from`` nor
                 ``intermediate_output_from`` is provided, legacy mode applies and every
                 ``yield_output`` produces ``type='output'``. If either is provided, explicit
-                mode applies: listed final-output executors emit ``output``, listed intermediate
+                mode applies: listed workflow-output executors emit ``output``, listed intermediate
                 executors emit ``intermediate``, and unlisted executor yields are hidden.
-            output_executors: Deprecated alias for ``final_output_from``. Will be removed in a
+            output_executors: Deprecated alias for ``output_from``. Will be removed in a
                 future version.
-            intermediate_executors: Deprecated alias for ``intermediate_output_from``. Will be
-                removed in a future version.
+            final_output_from: Deprecated alias for ``output_from``. Will be removed in a
+                future version.
         """
-        final_output_from = _coalesce_renamed_kwarg(
-            "output_executors", output_executors, "final_output_from", final_output_from
-        )
-        intermediate_output_from = _coalesce_renamed_kwarg(
-            "intermediate_executors", intermediate_executors, "intermediate_output_from", intermediate_output_from
-        )
+        output_from = _coalesce_output_from_kwarg(output_from, output_executors, final_output_from)
+        if intermediate_output_from is _MISSING:
+            intermediate_output_from = None
         self._edge_groups: list[EdgeGroup] = []
         self._executors: dict[str, Executor] = {}
         self._start_executor: Executor | None = None
@@ -139,8 +136,8 @@ class WorkflowBuilder:
 
         # ``None`` for both means legacy mode (every yield_output produces type='output').
         # If either is provided, explicit mode applies and unlisted executor yields are hidden.
-        self._final_output_from: list[Executor | SupportsAgentRun] | None = (
-            list(final_output_from) if final_output_from is not None else None
+        self._output_from: list[Executor | SupportsAgentRun] | None = (
+            list(output_from) if output_from is not None else None
         )
         self._intermediate_output_from: list[Executor | SupportsAgentRun] | None = (
             list(intermediate_output_from) if intermediate_output_from is not None else None
@@ -728,10 +725,10 @@ class WorkflowBuilder:
                         "Starting executor must be set via the start_executor constructor parameter before building."
                     )
 
-                if self._final_output_from is None and self._intermediate_output_from is None:
+                if self._output_from is None and self._intermediate_output_from is None:
                     warnings.warn(
-                        "WorkflowBuilder built without explicit final_output_from or intermediate_output_from; "
-                        "every yield_output produces type='output' (legacy default). Pass final_output_from=[...] "
+                        "WorkflowBuilder built without explicit output_from or intermediate_output_from; "
+                        "every yield_output produces type='output' (legacy default). Pass output_from=[...] "
                         "or intermediate_output_from=[...] to opt into explicit designation — explicit designation "
                         "will be required in a future version.",
                         DeprecationWarning,
@@ -741,7 +738,7 @@ class WorkflowBuilder:
                 start_executor = self._start_executor
                 executors = self._executors
                 edge_groups = self._edge_groups
-                final_output_ids = self._resolve_designated_executor_ids(self._final_output_from)
+                final_output_ids = self._resolve_designated_executor_ids(self._output_from)
                 intermediate_output_ids = self._resolve_designated_executor_ids(self._intermediate_output_from)
                 self._validate_designation_lists(final_output_ids, intermediate_output_ids)
 
@@ -776,7 +773,7 @@ class WorkflowBuilder:
                     self._name,
                     description=self._description,
                     max_iterations=self._max_iterations,
-                    final_output_from=final_output_for_workflow,
+                    output_from=final_output_for_workflow,
                     intermediate_output_from=intermediate_output_for_workflow,
                 )
                 build_attributes: dict[str, Any] = {

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -97,7 +97,6 @@ class WorkflowBuilder:
         output_from: list[Executor | SupportsAgentRun] | Literal["all"] | None = _MISSING,
         intermediate_output_from: list[Executor | SupportsAgentRun] | Literal["all_other"] | None = _MISSING,
         output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
-        final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
     ):
         """Initialize the WorkflowBuilder.
 
@@ -118,17 +117,29 @@ class WorkflowBuilder:
             intermediate_output_from: Designates which executors emit intermediate output
                 (``type='intermediate'`` workflow events). Pass ``"all_other"`` to select every
                 executor with declared workflow output types that is not selected by ``output_from``.
-                If neither ``output_from`` nor ``intermediate_output_from`` is provided, legacy
-                mode applies and every ``yield_output`` produces ``type='output'``. If either is
-                provided, explicit mode applies: listed workflow-output executors emit ``output``,
-                listed intermediate executors emit ``intermediate``, and unlisted executor yields
-                are hidden.
-            output_executors: Deprecated alias for ``output_from``. Will be removed in a
-                future version.
-            final_output_from: Deprecated alias for ``output_from``. Will be removed in a
+                If neither ``output_from`` nor ``intermediate_output_from`` is provided,
+                omitted-selection compatibility behavior applies and every ``yield_output`` produces
+                ``type='output'``. If either is provided, explicit mode applies: listed
+                workflow-output executors emit ``output``, listed intermediate executors emit
+                ``intermediate``, and unlisted executor yields are hidden.
+
+                Output selection behavior:
+                - Omit both selections: every ``yield_output`` emits ``output`` for compatibility,
+                  with a deprecation warning.
+                - ``output_from="all"``: every output-capable executor emits ``output``.
+                - ``output_from=[A]``: only A emits ``output``; other executor payloads are hidden.
+                - ``output_from=[A], intermediate_output_from="all_other"``: A emits ``output``;
+                  all other output-capable executors emit ``intermediate``.
+                - ``intermediate_output_from="all_other"``: no executor emits ``output``; every
+                  output-capable executor emits ``intermediate``.
+                - ``output_from=[], intermediate_output_from="all_other"``: no executor emits
+                  ``output``; every output-capable executor emits ``intermediate``.
+                - ``output_from=[A], intermediate_output_from=[B, C]``: A emits ``output``; B and C
+                  emit ``intermediate``; other executor payloads are hidden.
+            output_executors: **Deprecated** alias for ``output_from``. Will be removed in a
                 future version.
         """
-        output_from = _coalesce_output_from_kwarg(output_from, output_executors, final_output_from)
+        output_from = _coalesce_output_from_kwarg(output_from, output_executors)
         if intermediate_output_from is _MISSING:
             intermediate_output_from = None
         self._edge_groups: list[EdgeGroup] = []
@@ -143,7 +154,8 @@ class WorkflowBuilder:
         # being created for the same agent.
         self._agent_wrappers: dict[str, Executor] = {}
 
-        # ``None`` for both means legacy mode (every yield_output produces type='output').
+        # ``None`` for both means omitted-selection compatibility behavior
+        # (every yield_output produces type='output').
         # If either is provided, explicit mode applies and unlisted executor yields are hidden.
         self._output_from: _OutputSelection = self._coerce_output_from(output_from)
         self._intermediate_output_from: _IntermediateOutputSelection = self._coerce_intermediate_output_from(
@@ -672,7 +684,7 @@ class WorkflowBuilder:
         output_executor_ids: list[str] | None,
         intermediate_executor_ids: list[str] | None,
     ) -> None:
-        """Validate builder-level designation rules that need legacy-vs-explicit context."""
+        """Validate builder-level designation rules that need omitted-vs-explicit context."""
         explicit_mode = output_executor_ids is not None or intermediate_executor_ids is not None
         if not explicit_mode:
             return
@@ -749,6 +761,43 @@ class WorkflowBuilder:
                 # Workflows can be reused multiple times
                 events2 = await workflow.run("world")
                 print(events2.get_outputs())  # ['WORLD']
+
+                # Select one executor as Workflow Output.
+                workflow = WorkflowBuilder(start_executor=executor, output_from=[executor]).build()
+                events = await workflow.run("hello")
+                print(events.get_outputs())  # ['HELLO']
+                print(events.get_intermediate_outputs())  # []
+
+                # Make one executor Workflow Output and every other output-capable executor Intermediate Output.
+                workflow = (
+                    WorkflowBuilder(
+                        start_executor=planner,
+                        output_from=[answerer],
+                        intermediate_output_from="all_other",
+                    )
+                    .add_edge(planner, answerer)
+                    .build()
+                )
+                events = await workflow.run("hello")
+                print(events.get_outputs())  # outputs from answerer
+                print(events.get_intermediate_outputs())  # outputs from planner
+
+                # Build a progress-only workflow: no Workflow Output, all output-capable executors are intermediate.
+                workflow = (
+                    WorkflowBuilder(start_executor=planner, intermediate_output_from="all_other")
+                    .add_edge(planner, answerer)
+                    .build()
+                )
+                events = await workflow.run("hello")
+                print(events.get_outputs())  # []
+                print(events.get_intermediate_outputs())  # outputs from planner and answerer
+
+                # Explicitly preserve all-output behavior without relying on omitted-selection compatibility.
+                workflow = (
+                    WorkflowBuilder(start_executor=planner, output_from="all").add_edge(planner, answerer).build()
+                )
+                events = await workflow.run("hello")
+                print(events.get_outputs())  # outputs from planner and answerer
         """
         # Create workflow build span that includes validation and workflow creation
         with create_workflow_span(OtelAttr.WORKFLOW_BUILD_SPAN) as span:
@@ -764,8 +813,8 @@ class WorkflowBuilder:
                 if self._output_from is None and self._intermediate_output_from is None:
                     warnings.warn(
                         "WorkflowBuilder built without explicit output_from or intermediate_output_from; "
-                        "every yield_output produces type='output' (legacy default). Pass output_from='all', "
-                        "output_from=[...], or intermediate_output_from=[...] to opt into explicit designation — "
+                        "every yield_output produces type='output' for compatibility. Pass output_from='all', "
+                        "output_from=[...], or intermediate_output_from=[...] to opt into explicit designation - "
                         "explicit designation will be required in a future version.",
                         DeprecationWarning,
                         stacklevel=2,
@@ -774,9 +823,9 @@ class WorkflowBuilder:
                 start_executor = self._start_executor
                 executors = self._executors
                 edge_groups = self._edge_groups
-                final_output_ids = self._resolve_designated_executor_ids(self._output_from)
+                output_ids = self._resolve_designated_executor_ids(self._output_from)
                 if self._intermediate_output_from == _ALL_OTHER_OUTPUTS:
-                    output_ids_for_all_other = final_output_ids or []
+                    output_ids_for_all_other = output_ids or []
                     intermediate_output_ids = [
                         executor_id
                         for executor_id, executor in self._executors.items()
@@ -784,12 +833,12 @@ class WorkflowBuilder:
                     ]
                 else:
                     intermediate_output_ids = self._resolve_designated_executor_ids(self._intermediate_output_from)
-                self._validate_designation_lists(final_output_ids, intermediate_output_ids)
+                self._validate_designation_lists(output_ids, intermediate_output_ids)
 
-                explicit_mode = final_output_ids is not None or intermediate_output_ids is not None
-                final_output_for_workflow: list[str] | None = final_output_ids if explicit_mode else None
-                if explicit_mode and final_output_for_workflow is None:
-                    final_output_for_workflow = []
+                explicit_mode = output_ids is not None or intermediate_output_ids is not None
+                output_for_workflow: list[str] | None = output_ids if explicit_mode else None
+                if explicit_mode and output_for_workflow is None:
+                    output_for_workflow = []
                 intermediate_output_for_workflow: list[str] | None = intermediate_output_ids if explicit_mode else None
                 if explicit_mode and intermediate_output_for_workflow is None:
                     intermediate_output_for_workflow = []
@@ -799,7 +848,7 @@ class WorkflowBuilder:
                     edge_groups,
                     executors,
                     start_executor,
-                    final_output_for_workflow or [],
+                    output_for_workflow or [],
                     intermediate_output_for_workflow or [],
                 )
 
@@ -817,7 +866,7 @@ class WorkflowBuilder:
                     self._name,
                     description=self._description,
                     max_iterations=self._max_iterations,
-                    output_from=final_output_for_workflow,
+                    output_from=output_for_workflow,
                     intermediate_output_from=intermediate_output_for_workflow,
                 )
                 build_attributes: dict[str, Any] = {

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -29,7 +29,7 @@ from ._edge import (
 from ._executor import Executor
 from ._runner_context import InProcRunnerContext
 from ._validation import ValidationTypeEnum, WorkflowValidationError, validate_workflow_graph
-from ._workflow import Workflow
+from ._workflow import _MISSING, Workflow, _coalesce_renamed_kwarg
 
 if sys.version_info >= (3, 11):
     from typing import Self  # type: ignore # pragma: no cover
@@ -84,8 +84,10 @@ class WorkflowBuilder:
         *,
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_executors: list[Executor | SupportsAgentRun] | None = None,
-        intermediate_executors: list[Executor | SupportsAgentRun] | None = None,
+        final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
+        intermediate_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
+        output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
+        intermediate_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
     ):
         """Initialize the WorkflowBuilder.
 
@@ -100,15 +102,25 @@ class WorkflowBuilder:
             start_executor: The starting executor for the workflow. Can be an Executor instance
                 or SupportsAgentRun instance.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_executors: Designates which executors emit terminal output
+            final_output_from: Designates which executors emit terminal output
                 (``type='output'`` workflow events).
-            intermediate_executors: Designates which executors emit intermediate output
-                (``type='intermediate'`` workflow events). If neither output nor intermediate
-                designation is provided, legacy mode applies and every ``yield_output`` produces
-                ``type='output'``. If either designation is provided, explicit mode applies:
-                listed output executors emit ``output``, listed intermediate executors emit
-                ``intermediate``, and unlisted executor yields are hidden.
+            intermediate_output_from: Designates which executors emit intermediate output
+                (``type='intermediate'`` workflow events). If neither ``final_output_from`` nor
+                ``intermediate_output_from`` is provided, legacy mode applies and every
+                ``yield_output`` produces ``type='output'``. If either is provided, explicit
+                mode applies: listed final-output executors emit ``output``, listed intermediate
+                executors emit ``intermediate``, and unlisted executor yields are hidden.
+            output_executors: Deprecated alias for ``final_output_from``. Will be removed in a
+                future version.
+            intermediate_executors: Deprecated alias for ``intermediate_output_from``. Will be
+                removed in a future version.
         """
+        final_output_from = _coalesce_renamed_kwarg(
+            "output_executors", output_executors, "final_output_from", final_output_from
+        )
+        intermediate_output_from = _coalesce_renamed_kwarg(
+            "intermediate_executors", intermediate_executors, "intermediate_output_from", intermediate_output_from
+        )
         self._edge_groups: list[EdgeGroup] = []
         self._executors: dict[str, Executor] = {}
         self._start_executor: Executor | None = None
@@ -121,14 +133,13 @@ class WorkflowBuilder:
         # being created for the same agent.
         self._agent_wrappers: dict[str, Executor] = {}
 
-        # Output/intermediate executors filter. ``None`` for both means legacy mode
-        # (every yield_output produces type='output'). If either is provided, explicit
-        # mode applies and unlisted executor yields are hidden.
-        self._output_executors: list[Executor | SupportsAgentRun] | None = (
-            list(output_executors) if output_executors is not None else None
+        # ``None`` for both means legacy mode (every yield_output produces type='output').
+        # If either is provided, explicit mode applies and unlisted executor yields are hidden.
+        self._final_output_from: list[Executor | SupportsAgentRun] | None = (
+            list(final_output_from) if final_output_from is not None else None
         )
-        self._intermediate_executors: list[Executor | SupportsAgentRun] | None = (
-            list(intermediate_executors) if intermediate_executors is not None else None
+        self._intermediate_output_from: list[Executor | SupportsAgentRun] | None = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
         # Set the start executor
@@ -713,12 +724,12 @@ class WorkflowBuilder:
                         "Starting executor must be set via the start_executor constructor parameter before building."
                     )
 
-                if self._output_executors is None and self._intermediate_executors is None:
+                if self._final_output_from is None and self._intermediate_output_from is None:
                     warnings.warn(
-                        "WorkflowBuilder built without explicit output_executors or intermediate_executors; "
-                        "every yield_output produces type='output' (legacy default). Pass output_executors=[...] "
-                        "or intermediate_executors=[...] to opt into explicit designation — explicit designation "
-                        "will be required in a future major release.",
+                        "WorkflowBuilder built without explicit final_output_from or intermediate_output_from; "
+                        "every yield_output produces type='output' (legacy default). Pass final_output_from=[...] "
+                        "or intermediate_output_from=[...] to opt into explicit designation — explicit designation "
+                        "will be required in a future version.",
                         DeprecationWarning,
                         stacklevel=2,
                     )
@@ -726,27 +737,25 @@ class WorkflowBuilder:
                 start_executor = self._start_executor
                 executors = self._executors
                 edge_groups = self._edge_groups
-                output_executor_ids = self._resolve_designated_executor_ids(self._output_executors)
-                intermediate_executor_ids = self._resolve_designated_executor_ids(self._intermediate_executors)
-                self._validate_designation_lists(output_executor_ids, intermediate_executor_ids)
+                final_output_ids = self._resolve_designated_executor_ids(self._final_output_from)
+                intermediate_output_ids = self._resolve_designated_executor_ids(self._intermediate_output_from)
+                self._validate_designation_lists(final_output_ids, intermediate_output_ids)
 
-                explicit_mode = output_executor_ids is not None or intermediate_executor_ids is not None
-                output_executors_for_workflow: list[str] | None = output_executor_ids if explicit_mode else None
-                if explicit_mode and output_executors_for_workflow is None:
-                    output_executors_for_workflow = []
-                intermediate_executors_for_workflow: list[str] | None = (
-                    intermediate_executor_ids if explicit_mode else None
-                )
-                if explicit_mode and intermediate_executors_for_workflow is None:
-                    intermediate_executors_for_workflow = []
+                explicit_mode = final_output_ids is not None or intermediate_output_ids is not None
+                final_output_for_workflow: list[str] | None = final_output_ids if explicit_mode else None
+                if explicit_mode and final_output_for_workflow is None:
+                    final_output_for_workflow = []
+                intermediate_output_for_workflow: list[str] | None = intermediate_output_ids if explicit_mode else None
+                if explicit_mode and intermediate_output_for_workflow is None:
+                    intermediate_output_for_workflow = []
 
                 # Perform validation before creating the workflow
                 validate_workflow_graph(
                     edge_groups,
                     executors,
                     start_executor,
-                    output_executors_for_workflow or [],
-                    intermediate_executors_for_workflow or [],
+                    final_output_for_workflow or [],
+                    intermediate_output_for_workflow or [],
                 )
 
                 # Add validation completed event
@@ -763,8 +772,8 @@ class WorkflowBuilder:
                     self._name,
                     description=self._description,
                     max_iterations=self._max_iterations,
-                    output_executors=output_executors_for_workflow,
-                    intermediate_executors=intermediate_executors_for_workflow,
+                    final_output_from=final_output_for_workflow,
+                    intermediate_output_from=intermediate_output_for_workflow,
                 )
                 build_attributes: dict[str, Any] = {
                     OtelAttr.WORKFLOW_BUILDER_NAME: self._name,

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -44,8 +44,10 @@ else:
 logger = logging.getLogger(__name__)
 
 _ALL_OUTPUTS: Literal["all"] = "all"
+_ALL_OTHER_OUTPUTS: Literal["all_other"] = "all_other"
 _OutputSelection = list[Executor | SupportsAgentRun] | Literal["all"] | None
-_IntermediateOutputSelection = list[Executor | SupportsAgentRun] | None
+_IntermediateOutputSelection = list[Executor | SupportsAgentRun] | Literal["all_other"] | None
+_AnyOutputSelection = _OutputSelection | _IntermediateOutputSelection
 
 
 class WorkflowBuilder:
@@ -93,7 +95,7 @@ class WorkflowBuilder:
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: list[Executor | SupportsAgentRun] | Literal["all"] | None = _MISSING,
-        intermediate_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
+        intermediate_output_from: list[Executor | SupportsAgentRun] | Literal["all_other"] | None = _MISSING,
         output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
         final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
     ):
@@ -114,11 +116,13 @@ class WorkflowBuilder:
                 (``type='output'`` workflow events). Pass ``"all"`` to explicitly select every
                 executor with declared workflow output types.
             intermediate_output_from: Designates which executors emit intermediate output
-                (``type='intermediate'`` workflow events). If neither ``output_from`` nor
-                ``intermediate_output_from`` is provided, legacy mode applies and every
-                ``yield_output`` produces ``type='output'``. If either is provided, explicit
-                mode applies: listed workflow-output executors emit ``output``, listed intermediate
-                executors emit ``intermediate``, and unlisted executor yields are hidden.
+                (``type='intermediate'`` workflow events). Pass ``"all_other"`` to select every
+                executor with declared workflow output types that is not selected by ``output_from``.
+                If neither ``output_from`` nor ``intermediate_output_from`` is provided, legacy
+                mode applies and every ``yield_output`` produces ``type='output'``. If either is
+                provided, explicit mode applies: listed workflow-output executors emit ``output``,
+                listed intermediate executors emit ``intermediate``, and unlisted executor yields
+                are hidden.
             output_executors: Deprecated alias for ``output_from``. Will be removed in a
                 future version.
             final_output_from: Deprecated alias for ``output_from``. Will be removed in a
@@ -631,20 +635,25 @@ class WorkflowBuilder:
         if isinstance(intermediate_output_from, str):
             if intermediate_output_from == _ALL_OUTPUTS:
                 raise ValueError("intermediate_output_from='all' is invalid; use output_from='all' instead.")
+            if intermediate_output_from == _ALL_OTHER_OUTPUTS:
+                return _ALL_OTHER_OUTPUTS
             raise ValueError(
-                f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; use a list of executors."
+                f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; "
+                "use 'all_other' or a list of executors."
             )
         return list(intermediate_output_from)
 
     def _resolve_designated_executor_ids(
         self,
-        designated: _OutputSelection,
+        designated: _AnyOutputSelection,
     ) -> list[str] | None:
         """Resolve an optional designation list into executor IDs without mutating the graph."""
         if designated is None:
             return None
         if designated == _ALL_OUTPUTS:
             return [executor_id for executor_id, executor in self._executors.items() if executor.workflow_output_types]
+        if designated == _ALL_OTHER_OUTPUTS:
+            raise ValueError("intermediate_output_from='all_other' must be expanded relative to output_from.")
         ids: list[str] = []
         for item in designated:
             if isinstance(item, Executor):
@@ -766,7 +775,15 @@ class WorkflowBuilder:
                 executors = self._executors
                 edge_groups = self._edge_groups
                 final_output_ids = self._resolve_designated_executor_ids(self._output_from)
-                intermediate_output_ids = self._resolve_designated_executor_ids(self._intermediate_output_from)
+                if self._intermediate_output_from == _ALL_OTHER_OUTPUTS:
+                    output_ids_for_all_other = final_output_ids or []
+                    intermediate_output_ids = [
+                        executor_id
+                        for executor_id, executor in self._executors.items()
+                        if executor.workflow_output_types and executor_id not in output_ids_for_all_other
+                    ]
+                else:
+                    intermediate_output_ids = self._resolve_designated_executor_ids(self._intermediate_output_from)
                 self._validate_designation_lists(final_output_ids, intermediate_output_ids)
 
                 explicit_mode = final_output_ids is not None or intermediate_output_ids is not None

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 _ALL_OUTPUTS: Literal["all"] = "all"
 _ALL_OTHER_OUTPUTS: Literal["all_other"] = "all_other"
 _OutputSelection = list[Executor | SupportsAgentRun] | Literal["all"] | None
-_IntermediateOutputSelection = list[Executor | SupportsAgentRun] | Literal["all_other"] | None
+_IntermediateOutputSelection = list[Executor | SupportsAgentRun] | Literal["all", "all_other"] | None
 _AnyOutputSelection = _OutputSelection | _IntermediateOutputSelection
 
 
@@ -95,7 +95,7 @@ class WorkflowBuilder:
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: list[Executor | SupportsAgentRun] | Literal["all"] | None = _MISSING,
-        intermediate_output_from: list[Executor | SupportsAgentRun] | Literal["all_other"] | None = _MISSING,
+        intermediate_output_from: _IntermediateOutputSelection = _MISSING,
         output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
     ):
         """Initialize the WorkflowBuilder.
@@ -115,8 +115,10 @@ class WorkflowBuilder:
                 (``type='output'`` workflow events). Pass ``"all"`` to explicitly select every
                 executor with declared workflow output types.
             intermediate_output_from: Designates which executors emit intermediate output
-                (``type='intermediate'`` workflow events). Pass ``"all_other"`` to select every
-                executor with declared workflow output types that is not selected by ``output_from``.
+                (``type='intermediate'`` workflow events). Pass ``"all"`` to select every executor
+                with declared workflow output types as intermediate (no executor emits ``output``).
+                Pass ``"all_other"`` to select every executor with declared workflow output types
+                that is not selected by ``output_from``.
                 If neither ``output_from`` nor ``intermediate_output_from`` is provided,
                 omitted-selection compatibility behavior applies and every ``yield_output`` produces
                 ``type='output'``. If either is provided, explicit mode applies: listed
@@ -646,12 +648,12 @@ class WorkflowBuilder:
             return None
         if isinstance(intermediate_output_from, str):
             if intermediate_output_from == _ALL_OUTPUTS:
-                raise ValueError("intermediate_output_from='all' is invalid; use output_from='all' instead.")
+                return _ALL_OUTPUTS
             if intermediate_output_from == _ALL_OTHER_OUTPUTS:
                 return _ALL_OTHER_OUTPUTS
             raise ValueError(
                 f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; "
-                "use 'all_other' or a list of executors."
+                "use 'all', 'all_other', or a list of executors."
             )
         return list(intermediate_output_from)
 

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -824,6 +824,7 @@ class WorkflowBuilder:
                 executors = self._executors
                 edge_groups = self._edge_groups
                 output_ids = self._resolve_designated_executor_ids(self._output_from)
+                intermediate_output_ids: list[str] | None
                 if self._intermediate_output_from == _ALL_OTHER_OUTPUTS:
                     output_ids_for_all_other = output_ids or []
                     intermediate_output_ids = [

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 import warnings
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from .._agents import SupportsAgentRun
 from ..observability import OtelAttr, capture_exception, create_workflow_span
@@ -42,6 +42,10 @@ else:
 
 
 logger = logging.getLogger(__name__)
+
+_ALL_OUTPUTS: Literal["all"] = "all"
+_OutputSelection = list[Executor | SupportsAgentRun] | Literal["all"] | None
+_IntermediateOutputSelection = list[Executor | SupportsAgentRun] | None
 
 
 class WorkflowBuilder:
@@ -88,7 +92,7 @@ class WorkflowBuilder:
         *,
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
+        output_from: list[Executor | SupportsAgentRun] | Literal["all"] | None = _MISSING,
         intermediate_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
         output_executors: list[Executor | SupportsAgentRun] | None = _MISSING,
         final_output_from: list[Executor | SupportsAgentRun] | None = _MISSING,
@@ -107,7 +111,8 @@ class WorkflowBuilder:
                 or SupportsAgentRun instance.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
             output_from: Designates which executors emit workflow output
-                (``type='output'`` workflow events).
+                (``type='output'`` workflow events). Pass ``"all"`` to explicitly select every
+                executor with declared workflow output types.
             intermediate_output_from: Designates which executors emit intermediate output
                 (``type='intermediate'`` workflow events). If neither ``output_from`` nor
                 ``intermediate_output_from`` is provided, legacy mode applies and every
@@ -136,11 +141,9 @@ class WorkflowBuilder:
 
         # ``None`` for both means legacy mode (every yield_output produces type='output').
         # If either is provided, explicit mode applies and unlisted executor yields are hidden.
-        self._output_from: list[Executor | SupportsAgentRun] | None = (
-            list(output_from) if output_from is not None else None
-        )
-        self._intermediate_output_from: list[Executor | SupportsAgentRun] | None = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
+        self._output_from: _OutputSelection = self._coerce_output_from(output_from)
+        self._intermediate_output_from: _IntermediateOutputSelection = self._coerce_intermediate_output_from(
+            intermediate_output_from
         )
 
         # Set the start executor
@@ -611,13 +614,37 @@ class WorkflowBuilder:
         if existing is not wrapped:
             self._add_executor(wrapped)
 
+    def _coerce_output_from(self, output_from: Any) -> _OutputSelection:
+        """Coerce workflow-output selection while preserving the explicit ``"all"`` literal."""
+        if output_from is None:
+            return None
+        if output_from == _ALL_OUTPUTS:
+            return _ALL_OUTPUTS
+        if isinstance(output_from, str):
+            raise ValueError(f"Unsupported output_from literal {output_from!r}; use 'all' or a list of executors.")
+        return list(output_from)
+
+    def _coerce_intermediate_output_from(self, intermediate_output_from: Any) -> _IntermediateOutputSelection:
+        """Coerce intermediate-output selection and reject output-only literals."""
+        if intermediate_output_from is None:
+            return None
+        if isinstance(intermediate_output_from, str):
+            if intermediate_output_from == _ALL_OUTPUTS:
+                raise ValueError("intermediate_output_from='all' is invalid; use output_from='all' instead.")
+            raise ValueError(
+                f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; use a list of executors."
+            )
+        return list(intermediate_output_from)
+
     def _resolve_designated_executor_ids(
         self,
-        designated: list[Executor | SupportsAgentRun] | None,
+        designated: _OutputSelection,
     ) -> list[str] | None:
         """Resolve an optional designation list into executor IDs without mutating the graph."""
         if designated is None:
             return None
+        if designated == _ALL_OUTPUTS:
+            return [executor_id for executor_id, executor in self._executors.items() if executor.workflow_output_types]
         ids: list[str] = []
         for item in designated:
             if isinstance(item, Executor):
@@ -728,9 +755,9 @@ class WorkflowBuilder:
                 if self._output_from is None and self._intermediate_output_from is None:
                     warnings.warn(
                         "WorkflowBuilder built without explicit output_from or intermediate_output_from; "
-                        "every yield_output produces type='output' (legacy default). Pass output_from=[...] "
-                        "or intermediate_output_from=[...] to opt into explicit designation — explicit designation "
-                        "will be required in a future version.",
+                        "every yield_output produces type='output' (legacy default). Pass output_from='all', "
+                        "output_from=[...], or intermediate_output_from=[...] to opt into explicit designation — "
+                        "explicit designation will be required in a future version.",
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -28,7 +28,7 @@ from ._edge import (
 )
 from ._executor import Executor
 from ._runner_context import InProcRunnerContext
-from ._validation import validate_workflow_graph
+from ._validation import ValidationTypeEnum, WorkflowValidationError, validate_workflow_graph
 from ._workflow import Workflow
 
 if sys.version_info >= (3, 11):
@@ -85,6 +85,7 @@ class WorkflowBuilder:
         start_executor: Executor | SupportsAgentRun,
         checkpoint_storage: CheckpointStorage | None = None,
         output_executors: list[Executor | SupportsAgentRun] | None = None,
+        intermediate_executors: list[Executor | SupportsAgentRun] | None = None,
     ):
         """Initialize the WorkflowBuilder.
 
@@ -99,15 +100,14 @@ class WorkflowBuilder:
             start_executor: The starting executor for the workflow. Can be an Executor instance
                 or SupportsAgentRun instance.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_executors: Designates which executors emit terminal output (``type='output'``
-                workflow events). Three-state contract:
-
-                - **Unset (default):** legacy mode. Every ``yield_output`` produces ``type='output'``.
-                  A ``DeprecationWarning`` is raised at ``build()`` recommending explicit designation.
-                - **``[]`` (explicit empty list):** strict mode with no terminals. Every ``yield_output``
-                  produces ``type='intermediate'``. ``WorkflowRunResult.get_outputs()`` returns ``[]``.
-                - **``[X, ...]`` (explicit list):** strict mode. Yields from designated executors
-                  produce ``type='output'``; all other yields produce ``type='intermediate'``.
+            output_executors: Designates which executors emit terminal output
+                (``type='output'`` workflow events).
+            intermediate_executors: Designates which executors emit intermediate output
+                (``type='intermediate'`` workflow events). If neither output nor intermediate
+                designation is provided, legacy mode applies and every ``yield_output`` produces
+                ``type='output'``. If either designation is provided, explicit mode applies:
+                listed output executors emit ``output``, listed intermediate executors emit
+                ``intermediate``, and unlisted executor yields are hidden.
         """
         self._edge_groups: list[EdgeGroup] = []
         self._executors: dict[str, Executor] = {}
@@ -121,11 +121,14 @@ class WorkflowBuilder:
         # being created for the same agent.
         self._agent_wrappers: dict[str, Executor] = {}
 
-        # Output executors filter. ``None`` means legacy mode (every yield_output produces
-        # type='output'). Any list (including ``[]``) opts into strict mode — designated
-        # executors emit type='output', all other executors emit type='intermediate'.
+        # Output/intermediate executors filter. ``None`` for both means legacy mode
+        # (every yield_output produces type='output'). If either is provided, explicit
+        # mode applies and unlisted executor yields are hidden.
         self._output_executors: list[Executor | SupportsAgentRun] | None = (
             list(output_executors) if output_executors is not None else None
+        )
+        self._intermediate_executors: list[Executor | SupportsAgentRun] | None = (
+            list(intermediate_executors) if intermediate_executors is not None else None
         )
 
         # Set the start executor
@@ -596,6 +599,67 @@ class WorkflowBuilder:
         if existing is not wrapped:
             self._add_executor(wrapped)
 
+    def _resolve_designated_executor_ids(
+        self,
+        designated: list[Executor | SupportsAgentRun] | None,
+    ) -> list[str] | None:
+        """Resolve an optional designation list into executor IDs without mutating the graph."""
+        if designated is None:
+            return None
+        ids: list[str] = []
+        for item in designated:
+            if isinstance(item, Executor):
+                ids.append(item.id)
+            elif isinstance(item, SupportsAgentRun):
+                ids.append(resolve_agent_id(item))
+            else:
+                raise TypeError(
+                    "WorkflowBuilder expected designation entries to be Executor or SupportsAgentRun instances; "
+                    f"got {type(item).__name__}."
+                )
+        return ids
+
+    def _validate_designation_lists(
+        self,
+        output_executor_ids: list[str] | None,
+        intermediate_executor_ids: list[str] | None,
+    ) -> None:
+        """Validate builder-level designation rules that need legacy-vs-explicit context."""
+        explicit_mode = output_executor_ids is not None or intermediate_executor_ids is not None
+        if not explicit_mode:
+            return
+
+        output_ids = output_executor_ids or []
+        intermediate_ids = intermediate_executor_ids or []
+        if not output_ids and not intermediate_ids:
+            raise WorkflowValidationError(
+                "Explicit workflow output designation must include at least one output or intermediate executor.",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            )
+
+        duplicate_outputs = sorted({executor_id for executor_id in output_ids if output_ids.count(executor_id) > 1})
+        if duplicate_outputs:
+            raise WorkflowValidationError(
+                f"Duplicate output executor designation(s): {duplicate_outputs}",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            )
+
+        duplicate_intermediates = sorted({
+            executor_id for executor_id in intermediate_ids if intermediate_ids.count(executor_id) > 1
+        })
+        if duplicate_intermediates:
+            raise WorkflowValidationError(
+                f"Duplicate intermediate executor designation(s): {duplicate_intermediates}",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            )
+
+        overlap = sorted(set(output_ids).intersection(intermediate_ids))
+        if overlap:
+            raise WorkflowValidationError(
+                f"Executors cannot be both output and intermediate designated: {overlap}",
+                validation_type=ValidationTypeEnum.OUTPUT_VALIDATION,
+            )
+
     def build(self) -> Workflow:
         """Build and return the constructed workflow.
 
@@ -649,12 +713,12 @@ class WorkflowBuilder:
                         "Starting executor must be set via the start_executor constructor parameter before building."
                     )
 
-                if self._output_executors is None:
+                if self._output_executors is None and self._intermediate_executors is None:
                     warnings.warn(
-                        "WorkflowBuilder built without explicit output_executors; every yield_output "
-                        "produces type='output' (legacy default). Pass output_executors=[...] to opt "
-                        "into the strict contract — explicit designation will be required in a future "
-                        "major release.",
+                        "WorkflowBuilder built without explicit output_executors or intermediate_executors; "
+                        "every yield_output produces type='output' (legacy default). Pass output_executors=[...] "
+                        "or intermediate_executors=[...] to opt into explicit designation — explicit designation "
+                        "will be required in a future major release.",
                         DeprecationWarning,
                         stacklevel=2,
                     )
@@ -662,19 +726,19 @@ class WorkflowBuilder:
                 start_executor = self._start_executor
                 executors = self._executors
                 edge_groups = self._edge_groups
-                # Resolve designated executor ids when output_executors was passed explicitly.
-                # Legacy mode (None) and strict mode (any list) are distinguished here once;
-                # both the runner context and the Workflow receive a single shape.
-                output_executors_for_workflow: list[str] | None = (
-                    [ex.id for ex in self._output_executors if isinstance(ex, Executor)]
-                    + [
-                        resolve_agent_id(agent)
-                        for agent in self._output_executors
-                        if isinstance(agent, SupportsAgentRun)
-                    ]
-                    if self._output_executors is not None
-                    else None
+                output_executor_ids = self._resolve_designated_executor_ids(self._output_executors)
+                intermediate_executor_ids = self._resolve_designated_executor_ids(self._intermediate_executors)
+                self._validate_designation_lists(output_executor_ids, intermediate_executor_ids)
+
+                explicit_mode = output_executor_ids is not None or intermediate_executor_ids is not None
+                output_executors_for_workflow: list[str] | None = output_executor_ids if explicit_mode else None
+                if explicit_mode and output_executors_for_workflow is None:
+                    output_executors_for_workflow = []
+                intermediate_executors_for_workflow: list[str] | None = (
+                    intermediate_executor_ids if explicit_mode else None
                 )
+                if explicit_mode and intermediate_executors_for_workflow is None:
+                    intermediate_executors_for_workflow = []
 
                 # Perform validation before creating the workflow
                 validate_workflow_graph(
@@ -682,6 +746,7 @@ class WorkflowBuilder:
                     executors,
                     start_executor,
                     output_executors_for_workflow or [],
+                    intermediate_executors_for_workflow or [],
                 )
 
                 # Add validation completed event
@@ -699,6 +764,7 @@ class WorkflowBuilder:
                     description=self._description,
                     max_iterations=self._max_iterations,
                     output_executors=output_executors_for_workflow,
+                    intermediate_executors=intermediate_executors_for_workflow,
                 )
                 build_attributes: dict[str, Any] = {
                     OtelAttr.WORKFLOW_BUILDER_NAME: self._name,

--- a/python/packages/core/agent_framework/_workflows/_workflow_builder.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_builder.py
@@ -29,7 +29,11 @@ from ._edge import (
 from ._executor import Executor
 from ._runner_context import InProcRunnerContext
 from ._validation import ValidationTypeEnum, WorkflowValidationError, validate_workflow_graph
-from ._workflow import _MISSING, Workflow, _coalesce_renamed_kwarg
+from ._workflow import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    Workflow,
+    _coalesce_renamed_kwarg,  # pyright: ignore[reportPrivateUsage]
+)
 
 if sys.version_info >= (3, 11):
     from typing import Self  # type: ignore # pragma: no cover

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -337,7 +337,18 @@ class WorkflowContext(Generic[OutT, W_OutT]):
             await self._runner_context.send_message(msg)
 
     async def yield_output(self, output: W_OutT) -> None:
-        """Set the output of the workflow.
+        """Yield an output from this executor.
+
+        The framework labels the resulting workflow event based on whether this executor
+        is designated as an output executor (see ``WorkflowBuilder.output_executors``):
+
+        - **Strict mode** (``output_executors`` was passed explicitly to ``WorkflowBuilder``):
+
+          - If this executor is designated → ``WorkflowEvent`` with ``type='output'``.
+          - If not designated → ``WorkflowEvent`` with ``type='intermediate'``.
+
+        - **Legacy mode** (``output_executors`` unset; deprecated): every yield produces
+          ``type='output'`` regardless of executor.
 
         Args:
             output: The output to yield. This must conform to the workflow output type(s)
@@ -348,7 +359,10 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         self._yielded_outputs.append(copy.deepcopy(output))
 
         with _framework_event_origin():
-            event = WorkflowEvent.output(self._executor_id, output)
+            if self._runner_context.should_label_as_intermediate(self._executor_id):
+                event = WorkflowEvent.intermediate(self._executor_id, output)
+            else:
+                event = WorkflowEvent.output(self._executor_id, output)
         await self._runner_context.add_event(event)
 
     async def add_event(self, event: WorkflowEvent[Any]) -> None:

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -24,6 +24,7 @@ from ._state import State
 
 if TYPE_CHECKING:
     from ._executor import Executor
+    from ._workflow import OutputDesignation
 
 OutT = TypeVar("OutT", default=Never)
 W_OutT = TypeVar("W_OutT", default=Never)
@@ -256,6 +257,7 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
+        output_designation: OutputDesignation | None = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
         request_id: str | None = None,
@@ -269,15 +271,21 @@ class WorkflowContext(Generic[OutT, W_OutT]):
                 messages to the same executor.
             state: The workflow state.
             runner_context: The runner context that provides methods to send messages and events.
+            output_designation: Snapshot of the workflow's output designation policy used by
+                ``yield_output`` to label events as terminal vs intermediate. Defaults to legacy
+                mode (every yield is type='output') when omitted.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking (not for nesting).
             request_id: Optional request ID if this context is for a `handle_response` handler.
         """
+        from ._workflow import OutputDesignation
+
         self._executor = executor
         self._executor_id = executor.id
         self._source_executor_ids = source_executor_ids
         self._runner_context = runner_context
         self._state = state
+        self._output_designation: OutputDesignation = output_designation or OutputDesignation()
 
         # Track messages sent via send_message() for executor_completed event (type='executor_completed')
         self._sent_messages: list[Any] = []
@@ -359,10 +367,10 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         self._yielded_outputs.append(copy.deepcopy(output))
 
         with _framework_event_origin():
-            if self._runner_context.should_label_as_intermediate(self._executor_id):
-                event = WorkflowEvent.intermediate(self._executor_id, output)
-            else:
+            if self._output_designation.is_terminal(self._executor_id):
                 event = WorkflowEvent.output(self._executor_id, output)
+            else:
+                event = WorkflowEvent.intermediate(self._executor_id, output)
         await self._runner_context.add_event(event)
 
     async def add_event(self, event: WorkflowEvent[Any]) -> None:

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -355,6 +355,11 @@ class WorkflowContext(Generic[OutT, W_OutT]):
           intermediate-designated executors produce ``type='intermediate'``, and
           unlisted executor yields are hidden from caller-facing events.
 
+        Whether a given executor produces ``output`` or ``intermediate`` events is fixed at
+        workflow-build time via ``final_output_from`` / ``intermediate_output_from`` on
+        :class:`WorkflowBuilder`; an executor cannot vary the label per yield. To change an
+        executor's role, list it under a different designation when building the workflow.
+
         Args:
             output: The output to yield. This must conform to the workflow output type(s)
                     declared on this context.

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -347,16 +347,13 @@ class WorkflowContext(Generic[OutT, W_OutT]):
     async def yield_output(self, output: W_OutT) -> None:
         """Yield an output from this executor.
 
-        The framework labels the resulting workflow event based on whether this executor
-        is designated as an output executor (see ``WorkflowBuilder.output_executors``):
+        The framework labels the resulting workflow event based on the workflow's explicit
+        output designation:
 
-        - **Strict mode** (``output_executors`` was passed explicitly to ``WorkflowBuilder``):
-
-          - If this executor is designated → ``WorkflowEvent`` with ``type='output'``.
-          - If not designated → ``WorkflowEvent`` with ``type='intermediate'``.
-
-        - **Legacy mode** (``output_executors`` unset; deprecated): every yield produces
-          ``type='output'`` regardless of executor.
+        - Legacy mode: every yield produces ``type='output'``.
+        - Explicit mode: output-designated executors produce ``type='output'``,
+          intermediate-designated executors produce ``type='intermediate'``, and
+          unlisted executor yields are hidden from caller-facing events.
 
         Args:
             output: The output to yield. This must conform to the workflow output type(s)
@@ -366,8 +363,12 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         # (deepcopy to capture state at yield time)
         self._yielded_outputs.append(copy.deepcopy(output))
 
+        event_type = self._output_designation.classify(self._executor_id)
+        if event_type is None:
+            return
+
         with _framework_event_origin():
-            if self._output_designation.is_terminal(self._executor_id):
+            if event_type == "output":
                 event = WorkflowEvent.output(self._executor_id, output)
             else:
                 event = WorkflowEvent.intermediate(self._executor_id, output)

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -356,7 +356,7 @@ class WorkflowContext(Generic[OutT, W_OutT]):
           unlisted executor yields are hidden from caller-facing events.
 
         Whether a given executor produces ``output`` or ``intermediate`` events is fixed at
-        workflow-build time via ``final_output_from`` / ``intermediate_output_from`` on
+        workflow-build time via ``output_from`` / ``intermediate_output_from`` on
         :class:`WorkflowBuilder`; an executor cannot vary the label per yield. To change an
         executor's role, list it under a different designation when building the workflow.
 

--- a/python/packages/core/agent_framework/_workflows/_workflow_context.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_context.py
@@ -24,7 +24,6 @@ from ._state import State
 
 if TYPE_CHECKING:
     from ._executor import Executor
-    from ._workflow import OutputDesignation
 
 OutT = TypeVar("OutT", default=Never)
 W_OutT = TypeVar("W_OutT", default=Never)
@@ -202,6 +201,7 @@ def validate_workflow_context_annotation(
 
 # Event types reserved for framework lifecycle (not allowed from user code)
 _FRAMEWORK_LIFECYCLE_EVENT_TYPES: frozenset[str] = frozenset({"started", "status", "failed"})
+_OUTPUT_SELECTION_EVENT_TYPES: frozenset[str] = frozenset({"output", "intermediate"})
 
 
 class WorkflowContext(Generic[OutT, W_OutT]):
@@ -257,7 +257,6 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         source_executor_ids: list[str],
         state: State,
         runner_context: RunnerContext,
-        output_designation: OutputDesignation | None = None,
         trace_contexts: list[dict[str, str]] | None = None,
         source_span_ids: list[str] | None = None,
         request_id: str | None = None,
@@ -271,21 +270,15 @@ class WorkflowContext(Generic[OutT, W_OutT]):
                 messages to the same executor.
             state: The workflow state.
             runner_context: The runner context that provides methods to send messages and events.
-            output_designation: Snapshot of the workflow's output designation policy used by
-                ``yield_output`` to label events as terminal vs intermediate. Defaults to legacy
-                mode (every yield is type='output') when omitted.
             trace_contexts: Optional trace contexts from multiple sources for OpenTelemetry propagation.
             source_span_ids: Optional source span IDs from multiple sources for linking (not for nesting).
             request_id: Optional request ID if this context is for a `handle_response` handler.
         """
-        from ._workflow import OutputDesignation
-
         self._executor = executor
         self._executor_id = executor.id
         self._source_executor_ids = source_executor_ids
         self._runner_context = runner_context
         self._state = state
-        self._output_designation: OutputDesignation = output_designation or OutputDesignation()
 
         # Track messages sent via send_message() for executor_completed event (type='executor_completed')
         self._sent_messages: list[Any] = []
@@ -350,7 +343,7 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         The framework labels the resulting workflow event based on the workflow's explicit
         output designation:
 
-        - Legacy mode: every yield produces ``type='output'``.
+        - Omitted-selection compatibility behavior: every yield produces ``type='output'``.
         - Explicit mode: output-designated executors produce ``type='output'``,
           intermediate-designated executors produce ``type='intermediate'``, and
           unlisted executor yields are hidden from caller-facing events.
@@ -368,19 +361,24 @@ class WorkflowContext(Generic[OutT, W_OutT]):
         # (deepcopy to capture state at yield time)
         self._yielded_outputs.append(copy.deepcopy(output))
 
-        event_type = self._output_designation.classify(self._executor_id)
+        event_type = self._runner_context.classify_yielded_output(self._executor_id)
         if event_type is None:
             return
 
         with _framework_event_origin():
-            if event_type == "output":
-                event = WorkflowEvent.output(self._executor_id, output)
-            else:
-                event = WorkflowEvent.intermediate(self._executor_id, output)
+            event = WorkflowEvent(event_type, executor_id=self._executor_id, data=output)
         await self._runner_context.add_event(event)
 
     async def add_event(self, event: WorkflowEvent[Any]) -> None:
         """Add an event to the workflow context."""
+        if event.origin == WorkflowEventSource.EXECUTOR and event.type in _OUTPUT_SELECTION_EVENT_TYPES:
+            warning_msg = (
+                f"Executor '{self._executor_id}' attempted to emit a '{event.type}' event directly, "
+                "which is reserved for ctx.yield_output(). The event was ignored."
+            )
+            logger.warning(warning_msg)
+            await self._runner_context.add_event(WorkflowEvent.warning(warning_msg))
+            return
         if event.origin == WorkflowEventSource.EXECUTOR and event.type in _FRAMEWORK_LIFECYCLE_EVENT_TYPES:
             warning_msg = (
                 f"Executor '{self._executor_id}' attempted to emit a '{event.type}' event, "

--- a/python/packages/core/agent_framework/_workflows/_workflow_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_executor.py
@@ -552,10 +552,12 @@ class WorkflowExecutor(Executor):
         # Collect all events from the workflow
         request_info_events = result.get_request_info_events()
         outputs = result.get_outputs()
+        intermediate_outputs = result.get_intermediate_outputs()
         workflow_run_state = result.get_final_state()
         logger.debug(
             f"WorkflowExecutor {self.id} processing workflow result with "
-            f"{len(outputs)} outputs and {len(request_info_events)} request info events. "
+            f"{len(outputs)} outputs, {len(intermediate_outputs)} intermediate outputs, "
+            f"and {len(request_info_events)} request info events. "
             f"Workflow run state: {workflow_run_state}"
         )
 
@@ -565,6 +567,15 @@ class WorkflowExecutor(Executor):
             await asyncio.gather(*[ctx.yield_output(output) for output in outputs])
         else:
             await asyncio.gather(*[ctx.send_message(output) for output in outputs])
+
+        # Pipe sub-workflow intermediate emissions up through the parent's event stream.
+        # Bypasses the parent's OutputDesignation so the 'intermediate' label is preserved
+        # across the encapsulation boundary; uses this WorkflowExecutor's id as the source
+        # so outer callers don't need to know the sub-workflow's internal executor layout.
+        if intermediate_outputs:
+            await asyncio.gather(*[
+                ctx.add_event(WorkflowEvent.intermediate(self.id, output)) for output in intermediate_outputs
+            ])
 
         # Process request info events
         for event in request_info_events:

--- a/python/packages/core/agent_framework/_workflows/_workflow_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_executor.py
@@ -16,6 +16,7 @@ from ._const import GLOBAL_KWARGS_KEY, WORKFLOW_RUN_KWARGS_KEY
 from ._events import (
     WorkflowEvent,
     WorkflowRunState,
+    _framework_event_origin,  # type: ignore[reportPrivateUsage]
 )
 from ._executor import Executor, handler
 from ._request_info_mixin import response_handler
@@ -569,13 +570,17 @@ class WorkflowExecutor(Executor):
             await asyncio.gather(*[ctx.send_message(output) for output in outputs])
 
         # Pipe sub-workflow intermediate emissions up through the parent's event stream.
-        # Bypasses the parent's OutputDesignation so the 'intermediate' label is preserved
+        # Bypasses the parent's yield-output classifier so the 'intermediate' label is preserved
         # across the encapsulation boundary; uses this WorkflowExecutor's id as the source
         # so outer callers don't need to know the sub-workflow's internal executor layout.
         if intermediate_outputs:
-            await asyncio.gather(*[
-                ctx.add_event(WorkflowEvent.intermediate(self.id, output)) for output in intermediate_outputs
-            ])
+
+            async def _forward_intermediate_output(output: Any) -> None:
+                with _framework_event_origin():
+                    event = WorkflowEvent("intermediate", executor_id=self.id, data=output)
+                await ctx.add_event(event)
+
+            await asyncio.gather(*[_forward_intermediate_output(output) for output in intermediate_outputs])
 
         # Process request info events
         for event in request_info_events:

--- a/python/packages/core/tests/workflow/test_agent_executor_tool_calls.py
+++ b/python/packages/core/tests/workflow/test_agent_executor_tool_calls.py
@@ -272,9 +272,7 @@ async def test_agent_executor_tool_call_with_approval() -> None:
         tools=[mock_tool_requiring_approval],
     )
 
-    workflow = (
-        WorkflowBuilder(start_executor=agent, output_executors=[test_executor]).add_edge(agent, test_executor).build()
-    )
+    workflow = WorkflowBuilder(start_executor=agent, output_from=[test_executor]).add_edge(agent, test_executor).build()
 
     # Act
     events = await workflow.run("Invoke tool requiring approval")
@@ -343,9 +341,7 @@ async def test_agent_executor_parallel_tool_call_with_approval() -> None:
         tools=[mock_tool_requiring_approval],
     )
 
-    workflow = (
-        WorkflowBuilder(start_executor=agent, output_executors=[test_executor]).add_edge(agent, test_executor).build()
-    )
+    workflow = WorkflowBuilder(start_executor=agent, output_from=[test_executor]).add_edge(agent, test_executor).build()
 
     # Act
     events = await workflow.run("Invoke tool requiring approval")
@@ -512,9 +508,7 @@ async def test_agent_executor_declaration_only_tool_emits_request_info() -> None
         tools=[declaration_only_tool],
     )
 
-    workflow = (
-        WorkflowBuilder(start_executor=agent, output_executors=[test_executor]).add_edge(agent, test_executor).build()
-    )
+    workflow = WorkflowBuilder(start_executor=agent, output_from=[test_executor]).add_edge(agent, test_executor).build()
 
     # Act
     events = await workflow.run("Use the client side tool")
@@ -587,9 +581,7 @@ async def test_agent_executor_parallel_declaration_only_tool_emits_request_info(
         tools=[declaration_only_tool],
     )
 
-    workflow = (
-        WorkflowBuilder(start_executor=agent, output_executors=[test_executor]).add_edge(agent, test_executor).build()
-    )
+    workflow = WorkflowBuilder(start_executor=agent, output_from=[test_executor]).add_edge(agent, test_executor).build()
 
     # Act
     events = await workflow.run("Use the client side tool")

--- a/python/packages/core/tests/workflow/test_agent_run_event_typing.py
+++ b/python/packages/core/tests/workflow/test_agent_run_event_typing.py
@@ -9,7 +9,7 @@ from agent_framework._workflows._events import WorkflowEvent
 def test_workflow_event_with_agent_response_data_type() -> None:
     """Verify WorkflowEvent[AgentResponse].data is typed as AgentResponse."""
     response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
-    event: WorkflowEvent[AgentResponse] = WorkflowEvent.emit(executor_id="test", data=response)
+    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
 
     # This assignment should pass type checking without a cast
     data: AgentResponse = event.data
@@ -20,7 +20,7 @@ def test_workflow_event_with_agent_response_data_type() -> None:
 def test_workflow_event_with_agent_response_update_data_type() -> None:
     """Verify WorkflowEvent[AgentResponseUpdate].data is typed as AgentResponseUpdate."""
     update = AgentResponseUpdate()
-    event: WorkflowEvent[AgentResponseUpdate] = WorkflowEvent.emit(executor_id="test", data=update)
+    event: WorkflowEvent[AgentResponseUpdate] = WorkflowEvent.intermediate(executor_id="test", data=update)
 
     # This assignment should pass type checking without a cast
     data: AgentResponseUpdate = event.data
@@ -30,7 +30,7 @@ def test_workflow_event_with_agent_response_update_data_type() -> None:
 def test_workflow_event_repr() -> None:
     """Verify WorkflowEvent.__repr__ uses consistent format."""
     response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
-    event: WorkflowEvent[AgentResponse] = WorkflowEvent.emit(executor_id="test", data=response)
+    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
 
     repr_str = repr(event)
     assert "WorkflowEvent" in repr_str

--- a/python/packages/core/tests/workflow/test_agent_run_event_typing.py
+++ b/python/packages/core/tests/workflow/test_agent_run_event_typing.py
@@ -9,7 +9,7 @@ from agent_framework._workflows._events import WorkflowEvent
 def test_workflow_event_with_agent_response_data_type() -> None:
     """Verify WorkflowEvent[AgentResponse].data is typed as AgentResponse."""
     response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
-    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
+    event: WorkflowEvent[AgentResponse] = WorkflowEvent("intermediate", executor_id="test", data=response)
 
     # This assignment should pass type checking without a cast
     data: AgentResponse = event.data
@@ -20,7 +20,7 @@ def test_workflow_event_with_agent_response_data_type() -> None:
 def test_workflow_event_with_agent_response_update_data_type() -> None:
     """Verify WorkflowEvent[AgentResponseUpdate].data is typed as AgentResponseUpdate."""
     update = AgentResponseUpdate()
-    event: WorkflowEvent[AgentResponseUpdate] = WorkflowEvent.intermediate(executor_id="test", data=update)
+    event: WorkflowEvent[AgentResponseUpdate] = WorkflowEvent("intermediate", executor_id="test", data=update)
 
     # This assignment should pass type checking without a cast
     data: AgentResponseUpdate = event.data
@@ -30,7 +30,7 @@ def test_workflow_event_with_agent_response_update_data_type() -> None:
 def test_workflow_event_repr() -> None:
     """Verify WorkflowEvent.__repr__ uses consistent format."""
     response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
-    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
+    event: WorkflowEvent[AgentResponse] = WorkflowEvent("intermediate", executor_id="test", data=response)
 
     repr_str = repr(event)
     assert "WorkflowEvent" in repr_str

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -177,7 +177,7 @@ async def test_agent_executor_populates_full_conversation_non_streaming() -> Non
     agent_exec = AgentExecutor(agent, id="agent1-exec")
     capturer = _CaptureFullConversation(id="capture")
 
-    wf = WorkflowBuilder(start_executor=agent_exec, output_executors=[capturer]).add_edge(agent_exec, capturer).build()
+    wf = WorkflowBuilder(start_executor=agent_exec, output_from=[capturer]).add_edge(agent_exec, capturer).build()
 
     # Act: use run() to test non-streaming mode
     result = await wf.run("hello world")
@@ -344,7 +344,7 @@ async def test_agent_executor_full_conversation_round_trip_does_not_duplicate_hi
     coordinator = _RoundTripCoordinator(target_agent_id="writer_agent")
 
     wf = (
-        WorkflowBuilder(start_executor=agent_exec, output_executors=[coordinator])
+        WorkflowBuilder(start_executor=agent_exec, output_from=[coordinator])
         .add_edge(agent_exec, coordinator)
         .add_edge(coordinator, agent_exec)
         .build()
@@ -445,7 +445,7 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     coordinator = _FullHistoryReplayCoordinator(id="coord", target_exec=spy_exec)
 
     wf = (
-        WorkflowBuilder(start_executor=tool_exec, output_executors=[coordinator])
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
         .add_edge(tool_exec, coordinator)
         .add_edge(coordinator, spy_exec)
         .build()
@@ -473,7 +473,7 @@ async def test_from_response_preserves_service_session_id() -> None:
     # Simulate a prior run on the spy executor.
     spy_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
-    wf = WorkflowBuilder(start_executor=tool_exec, output_executors=[spy_exec]).add_edge(tool_exec, spy_exec).build()
+    wf = WorkflowBuilder(start_executor=tool_exec, output_from=[spy_exec]).add_edge(tool_exec, spy_exec).build()
 
     result = await wf.run("start")
     assert result.get_outputs() is not None
@@ -512,7 +512,7 @@ async def test_with_text_preserves_full_conversation_through_custom_executor() -
     capturer = _CaptureFullConversation(id="capture")
 
     wf = (
-        WorkflowBuilder(start_executor=agent1, output_executors=[capturer])
+        WorkflowBuilder(start_executor=agent1, output_from=[capturer])
         .add_chain([agent1, agent2, _upper_case_executor, agent3, capturer])
         .build()
     )

--- a/python/packages/core/tests/workflow/test_functional_workflow.py
+++ b/python/packages/core/tests/workflow/test_functional_workflow.py
@@ -165,13 +165,13 @@ class TestEventEmission:
 
         @workflow
         async def pipeline(x: int, ctx: RunContext) -> int:
-            await ctx.add_event(WorkflowEvent.emit("pipeline", "custom_data"))
+            await ctx.add_event(WorkflowEvent.intermediate("pipeline", "custom_data"))
             return x
 
         result = await pipeline.run(1)
-        data_events = [e for e in result if e.type == "data"]
-        assert len(data_events) == 1
-        assert data_events[0].data == "custom_data"
+        intermediate_events = [e for e in result if e.type == "intermediate"]
+        assert len(intermediate_events) == 1
+        assert intermediate_events[0].data == "custom_data"
 
 
 # ---------------------------------------------------------------------------

--- a/python/packages/core/tests/workflow/test_functional_workflow.py
+++ b/python/packages/core/tests/workflow/test_functional_workflow.py
@@ -165,7 +165,7 @@ class TestEventEmission:
 
         @workflow
         async def pipeline(x: int, ctx: RunContext) -> int:
-            await ctx.add_event(WorkflowEvent.intermediate("pipeline", "custom_data"))
+            await ctx.add_event(WorkflowEvent("intermediate", executor_id="pipeline", data="custom_data"))
             return x
 
         result = await pipeline.run(1)

--- a/python/packages/core/tests/workflow/test_output_designation.py
+++ b/python/packages/core/tests/workflow/test_output_designation.py
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for the ``OutputDesignation`` value type and the ``Workflow.is_terminal_executor``
+public predicate that delegates to it.
+
+The three states the value type encodes:
+- Legacy: ``designated=None`` -> every executor is terminal.
+- Strict-empty: ``designated=frozenset()`` -> no executor is terminal.
+- Strict-list: ``designated=frozenset({...})`` -> only listed executors are terminal.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typing_extensions import Never
+
+from agent_framework import (
+    Message,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+)
+from agent_framework._workflows._workflow import OutputDesignation
+
+# ---------------------------------------------------------------------------
+# OutputDesignation value type
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_designation_marks_every_executor_as_terminal() -> None:
+    designation = OutputDesignation()  # designated defaults to None
+    assert designation.designated is None
+    assert designation.is_terminal("anything")
+    assert designation.is_terminal("else")
+
+
+def test_strict_empty_designation_marks_no_executor_as_terminal() -> None:
+    designation = OutputDesignation(designated=frozenset())
+    assert designation.designated == frozenset()
+    assert not designation.is_terminal("anything")
+    assert not designation.is_terminal("else")
+
+
+def test_strict_designated_set_only_terminal_for_members() -> None:
+    designation = OutputDesignation(designated=frozenset({"alpha", "beta"}))
+    assert designation.is_terminal("alpha")
+    assert designation.is_terminal("beta")
+    assert not designation.is_terminal("gamma")
+
+
+def test_designation_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+
+    designation = OutputDesignation(designated=frozenset({"alpha"}))
+    with pytest.raises(FrozenInstanceError):
+        designation.designated = frozenset({"beta"})  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Workflow.is_terminal_executor delegates to the designation
+# ---------------------------------------------------------------------------
+
+
+@executor
+async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+    await ctx.yield_output("hello")
+
+
+@executor
+async def _downstream(message: str, ctx: WorkflowContext[Never, str]) -> None:
+    await ctx.yield_output("downstream")
+
+
+def test_is_terminal_executor_legacy_mode_returns_true_for_any_id() -> None:
+    """Legacy mode (output_executors unset): every executor is terminal."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        workflow = WorkflowBuilder(start_executor=_emit_one).build()
+    assert workflow.is_terminal_executor(_emit_one.id)
+    assert workflow.is_terminal_executor("anything-else")
+
+
+def test_is_terminal_executor_strict_empty_returns_false_for_every_id() -> None:
+    """Strict mode with empty list: no executor is terminal."""
+    workflow = WorkflowBuilder(start_executor=_emit_one, output_executors=[]).build()
+    assert not workflow.is_terminal_executor(_emit_one.id)
+    assert not workflow.is_terminal_executor("nope")
+
+
+def test_is_terminal_executor_strict_list_returns_true_only_for_designated() -> None:
+    """Strict mode with a designated list: only listed executors are terminal."""
+    workflow = (
+        WorkflowBuilder(start_executor=_emit_one, output_executors=[_emit_one]).add_edge(_emit_one, _downstream).build()
+    )
+    assert workflow.is_terminal_executor(_emit_one.id)
+    assert not workflow.is_terminal_executor(_downstream.id)

--- a/python/packages/core/tests/workflow/test_output_designation.py
+++ b/python/packages/core/tests/workflow/test_output_designation.py
@@ -3,10 +3,10 @@
 """Tests for the ``OutputDesignation`` value type and the ``Workflow.is_terminal_executor``
 public predicate that delegates to it.
 
-The three states the value type encodes:
-- Legacy: ``designated=None`` -> every executor is terminal.
-- Strict-empty: ``designated=frozenset()`` -> no executor is terminal.
-- Strict-list: ``designated=frozenset({...})`` -> only listed executors are terminal.
+The states the value type encodes:
+- Legacy: ``outputs=None`` -> every executor is terminal.
+- Explicit: disjoint ``outputs`` and ``intermediates`` sets classify listed executors,
+  and hide unlisted executors.
 """
 
 from __future__ import annotations
@@ -29,31 +29,37 @@ from agent_framework._workflows._workflow import OutputDesignation
 
 def test_legacy_designation_marks_every_executor_as_terminal() -> None:
     designation = OutputDesignation()  # designated defaults to None
-    assert designation.designated is None
+    assert designation.outputs is None
     assert designation.is_terminal("anything")
     assert designation.is_terminal("else")
+    assert designation.classify("anything") == "output"
 
 
 def test_strict_empty_designation_marks_no_executor_as_terminal() -> None:
-    designation = OutputDesignation(designated=frozenset())
-    assert designation.designated == frozenset()
+    designation = OutputDesignation(outputs=frozenset())
+    assert designation.outputs == frozenset()
     assert not designation.is_terminal("anything")
     assert not designation.is_terminal("else")
+    assert designation.classify("anything") is None
 
 
 def test_strict_designated_set_only_terminal_for_members() -> None:
-    designation = OutputDesignation(designated=frozenset({"alpha", "beta"}))
+    designation = OutputDesignation(outputs=frozenset({"alpha", "beta"}), intermediates=frozenset({"gamma"}))
     assert designation.is_terminal("alpha")
     assert designation.is_terminal("beta")
     assert not designation.is_terminal("gamma")
+    assert designation.is_intermediate("gamma")
+    assert designation.classify("alpha") == "output"
+    assert designation.classify("gamma") == "intermediate"
+    assert designation.classify("delta") is None
 
 
 def test_designation_is_frozen() -> None:
     from dataclasses import FrozenInstanceError
 
-    designation = OutputDesignation(designated=frozenset({"alpha"}))
+    designation = OutputDesignation(outputs=frozenset({"alpha"}))
     with pytest.raises(FrozenInstanceError):
-        designation.designated = frozenset({"beta"})  # type: ignore[misc]
+        designation.outputs = frozenset({"beta"})  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -82,11 +88,13 @@ def test_is_terminal_executor_legacy_mode_returns_true_for_any_id() -> None:
     assert workflow.is_terminal_executor("anything-else")
 
 
-def test_is_terminal_executor_strict_empty_returns_false_for_every_id() -> None:
-    """Strict mode with empty list: no executor is terminal."""
-    workflow = WorkflowBuilder(start_executor=_emit_one, output_executors=[]).build()
+def test_is_intermediate_executor_explicit_list_returns_true_only_for_designated() -> None:
+    """Explicit mode tracks intermediate-designated executors separately."""
+    workflow = WorkflowBuilder(start_executor=_emit_one, intermediate_executors=[_emit_one]).build()
     assert not workflow.is_terminal_executor(_emit_one.id)
     assert not workflow.is_terminal_executor("nope")
+    assert workflow.is_intermediate_executor(_emit_one.id)
+    assert not workflow.is_intermediate_executor("nope")
 
 
 def test_is_terminal_executor_strict_list_returns_true_only_for_designated() -> None:

--- a/python/packages/core/tests/workflow/test_output_designation.py
+++ b/python/packages/core/tests/workflow/test_output_designation.py
@@ -4,7 +4,7 @@
 public predicate that delegates to it.
 
 The states the value type encodes:
-- Legacy: ``outputs=None`` -> every executor is terminal.
+- Omitted-selection compatibility: ``outputs=None`` -> every executor is terminal.
 - Explicit: disjoint ``outputs`` and ``intermediates`` sets classify listed executors,
   and hide unlisted executors.
 """
@@ -18,16 +18,18 @@ from agent_framework import (
     Message,
     WorkflowBuilder,
     WorkflowContext,
+    WorkflowValidationError,
     executor,
 )
-from agent_framework._workflows._workflow import OutputDesignation
+from agent_framework._workflows._runner_context import InProcRunnerContext
+from agent_framework._workflows._workflow import OutputDesignation, Workflow
 
 # ---------------------------------------------------------------------------
 # OutputDesignation value type
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_designation_marks_every_executor_as_terminal() -> None:
+def test_omitted_selection_designation_marks_every_executor_as_terminal() -> None:
     designation = OutputDesignation()  # designated defaults to None
     assert designation.outputs is None
     assert designation.is_terminal("anything")
@@ -77,8 +79,8 @@ async def _downstream(message: str, ctx: WorkflowContext[Never, str]) -> None:
     await ctx.yield_output("downstream")
 
 
-def test_is_terminal_executor_legacy_mode_returns_true_for_any_id() -> None:
-    """Legacy mode (output_executors unset): every executor is terminal."""
+def test_is_terminal_executor_omitted_selection_returns_true_for_any_id() -> None:
+    """Omitted-selection compatibility behavior: every executor is terminal."""
     import warnings
 
     with warnings.catch_warnings():
@@ -104,3 +106,32 @@ def test_is_terminal_executor_strict_list_returns_true_only_for_designated() -> 
     )
     assert workflow.is_terminal_executor(_emit_one.id)
     assert not workflow.is_terminal_executor(_downstream.id)
+
+
+def test_get_output_executors_throws_when_designation_references_missing_executor() -> None:
+    workflow = Workflow(
+        [],
+        {_emit_one.id: _emit_one},
+        _emit_one,
+        InProcRunnerContext(),
+        "test",
+        output_from=["missing"],
+    )
+
+    with pytest.raises(WorkflowValidationError, match="Output executor 'missing' is not present"):
+        workflow.get_output_executors()
+
+
+def test_get_intermediate_executors_throws_when_designation_references_missing_executor() -> None:
+    workflow = Workflow(
+        [],
+        {_emit_one.id: _emit_one},
+        _emit_one,
+        InProcRunnerContext(),
+        "test",
+        output_from=[],
+        intermediate_output_from=["missing"],
+    )
+
+    with pytest.raises(WorkflowValidationError, match="Intermediate executor 'missing' is not present"):
+        workflow.get_intermediate_executors()

--- a/python/packages/core/tests/workflow/test_output_designation.py
+++ b/python/packages/core/tests/workflow/test_output_designation.py
@@ -90,7 +90,7 @@ def test_is_terminal_executor_legacy_mode_returns_true_for_any_id() -> None:
 
 def test_is_intermediate_executor_explicit_list_returns_true_only_for_designated() -> None:
     """Explicit mode tracks intermediate-designated executors separately."""
-    workflow = WorkflowBuilder(start_executor=_emit_one, intermediate_executors=[_emit_one]).build()
+    workflow = WorkflowBuilder(start_executor=_emit_one, intermediate_output_from=[_emit_one]).build()
     assert not workflow.is_terminal_executor(_emit_one.id)
     assert not workflow.is_terminal_executor("nope")
     assert workflow.is_intermediate_executor(_emit_one.id)
@@ -100,7 +100,7 @@ def test_is_intermediate_executor_explicit_list_returns_true_only_for_designated
 def test_is_terminal_executor_strict_list_returns_true_only_for_designated() -> None:
     """Strict mode with a designated list: only listed executors are terminal."""
     workflow = (
-        WorkflowBuilder(start_executor=_emit_one, output_executors=[_emit_one]).add_edge(_emit_one, _downstream).build()
+        WorkflowBuilder(start_executor=_emit_one, output_from=[_emit_one]).add_edge(_emit_one, _downstream).build()
     )
     assert workflow.is_terminal_executor(_emit_one.id)
     assert not workflow.is_terminal_executor(_downstream.id)

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for the three-state output_executors contract on WorkflowBuilder.
+
+State A: output_executors=None (unset, legacy)  -> DeprecationWarning at build
+State B: output_executors=[] (explicit, no terminals) -> strict mode
+State C: output_executors=[X, ...] (explicit list) -> strict mode
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from typing_extensions import Never
+
+from agent_framework import (
+    Message,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+)
+
+
+@executor
+async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+    await ctx.yield_output("hello")
+
+
+def test_output_executors_unset_emits_deprecation_warning() -> None:
+    """State A: WorkflowBuilder built without explicit output_executors warns."""
+    with pytest.warns(DeprecationWarning, match="output_executors"):
+        WorkflowBuilder(start_executor=_emit_one).build()
+
+
+@pytest.mark.parametrize("output_executors", [[], [_emit_one]], ids=["empty_list", "designated_list"])
+def test_output_executors_explicit_value_does_not_warn(output_executors) -> None:
+    """States B and C: any explicit list (including ``[]``) opts into strict mode without warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        WorkflowBuilder(start_executor=_emit_one, output_executors=output_executors).build()

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Tests for the three-state output_executors contract on WorkflowBuilder.
+"""Tests for the explicit output/intermediate designation contract on WorkflowBuilder.
 
-State A: output_executors=None (unset, legacy)  -> DeprecationWarning at build
-State B: output_executors=[] (explicit, no terminals) -> strict mode
-State C: output_executors=[X, ...] (explicit list) -> strict mode
+State A: output_executors=None and intermediate_executors=None -> DeprecationWarning at build
+State B: explicit designation with at least one executor -> no warning
+State C: explicit designation with no executors -> validation error
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from agent_framework import (
     Message,
     WorkflowBuilder,
     WorkflowContext,
+    WorkflowValidationError,
     executor,
 )
 
@@ -27,15 +28,38 @@ async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -
     await ctx.yield_output("hello")
 
 
-def test_output_executors_unset_emits_deprecation_warning() -> None:
-    """State A: WorkflowBuilder built without explicit output_executors warns."""
-    with pytest.warns(DeprecationWarning, match="output_executors"):
+def test_designation_unset_emits_deprecation_warning() -> None:
+    """State A: WorkflowBuilder built without explicit designation warns."""
+    with pytest.warns(DeprecationWarning, match="output_executors or intermediate_executors"):
         WorkflowBuilder(start_executor=_emit_one).build()
 
 
-@pytest.mark.parametrize("output_executors", [[], [_emit_one]], ids=["empty_list", "designated_list"])
-def test_output_executors_explicit_value_does_not_warn(output_executors) -> None:
-    """States B and C: any explicit list (including ``[]``) opts into strict mode without warning."""
+@pytest.mark.parametrize(
+    ("output_executors", "intermediate_executors"),
+    [([_emit_one], None), (None, [_emit_one]), ([], [_emit_one])],
+    ids=["output_list", "intermediate_list", "empty_output_with_intermediate"],
+)
+def test_explicit_designation_with_executor_does_not_warn(output_executors, intermediate_executors) -> None:
+    """State B: any explicit designation with at least one executor opts into explicit mode without warning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        WorkflowBuilder(start_executor=_emit_one, output_executors=output_executors).build()
+        WorkflowBuilder(
+            start_executor=_emit_one,
+            output_executors=output_executors,
+            intermediate_executors=intermediate_executors,
+        ).build()
+
+
+@pytest.mark.parametrize(
+    ("output_executors", "intermediate_executors"),
+    [([], None), (None, []), ([], [])],
+    ids=["empty_output", "empty_intermediate", "both_empty"],
+)
+def test_empty_explicit_designation_fails(output_executors, intermediate_executors) -> None:
+    """State C: explicit mode needs at least one output or intermediate executor."""
+    with pytest.raises(WorkflowValidationError, match="at least one output or intermediate executor"):
+        WorkflowBuilder(
+            start_executor=_emit_one,
+            output_executors=output_executors,
+            intermediate_executors=intermediate_executors,
+        ).build()

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -30,36 +30,36 @@ async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -
 
 def test_designation_unset_emits_deprecation_warning() -> None:
     """State A: WorkflowBuilder built without explicit designation warns."""
-    with pytest.warns(DeprecationWarning, match="output_executors or intermediate_executors"):
+    with pytest.warns(DeprecationWarning, match="final_output_from or intermediate_output_from"):
         WorkflowBuilder(start_executor=_emit_one).build()
 
 
 @pytest.mark.parametrize(
-    ("output_executors", "intermediate_executors"),
+    ("final_output_from", "intermediate_output_from"),
     [([_emit_one], None), (None, [_emit_one]), ([], [_emit_one])],
     ids=["output_list", "intermediate_list", "empty_output_with_intermediate"],
 )
-def test_explicit_designation_with_executor_does_not_warn(output_executors, intermediate_executors) -> None:
+def test_explicit_designation_with_executor_does_not_warn(final_output_from, intermediate_output_from) -> None:
     """State B: any explicit designation with at least one executor opts into explicit mode without warning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         WorkflowBuilder(
             start_executor=_emit_one,
-            output_executors=output_executors,
-            intermediate_executors=intermediate_executors,
+            final_output_from=final_output_from,
+            intermediate_output_from=intermediate_output_from,
         ).build()
 
 
 @pytest.mark.parametrize(
-    ("output_executors", "intermediate_executors"),
+    ("final_output_from", "intermediate_output_from"),
     [([], None), (None, []), ([], [])],
     ids=["empty_output", "empty_intermediate", "both_empty"],
 )
-def test_empty_explicit_designation_fails(output_executors, intermediate_executors) -> None:
+def test_empty_explicit_designation_fails(final_output_from, intermediate_output_from) -> None:
     """State C: explicit mode needs at least one output or intermediate executor."""
     with pytest.raises(WorkflowValidationError, match="at least one output or intermediate executor"):
         WorkflowBuilder(
             start_executor=_emit_one,
-            output_executors=output_executors,
-            intermediate_executors=intermediate_executors,
+            final_output_from=final_output_from,
+            intermediate_output_from=intermediate_output_from,
         ).build()

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -37,13 +37,19 @@ async def _downstream(message: str, ctx: WorkflowContext[Never, str]) -> None:
 
 def test_designation_unset_emits_deprecation_warning() -> None:
     """State A: WorkflowBuilder built without explicit designation warns."""
-    with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from"):
+    with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from") as warning_info:
         WorkflowBuilder(start_executor=_emit_one).build()
+    assert str(warning_info[0].message) == (
+        "WorkflowBuilder built without explicit output_from or intermediate_output_from; "
+        "every yield_output produces type='output' for compatibility. Pass output_from='all', "
+        "output_from=[...], or intermediate_output_from=[...] to opt into explicit designation - "
+        "explicit designation will be required in a future version."
+    )
 
 
 @pytest.mark.asyncio
-async def test_designation_unset_preserves_legacy_all_output_behavior() -> None:
-    """Omitted designation keeps legacy all-output behavior while warning."""
+async def test_designation_unset_preserves_compatibility_all_output_behavior() -> None:
+    """Omitted designation keeps compatibility all-output behavior while warning."""
     with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from"):
         workflow = WorkflowBuilder(start_executor=_start).add_edge(_start, _downstream).build()
 
@@ -54,8 +60,8 @@ async def test_designation_unset_preserves_legacy_all_output_behavior() -> None:
 
 
 @pytest.mark.asyncio
-async def test_output_from_all_emits_all_outputs_without_legacy_warning() -> None:
-    """Explicit all-output designation emits every executor payload without legacy warning."""
+async def test_output_from_all_emits_all_outputs_without_omitted_selection_warning() -> None:
+    """Explicit all-output designation emits every executor payload without omitted-selection warning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         workflow = WorkflowBuilder(start_executor=_start, output_from="all").add_edge(_start, _downstream).build()
@@ -147,7 +153,7 @@ def test_all_other_expands_to_concrete_intermediate_executor_selection_at_build_
 
 @pytest.mark.asyncio
 async def test_all_other_with_omitted_output_from_emits_only_intermediate_outputs() -> None:
-    """All-other intermediate designation opts out of legacy all-output mode."""
+    """All-other intermediate designation opts out of omitted-selection all-output behavior."""
     workflow = (
         WorkflowBuilder(
             start_executor=_start,
@@ -261,4 +267,14 @@ def test_intermediate_executors_builder_parameter_is_not_public() -> None:
         builder_type(
             start_executor=_emit_one,
             intermediate_executors=[_emit_one],
+        )
+
+
+def test_final_output_from_builder_parameter_is_not_public() -> None:
+    """The branch-only final_output_from builder parameter is not supported."""
+    builder_type: Any = WorkflowBuilder
+    with pytest.raises(TypeError, match="unexpected keyword argument 'final_output_from'"):
+        builder_type(
+            start_executor=_emit_one,
+            final_output_from=[_emit_one],
         )

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -24,10 +24,69 @@ async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -
     await ctx.yield_output("hello")
 
 
+@executor
+async def _start(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+    await ctx.yield_output("from-start")
+    await ctx.send_message("downstream")
+
+
+@executor
+async def _downstream(message: str, ctx: WorkflowContext[Never, str]) -> None:
+    await ctx.yield_output("from-downstream")
+
+
 def test_designation_unset_emits_deprecation_warning() -> None:
     """State A: WorkflowBuilder built without explicit designation warns."""
     with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from"):
         WorkflowBuilder(start_executor=_emit_one).build()
+
+
+@pytest.mark.asyncio
+async def test_designation_unset_preserves_legacy_all_output_behavior() -> None:
+    """Omitted designation keeps legacy all-output behavior while warning."""
+    with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from"):
+        workflow = WorkflowBuilder(start_executor=_start).add_edge(_start, _downstream).build()
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == ["from-start", "from-downstream"]
+    assert result.get_intermediate_outputs() == []
+
+
+@pytest.mark.asyncio
+async def test_output_from_all_emits_all_outputs_without_legacy_warning() -> None:
+    """Explicit all-output designation emits every executor payload without legacy warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        workflow = WorkflowBuilder(start_executor=_start, output_from="all").add_edge(_start, _downstream).build()
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == ["from-start", "from-downstream"]
+    assert result.get_intermediate_outputs() == []
+
+
+@pytest.mark.asyncio
+async def test_output_from_all_with_empty_intermediate_list_is_valid() -> None:
+    """Explicit all-output plus an empty intermediate list is a concrete no-intermediate selection."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        workflow = (
+            WorkflowBuilder(start_executor=_start, output_from="all", intermediate_output_from=[])
+            .add_edge(_start, _downstream)
+            .build()
+        )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == ["from-start", "from-downstream"]
+    assert result.get_intermediate_outputs() == []
+
+
+def test_intermediate_output_from_all_is_rejected() -> None:
+    """The all-output literal is only valid for workflow output selection."""
+    with pytest.raises(ValueError, match="intermediate_output_from.*all.*output_from"):
+        WorkflowBuilder(start_executor=_emit_one, intermediate_output_from="all")  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -83,10 +83,134 @@ async def test_output_from_all_with_empty_intermediate_list_is_valid() -> None:
     assert result.get_intermediate_outputs() == []
 
 
+@pytest.mark.asyncio
+async def test_intermediate_output_from_all_other_marks_non_outputs_as_intermediate() -> None:
+    """All-other intermediate designation classifies every non-output executor yield as intermediate."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_from=[_downstream],
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == ["from-downstream"]
+    assert result.get_intermediate_outputs() == ["from-start"]
+
+
+@pytest.mark.asyncio
+async def test_all_other_streaming_events_mark_non_outputs_as_intermediate() -> None:
+    """All-other emits intermediate events while streaming, not just in collected results."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_from=[_downstream],
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+    outputs: list[str] = []
+    intermediates: list[str] = []
+
+    async for event in workflow.run([Message(role="user", contents=["hi"])], stream=True):
+        if event.type == "output":
+            outputs.append(event.data)
+        elif event.type == "intermediate":
+            intermediates.append(event.data)
+
+    assert outputs == ["from-downstream"]
+    assert intermediates == ["from-start"]
+
+
+def test_all_other_expands_to_concrete_intermediate_executor_selection_at_build_time() -> None:
+    """The runner receives concrete executor IDs after all-other expansion."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_from=[_downstream],
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+
+    assert {executor.id for executor in workflow.get_output_executors()} == {_downstream.id}
+    assert {executor.id for executor in workflow.get_intermediate_executors()} == {_start.id}
+    assert workflow.is_intermediate_executor(_start.id)
+    assert not workflow.is_intermediate_executor(_downstream.id)
+
+
+@pytest.mark.asyncio
+async def test_all_other_with_omitted_output_from_emits_only_intermediate_outputs() -> None:
+    """All-other intermediate designation opts out of legacy all-output mode."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == []
+    assert result.get_intermediate_outputs() == ["from-start", "from-downstream"]
+
+
+@pytest.mark.asyncio
+async def test_all_other_with_empty_output_from_emits_only_intermediate_outputs() -> None:
+    """All-other intermediate designation treats an empty output list as selecting no workflow outputs."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_from=[],
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == []
+    assert result.get_intermediate_outputs() == ["from-start", "from-downstream"]
+
+
+@pytest.mark.asyncio
+async def test_all_other_with_output_from_all_expands_to_empty_intermediate_selection() -> None:
+    """All-other is empty when every output-capable executor is already selected as workflow output."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_from="all",
+            intermediate_output_from="all_other",
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == ["from-start", "from-downstream"]
+    assert result.get_intermediate_outputs() == []
+
+
 def test_intermediate_output_from_all_is_rejected() -> None:
     """The all-output literal is only valid for workflow output selection."""
     with pytest.raises(ValueError, match="intermediate_output_from.*all.*output_from"):
         WorkflowBuilder(start_executor=_emit_one, intermediate_output_from="all")  # type: ignore[arg-type]
+
+
+def test_output_from_all_other_is_rejected() -> None:
+    """The all-other literal is only valid for intermediate output selection."""
+    with pytest.raises(ValueError, match="output_from.*all_other"):
+        WorkflowBuilder(start_executor=_emit_one, output_from="all_other")  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -207,10 +207,17 @@ async def test_all_other_with_output_from_all_expands_to_empty_intermediate_sele
     assert result.get_intermediate_outputs() == []
 
 
-def test_intermediate_output_from_all_is_rejected() -> None:
-    """The all-output literal is only valid for workflow output selection."""
-    with pytest.raises(ValueError, match="intermediate_output_from.*all.*output_from"):
-        WorkflowBuilder(start_executor=_emit_one, intermediate_output_from="all")  # type: ignore[arg-type]
+@pytest.mark.asyncio
+async def test_intermediate_output_from_all_routes_every_yield_to_intermediate() -> None:
+    """``intermediate_output_from="all"`` designates every output-capable executor as intermediate."""
+    workflow = (
+        WorkflowBuilder(start_executor=_start, intermediate_output_from="all").add_edge(_start, _downstream).build()
+    )
+
+    result = await workflow.run([Message(role="user", contents=["hi"])])
+
+    assert result.get_outputs() == []
+    assert result.get_intermediate_outputs() == ["from-start", "from-downstream"]
 
 
 def test_output_from_all_other_is_rejected() -> None:

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -1,16 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Tests for the explicit output/intermediate designation contract on WorkflowBuilder.
-
-State A: output_executors=None and intermediate_executors=None -> DeprecationWarning at build
-State B: explicit designation with at least one executor -> no warning
-State C: explicit designation with no executors -> validation error
-State D: deprecated alias and new canonical kwarg both supplied -> TypeError at construction
-"""
+"""Tests for the explicit output/intermediate selection contract on WorkflowBuilder."""
 
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 import pytest
 from typing_extensions import Never
@@ -31,56 +26,56 @@ async def _emit_one(messages: list[Message], ctx: WorkflowContext[Never, str]) -
 
 def test_designation_unset_emits_deprecation_warning() -> None:
     """State A: WorkflowBuilder built without explicit designation warns."""
-    with pytest.warns(DeprecationWarning, match="final_output_from or intermediate_output_from"):
+    with pytest.warns(DeprecationWarning, match="output_from or intermediate_output_from"):
         WorkflowBuilder(start_executor=_emit_one).build()
 
 
 @pytest.mark.parametrize(
-    ("final_output_from", "intermediate_output_from"),
+    ("output_from", "intermediate_output_from"),
     [([_emit_one], None), (None, [_emit_one]), ([], [_emit_one])],
     ids=["output_list", "intermediate_list", "empty_output_with_intermediate"],
 )
-def test_explicit_designation_with_executor_does_not_warn(final_output_from, intermediate_output_from) -> None:
+def test_explicit_designation_with_executor_does_not_warn(output_from, intermediate_output_from) -> None:
     """State B: any explicit designation with at least one executor opts into explicit mode without warning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         WorkflowBuilder(
             start_executor=_emit_one,
-            final_output_from=final_output_from,
+            output_from=output_from,
             intermediate_output_from=intermediate_output_from,
         ).build()
 
 
 @pytest.mark.parametrize(
-    ("final_output_from", "intermediate_output_from"),
+    ("output_from", "intermediate_output_from"),
     [([], None), (None, []), ([], [])],
     ids=["empty_output", "empty_intermediate", "both_empty"],
 )
-def test_empty_explicit_designation_fails(final_output_from, intermediate_output_from) -> None:
+def test_empty_explicit_designation_fails(output_from, intermediate_output_from) -> None:
     """State C: explicit mode needs at least one output or intermediate executor."""
     with pytest.raises(WorkflowValidationError, match="at least one output or intermediate executor"):
         WorkflowBuilder(
             start_executor=_emit_one,
-            final_output_from=final_output_from,
+            output_from=output_from,
             intermediate_output_from=intermediate_output_from,
         ).build()
 
 
-def test_passing_both_output_executors_and_final_output_from_raises_type_error() -> None:
-    """State D: supplying both the deprecated alias and the new canonical kwarg is unambiguous user error."""
-    with pytest.raises(TypeError, match="Cannot pass both `output_executors`.*and `final_output_from`"):
+def test_passing_both_output_executors_and_output_from_raises_type_error() -> None:
+    """State D: supplying a deprecated alias and the canonical kwarg is unambiguous user error."""
+    with pytest.raises(TypeError, match="Cannot pass multiple workflow output selection parameters"):
         WorkflowBuilder(
             start_executor=_emit_one,
             output_executors=[_emit_one],
-            final_output_from=[_emit_one],
+            output_from=[_emit_one],
         )
 
 
-def test_passing_both_intermediate_executors_and_intermediate_output_from_raises_type_error() -> None:
-    """State D: same rule for the intermediate pair."""
-    with pytest.raises(TypeError, match="Cannot pass both `intermediate_executors`.*and `intermediate_output_from`"):
-        WorkflowBuilder(
+def test_intermediate_executors_builder_parameter_is_not_public() -> None:
+    """The branch-only intermediate_executors builder parameter is not supported."""
+    builder_type: Any = WorkflowBuilder
+    with pytest.raises(TypeError, match="unexpected keyword argument 'intermediate_executors'"):
+        builder_type(
             start_executor=_emit_one,
             intermediate_executors=[_emit_one],
-            intermediate_output_from=[_emit_one],
         )

--- a/python/packages/core/tests/workflow/test_output_executors_contract.py
+++ b/python/packages/core/tests/workflow/test_output_executors_contract.py
@@ -5,6 +5,7 @@
 State A: output_executors=None and intermediate_executors=None -> DeprecationWarning at build
 State B: explicit designation with at least one executor -> no warning
 State C: explicit designation with no executors -> validation error
+State D: deprecated alias and new canonical kwarg both supplied -> TypeError at construction
 """
 
 from __future__ import annotations
@@ -63,3 +64,23 @@ def test_empty_explicit_designation_fails(final_output_from, intermediate_output
             final_output_from=final_output_from,
             intermediate_output_from=intermediate_output_from,
         ).build()
+
+
+def test_passing_both_output_executors_and_final_output_from_raises_type_error() -> None:
+    """State D: supplying both the deprecated alias and the new canonical kwarg is unambiguous user error."""
+    with pytest.raises(TypeError, match="Cannot pass both `output_executors`.*and `final_output_from`"):
+        WorkflowBuilder(
+            start_executor=_emit_one,
+            output_executors=[_emit_one],
+            final_output_from=[_emit_one],
+        )
+
+
+def test_passing_both_intermediate_executors_and_intermediate_output_from_raises_type_error() -> None:
+    """State D: same rule for the intermediate pair."""
+    with pytest.raises(TypeError, match="Cannot pass both `intermediate_executors`.*and `intermediate_output_from`"):
+        WorkflowBuilder(
+            start_executor=_emit_one,
+            intermediate_executors=[_emit_one],
+            intermediate_output_from=[_emit_one],
+        )

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -158,7 +158,9 @@ async def test_runner_run_iteration_preserves_message_order_per_edge_runner() ->
         def __init__(self) -> None:
             self.received: list[int] = []
 
-        async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+        async def send_message(
+            self, message: WorkflowMessage, state: State, ctx: RunnerContext, *args: object, **kwargs: object
+        ) -> bool:
             message_data = message.data
             assert isinstance(message_data, MockMessage)
             self.received.append(message_data.data)
@@ -188,7 +190,9 @@ async def test_runner_run_iteration_delivers_different_edge_runners_concurrently
             self.release = asyncio.Event()
             self.call_count = 0
 
-        async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+        async def send_message(
+            self, message: WorkflowMessage, state: State, ctx: RunnerContext, *args: object, **kwargs: object
+        ) -> bool:
             self.call_count += 1
             self.started.set()
             await self.release.wait()
@@ -199,7 +203,9 @@ async def test_runner_run_iteration_delivers_different_edge_runners_concurrently
             self.probe_completed = asyncio.Event()
             self.call_count = 0
 
-        async def send_message(self, message: WorkflowMessage, state: State, ctx: RunnerContext) -> bool:
+        async def send_message(
+            self, message: WorkflowMessage, state: State, ctx: RunnerContext, *args: object, **kwargs: object
+        ) -> bool:
             self.call_count += 1
             self.probe_completed.set()
             return True

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -772,7 +772,7 @@ async def test_runner_with_pre_loop_events():
     runner = Runner([], {}, state, ctx, "test_name", graph_signature_hash="test_hash")
 
     # Add an event before running
-    await ctx.add_event(WorkflowEvent.output(executor_id="test_executor", data="pre-loop-output"))
+    await ctx.add_event(WorkflowEvent("output", executor_id="test_executor", data="pre-loop-output"))
 
     events: list[WorkflowEvent] = []
     async for event in runner.run_until_convergence():
@@ -897,7 +897,7 @@ class ExecutorThatFailsWithEvents(Executor):
         # First emit an output event to the workflow context
         await ctx.yield_output(f"output-before-failure-{message.data}")
         # Add some events directly to the runner context
-        await self._runner_ctx.add_event(WorkflowEvent.output(executor_id=self.id, data="pending-event"))
+        await self._runner_ctx.add_event(WorkflowEvent("output", executor_id=self.id, data="pending-event"))
         # Fail on the specified iteration
         if self._iteration_count >= self._fail_on_iteration:
             raise RuntimeError("Executor failed with pending events")

--- a/python/packages/core/tests/workflow/test_serialization.py
+++ b/python/packages/core/tests/workflow/test_serialization.py
@@ -801,8 +801,8 @@ def test_comprehensive_edge_groups_workflow_serialization() -> None:
         assert len(single_group["edges"]) == 1, "Each SingleEdgeGroup should have exactly 1 edge"
 
 
-def test_to_dict_preserves_legacy_wire_keys_for_output_designation() -> None:
-    """to_dict() must emit the legacy wire keys regardless of the Python kwarg names.
+def test_to_dict_preserves_compatibility_wire_keys_for_output_designation() -> None:
+    """to_dict() must emit the compatibility wire keys regardless of the Python kwarg names.
 
     The Python API renamed ``output_executors`` -> ``output_from`` and
     uses ``intermediate_output_from`` for intermediate selection, but the serialized

--- a/python/packages/core/tests/workflow/test_serialization.py
+++ b/python/packages/core/tests/workflow/test_serialization.py
@@ -804,8 +804,8 @@ def test_comprehensive_edge_groups_workflow_serialization() -> None:
 def test_to_dict_preserves_legacy_wire_keys_for_output_designation() -> None:
     """to_dict() must emit the legacy wire keys regardless of the Python kwarg names.
 
-    The Python API renamed ``output_executors`` -> ``final_output_from`` and
-    ``intermediate_executors`` -> ``intermediate_output_from``, but the serialized
+    The Python API renamed ``output_executors`` -> ``output_from`` and
+    uses ``intermediate_output_from`` for intermediate selection, but the serialized
     dict must keep the old keys so existing checkpoints stay readable. This is a
     regression guard against accidental renames of the wire format.
     """
@@ -828,7 +828,7 @@ def test_to_dict_preserves_legacy_wire_keys_for_output_designation() -> None:
     workflow = (
         WorkflowBuilder(
             start_executor=start,
-            final_output_from=[final],
+            output_from=[final],
             intermediate_output_from=[progress],
         )
         .add_edge(start, progress)
@@ -840,7 +840,7 @@ def test_to_dict_preserves_legacy_wire_keys_for_output_designation() -> None:
 
     assert "output_executors" in d, "wire key 'output_executors' must be preserved"
     assert "intermediate_executors" in d, "wire key 'intermediate_executors' must be preserved"
-    assert "final_output_from" not in d, "new Python kwarg name must NOT leak into the wire format"
+    assert "output_from" not in d, "new Python kwarg name must NOT leak into the wire format"
     assert "intermediate_output_from" not in d, "new Python kwarg name must NOT leak into the wire format"
     assert d["output_executors"] == ["final"]
     assert d["intermediate_executors"] == ["progress"]

--- a/python/packages/core/tests/workflow/test_serialization.py
+++ b/python/packages/core/tests/workflow/test_serialization.py
@@ -799,3 +799,48 @@ def test_comprehensive_edge_groups_workflow_serialization() -> None:
     assert len(fan_in_groups[0]["edges"]) == 2, "FanInEdgeGroup should have 2 edges (from parallel_1 and parallel_2)"
     for single_group in single_groups:
         assert len(single_group["edges"]) == 1, "Each SingleEdgeGroup should have exactly 1 edge"
+
+
+def test_to_dict_preserves_legacy_wire_keys_for_output_designation() -> None:
+    """to_dict() must emit the legacy wire keys regardless of the Python kwarg names.
+
+    The Python API renamed ``output_executors`` -> ``final_output_from`` and
+    ``intermediate_executors`` -> ``intermediate_output_from``, but the serialized
+    dict must keep the old keys so existing checkpoints stay readable. This is a
+    regression guard against accidental renames of the wire format.
+    """
+
+    class _Yielder(Executor):
+        @handler
+        async def handle(self, message: str, ctx: WorkflowContext[str, str]) -> None:
+            await ctx.yield_output(message)
+            await ctx.send_message(message)
+
+    class _Terminal(Executor):
+        @handler
+        async def handle(self, message: str, ctx: WorkflowContext[str, str]) -> None:
+            await ctx.yield_output(f"final: {message}")
+
+    start = _Yielder(id="start")
+    progress = _Yielder(id="progress")
+    final = _Terminal(id="final")
+
+    workflow = (
+        WorkflowBuilder(
+            start_executor=start,
+            final_output_from=[final],
+            intermediate_output_from=[progress],
+        )
+        .add_edge(start, progress)
+        .add_edge(progress, final)
+        .build()
+    )
+
+    d = workflow.to_dict()
+
+    assert "output_executors" in d, "wire key 'output_executors' must be preserved"
+    assert "intermediate_executors" in d, "wire key 'intermediate_executors' must be preserved"
+    assert "final_output_from" not in d, "new Python kwarg name must NOT leak into the wire format"
+    assert "intermediate_output_from" not in d, "new Python kwarg name must NOT leak into the wire format"
+    assert d["output_executors"] == ["final"]
+    assert d["intermediate_executors"] == ["progress"]

--- a/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
+++ b/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for the runner's strict-mode event labeling.
+
+Strict mode = WorkflowBuilder built with explicit output_executors=[...].
+- Yields from designated executors -> type='output'.
+- Yields from non-designated executors -> type='intermediate'.
+
+Legacy mode (output_executors unset) preserves today's behavior:
+every yield -> type='output'.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+from typing_extensions import Never
+
+from agent_framework import (
+    Message,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+)
+
+
+@executor
+async def _start(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+    await ctx.yield_output("from-start")
+    await ctx.send_message("downstream")
+
+
+@executor
+async def _downstream(message: str, ctx: WorkflowContext[Never, str]) -> None:
+    await ctx.yield_output("from-downstream")
+
+
+def _input_msg() -> list[Message]:
+    return [Message(role="user", contents=["hi"])]
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_designated_executor_emits_output_events() -> None:
+    """In strict mode, the designated executor's yields produce type='output' events."""
+    workflow = WorkflowBuilder(start_executor=_start, output_executors=[_start]).add_edge(_start, _downstream).build()
+    output_events: list[Any] = []
+    intermediate_events: list[Any] = []
+    async for event in workflow.run(_input_msg(), stream=True):
+        if event.type == "output":
+            output_events.append(event)
+        elif event.type == "intermediate":
+            intermediate_events.append(event)
+
+    assert any(ev.data == "from-start" for ev in output_events), "designated executor's yield is type='output'"
+    assert any(ev.data == "from-downstream" for ev in intermediate_events), (
+        "non-designated executor's yield is relabeled to type='intermediate'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_empty_list_means_no_terminals() -> None:
+    """Strict mode with output_executors=[] produces zero type='output' events; everything is intermediate."""
+    workflow = WorkflowBuilder(start_executor=_start, output_executors=[]).add_edge(_start, _downstream).build()
+    output_events: list[Any] = []
+    intermediate_events: list[Any] = []
+    async for event in workflow.run(_input_msg(), stream=True):
+        if event.type == "output":
+            output_events.append(event)
+        elif event.type == "intermediate":
+            intermediate_events.append(event)
+
+    assert len(output_events) == 0
+    assert {ev.data for ev in intermediate_events} == {"from-start", "from-downstream"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_mode_unset_keeps_all_yields_as_output() -> None:
+    """Legacy mode (output_executors unset) preserves today's behavior — all yields are type='output'."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        workflow = WorkflowBuilder(start_executor=_start).add_edge(_start, _downstream).build()
+    output_events: list[Any] = []
+    intermediate_events: list[Any] = []
+    async for event in workflow.run(_input_msg(), stream=True):
+        if event.type == "output":
+            output_events.append(event)
+        elif event.type == "intermediate":
+            intermediate_events.append(event)
+
+    assert {ev.data for ev in output_events} == {"from-start", "from-downstream"}
+    assert len(intermediate_events) == 0
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_get_outputs_returns_only_designated() -> None:
+    """WorkflowRunResult.get_outputs() returns only designated outputs in strict mode."""
+    workflow = (
+        WorkflowBuilder(start_executor=_start, output_executors=[_downstream]).add_edge(_start, _downstream).build()
+    )
+    result = await workflow.run(_input_msg())
+    outputs = result.get_outputs()
+    assert outputs == ["from-downstream"]
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_get_outputs_empty_with_no_terminals() -> None:
+    """output_executors=[] yields no terminal outputs."""
+    workflow = WorkflowBuilder(start_executor=_start, output_executors=[]).add_edge(_start, _downstream).build()
+    result = await workflow.run(_input_msg())
+    assert result.get_outputs() == []

--- a/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
+++ b/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
@@ -1,16 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Tests for the runner's strict-mode event labeling.
-
-Explicit designation mode = WorkflowBuilder built with explicit output_executors
-or intermediate_executors.
-- Yields from output executors -> type='output'.
-- Yields from intermediate executors -> type='intermediate'.
-- Yields from unlisted executors -> hidden from caller-facing output/intermediate events.
-
-Legacy mode (output_executors unset) preserves today's behavior:
-every yield -> type='output'.
-"""
+"""Tests for the runner's explicit output selection event labeling."""
 
 from __future__ import annotations
 
@@ -46,7 +36,7 @@ def _input_msg() -> list[Message]:
 @pytest.mark.asyncio
 async def test_strict_mode_designated_executor_emits_output_events() -> None:
     """Output-designated executor yields produce type='output' events."""
-    workflow = WorkflowBuilder(start_executor=_start, output_executors=[_start]).add_edge(_start, _downstream).build()
+    workflow = WorkflowBuilder(start_executor=_start, output_from=[_start]).add_edge(_start, _downstream).build()
     output_events: list[Any] = []
     intermediate_events: list[Any] = []
     async for event in workflow.run(_input_msg(), stream=True):
@@ -64,7 +54,7 @@ async def test_strict_mode_designated_executor_emits_output_events() -> None:
 async def test_intermediate_designated_executor_emits_intermediate_events() -> None:
     """Intermediate-designated executor yields produce type='intermediate' events."""
     workflow = (
-        WorkflowBuilder(start_executor=_start, intermediate_executors=[_downstream])
+        WorkflowBuilder(start_executor=_start, intermediate_output_from=[_downstream])
         .add_edge(_start, _downstream)
         .build()
     )
@@ -104,8 +94,8 @@ async def test_strict_mode_get_outputs_returns_only_designated() -> None:
     workflow = (
         WorkflowBuilder(
             start_executor=_start,
-            output_executors=[_downstream],
-            intermediate_executors=[_start],
+            output_from=[_downstream],
+            intermediate_output_from=[_start],
         )
         .add_edge(_start, _downstream)
         .build()
@@ -118,9 +108,7 @@ async def test_strict_mode_get_outputs_returns_only_designated() -> None:
 @pytest.mark.asyncio
 async def test_hidden_yields_remain_in_executor_completion_events() -> None:
     """Hidden yield_output payloads stay available through executor_completed observability."""
-    workflow = (
-        WorkflowBuilder(start_executor=_start, output_executors=[_downstream]).add_edge(_start, _downstream).build()
-    )
+    workflow = WorkflowBuilder(start_executor=_start, output_from=[_downstream]).add_edge(_start, _downstream).build()
     result = await workflow.run(_input_msg())
     assert result.get_outputs() == ["from-downstream"]
     assert result.get_intermediate_outputs() == []

--- a/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
+++ b/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
@@ -2,9 +2,11 @@
 
 """Tests for the runner's strict-mode event labeling.
 
-Strict mode = WorkflowBuilder built with explicit output_executors=[...].
-- Yields from designated executors -> type='output'.
-- Yields from non-designated executors -> type='intermediate'.
+Explicit designation mode = WorkflowBuilder built with explicit output_executors
+or intermediate_executors.
+- Yields from output executors -> type='output'.
+- Yields from intermediate executors -> type='intermediate'.
+- Yields from unlisted executors -> hidden from caller-facing output/intermediate events.
 
 Legacy mode (output_executors unset) preserves today's behavior:
 every yield -> type='output'.
@@ -43,7 +45,7 @@ def _input_msg() -> list[Message]:
 
 @pytest.mark.asyncio
 async def test_strict_mode_designated_executor_emits_output_events() -> None:
-    """In strict mode, the designated executor's yields produce type='output' events."""
+    """Output-designated executor yields produce type='output' events."""
     workflow = WorkflowBuilder(start_executor=_start, output_executors=[_start]).add_edge(_start, _downstream).build()
     output_events: list[Any] = []
     intermediate_events: list[Any] = []
@@ -54,15 +56,18 @@ async def test_strict_mode_designated_executor_emits_output_events() -> None:
             intermediate_events.append(event)
 
     assert any(ev.data == "from-start" for ev in output_events), "designated executor's yield is type='output'"
-    assert any(ev.data == "from-downstream" for ev in intermediate_events), (
-        "non-designated executor's yield is relabeled to type='intermediate'"
-    )
+    assert intermediate_events == []
+    assert all(ev.data != "from-downstream" for ev in output_events), "unlisted executor yield is hidden"
 
 
 @pytest.mark.asyncio
-async def test_strict_mode_empty_list_means_no_terminals() -> None:
-    """Strict mode with output_executors=[] produces zero type='output' events; everything is intermediate."""
-    workflow = WorkflowBuilder(start_executor=_start, output_executors=[]).add_edge(_start, _downstream).build()
+async def test_intermediate_designated_executor_emits_intermediate_events() -> None:
+    """Intermediate-designated executor yields produce type='intermediate' events."""
+    workflow = (
+        WorkflowBuilder(start_executor=_start, intermediate_executors=[_downstream])
+        .add_edge(_start, _downstream)
+        .build()
+    )
     output_events: list[Any] = []
     intermediate_events: list[Any] = []
     async for event in workflow.run(_input_msg(), stream=True):
@@ -72,7 +77,7 @@ async def test_strict_mode_empty_list_means_no_terminals() -> None:
             intermediate_events.append(event)
 
     assert len(output_events) == 0
-    assert {ev.data for ev in intermediate_events} == {"from-start", "from-downstream"}
+    assert {ev.data for ev in intermediate_events} == {"from-downstream"}
 
 
 @pytest.mark.asyncio
@@ -95,18 +100,31 @@ async def test_legacy_mode_unset_keeps_all_yields_as_output() -> None:
 
 @pytest.mark.asyncio
 async def test_strict_mode_get_outputs_returns_only_designated() -> None:
-    """WorkflowRunResult.get_outputs() returns only designated outputs in strict mode."""
+    """WorkflowRunResult.get_outputs() returns only output-designated payloads."""
+    workflow = (
+        WorkflowBuilder(
+            start_executor=_start,
+            output_executors=[_downstream],
+            intermediate_executors=[_start],
+        )
+        .add_edge(_start, _downstream)
+        .build()
+    )
+    result = await workflow.run(_input_msg())
+    assert result.get_outputs() == ["from-downstream"]
+    assert result.get_intermediate_outputs() == ["from-start"]
+
+
+@pytest.mark.asyncio
+async def test_hidden_yields_remain_in_executor_completion_events() -> None:
+    """Hidden yield_output payloads stay available through executor_completed observability."""
     workflow = (
         WorkflowBuilder(start_executor=_start, output_executors=[_downstream]).add_edge(_start, _downstream).build()
     )
     result = await workflow.run(_input_msg())
-    outputs = result.get_outputs()
-    assert outputs == ["from-downstream"]
-
-
-@pytest.mark.asyncio
-async def test_strict_mode_get_outputs_empty_with_no_terminals() -> None:
-    """output_executors=[] yields no terminal outputs."""
-    workflow = WorkflowBuilder(start_executor=_start, output_executors=[]).add_edge(_start, _downstream).build()
-    result = await workflow.run(_input_msg())
-    assert result.get_outputs() == []
+    assert result.get_outputs() == ["from-downstream"]
+    assert result.get_intermediate_outputs() == []
+    assert not any(event.type in {"output", "intermediate"} and event.data == "from-start" for event in result)
+    completed = [event for event in result if event.type == "executor_completed" and event.executor_id == _start.id]
+    assert completed
+    assert completed[0].data == ["downstream", "from-start"]

--- a/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
+++ b/python/packages/core/tests/workflow/test_strict_mode_event_labeling.py
@@ -71,8 +71,8 @@ async def test_intermediate_designated_executor_emits_intermediate_events() -> N
 
 
 @pytest.mark.asyncio
-async def test_legacy_mode_unset_keeps_all_yields_as_output() -> None:
-    """Legacy mode (output_executors unset) preserves today's behavior — all yields are type='output'."""
+async def test_omitted_selection_keeps_all_yields_as_output() -> None:
+    """Omitted output selection preserves today's behavior: all yields are type='output'."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         workflow = WorkflowBuilder(start_executor=_start).add_edge(_start, _downstream).build()

--- a/python/packages/core/tests/workflow/test_sub_workflow.py
+++ b/python/packages/core/tests/workflow/test_sub_workflow.py
@@ -651,7 +651,7 @@ async def test_sub_workflow_intermediate_outputs_propagate_to_parent() -> None:
     child = (
         WorkflowBuilder(
             start_executor=progress,
-            final_output_from=[finalizer],
+            output_from=[finalizer],
             intermediate_output_from=[progress],
         )
         .add_edge(progress, finalizer)
@@ -671,7 +671,7 @@ async def test_sub_workflow_intermediate_outputs_propagate_to_parent() -> None:
             await ctx.yield_output(message)
 
     sink = _ParentSink()
-    parent = WorkflowBuilder(start_executor=sub, final_output_from=[sink]).add_edge(sub, sink).build()
+    parent = WorkflowBuilder(start_executor=sub, output_from=[sink]).add_edge(sub, sink).build()
 
     intermediate_events: list[WorkflowEvent[Any]] = []
     output_events: list[WorkflowEvent[Any]] = []

--- a/python/packages/core/tests/workflow/test_sub_workflow.py
+++ b/python/packages/core/tests/workflow/test_sub_workflow.py
@@ -617,3 +617,75 @@ async def test_sub_workflow_checkpoint_restore_no_duplicate_requests() -> None:
     # Key assertion: Only the second request should be received, not a duplicate of the first
     assert len(request_events) == 1
     assert request_events[0].data.prompt == "Second request"
+
+
+async def test_sub_workflow_intermediate_outputs_propagate_to_parent() -> None:
+    """A child workflow's intermediate emissions must bubble up through the parent.
+
+    Regression guard for the bug where WorkflowExecutor._process_workflow_result only
+    forwarded result.get_outputs() and silently dropped result.get_intermediate_outputs().
+    The forwarded event must carry the WorkflowExecutor's own id as the source so outer
+    callers don't have to know the child's internal executor layout, and it must keep
+    type='intermediate' regardless of how the parent designates the WorkflowExecutor.
+    """
+
+    class _ProgressEmitter(Executor):
+        def __init__(self) -> None:
+            super().__init__(id="progress_emitter")
+
+        @handler
+        async def run(self, message: str, ctx: WorkflowContext[str, str]) -> None:
+            await ctx.yield_output(f"progress: {message}")
+            await ctx.send_message(message)
+
+    class _Finalizer(Executor):
+        def __init__(self) -> None:
+            super().__init__(id="finalizer")
+
+        @handler
+        async def run(self, message: str, ctx: WorkflowContext[Never, str]) -> None:
+            await ctx.yield_output(f"final: {message}")
+
+    progress = _ProgressEmitter()
+    finalizer = _Finalizer()
+    child = (
+        WorkflowBuilder(
+            start_executor=progress,
+            final_output_from=[finalizer],
+            intermediate_output_from=[progress],
+        )
+        .add_edge(progress, finalizer)
+        .build()
+    )
+
+    sub = WorkflowExecutor(child, id="sub")
+
+    class _ParentSink(Executor):
+        def __init__(self) -> None:
+            super().__init__(id="parent_sink")
+            self.received: list[str] = []
+
+        @handler
+        async def run(self, message: str, ctx: WorkflowContext[Never, str]) -> None:
+            self.received.append(message)
+            await ctx.yield_output(message)
+
+    sink = _ParentSink()
+    parent = WorkflowBuilder(start_executor=sub, final_output_from=[sink]).add_edge(sub, sink).build()
+
+    intermediate_events: list[WorkflowEvent[Any]] = []
+    output_events: list[WorkflowEvent[Any]] = []
+    async for event in parent.run("hello", stream=True):
+        if event.type == "intermediate":
+            intermediate_events.append(event)
+        elif event.type == "output":
+            output_events.append(event)
+
+    # The child's intermediate emission bubbled up labeled with the WorkflowExecutor id,
+    # not the child's internal executor id.
+    assert len(intermediate_events) == 1, [(e.executor_id, e.data) for e in intermediate_events]
+    assert intermediate_events[0].executor_id == "sub"
+    assert intermediate_events[0].data == "progress: hello"
+
+    # The parent's own terminal output is unaffected.
+    assert any(e.executor_id == "parent_sink" and e.data == "final: hello" for e in output_events)

--- a/python/packages/core/tests/workflow/test_validation.py
+++ b/python/packages/core/tests/workflow/test_validation.py
@@ -609,15 +609,20 @@ def test_output_validation_fails_for_executor_without_output_types():
 
 
 def test_output_validation_empty_list_passes():
-    """Test that output validation passes with an empty output executors list."""
+    """Test that output validation passes with an explicit empty output executors list.
+
+    Under the strict-output contract, ``output_executors=[]`` means "no terminals" —
+    no executor's yield is type='output'. This is distinct from the legacy default
+    (``output_executors=None``) which treats every executor as an output.
+    """
     executor1 = OutputExecutor(id="executor1")
     executor2 = OutputExecutor(id="executor2")
 
     workflow = WorkflowBuilder(start_executor=executor1, output_executors=[]).add_edge(executor1, executor2).build()
 
     assert workflow is not None
-    # All executors are outputs
-    assert workflow._output_executors == ["executor1", "executor2"]  # type: ignore
+    # Explicit empty list = strict mode with zero designated outputs.
+    assert workflow._output_executors == []  # type: ignore[attr-defined]
 
 
 def test_output_validation_with_direct_validate_workflow_graph():

--- a/python/packages/core/tests/workflow/test_validation.py
+++ b/python/packages/core/tests/workflow/test_validation.py
@@ -555,7 +555,7 @@ def test_output_validation_with_valid_output_executors():
     )
 
     assert workflow is not None
-    assert workflow._output_executors == ["executor2"]  # pyright: ignore[reportPrivateUsage]
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor2"}
 
 
 def test_output_validation_with_multiple_valid_output_executors():
@@ -572,7 +572,7 @@ def test_output_validation_with_multiple_valid_output_executors():
     )
 
     assert workflow is not None
-    assert set(workflow._output_executors) == {"executor1", "executor3"}  # pyright: ignore[reportPrivateUsage]
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor1", "executor3"}
 
 
 def test_output_validation_fails_for_nonexistent_executor():
@@ -622,7 +622,9 @@ def test_output_validation_empty_list_passes():
 
     assert workflow is not None
     # Explicit empty list = strict mode with zero designated outputs.
-    assert workflow._output_executors == []  # type: ignore[attr-defined]
+    assert workflow.get_output_executors() == []
+    assert not workflow.is_terminal_executor("executor1")
+    assert not workflow.is_terminal_executor("executor2")
 
 
 def test_output_validation_with_direct_validate_workflow_graph():

--- a/python/packages/core/tests/workflow/test_validation.py
+++ b/python/packages/core/tests/workflow/test_validation.py
@@ -550,9 +550,7 @@ def test_output_validation_with_valid_output_executors():
     executor2 = OutputExecutor(id="executor2")
 
     # Build workflow with valid output executors
-    workflow = (
-        WorkflowBuilder(start_executor=executor1, output_executors=[executor2]).add_edge(executor1, executor2).build()
-    )
+    workflow = WorkflowBuilder(start_executor=executor1, output_from=[executor2]).add_edge(executor1, executor2).build()
 
     assert workflow is not None
     assert {ex.id for ex in workflow.get_output_executors()} == {"executor2"}
@@ -565,7 +563,7 @@ def test_output_validation_with_multiple_valid_output_executors():
     executor3 = OutputExecutor(id="executor3")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor1, output_executors=[executor1, executor3])
+        WorkflowBuilder(start_executor=executor1, output_from=[executor1, executor3])
         .add_edge(executor1, executor2)
         .add_edge(executor2, executor3)
         .build()
@@ -598,7 +596,7 @@ def test_output_validation_fails_for_executor_without_output_types():
 
     with pytest.raises(WorkflowValidationError) as exc_info:
         (
-            WorkflowBuilder(start_executor=executor1, output_executors=[no_output_executor])
+            WorkflowBuilder(start_executor=executor1, output_from=[no_output_executor])
             .add_edge(executor1, no_output_executor)
             .build()
         )
@@ -614,7 +612,7 @@ def test_output_validation_empty_explicit_designation_fails():
     executor2 = OutputExecutor(id="executor2")
 
     with pytest.raises(WorkflowValidationError) as exc_info:
-        WorkflowBuilder(start_executor=executor1, output_executors=[]).add_edge(executor1, executor2).build()
+        WorkflowBuilder(start_executor=executor1, output_from=[]).add_edge(executor1, executor2).build()
 
     assert "at least one output or intermediate executor" in str(exc_info.value)
     assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
@@ -626,7 +624,7 @@ def test_output_validation_with_valid_intermediate_executors():
     executor2 = OutputExecutor(id="executor2")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor1, intermediate_executors=[executor1])
+        WorkflowBuilder(start_executor=executor1, intermediate_output_from=[executor1])
         .add_edge(executor1, executor2)
         .build()
     )
@@ -644,8 +642,8 @@ def test_output_validation_fails_for_designation_overlap():
     with pytest.raises(WorkflowValidationError) as exc_info:
         WorkflowBuilder(
             start_executor=executor1,
-            output_executors=[executor1],
-            intermediate_executors=[executor1],
+            output_from=[executor1],
+            intermediate_output_from=[executor1],
         ).build()
 
     assert "both output and intermediate" in str(exc_info.value)
@@ -657,7 +655,7 @@ def test_output_validation_fails_for_duplicate_designation():
     executor1 = OutputExecutor(id="executor1")
 
     with pytest.raises(WorkflowValidationError) as exc_info:
-        WorkflowBuilder(start_executor=executor1, output_executors=[executor1, executor1]).build()
+        WorkflowBuilder(start_executor=executor1, output_from=[executor1, executor1]).build()
 
     assert "Duplicate output executor designation" in str(exc_info.value)
     assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
@@ -671,7 +669,7 @@ def test_output_validation_fails_for_unknown_intermediate_executor():
 
     with pytest.raises(WorkflowValidationError) as exc_info:
         (
-            WorkflowBuilder(start_executor=executor1, intermediate_executors=[missing])
+            WorkflowBuilder(start_executor=executor1, intermediate_output_from=[missing])
             .add_edge(executor1, executor2)
             .build()
         )

--- a/python/packages/core/tests/workflow/test_validation.py
+++ b/python/packages/core/tests/workflow/test_validation.py
@@ -608,23 +608,77 @@ def test_output_validation_fails_for_executor_without_output_types():
     assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
 
 
-def test_output_validation_empty_list_passes():
-    """Test that output validation passes with an explicit empty output executors list.
-
-    Under the strict-output contract, ``output_executors=[]`` means "no terminals" —
-    no executor's yield is type='output'. This is distinct from the legacy default
-    (``output_executors=None``) which treats every executor as an output.
-    """
+def test_output_validation_empty_explicit_designation_fails():
+    """Test that explicit mode rejects an empty output/intermediate designation."""
     executor1 = OutputExecutor(id="executor1")
     executor2 = OutputExecutor(id="executor2")
 
-    workflow = WorkflowBuilder(start_executor=executor1, output_executors=[]).add_edge(executor1, executor2).build()
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        WorkflowBuilder(start_executor=executor1, output_executors=[]).add_edge(executor1, executor2).build()
+
+    assert "at least one output or intermediate executor" in str(exc_info.value)
+    assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
+
+
+def test_output_validation_with_valid_intermediate_executors():
+    """Test that output validation passes when intermediate executors exist and have output types."""
+    executor1 = OutputExecutor(id="executor1")
+    executor2 = OutputExecutor(id="executor2")
+
+    workflow = (
+        WorkflowBuilder(start_executor=executor1, intermediate_executors=[executor1])
+        .add_edge(executor1, executor2)
+        .build()
+    )
 
     assert workflow is not None
-    # Explicit empty list = strict mode with zero designated outputs.
-    assert workflow.get_output_executors() == []
-    assert not workflow.is_terminal_executor("executor1")
+    assert {ex.id for ex in workflow.get_intermediate_executors()} == {"executor1"}
+    assert workflow.is_intermediate_executor("executor1")
     assert not workflow.is_terminal_executor("executor2")
+
+
+def test_output_validation_fails_for_designation_overlap():
+    """Test that an executor cannot be both terminal and intermediate."""
+    executor1 = OutputExecutor(id="executor1")
+
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        WorkflowBuilder(
+            start_executor=executor1,
+            output_executors=[executor1],
+            intermediate_executors=[executor1],
+        ).build()
+
+    assert "both output and intermediate" in str(exc_info.value)
+    assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
+
+
+def test_output_validation_fails_for_duplicate_designation():
+    """Test that duplicate output or intermediate designation entries are rejected."""
+    executor1 = OutputExecutor(id="executor1")
+
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        WorkflowBuilder(start_executor=executor1, output_executors=[executor1, executor1]).build()
+
+    assert "Duplicate output executor designation" in str(exc_info.value)
+    assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
+
+
+def test_output_validation_fails_for_unknown_intermediate_executor():
+    """Test that intermediate designation rejects executors outside the workflow graph."""
+    executor1 = OutputExecutor(id="executor1")
+    executor2 = OutputExecutor(id="executor2")
+    missing = OutputExecutor(id="missing")
+
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        (
+            WorkflowBuilder(start_executor=executor1, intermediate_executors=[missing])
+            .add_edge(executor1, executor2)
+            .build()
+        )
+
+    assert "not present in the workflow graph" in str(exc_info.value)
+    assert "missing" in str(exc_info.value)
+    assert exc_info.value.validation_type == ValidationTypeEnum.OUTPUT_VALIDATION
 
 
 def test_output_validation_with_direct_validate_workflow_graph():

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -1056,7 +1056,7 @@ class PassthroughExecutor(Executor):
 
 
 async def test_output_executors_empty_yields_all_outputs() -> None:
-    """Test that when _output_executors is empty (default), all outputs are yielded."""
+    """Test that in legacy mode (no output_executors specified), all outputs are yielded."""
     # Create executors that each produce different outputs
     executor_a = PassthroughExecutor(id="executor_a", output_value=10)
     executor_b = OutputProducerExecutor(id="executor_b", output_value=20)
@@ -1154,12 +1154,14 @@ async def test_output_executors_with_multiple_specified_executors() -> None:
 
 async def test_output_executors_with_nonexistent_executor_id() -> None:
     """Test that specifying a non-existent executor ID doesn't break the workflow."""
+    from agent_framework._workflows._workflow import OutputDesignation
+
     executor_a = OutputProducerExecutor(id="executor_a", output_value=42)
 
     workflow = WorkflowBuilder(start_executor=executor_a).build()
 
-    # Set output_executors to an ID that doesn't exist
-    workflow._output_executors = ["nonexistent_executor"]  # type: ignore
+    # Designate a nonexistent executor so the workflow-level filter drops every yield.
+    workflow._output_designation = OutputDesignation(designated=frozenset({"nonexistent_executor"}))  # type: ignore[attr-defined]
 
     result = await workflow.run(NumberMessage(data=0))
     outputs = result.get_outputs()
@@ -1252,8 +1254,10 @@ async def test_output_executors_filtering_with_run_responses_streaming() -> None
     request_events = [e for e in events_list if e.type == "request_info"]
     assert len(request_events) == 1
 
-    # Set output_executors to exclude the approval executor
-    workflow._output_executors = ["other_executor"]  # type: ignore
+    # Designate a different executor so the workflow-level filter drops the approval yield.
+    from agent_framework._workflows._workflow import OutputDesignation
+
+    workflow._output_designation = OutputDesignation(designated=frozenset({"other_executor"}))  # type: ignore[attr-defined]
 
     # Send approval response via streaming
     responses = {request_events[0].request_id: ApprovalMessage(approved=True)}

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -1056,7 +1056,7 @@ class PassthroughExecutor(Executor):
 
 
 async def test_output_executors_empty_yields_all_outputs() -> None:
-    """Test that in legacy mode (no output_executors specified), all outputs are yielded."""
+    """Test that omitted output selection yields all outputs for compatibility."""
     # Create executors that each produce different outputs
     executor_a = PassthroughExecutor(id="executor_a", output_value=10)
     executor_b = OutputProducerExecutor(id="executor_b", output_value=20)
@@ -1158,6 +1158,7 @@ async def test_output_executors_with_nonexistent_executor_id() -> None:
 
     # Designate a nonexistent executor so the workflow-level filter drops every yield.
     workflow._output_designation = OutputDesignation(outputs=frozenset({"nonexistent_executor"}))  # type: ignore[attr-defined]
+    workflow._runner.context.set_yield_output_classifier(workflow._output_designation.classify)  # type: ignore[attr-defined,reportPrivateUsage]
 
     result = await workflow.run(NumberMessage(data=0))
     outputs = result.get_outputs()
@@ -1254,6 +1255,7 @@ async def test_output_executors_filtering_with_run_responses_streaming() -> None
     from agent_framework._workflows._workflow import OutputDesignation
 
     workflow._output_designation = OutputDesignation(outputs=frozenset({"other_executor"}))  # type: ignore[attr-defined]
+    workflow._runner.context.set_yield_output_classifier(workflow._output_designation.classify)  # type: ignore[attr-defined,reportPrivateUsage]
 
     # Send approval response via streaming
     responses = {request_events[0].request_id: ApprovalMessage(approved=True)}

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -1161,7 +1161,7 @@ async def test_output_executors_with_nonexistent_executor_id() -> None:
     workflow = WorkflowBuilder(start_executor=executor_a).build()
 
     # Designate a nonexistent executor so the workflow-level filter drops every yield.
-    workflow._output_designation = OutputDesignation(designated=frozenset({"nonexistent_executor"}))  # type: ignore[attr-defined]
+    workflow._output_designation = OutputDesignation(outputs=frozenset({"nonexistent_executor"}))  # type: ignore[attr-defined]
 
     result = await workflow.run(NumberMessage(data=0))
     outputs = result.get_outputs()
@@ -1257,7 +1257,7 @@ async def test_output_executors_filtering_with_run_responses_streaming() -> None
     # Designate a different executor so the workflow-level filter drops the approval yield.
     from agent_framework._workflows._workflow import OutputDesignation
 
-    workflow._output_designation = OutputDesignation(designated=frozenset({"other_executor"}))  # type: ignore[attr-defined]
+    workflow._output_designation = OutputDesignation(outputs=frozenset({"other_executor"}))  # type: ignore[attr-defined]
 
     # Send approval response via streaming
     responses = {request_events[0].request_id: ApprovalMessage(approved=True)}

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -1085,9 +1085,7 @@ async def test_output_executors_filters_outputs_non_streaming() -> None:
 
     # Build workflow with a -> b
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_b])
-        .add_edge(executor_a, executor_b)
-        .build()
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_b]).add_edge(executor_a, executor_b).build()
     )
 
     result = await workflow.run(NumberMessage(data=0))
@@ -1110,9 +1108,7 @@ async def test_output_executors_filters_outputs_streaming() -> None:
 
     # Build workflow with a -> b
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_a])
-        .add_edge(executor_a, executor_b)
-        .build()
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_a]).add_edge(executor_a, executor_b).build()
     )
 
     # Collect outputs from streaming
@@ -1136,7 +1132,7 @@ async def test_output_executors_with_multiple_specified_executors() -> None:
 
     # Build workflow with a -> b -> c
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_a, executor_c])
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_a, executor_c])
         .add_edge(executor_a, executor_b)
         .add_edge(executor_b, executor_c)
         .build()
@@ -1201,7 +1197,7 @@ async def test_output_executors_filtering_with_fan_in() -> None:
 
     # Build fan-in workflow: start -> [a, b] -> aggregator
     workflow = (
-        WorkflowBuilder(start_executor=executor_start, output_executors=[aggregator])
+        WorkflowBuilder(start_executor=executor_start, output_from=[aggregator])
         .add_fan_out_edges(executor_start, [executor_a, executor_b])
         .add_fan_in_edges([executor_a, executor_b], aggregator)
         .build()
@@ -1220,7 +1216,7 @@ async def test_output_executors_filtering_with_run_responses() -> None:
     """Test output filtering works correctly with run(responses=...) method."""
     executor = MockExecutorRequestApproval(id="approval_executor")
 
-    workflow = WorkflowBuilder(start_executor=executor, output_executors=[executor]).build()
+    workflow = WorkflowBuilder(start_executor=executor, output_from=[executor]).build()
 
     # Run workflow which will request approval
     result = await workflow.run(NumberMessage(data=42))

--- a/python/packages/core/tests/workflow/test_workflow_agent.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent.py
@@ -923,7 +923,7 @@ class TestWorkflowAgent:
 
         # Build workflow: start -> agent1 (no output) -> agent2 (output visible)
         workflow = (
-            WorkflowBuilder(start_executor=start_exec, output_executors=[start_exec, agent2])
+            WorkflowBuilder(start_executor=start_exec, output_from=[start_exec, agent2])
             .add_edge(start_exec, agent1)
             .add_edge(agent1, agent2)
             .build()

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -156,3 +156,74 @@ async def test_workflow_agent_terminal_text_stays_text_not_reasoning() -> None:
     assert response.text == "the-answer"
     # No text_reasoning content because everything from `only` is terminal.
     assert all(c.type != "text_reasoning" for m in response.messages for c in m.contents)
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_non_streaming_accepts_intermediate_update() -> None:
+    """An intermediate event carrying AgentResponseUpdate must not raise in non-streaming
+    mode. It surfaces as a Message with text_reasoning content."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[Never, AgentResponseUpdate]) -> None:
+        await ctx.add_event(
+            WorkflowEvent.intermediate(
+                "emit",
+                AgentResponseUpdate(contents=[Content.from_text(text="partial-thought")], role="assistant"),
+            )
+        )
+        await ctx.yield_output("FINAL")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    reasoning = " ".join(c.text for m in response.messages for c in m.contents if c.type == "text_reasoning")
+    assert "partial-thought" in reasoning
+    assert response.text == "FINAL"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_drops_orchestration_internal_events() -> None:
+    """Orchestration-internal event types (group_chat / handoff_sent / magentic_orchestrator)
+    must not surface through workflow.as_agent(). Their dataclass payloads would otherwise
+    be stringified by the generic fallback path and leak into response history."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+        # Construct typed orchestration-internal events directly to assert they get
+        # dropped at the agent boundary regardless of payload.
+        await ctx.add_event(WorkflowEvent("group_chat", data={"orchestrator": "details"}))  # type: ignore[arg-type]
+        await ctx.add_event(WorkflowEvent("handoff_sent", data={"target": "agent_b"}))  # type: ignore[arg-type]
+        await ctx.add_event(WorkflowEvent("magentic_orchestrator", data={"plan": "..."}))  # type: ignore[arg-type]
+        await ctx.yield_output("FINAL")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    all_text = " ".join(c.text for m in response.messages for c in m.contents if hasattr(c, "text"))
+    assert "orchestrator" not in all_text
+    assert "agent_b" not in all_text
+    assert "plan" not in all_text
+    assert response.text == "FINAL"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_drops_orchestration_internal_events_streaming() -> None:
+    """Streaming counterpart — orchestration-internal events stay inside the workflow."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.add_event(WorkflowEvent("group_chat", data={"orchestrator": "details"}))  # type: ignore[arg-type]
+        await ctx.yield_output("FINAL")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    agent = workflow.as_agent("test")
+
+    updates: list[AgentResponseUpdate] = []
+    async for update in agent.run("hi", stream=True):
+        updates.append(update)
+
+    all_text = " ".join(c.text for u in updates for c in u.contents if hasattr(c, "text"))
+    assert "orchestrator" not in all_text
+    assert "FINAL" in all_text

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -1,0 +1,158 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for WorkflowAgent translation of intermediate events to text_reasoning content.
+
+Covers:
+- type='intermediate' surfaces as AgentResponseUpdate with text_reasoning content
+- type='data' (legacy via WorkflowEvent.emit) surfaces the same way (fixes F7)
+- update.text returns terminal-only by virtue of the existing content-type filter
+- Message.additional_properties survives the intermediate translation path
+- Terminal yields keep using regular text content (backward compat)
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from typing_extensions import Never
+
+from agent_framework import (
+    AgentResponse,
+    AgentResponseUpdate,
+    Content,
+    Message,
+    WorkflowBuilder,
+    WorkflowContext,
+    WorkflowEvent,
+    executor,
+)
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -> None:
+    """An intermediate yield from a non-designated executor surfaces through as_agent
+    as an AgentResponseUpdate carrying text_reasoning content."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+        await ctx.yield_output("intermediate progress")
+        await ctx.send_message("downstream")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("FINAL")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    agent = workflow.as_agent("test")
+
+    updates: list[AgentResponseUpdate] = []
+    async for update in agent.run("hi", stream=True):
+        updates.append(update)
+
+    # Find the intermediate progress: it has text_reasoning content.
+    intermediate_updates = [u for u in updates if any(c.type == "text_reasoning" for c in u.contents)]
+    terminal_updates = [u for u in updates if any(c.type == "text" for c in u.contents)]
+
+    intermediate_text = " ".join(c.text for u in intermediate_updates for c in u.contents if c.type == "text_reasoning")
+    terminal_text = " ".join(u.text for u in terminal_updates)
+
+    assert "intermediate progress" in intermediate_text
+    assert "FINAL" in terminal_text
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
+    """update.text excludes text_reasoning content automatically. The non-streaming
+    AgentResponse.text returns only terminal text — intermediate progress is invisible
+    to existing callers using .text."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+        await ctx.yield_output("invisible-progress")
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("the-answer")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    assert isinstance(response, AgentResponse)
+    # .text filters to content.type == "text" — intermediate text_reasoning is excluded.
+    assert response.text == "the-answer"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_legacy_data_event_emit_factory_still_forwarded() -> None:
+    """Even the deprecated WorkflowEvent.emit() / type='data' path is forwarded as
+    text_reasoning content (was previously dropped — F7 fix)."""
+
+    @executor
+    async def emit_legacy(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            await ctx.add_event(WorkflowEvent.emit("emit_legacy", "legacy-payload"))
+        await ctx.yield_output("DONE")
+
+    workflow = WorkflowBuilder(start_executor=emit_legacy, output_executors=[emit_legacy]).build()
+    agent = workflow.as_agent("test")
+
+    updates: list[AgentResponseUpdate] = []
+    async for update in agent.run("hi", stream=True):
+        updates.append(update)
+
+    reasoning_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text_reasoning")
+    assert "legacy-payload" in reasoning_text
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_intermediate_message_preserves_additional_properties() -> None:
+    """Message.additional_properties survives the intermediate translation path.
+
+    Regression test for the omitted field in _mark_msg — without forwarding
+    additional_properties, producer-attached metadata (tracking_id, conversation_id, etc.)
+    silently disappears for messages flowing through non-designated executors.
+    """
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[str, AgentResponse]) -> None:
+        msg = Message(
+            role="assistant",
+            contents=[Content.from_text(text="hi")],
+            additional_properties={"tracking_id": "abc-123"},
+        )
+        await ctx.yield_output(AgentResponse(messages=[msg]))
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("done")
+
+    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    intermediate_msgs = [m for m in response.messages if any(c.type == "text_reasoning" for c in m.contents)]
+    assert intermediate_msgs, "expected at least one intermediate message in the response"
+    assert intermediate_msgs[0].additional_properties.get("tracking_id") == "abc-123"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_terminal_text_stays_text_not_reasoning() -> None:
+    """Backward compat — a designated executor's text yield surfaces as Content.text,
+    not text_reasoning. Existing consumers reading .text on the response work unchanged."""
+
+    @executor
+    async def only(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("the-answer")
+
+    workflow = WorkflowBuilder(start_executor=only, output_executors=[only]).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    assert response.text == "the-answer"
+    # No text_reasoning content because everything from `only` is terminal.
+    assert all(c.type != "text_reasoning" for m in response.messages for c in m.contents)

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -47,8 +47,8 @@ async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -
     workflow = (
         WorkflowBuilder(
             start_executor=emit,
-            output_executors=[terminal],
-            intermediate_executors=[emit],
+            output_from=[terminal],
+            intermediate_output_from=[emit],
         )
         .add_edge(emit, terminal)
         .build()
@@ -88,8 +88,8 @@ async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
     workflow = (
         WorkflowBuilder(
             start_executor=emit,
-            output_executors=[terminal],
-            intermediate_executors=[emit],
+            output_from=[terminal],
+            intermediate_output_from=[emit],
         )
         .add_edge(emit, terminal)
         .build()
@@ -115,7 +115,7 @@ async def test_workflow_agent_hidden_yields_do_not_surface_non_streaming() -> No
     async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("visible-answer")
 
-    workflow = WorkflowBuilder(start_executor=hidden, output_executors=[terminal]).add_edge(hidden, terminal).build()
+    workflow = WorkflowBuilder(start_executor=hidden, output_from=[terminal]).add_edge(hidden, terminal).build()
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")
@@ -138,7 +138,7 @@ async def test_workflow_agent_hidden_yields_do_not_surface_streaming() -> None:
     async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("visible-answer")
 
-    workflow = WorkflowBuilder(start_executor=hidden, output_executors=[terminal]).add_edge(hidden, terminal).build()
+    workflow = WorkflowBuilder(start_executor=hidden, output_from=[terminal]).add_edge(hidden, terminal).build()
     agent = workflow.as_agent("test")
 
     updates: list[AgentResponseUpdate] = []
@@ -163,7 +163,7 @@ async def test_workflow_agent_legacy_data_event_emit_factory_still_forwarded() -
             await ctx.add_event(WorkflowEvent.emit("emit_legacy", "legacy-payload"))
         await ctx.yield_output("DONE")
 
-    workflow = WorkflowBuilder(start_executor=emit_legacy, output_executors=[emit_legacy]).build()
+    workflow = WorkflowBuilder(start_executor=emit_legacy, output_from=[emit_legacy]).build()
     agent = workflow.as_agent("test")
 
     updates: list[AgentResponseUpdate] = []
@@ -200,8 +200,8 @@ async def test_workflow_agent_intermediate_message_preserves_additional_properti
     workflow = (
         WorkflowBuilder(
             start_executor=emit,
-            output_executors=[terminal],
-            intermediate_executors=[emit],
+            output_from=[terminal],
+            intermediate_output_from=[emit],
         )
         .add_edge(emit, terminal)
         .build()
@@ -223,7 +223,7 @@ async def test_workflow_agent_terminal_text_stays_text_not_reasoning() -> None:
     async def only(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("the-answer")
 
-    workflow = WorkflowBuilder(start_executor=only, output_executors=[only]).build()
+    workflow = WorkflowBuilder(start_executor=only, output_from=[only]).build()
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")
@@ -240,7 +240,7 @@ async def test_workflow_agent_non_streaming_rejects_terminal_update() -> None:
     async def emit(messages: list[Message], ctx: WorkflowContext[Never, AgentResponseUpdate]) -> None:
         await ctx.yield_output(AgentResponseUpdate(contents=[Content.from_text(text="partial")], role="assistant"))
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    workflow = WorkflowBuilder(start_executor=emit, output_from=[emit]).build()
     agent = workflow.as_agent("test")
 
     with pytest.raises(AgentInvalidRequestException, match="AgentResponseUpdate"):
@@ -263,8 +263,8 @@ async def test_workflow_agent_non_streaming_rejects_intermediate_update() -> Non
     workflow = (
         WorkflowBuilder(
             start_executor=emit,
-            output_executors=[terminal],
-            intermediate_executors=[emit],
+            output_from=[terminal],
+            intermediate_output_from=[emit],
         )
         .add_edge(emit, terminal)
         .build()
@@ -295,8 +295,8 @@ async def test_workflow_agent_streaming_update_payloads_preserve_classification(
     workflow = (
         WorkflowBuilder(
             start_executor=emit,
-            output_executors=[terminal],
-            intermediate_executors=[emit],
+            output_from=[terminal],
+            intermediate_output_from=[emit],
         )
         .add_edge(emit, terminal)
         .build()
@@ -329,7 +329,7 @@ async def test_workflow_agent_drops_orchestration_internal_events() -> None:
         await ctx.add_event(WorkflowEvent("magentic_orchestrator", data={"plan": "..."}))  # type: ignore[arg-type]
         await ctx.yield_output("FINAL")
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    workflow = WorkflowBuilder(start_executor=emit, output_from=[emit]).build()
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")
@@ -349,7 +349,7 @@ async def test_workflow_agent_drops_orchestration_internal_events_streaming() ->
         await ctx.add_event(WorkflowEvent("group_chat", data={"orchestrator": "details"}))  # type: ignore[arg-type]
         await ctx.yield_output("FINAL")
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
+    workflow = WorkflowBuilder(start_executor=emit, output_from=[emit]).build()
     agent = workflow.as_agent("test")
 
     updates: list[AgentResponseUpdate] = []

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -27,6 +27,7 @@ from agent_framework import (
     WorkflowEvent,
     executor,
 )
+from agent_framework.exceptions import AgentInvalidRequestException
 
 
 @pytest.mark.asyncio
@@ -99,6 +100,55 @@ async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
     assert isinstance(response, AgentResponse)
     # .text filters to content.type == "text" — intermediate text_reasoning is excluded.
     assert response.text == "the-answer"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_hidden_yields_do_not_surface_non_streaming() -> None:
+    """In explicit designation mode, unlisted executor yields stay out of agent responses."""
+
+    @executor
+    async def hidden(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+        await ctx.yield_output("hidden-progress")
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("visible-answer")
+
+    workflow = WorkflowBuilder(start_executor=hidden, output_executors=[terminal]).add_edge(hidden, terminal).build()
+    agent = workflow.as_agent("test")
+
+    response = await agent.run("hi")
+    all_text = " ".join(c.text for m in response.messages for c in m.contents if hasattr(c, "text"))
+
+    assert response.text == "visible-answer"
+    assert "hidden-progress" not in all_text
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_hidden_yields_do_not_surface_streaming() -> None:
+    """In explicit designation mode, unlisted executor yields stay out of agent updates."""
+
+    @executor
+    async def hidden(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
+        await ctx.yield_output("hidden-progress")
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("visible-answer")
+
+    workflow = WorkflowBuilder(start_executor=hidden, output_executors=[terminal]).add_edge(hidden, terminal).build()
+    agent = workflow.as_agent("test")
+
+    updates: list[AgentResponseUpdate] = []
+    async for update in agent.run("hi", stream=True):
+        updates.append(update)
+
+    all_text = " ".join(c.text for u in updates for c in u.contents if hasattr(c, "text"))
+
+    assert "visible-answer" in all_text
+    assert "hidden-progress" not in all_text
 
 
 @pytest.mark.asyncio
@@ -183,27 +233,85 @@ async def test_workflow_agent_terminal_text_stays_text_not_reasoning() -> None:
 
 
 @pytest.mark.asyncio
-async def test_workflow_agent_non_streaming_accepts_intermediate_update() -> None:
-    """An intermediate event carrying AgentResponseUpdate must not raise in non-streaming
-    mode. It surfaces as a Message with text_reasoning content."""
+async def test_workflow_agent_non_streaming_rejects_terminal_update() -> None:
+    """A terminal event carrying AgentResponseUpdate is streaming-only and invalid in run()."""
 
     @executor
     async def emit(messages: list[Message], ctx: WorkflowContext[Never, AgentResponseUpdate]) -> None:
-        await ctx.add_event(
-            WorkflowEvent.intermediate(
-                "emit",
-                AgentResponseUpdate(contents=[Content.from_text(text="partial-thought")], role="assistant"),
-            )
-        )
-        await ctx.yield_output("FINAL")
+        await ctx.yield_output(AgentResponseUpdate(contents=[Content.from_text(text="partial")], role="assistant"))
 
     workflow = WorkflowBuilder(start_executor=emit, output_executors=[emit]).build()
     agent = workflow.as_agent("test")
 
-    response = await agent.run("hi")
-    reasoning = " ".join(c.text for m in response.messages for c in m.contents if c.type == "text_reasoning")
-    assert "partial-thought" in reasoning
-    assert response.text == "FINAL"
+    with pytest.raises(AgentInvalidRequestException, match="AgentResponseUpdate"):
+        await agent.run("hi")
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_non_streaming_rejects_intermediate_update() -> None:
+    """An intermediate event carrying AgentResponseUpdate is streaming-only and invalid in run()."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[str, AgentResponseUpdate]) -> None:
+        await ctx.yield_output(AgentResponseUpdate(contents=[Content.from_text(text="partial")], role="assistant"))
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output("FINAL")
+
+    workflow = (
+        WorkflowBuilder(
+            start_executor=emit,
+            output_executors=[terminal],
+            intermediate_executors=[emit],
+        )
+        .add_edge(emit, terminal)
+        .build()
+    )
+    agent = workflow.as_agent("test")
+
+    with pytest.raises(AgentInvalidRequestException, match="AgentResponseUpdate"):
+        await agent.run("hi")
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_streaming_update_payloads_preserve_classification() -> None:
+    """Streaming AgentResponseUpdate payloads keep output as text and intermediate as reasoning."""
+
+    @executor
+    async def emit(messages: list[Message], ctx: WorkflowContext[str, AgentResponseUpdate]) -> None:
+        await ctx.yield_output(
+            AgentResponseUpdate(contents=[Content.from_text(text="intermediate-chunk")], role="assistant")
+        )
+        await ctx.send_message("forward")
+
+    @executor
+    async def terminal(message: str, ctx: WorkflowContext[Never, AgentResponseUpdate]) -> None:
+        await ctx.yield_output(
+            AgentResponseUpdate(contents=[Content.from_text(text="terminal-chunk")], role="assistant")
+        )
+
+    workflow = (
+        WorkflowBuilder(
+            start_executor=emit,
+            output_executors=[terminal],
+            intermediate_executors=[emit],
+        )
+        .add_edge(emit, terminal)
+        .build()
+    )
+    agent = workflow.as_agent("test")
+
+    updates: list[AgentResponseUpdate] = []
+    async for update in agent.run("hi", stream=True):
+        updates.append(update)
+
+    reasoning_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text_reasoning")
+    terminal_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text")
+
+    assert "intermediate-chunk" in reasoning_text
+    assert "terminal-chunk" in terminal_text
 
 
 @pytest.mark.asyncio

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Tests for WorkflowAgent translation of intermediate events to text_reasoning content.
+"""Tests for WorkflowAgent forwarding of intermediate workflow events.
 
 Covers:
-- type='intermediate' surfaces as AgentResponseUpdate with text_reasoning content
-- type='data' (legacy via WorkflowEvent.emit) surfaces the same way (fixes F7)
-- update.text returns terminal-only by virtue of the existing content-type filter
+- type='intermediate' surfaces as AgentResponseUpdate without content-type rewriting
+- type='data' (compatibility alias via WorkflowEvent.emit) is forwarded
 - Message.additional_properties survives the intermediate translation path
 - Terminal yields keep using regular text content (backward compat)
 """
@@ -31,9 +30,9 @@ from agent_framework.exceptions import AgentInvalidRequestException
 
 
 @pytest.mark.asyncio
-async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -> None:
+async def test_workflow_agent_forwards_intermediate_events_without_content_rewrite() -> None:
     """An intermediate yield from an intermediate-designated executor surfaces through as_agent
-    as an AgentResponseUpdate carrying text_reasoning content."""
+    as an AgentResponseUpdate carrying its original content type."""
 
     @executor
     async def emit(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
@@ -59,22 +58,17 @@ async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -
     async for update in agent.run("hi", stream=True):
         updates.append(update)
 
-    # Find the intermediate progress: it has text_reasoning content.
-    intermediate_updates = [u for u in updates if any(c.type == "text_reasoning" for c in u.contents)]
-    terminal_updates = [u for u in updates if any(c.type == "text" for c in u.contents)]
+    text = " ".join(c.text for u in updates for c in u.contents if c.type == "text")
+    reasoning_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text_reasoning")
 
-    intermediate_text = " ".join(c.text for u in intermediate_updates for c in u.contents if c.type == "text_reasoning")
-    terminal_text = " ".join(u.text for u in terminal_updates)
-
-    assert "intermediate progress" in intermediate_text
-    assert "FINAL" in terminal_text
+    assert "intermediate progress" in text
+    assert "FINAL" in text
+    assert reasoning_text == ""
 
 
 @pytest.mark.asyncio
-async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
-    """update.text excludes text_reasoning content automatically. The non-streaming
-    AgentResponse.text returns only terminal text — intermediate progress is invisible
-    to existing callers using .text."""
+async def test_workflow_agent_text_accessor_includes_forwarded_intermediate_text() -> None:
+    """Intermediate text is forwarded as text until issue 5885 defines the final mapping."""
 
     @executor
     async def emit(messages: list[Message], ctx: WorkflowContext[str, str]) -> None:
@@ -98,8 +92,8 @@ async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
 
     response = await agent.run("hi")
     assert isinstance(response, AgentResponse)
-    # .text filters to content.type == "text" — intermediate text_reasoning is excluded.
-    assert response.text == "the-answer"
+    assert "invisible-progress" in response.text
+    assert "the-answer" in response.text
 
 
 @pytest.mark.asyncio
@@ -152,35 +146,33 @@ async def test_workflow_agent_hidden_yields_do_not_surface_streaming() -> None:
 
 
 @pytest.mark.asyncio
-async def test_workflow_agent_legacy_data_event_emit_factory_still_forwarded() -> None:
-    """Even the deprecated WorkflowEvent.emit() / type='data' path is forwarded as
-    text_reasoning content (was previously dropped — F7 fix)."""
+async def test_workflow_agent_data_event_emit_factory_still_forwarded() -> None:
+    """Even the deprecated WorkflowEvent.emit() / type='data' path is forwarded."""
 
     @executor
-    async def emit_legacy(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+    async def emit_data_alias(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            await ctx.add_event(WorkflowEvent.emit("emit_legacy", "legacy-payload"))
+            await ctx.add_event(WorkflowEvent.emit("emit_data_alias", "data-alias-payload"))
         await ctx.yield_output("DONE")
 
-    workflow = WorkflowBuilder(start_executor=emit_legacy, output_from=[emit_legacy]).build()
+    workflow = WorkflowBuilder(start_executor=emit_data_alias, output_from=[emit_data_alias]).build()
     agent = workflow.as_agent("test")
 
     updates: list[AgentResponseUpdate] = []
     async for update in agent.run("hi", stream=True):
         updates.append(update)
 
-    reasoning_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text_reasoning")
-    assert "legacy-payload" in reasoning_text
+    text = " ".join(c.text for u in updates for c in u.contents if c.type == "text")
+    assert "data-alias-payload" in text
 
 
 @pytest.mark.asyncio
 async def test_workflow_agent_intermediate_message_preserves_additional_properties() -> None:
-    """Message.additional_properties survives the intermediate translation path.
+    """Message.additional_properties survives intermediate forwarding.
 
-    Regression test for the omitted field in _mark_msg — without forwarding
-    additional_properties, producer-attached metadata (tracking_id, conversation_id, etc.)
-    silently disappears for messages flowing through intermediate-designated executors.
+    Producer-attached metadata (tracking_id, conversation_id, etc.) must not disappear
+    for messages flowing through intermediate-designated executors.
     """
 
     @executor
@@ -209,15 +201,14 @@ async def test_workflow_agent_intermediate_message_preserves_additional_properti
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")
-    intermediate_msgs = [m for m in response.messages if any(c.type == "text_reasoning" for c in m.contents)]
+    intermediate_msgs = [m for m in response.messages if any(c.type == "text" and c.text == "hi" for c in m.contents)]
     assert intermediate_msgs, "expected at least one intermediate message in the response"
     assert intermediate_msgs[0].additional_properties.get("tracking_id") == "abc-123"
 
 
 @pytest.mark.asyncio
 async def test_workflow_agent_terminal_text_stays_text_not_reasoning() -> None:
-    """Backward compat — a designated executor's text yield surfaces as Content.text,
-    not text_reasoning. Existing consumers reading .text on the response work unchanged."""
+    """A designated executor's text yield surfaces as Content.text."""
 
     @executor
     async def only(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
@@ -277,7 +268,7 @@ async def test_workflow_agent_non_streaming_rejects_intermediate_update() -> Non
 
 @pytest.mark.asyncio
 async def test_workflow_agent_streaming_update_payloads_preserve_classification() -> None:
-    """Streaming AgentResponseUpdate payloads keep output as text and intermediate as reasoning."""
+    """Streaming AgentResponseUpdate payloads preserve original content types."""
 
     @executor
     async def emit(messages: list[Message], ctx: WorkflowContext[str, AgentResponseUpdate]) -> None:
@@ -307,11 +298,12 @@ async def test_workflow_agent_streaming_update_payloads_preserve_classification(
     async for update in agent.run("hi", stream=True):
         updates.append(update)
 
+    text = " ".join(c.text for u in updates for c in u.contents if c.type == "text")
     reasoning_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text_reasoning")
-    terminal_text = " ".join(c.text for u in updates for c in u.contents if c.type == "text")
 
-    assert "intermediate-chunk" in reasoning_text
-    assert "terminal-chunk" in terminal_text
+    assert "intermediate-chunk" in text
+    assert "terminal-chunk" in text
+    assert reasoning_text == ""
 
 
 @pytest.mark.asyncio

--- a/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent_intermediate.py
@@ -31,7 +31,7 @@ from agent_framework import (
 
 @pytest.mark.asyncio
 async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -> None:
-    """An intermediate yield from a non-designated executor surfaces through as_agent
+    """An intermediate yield from an intermediate-designated executor surfaces through as_agent
     as an AgentResponseUpdate carrying text_reasoning content."""
 
     @executor
@@ -43,7 +43,15 @@ async def test_workflow_agent_forwards_intermediate_events_as_text_reasoning() -
     async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("FINAL")
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    workflow = (
+        WorkflowBuilder(
+            start_executor=emit,
+            output_executors=[terminal],
+            intermediate_executors=[emit],
+        )
+        .add_edge(emit, terminal)
+        .build()
+    )
     agent = workflow.as_agent("test")
 
     updates: list[AgentResponseUpdate] = []
@@ -76,7 +84,15 @@ async def test_workflow_agent_text_accessor_returns_terminal_only() -> None:
     async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("the-answer")
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    workflow = (
+        WorkflowBuilder(
+            start_executor=emit,
+            output_executors=[terminal],
+            intermediate_executors=[emit],
+        )
+        .add_edge(emit, terminal)
+        .build()
+    )
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")
@@ -114,7 +130,7 @@ async def test_workflow_agent_intermediate_message_preserves_additional_properti
 
     Regression test for the omitted field in _mark_msg — without forwarding
     additional_properties, producer-attached metadata (tracking_id, conversation_id, etc.)
-    silently disappears for messages flowing through non-designated executors.
+    silently disappears for messages flowing through intermediate-designated executors.
     """
 
     @executor
@@ -131,7 +147,15 @@ async def test_workflow_agent_intermediate_message_preserves_additional_properti
     async def terminal(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output("done")
 
-    workflow = WorkflowBuilder(start_executor=emit, output_executors=[terminal]).add_edge(emit, terminal).build()
+    workflow = (
+        WorkflowBuilder(
+            start_executor=emit,
+            output_executors=[terminal],
+            intermediate_executors=[emit],
+        )
+        .add_edge(emit, terminal)
+        .build()
+    )
     agent = workflow.as_agent("test")
 
     response = await agent.run("hi")

--- a/python/packages/core/tests/workflow/test_workflow_builder.py
+++ b/python/packages/core/tests/workflow/test_workflow_builder.py
@@ -272,7 +272,7 @@ def test_with_output_from_with_executor_instances():
     )
 
     # Verify that the workflow was built with the correct output executors
-    assert workflow._output_executors == ["executor_b"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor_b"}
 
 
 def test_with_output_from_with_agent_instances():
@@ -283,7 +283,7 @@ def test_with_output_from_with_agent_instances():
     workflow = WorkflowBuilder(start_executor=agent_a, output_executors=[agent_b]).add_edge(agent_a, agent_b).build()
 
     # Verify that the workflow was built with the agent's name as output executor
-    assert workflow._output_executors == ["reviewer"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"reviewer"}
 
 
 def test_with_output_from_with_executor_instances_by_id():
@@ -297,7 +297,7 @@ def test_with_output_from_with_executor_instances_by_id():
         .build()
     )
 
-    assert workflow._output_executors == ["ExecutorB"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"ExecutorB"}
 
 
 def test_with_output_from_with_multiple_executors():
@@ -314,7 +314,7 @@ def test_with_output_from_with_multiple_executors():
     )
 
     # Verify that the workflow was built with both output executors
-    assert set(workflow._output_executors) == {"executor_a", "executor_c"}  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor_a", "executor_c"}
 
 
 def test_with_output_from_can_be_set_to_different_value():
@@ -329,7 +329,7 @@ def test_with_output_from_can_be_set_to_different_value():
     )
 
     # Verify that the setting is applied
-    assert workflow._output_executors == ["executor_b"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor_b"}
 
 
 def test_with_output_from_with_agent_instances_resolves_name():
@@ -343,7 +343,7 @@ def test_with_output_from_with_agent_instances_resolves_name():
         .build()
     )
 
-    assert workflow._output_executors == ["reviewer"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"reviewer"}
 
 
 def test_with_output_from_in_constructor():
@@ -361,7 +361,7 @@ def test_with_output_from_in_constructor():
     )
 
     # Verify that the setting persists through the chain
-    assert workflow._output_executors == ["executor_c"]  # type: ignore
+    assert {ex.id for ex in workflow.get_output_executors()} == {"executor_c"}
 
 
 def test_with_output_from_with_invalid_executor_raises_validation_error():

--- a/python/packages/core/tests/workflow/test_workflow_builder.py
+++ b/python/packages/core/tests/workflow/test_workflow_builder.py
@@ -254,10 +254,10 @@ def test_switch_case_with_agents():
 def test_with_output_from_returns_builder():
     """Test that with_output_from returns the builder for method chaining."""
     executor_a = MockExecutor(id="executor_a")
-    builder = WorkflowBuilder(final_output_from=[executor_a], start_executor=executor_a)
+    builder = WorkflowBuilder(output_from=[executor_a], start_executor=executor_a)
 
-    # Verify builder was created with final_output_from
-    assert builder._final_output_from == [executor_a]  # pyright: ignore[reportPrivateUsage]
+    # Verify builder was created with output_from
+    assert builder._output_from == [executor_a]  # pyright: ignore[reportPrivateUsage]
 
 
 def test_with_output_from_with_executor_instances():
@@ -266,9 +266,7 @@ def test_with_output_from_with_executor_instances():
     executor_b = MockExecutor(id="executor_b")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
-        .add_edge(executor_a, executor_b)
-        .build()
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_b]).add_edge(executor_a, executor_b).build()
     )
 
     # Verify that the workflow was built with the correct output executors
@@ -280,7 +278,7 @@ def test_with_output_from_with_agent_instances():
     agent_a = DummyAgent(id="agent_a", name="writer")
     agent_b = DummyAgent(id="agent_b", name="reviewer")
 
-    workflow = WorkflowBuilder(start_executor=agent_a, final_output_from=[agent_b]).add_edge(agent_a, agent_b).build()
+    workflow = WorkflowBuilder(start_executor=agent_a, output_from=[agent_b]).add_edge(agent_a, agent_b).build()
 
     # Verify that the workflow was built with the agent's name as output executor
     assert {ex.id for ex in workflow.get_output_executors()} == {"reviewer"}
@@ -292,9 +290,7 @@ def test_with_output_from_with_executor_instances_by_id():
     executor_b = MockExecutor(id="ExecutorB")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
-        .add_edge(executor_a, executor_b)
-        .build()
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_b]).add_edge(executor_a, executor_b).build()
     )
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"ExecutorB"}
@@ -307,7 +303,7 @@ def test_with_output_from_with_multiple_executors():
     executor_c = MockExecutor(id="executor_c")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_a, executor_c])
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_a, executor_c])
         .add_edge(executor_a, executor_b)
         .add_edge(executor_b, executor_c)
         .build()
@@ -318,14 +314,12 @@ def test_with_output_from_with_multiple_executors():
 
 
 def test_with_output_from_can_be_set_to_different_value():
-    """Test that final_output_from can be set at construction time."""
+    """Test that output_from can be set at construction time."""
     executor_a = MockExecutor(id="executor_a")
     executor_b = MockExecutor(id="executor_b")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
-        .add_edge(executor_a, executor_b)
-        .build()
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_b]).add_edge(executor_a, executor_b).build()
     )
 
     # Verify that the setting is applied
@@ -338,7 +332,7 @@ def test_with_output_from_with_agent_instances_resolves_name():
     agent_reviewer = DummyAgent(id="agent2", name="reviewer")
 
     workflow = (
-        WorkflowBuilder(start_executor=agent_writer, final_output_from=[agent_reviewer])
+        WorkflowBuilder(start_executor=agent_writer, output_from=[agent_reviewer])
         .add_edge(agent_writer, agent_reviewer)
         .build()
     )
@@ -347,14 +341,14 @@ def test_with_output_from_with_agent_instances_resolves_name():
 
 
 def test_with_output_from_in_constructor():
-    """Test that final_output_from works correctly when set in the constructor."""
+    """Test that output_from works correctly when set in the constructor."""
     executor_a = MockExecutor(id="executor_a")
     executor_b = MockExecutor(id="executor_b")
     executor_c = MockExecutor(id="executor_c")
 
-    # Build workflow with final_output_from in the constructor
+    # Build workflow with output_from in the constructor
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_c])
+        WorkflowBuilder(start_executor=executor_a, output_from=[executor_c])
         .add_edge(executor_a, executor_b)
         .add_edge(executor_b, executor_c)
         .build()
@@ -368,7 +362,7 @@ def test_with_output_from_with_invalid_executor_raises_validation_error():
     """Test that with_output_from with an invalid executor raises an error."""
     executor_a = MockExecutor(id="executor_a")
 
-    builder = WorkflowBuilder(start_executor=executor_a, final_output_from=[MockExecutor(id="executor_b")])
+    builder = WorkflowBuilder(start_executor=executor_a, output_from=[MockExecutor(id="executor_b")])
 
     # Attempting to set output from an executor not in the workflow should raise an error
     with pytest.raises(

--- a/python/packages/core/tests/workflow/test_workflow_builder.py
+++ b/python/packages/core/tests/workflow/test_workflow_builder.py
@@ -254,10 +254,10 @@ def test_switch_case_with_agents():
 def test_with_output_from_returns_builder():
     """Test that with_output_from returns the builder for method chaining."""
     executor_a = MockExecutor(id="executor_a")
-    builder = WorkflowBuilder(output_executors=[executor_a], start_executor=executor_a)
+    builder = WorkflowBuilder(final_output_from=[executor_a], start_executor=executor_a)
 
-    # Verify builder was created with output_executors
-    assert builder._output_executors == [executor_a]  # pyright: ignore[reportPrivateUsage]
+    # Verify builder was created with final_output_from
+    assert builder._final_output_from == [executor_a]  # pyright: ignore[reportPrivateUsage]
 
 
 def test_with_output_from_with_executor_instances():
@@ -266,7 +266,7 @@ def test_with_output_from_with_executor_instances():
     executor_b = MockExecutor(id="executor_b")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_b])
+        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
         .add_edge(executor_a, executor_b)
         .build()
     )
@@ -280,7 +280,7 @@ def test_with_output_from_with_agent_instances():
     agent_a = DummyAgent(id="agent_a", name="writer")
     agent_b = DummyAgent(id="agent_b", name="reviewer")
 
-    workflow = WorkflowBuilder(start_executor=agent_a, output_executors=[agent_b]).add_edge(agent_a, agent_b).build()
+    workflow = WorkflowBuilder(start_executor=agent_a, final_output_from=[agent_b]).add_edge(agent_a, agent_b).build()
 
     # Verify that the workflow was built with the agent's name as output executor
     assert {ex.id for ex in workflow.get_output_executors()} == {"reviewer"}
@@ -292,7 +292,7 @@ def test_with_output_from_with_executor_instances_by_id():
     executor_b = MockExecutor(id="ExecutorB")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_b])
+        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
         .add_edge(executor_a, executor_b)
         .build()
     )
@@ -307,7 +307,7 @@ def test_with_output_from_with_multiple_executors():
     executor_c = MockExecutor(id="executor_c")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_a, executor_c])
+        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_a, executor_c])
         .add_edge(executor_a, executor_b)
         .add_edge(executor_b, executor_c)
         .build()
@@ -318,12 +318,12 @@ def test_with_output_from_with_multiple_executors():
 
 
 def test_with_output_from_can_be_set_to_different_value():
-    """Test that output_executors can be set at construction time."""
+    """Test that final_output_from can be set at construction time."""
     executor_a = MockExecutor(id="executor_a")
     executor_b = MockExecutor(id="executor_b")
 
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_b])
+        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_b])
         .add_edge(executor_a, executor_b)
         .build()
     )
@@ -338,7 +338,7 @@ def test_with_output_from_with_agent_instances_resolves_name():
     agent_reviewer = DummyAgent(id="agent2", name="reviewer")
 
     workflow = (
-        WorkflowBuilder(start_executor=agent_writer, output_executors=[agent_reviewer])
+        WorkflowBuilder(start_executor=agent_writer, final_output_from=[agent_reviewer])
         .add_edge(agent_writer, agent_reviewer)
         .build()
     )
@@ -347,14 +347,14 @@ def test_with_output_from_with_agent_instances_resolves_name():
 
 
 def test_with_output_from_in_constructor():
-    """Test that output_executors works correctly when set in the constructor."""
+    """Test that final_output_from works correctly when set in the constructor."""
     executor_a = MockExecutor(id="executor_a")
     executor_b = MockExecutor(id="executor_b")
     executor_c = MockExecutor(id="executor_c")
 
-    # Build workflow with output_executors in the constructor
+    # Build workflow with final_output_from in the constructor
     workflow = (
-        WorkflowBuilder(start_executor=executor_a, output_executors=[executor_c])
+        WorkflowBuilder(start_executor=executor_a, final_output_from=[executor_c])
         .add_edge(executor_a, executor_b)
         .add_edge(executor_b, executor_c)
         .build()
@@ -368,7 +368,7 @@ def test_with_output_from_with_invalid_executor_raises_validation_error():
     """Test that with_output_from with an invalid executor raises an error."""
     executor_a = MockExecutor(id="executor_a")
 
-    builder = WorkflowBuilder(start_executor=executor_a, output_executors=[MockExecutor(id="executor_b")])
+    builder = WorkflowBuilder(start_executor=executor_a, final_output_from=[MockExecutor(id="executor_b")])
 
     # Attempting to set output from an executor not in the workflow should raise an error
     with pytest.raises(

--- a/python/packages/core/tests/workflow/test_workflow_context.py
+++ b/python/packages/core/tests/workflow/test_workflow_context.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
+import pytest
 from typing_extensions import Never
 
 from agent_framework import (
@@ -70,6 +71,31 @@ async def test_executor_cannot_emit_framework_lifecycle_event(caplog: "LogCaptur
         assert isinstance(data, str)
         assert "reserved for framework lifecycle notifications" in data
         assert any("attempted to emit" in message and "'status'" in message for message in list(caplog.messages))
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        WorkflowEvent("output", executor_id="exec", data="output-payload"),
+        WorkflowEvent("intermediate", executor_id="exec", data="intermediate-payload"),
+    ],
+)
+async def test_executor_cannot_emit_output_selection_events(
+    event: WorkflowEvent[Any],
+    caplog: "LogCaptureFixture",
+) -> None:
+    async with make_context() as (ctx, runner_ctx):
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            await ctx.add_event(event)
+
+        events: list[WorkflowEvent] = await runner_ctx.drain_events()
+        assert len(events) == 1
+        assert events[0].type == "warning"
+        data = events[0].data
+        assert isinstance(data, str)
+        assert "reserved for ctx.yield_output()" in data
+        assert event.data not in [emitted.data for emitted in events]
 
 
 async def test_executor_emits_normal_event() -> None:

--- a/python/packages/core/tests/workflow/test_workflow_event_factories.py
+++ b/python/packages/core/tests/workflow/test_workflow_event_factories.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for WorkflowEvent factory methods, including the new intermediate factory
+and the deprecation of WorkflowEvent.emit() / type='data'."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from agent_framework import AgentResponse, Message
+from agent_framework._workflows._events import WorkflowEvent
+
+
+def test_workflow_event_intermediate_factory_creates_intermediate_event() -> None:
+    """WorkflowEvent.intermediate(executor_id, data) creates a type='intermediate' event."""
+    response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
+    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
+
+    assert event.type == "intermediate"
+    assert event.executor_id == "test"
+    assert event.data is response
+
+
+def test_workflow_event_emit_emits_deprecation_warning() -> None:
+    """Calling WorkflowEvent.emit() raises a DeprecationWarning recommending the new path."""
+    response = AgentResponse(messages=[Message(role="assistant", contents=["x"])])
+    with pytest.warns(DeprecationWarning, match="intermediate"):
+        WorkflowEvent.emit(executor_id="t", data=response)
+
+
+def test_workflow_event_emit_still_returns_data_event() -> None:
+    """During the deprecation window, emit() still produces a type='data' event."""
+    response = AgentResponse(messages=[Message(role="assistant", contents=["x"])])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        event = WorkflowEvent.emit(executor_id="t", data=response)
+    assert event.type == "data"

--- a/python/packages/core/tests/workflow/test_workflow_event_factories.py
+++ b/python/packages/core/tests/workflow/test_workflow_event_factories.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Tests for WorkflowEvent factory methods, including the new intermediate factory
-and the deprecation of WorkflowEvent.emit() / type='data'."""
+"""Tests for WorkflowEvent factory methods and WorkflowEvent.emit() deprecation."""
 
 from __future__ import annotations
 
@@ -13,20 +12,16 @@ from agent_framework import AgentResponse, Message
 from agent_framework._workflows._events import WorkflowEvent
 
 
-def test_workflow_event_intermediate_factory_creates_intermediate_event() -> None:
-    """WorkflowEvent.intermediate(executor_id, data) creates a type='intermediate' event."""
-    response = AgentResponse(messages=[Message(role="assistant", contents=["Hello"])])
-    event: WorkflowEvent[AgentResponse] = WorkflowEvent.intermediate(executor_id="test", data=response)
-
-    assert event.type == "intermediate"
-    assert event.executor_id == "test"
-    assert event.data is response
+def test_workflow_event_output_selection_factories_are_not_public() -> None:
+    """Callers should use ctx.yield_output(), not direct output/intermediate factories."""
+    assert not hasattr(WorkflowEvent, "output")
+    assert not hasattr(WorkflowEvent, "intermediate")
 
 
 def test_workflow_event_emit_emits_deprecation_warning() -> None:
     """Calling WorkflowEvent.emit() raises a DeprecationWarning recommending the new path."""
     response = AgentResponse(messages=[Message(role="assistant", contents=["x"])])
-    with pytest.warns(DeprecationWarning, match="intermediate"):
+    with pytest.warns(DeprecationWarning, match="yield_output"):
         WorkflowEvent.emit(executor_id="t", data=response)
 
 

--- a/python/packages/core/tests/workflow/test_workflow_kwargs.py
+++ b/python/packages/core/tests/workflow/test_workflow_kwargs.py
@@ -377,7 +377,7 @@ async def test_kwargs_preserved_on_response_continuation() -> None:
     from agent_framework import WorkflowBuilder
 
     agent = _ApprovalCapturingAgent()
-    workflow = WorkflowBuilder(start_executor=agent, output_executors=[agent]).build()
+    workflow = WorkflowBuilder(start_executor=agent, output_from=[agent]).build()
 
     # Initial run with function_invocation_kwargs — workflow should pause for approval
     fi_kwargs = {"token": "abc"}

--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -901,8 +901,11 @@ class MessageMapper:
 
                 return events
 
-            # Handle output events separately to preserve output data
-            if event_type == "output":
+            # Handle yield events (output / intermediate / data) by extracting visible
+            # text from the payload. All three render as a visible message item so the
+            # gap that previously dropped intermediate yields into generic completed-
+            # trace events is closed.
+            if event_type in ("output", "intermediate", "data"):
                 output_data = getattr(event, "data", None)
                 executor_id = getattr(event, "executor_id", "unknown")
 

--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -200,10 +200,12 @@ class MessageMapper:
         try:
             from agent_framework import AgentResponse, AgentResponseUpdate, WorkflowEvent
 
-            # Handle WorkflowEvent with type='output' or 'data' wrapping AgentResponseUpdate
-            # This must be checked BEFORE generic WorkflowEvent check
-            # Note: AgentExecutor uses type='output' for streaming updates
-            if isinstance(raw_event, WorkflowEvent) and raw_event.type in ("output", "data"):
+            # Handle WorkflowEvent with type='output', 'intermediate', or 'data' wrapping
+            # AgentResponseUpdate. This must be checked BEFORE generic WorkflowEvent check.
+            # Note: AgentExecutor uses type='output' for streaming updates from designated
+            # executors and type='intermediate' from non-designated executors. type='data'
+            # is the deprecated legacy variant retained for backward compat.
+            if isinstance(raw_event, WorkflowEvent) and raw_event.type in ("output", "intermediate", "data"):
                 event_data = getattr(cast(Any, raw_event), "data", None)
                 if isinstance(event_data, AgentResponseUpdate):
                     # Preserve executor_id in context for proper output routing

--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -72,6 +72,17 @@ def _stringify_name(value: Any) -> str:
     return value if isinstance(value, str) else str(value)
 
 
+def _workflow_output_metadata(event_type: Any, executor_id: Any) -> dict[str, Any] | None:
+    """Return metadata that preserves workflow yield designation on visible output."""
+    if event_type not in ("output", "intermediate", "data"):
+        return None
+    return {
+        "workflow_event_type": event_type,
+        "workflow_output_kind": "terminal" if event_type == "output" else "intermediate",
+        "executor_id": executor_id,
+    }
+
+
 def _serialize_content_recursive(value: Any) -> Any:
     """Recursively serialize Agent Framework Content objects to JSON-compatible values.
 
@@ -210,7 +221,11 @@ class MessageMapper:
                 if isinstance(event_data, AgentResponseUpdate):
                     # Preserve executor_id in context for proper output routing
                     context["current_executor_id"] = getattr(cast(Any, raw_event), "executor_id", None)
-                    return await self._convert_agent_update(event_data, context)
+                    context["current_workflow_event_type"] = raw_event.type
+                    try:
+                        return await self._convert_agent_update(event_data, context)
+                    finally:
+                        context.pop("current_workflow_event_type", None)
 
             # Handle complete agent response (AgentResponse) - for non-streaming agent execution
             if isinstance(raw_event, AgentResponse):
@@ -635,6 +650,13 @@ class MessageMapper:
             # Check if we're in an executor context with an existing item
             executor_id = context.get("current_executor_id")
             executor_item_key = f"exec_item_{executor_id}" if executor_id else None
+            workflow_metadata = _workflow_output_metadata(context.get("current_workflow_event_type"), executor_id)
+
+            if has_text_content and workflow_metadata is not None:
+                current_metadata = context.get("current_message_workflow_metadata")
+                if current_metadata != workflow_metadata:
+                    context.pop("current_message_id", None)
+                    context["current_message_workflow_metadata"] = workflow_metadata
 
             # If we have an executor item, use it for deltas instead of creating a message
             if has_text_content and executor_item_key and executor_item_key in context:
@@ -646,6 +668,15 @@ class MessageMapper:
                 message_id = f"msg_{uuid4().hex[:8]}"
                 context["current_message_id"] = message_id
                 context["output_index"] = context.get("output_index", -1) + 1
+                message_item = ResponseOutputMessage(
+                    type="message",
+                    id=message_id,
+                    role="assistant",
+                    content=[],
+                    status="in_progress",
+                )
+                if workflow_metadata is not None:
+                    cast(Any, message_item).metadata = workflow_metadata
 
                 # Add message output item
                 events.append(
@@ -653,9 +684,7 @@ class MessageMapper:
                         type="response.output_item.added",
                         output_index=context["output_index"],
                         sequence_number=self._next_sequence(context),
-                        item=ResponseOutputMessage(
-                            type="message", id=message_id, role="assistant", content=[], status="in_progress"
-                        ),
+                        item=message_item,
                     )
                 )
 
@@ -677,17 +706,18 @@ class MessageMapper:
                 # Special handling for TextContent to use proper delta events
                 if content.type == "text" and "current_message_id" in context:
                     # Stream text content via proper delta events
-                    events.append(
-                        ResponseTextDeltaEvent(
-                            type="response.output_text.delta",
-                            output_index=context["output_index"],
-                            content_index=context.get("content_index", 0),
-                            item_id=context["current_message_id"],
-                            delta=content.text,
-                            logprobs=[],  # We don't have logprobs from Agent Framework
-                            sequence_number=self._next_sequence(context),
-                        )
+                    delta_event = ResponseTextDeltaEvent(
+                        type="response.output_text.delta",
+                        output_index=context["output_index"],
+                        content_index=context.get("content_index", 0),
+                        item_id=context["current_message_id"],
+                        delta=content.text,
+                        logprobs=[],  # We don't have logprobs from Agent Framework
+                        sequence_number=self._next_sequence(context),
                     )
+                    if workflow_metadata is not None:
+                        cast(Any, delta_event).metadata = workflow_metadata
+                    events.append(delta_event)
                 elif content.type in self.content_mappers:
                     # Use existing mappers for other content types
                     mapped_events = await self.content_mappers[content.type](content, context)
@@ -908,6 +938,7 @@ class MessageMapper:
             if event_type in ("output", "intermediate", "data"):
                 output_data = getattr(event, "data", None)
                 executor_id = getattr(event, "executor_id", "unknown")
+                workflow_metadata = _workflow_output_metadata(event_type, executor_id)
 
                 if output_data is not None:
                     # Import required types
@@ -965,6 +996,8 @@ class MessageMapper:
                         content=[text_content],
                         status="completed",
                     )
+                    if workflow_metadata is not None:
+                        cast(Any, output_message).metadata = workflow_metadata
 
                     # Emit output_item.added for each yield_output
                     logger.debug(

--- a/python/packages/devui/frontend/src/components/features/workflow/execution-timeline.tsx
+++ b/python/packages/devui/frontend/src/components/features/workflow/execution-timeline.tsx
@@ -96,6 +96,14 @@ function getStateBadgeClass(state: ExecutorState) {
   }
 }
 
+function getMessageText(item: unknown): string {
+  const content = (item as { content?: Array<{ type: string; text?: string }> }).content;
+  return content
+    ?.filter((content) => content.type === "output_text" && content.text)
+    .map((content) => content.text)
+    .join("\n") ?? "";
+}
+
 function ExecutorRunItem({
   run,
   isExpanded,
@@ -282,7 +290,12 @@ export function ExecutionTimeline({
           });
         } else if (item && item.type === "message" && "metadata" in item && item.id) {
           // Handle message items from Magentic agents
-          const metadata = item.metadata as { agent_id?: string; source?: string } | undefined;
+          const metadata = item.metadata as {
+            agent_id?: string;
+            executor_id?: string;
+            source?: string;
+            workflow_output_kind?: string;
+          } | undefined;
           if (metadata?.agent_id && metadata?.source === "magentic") {
             const executorId = metadata.agent_id;
             const itemId = item.id;
@@ -295,6 +308,21 @@ export function ExecutionTimeline({
               itemId,
               state: "running",
               output: itemOutputs[itemId] || "",
+              timestamp: uiTimestamp,
+              runNumber,
+            });
+          } else if (metadata?.executor_id && metadata.workflow_output_kind === "intermediate") {
+            const executorId = metadata.executor_id;
+            const itemId = item.id;
+            const runNumber = (runCount.get(executorId) || 0) + 1;
+            runCount.set(executorId, runNumber);
+
+            runs.push({
+              executorId,
+              executorName: truncateText(executorId, 35),
+              itemId,
+              state: item.status === "completed" ? "completed" : "running",
+              output: itemOutputs[itemId] || getMessageText(item),
               timestamp: uiTimestamp,
               runNumber,
             });
@@ -327,7 +355,12 @@ export function ExecutionTimeline({
           }
         } else if (item && item.type === "message" && "metadata" in item && item.id) {
           // Handle message completion from Magentic agents
-          const metadata = item.metadata as { agent_id?: string; source?: string } | undefined;
+          const metadata = item.metadata as {
+            agent_id?: string;
+            executor_id?: string;
+            source?: string;
+            workflow_output_kind?: string;
+          } | undefined;
           if (metadata?.agent_id && metadata?.source === "magentic") {
             const itemId = item.id;
             const existingRun = runs.find((r) => r.itemId === itemId);
@@ -335,6 +368,14 @@ export function ExecutionTimeline({
             if (existingRun) {
               existingRun.state = item.status === "completed" ? "completed" : "failed";
               existingRun.output = itemOutputs[itemId] || "";
+            }
+          } else if (metadata?.executor_id && metadata.workflow_output_kind === "intermediate") {
+            const itemId = item.id;
+            const existingRun = runs.find((r) => r.itemId === itemId);
+
+            if (existingRun) {
+              existingRun.state = item.status === "completed" ? "completed" : "failed";
+              existingRun.output = itemOutputs[itemId] || getMessageText(item);
             }
           }
         }

--- a/python/packages/devui/frontend/src/components/features/workflow/workflow-view.tsx
+++ b/python/packages/devui/frontend/src/components/features/workflow/workflow-view.tsx
@@ -643,6 +643,7 @@ export function WorkflowView({
               item &&
               item.type === "message" &&
               (!("metadata" in item) || !(item.metadata as { source?: string } | undefined)?.source) &&
+              (item.metadata as { workflow_output_kind?: string } | undefined)?.workflow_output_kind !== "intermediate" &&
               "content" in item &&
               Array.isArray(item.content)
             ) {
@@ -1078,27 +1079,30 @@ export function WorkflowView({
 
           // Handle workflow output messages
           if (item && item.type === "message" && "content" in item && Array.isArray(item.content)) {
-            // Extract text from message content
-            for (const content of item.content as Array<{ type: string; text?: string }>) {
-              if (content.type === "output_text" && content.text) {
-                const text = content.text; // Capture for closure
-                // Append to workflow result (support multiple yield_output calls)
-                setWorkflowResult((prev) => {
-                  if (prev && prev.length > 0) {
-                    // If there's existing output, add separator
-                    return prev + "\n\n" + text;
-                  }
-                  return text;
-                });
+            const metadata = item.metadata as { workflow_output_kind?: string } | undefined;
+            if (metadata?.workflow_output_kind !== "intermediate") {
+              // Extract text from message content
+              for (const content of item.content as Array<{ type: string; text?: string }>) {
+                if (content.type === "output_text" && content.text) {
+                  const text = content.text; // Capture for closure
+                  // Append to workflow result (support multiple yield_output calls)
+                  setWorkflowResult((prev) => {
+                    if (prev && prev.length > 0) {
+                      // If there's existing output, add separator
+                      return prev + "\n\n" + text;
+                    }
+                    return text;
+                  });
 
-                // Try to parse as JSON for structured metadata
-                try {
-                  const parsed = JSON.parse(text);
-                  if (typeof parsed === "object" && parsed !== null) {
-                    workflowMetadata.current = parsed;
+                  // Try to parse as JSON for structured metadata
+                  try {
+                    const parsed = JSON.parse(text);
+                    if (typeof parsed === "object" && parsed !== null) {
+                      workflowMetadata.current = parsed;
+                    }
+                  } catch {
+                    // Not JSON, keep as text
                   }
-                } catch {
-                  // Not JSON, keep as text
                 }
               }
             }

--- a/python/packages/devui/frontend/src/types/openai.ts
+++ b/python/packages/devui/frontend/src/types/openai.ts
@@ -376,6 +376,7 @@ export interface ResponseTextDeltaEvent extends ResponseStreamEvent {
   content_index: number;
   sequence_number: number;
   logprobs: Record<string, unknown>[];
+  metadata?: Record<string, unknown>;
 }
 
 // OpenAI Response for non-streaming
@@ -397,6 +398,7 @@ export interface ResponseOutputMessage {
   content: ResponseOutputText[];
   id: string;
   status: "completed" | "failed" | "in_progress";
+  metadata?: Record<string, unknown>;
 }
 
 export interface ResponseOutputText {

--- a/python/packages/devui/tests/devui/test_mapper.py
+++ b/python/packages/devui/tests/devui/test_mapper.py
@@ -429,7 +429,7 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
     """Test that WorkflowEvent[AgentResponseUpdate] with magentic_event_type='agent_delta' is handled correctly.
 
     This tests the ACTUAL event format Magentic emits - not a fake MagenticAgentDeltaEvent class.
-    Magentic uses WorkflowEvent.emit() with additional_properties containing magentic_event_type.
+    Magentic uses WorkflowEvent.intermediate() with additional_properties containing magentic_event_type.
     """
     from agent_framework._types import AgentResponseUpdate
     from agent_framework._workflows._events import WorkflowEvent
@@ -444,7 +444,7 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
             "agent_id": "writer_agent",
         },
     )
-    event = WorkflowEvent.emit(executor_id="magentic_executor", data=update)
+    event = WorkflowEvent.intermediate(executor_id="magentic_executor", data=update)
 
     events = await mapper.convert_event(event, test_request)
 
@@ -459,7 +459,7 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
 async def test_magentic_orchestrator_message_event(mapper: MessageMapper, test_request: AgentFrameworkRequest) -> None:
     """Test that WorkflowEvent[AgentResponseUpdate] with magentic_event_type='orchestrator_message' is handled.
 
-    Magentic emits orchestrator planning/instruction messages using WorkflowEvent.emit()
+    Magentic emits orchestrator planning/instruction messages using WorkflowEvent.intermediate()
     with additional_properties containing magentic_event_type='orchestrator_message'.
     """
     from agent_framework._types import AgentResponseUpdate
@@ -476,7 +476,7 @@ async def test_magentic_orchestrator_message_event(mapper: MessageMapper, test_r
             "orchestrator_id": "magentic_orchestrator",
         },
     )
-    event = WorkflowEvent.emit(executor_id="magentic_orchestrator", data=update)
+    event = WorkflowEvent.intermediate(executor_id="magentic_orchestrator", data=update)
 
     events = await mapper.convert_event(event, test_request)
 
@@ -507,7 +507,7 @@ async def test_magentic_events_use_same_event_class_as_other_workflows(
         contents=[Content.from_text(text="Regular workflow response")],
         role="assistant",
     )
-    regular_event = WorkflowEvent.emit(executor_id="regular_executor", data=regular_update)
+    regular_event = WorkflowEvent.intermediate(executor_id="regular_executor", data=regular_update)
 
     # 2. Magentic workflow (with additional_properties)
     magentic_update = AgentResponseUpdate(
@@ -515,7 +515,7 @@ async def test_magentic_events_use_same_event_class_as_other_workflows(
         role="assistant",
         additional_properties={"magentic_event_type": "agent_delta"},
     )
-    magentic_event = WorkflowEvent.emit(executor_id="magentic_executor", data=magentic_update)
+    magentic_event = WorkflowEvent.intermediate(executor_id="magentic_executor", data=magentic_update)
 
     # Both should be the SAME class
     assert type(regular_event) is type(magentic_event)
@@ -592,6 +592,27 @@ async def test_workflow_output_event_with_list_data(mapper: MessageMapper, test_
 
     assert len(events) == 1
     assert events[0].type == "response.output_item.added"
+
+
+async def test_workflow_intermediate_event_with_agent_response_update_dispatched(
+    mapper: MessageMapper, test_request: AgentFrameworkRequest
+) -> None:
+    """A WorkflowEvent with type='intermediate' wrapping an AgentResponseUpdate is mapped
+    just like type='output' / type='data' — to OpenAI text-delta events."""
+    from agent_framework._workflows._events import WorkflowEvent
+
+    update = AgentResponseUpdate(
+        contents=[Content.from_text(text="intermediate progress")],
+        role="assistant",
+        author_name="non-designated-agent",
+    )
+    event = WorkflowEvent.intermediate(executor_id="non_designated", data=update)
+    events = await mapper.convert_event(event, test_request)
+
+    assert len(events) >= 1
+    text_events = [e for e in events if getattr(e, "type", "") == "response.output_text.delta"]
+    assert len(text_events) >= 1
+    assert text_events[0].delta == "intermediate progress"
 
 
 # =============================================================================

--- a/python/packages/devui/tests/devui/test_mapper.py
+++ b/python/packages/devui/tests/devui/test_mapper.py
@@ -615,6 +615,42 @@ async def test_workflow_intermediate_event_with_agent_response_update_dispatched
     assert text_events[0].delta == "intermediate progress"
 
 
+async def test_workflow_intermediate_event_with_string_payload_renders_visible_text(
+    mapper: MessageMapper, test_request: AgentFrameworkRequest
+) -> None:
+    """A WorkflowEvent with type='intermediate' wrapping a plain string surfaces as a
+    visible output item — not a generic completed-trace event. Without this, executors
+    that ``await ctx.yield_output("plan: …")`` from non-designated nodes are silently
+    dropped in DevUI."""
+    from agent_framework._workflows._events import WorkflowEvent
+
+    event = WorkflowEvent.intermediate(executor_id="planner", data="plan: starting work")
+    events = await mapper.convert_event(event, test_request)
+
+    assert len(events) == 1
+    assert events[0].type == "response.output_item.added"
+    item = events[0].item
+    assert item.type == "message"
+    assert any("plan: starting work" in str(c) for c in item.content)
+
+
+async def test_workflow_intermediate_event_with_message_payload_renders_visible_text(
+    mapper: MessageMapper, test_request: AgentFrameworkRequest
+) -> None:
+    """type='intermediate' wrapping a Message surfaces visibly — same path as type='output'."""
+    from agent_framework import Message
+    from agent_framework._workflows._events import WorkflowEvent
+
+    msg = Message(role="assistant", contents=[Content.from_text(text="research note")])
+    event = WorkflowEvent.intermediate(executor_id="researcher", data=msg)
+    events = await mapper.convert_event(event, test_request)
+
+    assert len(events) == 1
+    assert events[0].type == "response.output_item.added"
+    item = events[0].item
+    assert any("research note" in str(c) for c in item.content)
+
+
 # =============================================================================
 # failed event (type='failed') Tests
 # =============================================================================

--- a/python/packages/devui/tests/devui/test_mapper.py
+++ b/python/packages/devui/tests/devui/test_mapper.py
@@ -429,7 +429,8 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
     """Test that WorkflowEvent[AgentResponseUpdate] with magentic_event_type='agent_delta' is handled correctly.
 
     This tests the ACTUAL event format Magentic emits - not a fake MagenticAgentDeltaEvent class.
-    Magentic uses WorkflowEvent.intermediate() with additional_properties containing magentic_event_type.
+    Magentic emits type='intermediate' WorkflowEvent instances with additional_properties
+    containing magentic_event_type.
     """
     from agent_framework._types import AgentResponseUpdate
     from agent_framework._workflows._events import WorkflowEvent
@@ -444,7 +445,7 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
             "agent_id": "writer_agent",
         },
     )
-    event = WorkflowEvent.intermediate(executor_id="magentic_executor", data=update)
+    event = WorkflowEvent("intermediate", executor_id="magentic_executor", data=update)
 
     events = await mapper.convert_event(event, test_request)
 
@@ -459,8 +460,8 @@ async def test_magentic_executor_event_with_agent_delta_metadata(
 async def test_magentic_orchestrator_message_event(mapper: MessageMapper, test_request: AgentFrameworkRequest) -> None:
     """Test that WorkflowEvent[AgentResponseUpdate] with magentic_event_type='orchestrator_message' is handled.
 
-    Magentic emits orchestrator planning/instruction messages using WorkflowEvent.intermediate()
-    with additional_properties containing magentic_event_type='orchestrator_message'.
+    Magentic emits orchestrator planning/instruction messages using type='intermediate'
+    WorkflowEvent instances with additional_properties containing magentic_event_type='orchestrator_message'.
     """
     from agent_framework._types import AgentResponseUpdate
     from agent_framework._workflows._events import WorkflowEvent
@@ -476,7 +477,7 @@ async def test_magentic_orchestrator_message_event(mapper: MessageMapper, test_r
             "orchestrator_id": "magentic_orchestrator",
         },
     )
-    event = WorkflowEvent.intermediate(executor_id="magentic_orchestrator", data=update)
+    event = WorkflowEvent("intermediate", executor_id="magentic_orchestrator", data=update)
 
     events = await mapper.convert_event(event, test_request)
 
@@ -507,7 +508,7 @@ async def test_magentic_events_use_same_event_class_as_other_workflows(
         contents=[Content.from_text(text="Regular workflow response")],
         role="assistant",
     )
-    regular_event = WorkflowEvent.intermediate(executor_id="regular_executor", data=regular_update)
+    regular_event = WorkflowEvent("intermediate", executor_id="regular_executor", data=regular_update)
 
     # 2. Magentic workflow (with additional_properties)
     magentic_update = AgentResponseUpdate(
@@ -515,7 +516,7 @@ async def test_magentic_events_use_same_event_class_as_other_workflows(
         role="assistant",
         additional_properties={"magentic_event_type": "agent_delta"},
     )
-    magentic_event = WorkflowEvent.intermediate(executor_id="magentic_executor", data=magentic_update)
+    magentic_event = WorkflowEvent("intermediate", executor_id="magentic_executor", data=magentic_update)
 
     # Both should be the SAME class
     assert type(regular_event) is type(magentic_event)
@@ -565,7 +566,7 @@ async def test_workflow_output_event(mapper: MessageMapper, test_request: AgentF
     """Test output event (type='output') is converted to output_item.added."""
     from agent_framework._workflows._events import WorkflowEvent
 
-    event = WorkflowEvent.output(executor_id="final_executor", data="Final workflow output")
+    event = WorkflowEvent("output", executor_id="final_executor", data="Final workflow output")
     events = await mapper.convert_event(event, test_request)
 
     # output event (type='output') should emit output_item.added
@@ -590,7 +591,7 @@ async def test_workflow_output_event_with_list_data(mapper: MessageMapper, test_
         Message(role="user", contents=[Content.from_text(text="Hello")]),
         Message(role="assistant", contents=[Content.from_text(text="World")]),
     ]
-    event = WorkflowEvent.output(executor_id="complete", data=messages)
+    event = WorkflowEvent("output", executor_id="complete", data=messages)
     events = await mapper.convert_event(event, test_request)
 
     assert len(events) == 1
@@ -609,7 +610,7 @@ async def test_workflow_intermediate_event_with_agent_response_update_dispatched
         role="assistant",
         author_name="non-designated-agent",
     )
-    event = WorkflowEvent.intermediate(executor_id="non_designated", data=update)
+    event = WorkflowEvent("intermediate", executor_id="non_designated", data=update)
     events = await mapper.convert_event(event, test_request)
 
     assert len(events) >= 1
@@ -636,7 +637,7 @@ async def test_workflow_intermediate_event_with_string_payload_renders_visible_t
     dropped in DevUI."""
     from agent_framework._workflows._events import WorkflowEvent
 
-    event = WorkflowEvent.intermediate(executor_id="planner", data="plan: starting work")
+    event = WorkflowEvent("intermediate", executor_id="planner", data="plan: starting work")
     events = await mapper.convert_event(event, test_request)
 
     assert len(events) == 1
@@ -657,7 +658,7 @@ async def test_workflow_intermediate_event_with_message_payload_renders_visible_
     from agent_framework._workflows._events import WorkflowEvent
 
     msg = Message(role="assistant", contents=[Content.from_text(text="research note")])
-    event = WorkflowEvent.intermediate(executor_id="researcher", data=msg)
+    event = WorkflowEvent("intermediate", executor_id="researcher", data=msg)
     events = await mapper.convert_event(event, test_request)
 
     assert len(events) == 1

--- a/python/packages/devui/tests/devui/test_mapper.py
+++ b/python/packages/devui/tests/devui/test_mapper.py
@@ -574,6 +574,9 @@ async def test_workflow_output_event(mapper: MessageMapper, test_request: AgentF
     # Check item contains the output text
     item = events[0].item
     assert item.type == "message"
+    assert item.metadata["workflow_event_type"] == "output"
+    assert item.metadata["workflow_output_kind"] == "terminal"
+    assert item.metadata["executor_id"] == "final_executor"
     assert any("Final workflow output" in str(c) for c in item.content)
 
 
@@ -610,8 +613,17 @@ async def test_workflow_intermediate_event_with_agent_response_update_dispatched
     events = await mapper.convert_event(event, test_request)
 
     assert len(events) >= 1
+    added_events = [e for e in events if getattr(e, "type", "") == "response.output_item.added"]
+    assert added_events
+    item = added_events[0].item
+    assert item.metadata["workflow_event_type"] == "intermediate"
+    assert item.metadata["workflow_output_kind"] == "intermediate"
+    assert item.metadata["executor_id"] == "non_designated"
     text_events = [e for e in events if getattr(e, "type", "") == "response.output_text.delta"]
     assert len(text_events) >= 1
+    assert text_events[0].metadata["workflow_event_type"] == "intermediate"
+    assert text_events[0].metadata["workflow_output_kind"] == "intermediate"
+    assert text_events[0].metadata["executor_id"] == "non_designated"
     assert text_events[0].delta == "intermediate progress"
 
 
@@ -631,6 +643,9 @@ async def test_workflow_intermediate_event_with_string_payload_renders_visible_t
     assert events[0].type == "response.output_item.added"
     item = events[0].item
     assert item.type == "message"
+    assert item.metadata["workflow_event_type"] == "intermediate"
+    assert item.metadata["workflow_output_kind"] == "intermediate"
+    assert item.metadata["executor_id"] == "planner"
     assert any("plan: starting work" in str(c) for c in item.content)
 
 
@@ -648,7 +663,29 @@ async def test_workflow_intermediate_event_with_message_payload_renders_visible_
     assert len(events) == 1
     assert events[0].type == "response.output_item.added"
     item = events[0].item
+    assert item.metadata["workflow_event_type"] == "intermediate"
+    assert item.metadata["workflow_output_kind"] == "intermediate"
+    assert item.metadata["executor_id"] == "researcher"
     assert any("research note" in str(c) for c in item.content)
+
+
+async def test_workflow_data_event_keeps_intermediate_compatibility_metadata(
+    mapper: MessageMapper, test_request: AgentFrameworkRequest
+) -> None:
+    """Deprecated type='data' workflow events remain visible and explicitly intermediate."""
+    from agent_framework._workflows._events import WorkflowEvent
+
+    with pytest.warns(DeprecationWarning):
+        event = WorkflowEvent.emit(executor_id="legacy", data="legacy progress")
+    events = await mapper.convert_event(event, test_request)
+
+    assert len(events) == 1
+    assert events[0].type == "response.output_item.added"
+    item = events[0].item
+    assert item.metadata["workflow_event_type"] == "data"
+    assert item.metadata["workflow_output_kind"] == "intermediate"
+    assert item.metadata["executor_id"] == "legacy"
+    assert any("legacy progress" in str(c) for c in item.content)
 
 
 # =============================================================================

--- a/python/packages/foundry/tests/test_foundry_evals.py
+++ b/python/packages/foundry/tests/test_foundry_evals.py
@@ -1816,7 +1816,7 @@ class TestEvaluateWorkflow:
             WorkflowEvent.executor_completed("writer", [aer1]),
             WorkflowEvent.executor_invoked("reviewer", [aer1]),
             WorkflowEvent.executor_completed("reviewer", [aer2]),
-            WorkflowEvent.output("end", final_output),
+            WorkflowEvent("output", executor_id="end", data=final_output),
         ]
         wf_result = WorkflowRunResult(events, [])
 
@@ -1845,7 +1845,7 @@ class TestEvaluateWorkflow:
         events = [
             WorkflowEvent.executor_invoked("agent", "Test query"),
             WorkflowEvent.executor_completed("agent", [aer]),
-            WorkflowEvent.output("end", final_output),
+            WorkflowEvent("output", executor_id="end", data=final_output),
         ]
         wf_result = WorkflowRunResult(events, [])
 
@@ -1875,7 +1875,7 @@ class TestEvaluateWorkflow:
             WorkflowEvent.executor_completed("input-conversation", None),
             WorkflowEvent.executor_invoked("planner", "Plan trip"),
             WorkflowEvent.executor_completed("planner", [aer]),
-            WorkflowEvent.output("end", final_output),
+            WorkflowEvent("output", executor_id="end", data=final_output),
         ]
         wf_result = WorkflowRunResult(events, [])
 
@@ -1941,7 +1941,7 @@ class TestEvaluateWorkflow:
             WorkflowEvent.executor_completed("input-conversation", None),
             WorkflowEvent.executor_invoked("researcher", "What's the weather?"),
             WorkflowEvent.executor_completed("researcher", [aer]),
-            WorkflowEvent.output("end", [Message("assistant", ["Weather is sunny"])]),
+            WorkflowEvent("output", executor_id="end", data=[Message("assistant", ["Weather is sunny"])]),
         ]
         wf_result = WorkflowRunResult(events, [])
 
@@ -2050,7 +2050,7 @@ class TestEvaluateWorkflow:
         events = [
             WorkflowEvent.executor_invoked("agent", "Test query"),
             WorkflowEvent.executor_completed("agent", [aer]),
-            WorkflowEvent.output("end", final_output),
+            WorkflowEvent("output", executor_id="end", data=final_output),
         ]
         wf_result = WorkflowRunResult(events, [])
 
@@ -2089,7 +2089,7 @@ class TestEvaluateWorkflow:
         events = [
             WorkflowEvent.executor_invoked("agent", "Test query"),
             WorkflowEvent.executor_completed("agent", [aer]),
-            WorkflowEvent.output("end", final_output),
+            WorkflowEvent("output", executor_id="end", data=final_output),
         ]
         wf_result = WorkflowRunResult(events, [])
 

--- a/python/packages/orchestrations/README.md
+++ b/python/packages/orchestrations/README.md
@@ -19,7 +19,7 @@ from agent_framework.orchestrations import SequentialBuilder
 
 workflow = SequentialBuilder(participants=[agent1, agent2, agent3]).build()
 
-# Preserve agent1 and agent2 as visible progress, while agent3 remains terminal output.
+# Preserve agent1 and agent2 as visible progress, while the default builder output remains Workflow Output.
 workflow = SequentialBuilder(
     participants=[agent1, agent2, agent3],
     intermediate_output_from=[agent1, agent2],
@@ -79,22 +79,43 @@ workflow = MagenticBuilder(
 ).build()
 ```
 
-## Output Designation
+## Output Selection
 
-Orchestration builders expose workflow output selection using participant names:
+Orchestration builders expose Workflow Output selection using participant names. The core rule is that `output_from`
+is an allow-list for Workflow Output, not a routing rule for every other participant output. Unselected participant
+payloads are hidden unless `intermediate_output_from` explicitly selects them as Intermediate Output.
 
-- `final_output_from` designates participant emissions as terminal workflow `output` events.
-- `intermediate_output_from` designates participant emissions as visible workflow `intermediate` events.
-- Unlisted participant emissions are hidden in explicit designation mode.
+- `output_from` designates participant emissions as Workflow Output (`type='output'` events).
+- `intermediate_output_from` designates participant emissions as Intermediate Output (`type='intermediate'` events).
+- `final_output_from` is a deprecated compatibility alias for `output_from`.
 
-If neither list is provided, each builder uses its default terminal contract. Sequential emits the final participant;
-Concurrent, GroupChat, and Magentic emit their final aggregator/orchestrator/manager output; Handoff emits
-participants. Explicit designation is validated for empty lists, duplicates, output/intermediate overlap, and unknown
+If neither list is provided, each builder uses its documented default Workflow Output contract. Sequential emits the
+last participant; Concurrent, GroupChat, and Magentic emit their aggregator/orchestrator/manager output; Handoff emits
 participants.
 
-When an orchestration is wrapped with `workflow.as_agent()`, terminal workflow output becomes normal response text.
-Intermediate workflow output becomes `text_reasoning` content so callers can inspect progress without changing
-terminal `.text` behavior.
+| Selection | Workflow Output | Intermediate Output | Hidden payloads |
+| --- | --- | --- | --- |
+| Omit both selections | Builder default Workflow Output contract | None | Builder-specific non-output participant payloads |
+| `output_from="all"` | Every output-capable participant | None | None |
+| `output_from=[writer]` | Only `writer` | None | All other participant payloads |
+| `output_from=[writer], intermediate_output_from="all_other"` | Only `writer` | Every output-capable participant not selected by `output_from` | None |
+| `intermediate_output_from="all_other"` | None, except builder-internal default output executors where applicable | Every output-capable participant | Builder-internal plumbing payloads |
+| `output_from=[], intermediate_output_from="all_other"` | None, except builder-internal default output executors where applicable | Every output-capable participant | Builder-internal plumbing payloads |
+| `output_from=[writer], intermediate_output_from=[researcher, reviewer]` | Only `writer` | `researcher` and `reviewer` | Any other participant payloads |
+
+Invalid selections fail at construction or build time:
+
+| Invalid selection | Why it fails |
+| --- | --- |
+| `output_from="all_other"` | `"all_other"` is only valid for `intermediate_output_from` |
+| `intermediate_output_from="all"` | `"all"` is only valid for `output_from` |
+| The same participant in both selections | One payload cannot be both Workflow Output and Intermediate Output |
+| Duplicate participant selections | Duplicates are treated as configuration errors |
+| Unknown participant selections | Typos and missing participants are rejected |
+| `output_from=[], intermediate_output_from=[]` | Both explicit selections are empty |
+
+When an orchestration is wrapped with `workflow.as_agent()`, Workflow Output becomes normal response text. Intermediate
+Output becomes `text_reasoning` content so callers can inspect progress without changing `.text` behavior.
 
 ## Documentation
 

--- a/python/packages/orchestrations/README.md
+++ b/python/packages/orchestrations/README.md
@@ -22,7 +22,7 @@ workflow = SequentialBuilder(participants=[agent1, agent2, agent3]).build()
 # Preserve agent1 and agent2 as visible progress, while agent3 remains terminal output.
 workflow = SequentialBuilder(
     participants=[agent1, agent2, agent3],
-    intermediate_participants=[agent1, agent2],
+    intermediate_output_from=[agent1, agent2],
 ).build()
 ```
 
@@ -61,7 +61,7 @@ from agent_framework.orchestrations import GroupChatBuilder
 workflow = GroupChatBuilder(
     participants=[agent1, agent2],
     selection_func=my_selector,
-    intermediate_participants=[agent1, agent2],
+    intermediate_output_from=[agent1, agent2],
 ).build()
 ```
 
@@ -75,7 +75,7 @@ from agent_framework.orchestrations import MagenticBuilder
 workflow = MagenticBuilder(
     participants=[researcher, writer, reviewer],
     manager_agent=manager_agent,
-    intermediate_participants=[researcher, writer, reviewer],
+    intermediate_output_from=[researcher, writer, reviewer],
 ).build()
 ```
 
@@ -83,8 +83,8 @@ workflow = MagenticBuilder(
 
 Orchestration builders expose workflow output selection using participant names:
 
-- `output_participants` designates participant emissions as terminal workflow `output` events.
-- `intermediate_participants` designates participant emissions as visible workflow `intermediate` events.
+- `final_output_from` designates participant emissions as terminal workflow `output` events.
+- `intermediate_output_from` designates participant emissions as visible workflow `intermediate` events.
 - Unlisted participant emissions are hidden in explicit designation mode.
 
 If neither list is provided, each builder uses its default terminal contract. Sequential emits the final participant;

--- a/python/packages/orchestrations/README.md
+++ b/python/packages/orchestrations/README.md
@@ -87,7 +87,6 @@ payloads are hidden unless `intermediate_output_from` explicitly selects them as
 
 - `output_from` designates participant emissions as Workflow Output (`type='output'` events).
 - `intermediate_output_from` designates participant emissions as Intermediate Output (`type='intermediate'` events).
-- `final_output_from` is a deprecated compatibility alias for `output_from`.
 
 If neither list is provided, each builder uses its documented default Workflow Output contract. Sequential emits the
 last participant; Concurrent, GroupChat, and Magentic emit their aggregator/orchestrator/manager output; Handoff emits

--- a/python/packages/orchestrations/README.md
+++ b/python/packages/orchestrations/README.md
@@ -18,6 +18,12 @@ Chain agents/executors in sequence, passing conversation context along:
 from agent_framework.orchestrations import SequentialBuilder
 
 workflow = SequentialBuilder(participants=[agent1, agent2, agent3]).build()
+
+# Preserve agent1 and agent2 as visible progress, while agent3 remains terminal output.
+workflow = SequentialBuilder(
+    participants=[agent1, agent2, agent3],
+    intermediate_participants=[agent1, agent2],
+).build()
 ```
 
 ### ConcurrentBuilder
@@ -55,6 +61,7 @@ from agent_framework.orchestrations import GroupChatBuilder
 workflow = GroupChatBuilder(
     participants=[agent1, agent2],
     selection_func=my_selector,
+    intermediate_participants=[agent1, agent2],
 ).build()
 ```
 
@@ -68,8 +75,26 @@ from agent_framework.orchestrations import MagenticBuilder
 workflow = MagenticBuilder(
     participants=[researcher, writer, reviewer],
     manager_agent=manager_agent,
+    intermediate_participants=[researcher, writer, reviewer],
 ).build()
 ```
+
+## Output Designation
+
+Orchestration builders expose workflow output selection using participant names:
+
+- `output_participants` designates participant emissions as terminal workflow `output` events.
+- `intermediate_participants` designates participant emissions as visible workflow `intermediate` events.
+- Unlisted participant emissions are hidden in explicit designation mode.
+
+If neither list is provided, each builder uses its default terminal contract. Sequential emits the final participant;
+Concurrent, GroupChat, and Magentic emit their final aggregator/orchestrator/manager output; Handoff emits
+participants. Explicit designation is validated for empty lists, duplicates, output/intermediate overlap, and unknown
+participants.
+
+When an orchestration is wrapped with `workflow.as_agent()`, terminal workflow output becomes normal response text.
+Intermediate workflow output becomes `text_reasoning` content so callers can inspect progress without changing
+terminal `.text` behavior.
 
 ## Documentation
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -396,10 +396,16 @@ class ConcurrentBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
+        # Default: only the aggregator is designated; participants surface as intermediate.
+        # With intermediate_outputs=True, participants are also designated so their yields
+        # surface as type='output' — preserving the legacy "see every participant" contract.
+        designated: list[Executor | SupportsAgentRun] = (
+            [aggregator, *participants] if self._intermediate_outputs else [aggregator]
+        )
         builder = WorkflowBuilder(
             start_executor=dispatcher,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=[aggregator] if not self._intermediate_outputs else None,
+            output_executors=designated,
         )
         # Fan-out for parallel execution
         builder.add_fan_out_edges(dispatcher, participants)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -18,7 +18,10 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 from typing_extensions import Never
 
 from ._orchestration_request_info import AgentApprovalExecutor
-from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
+from ._participant_output_config import (
+    _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
+    _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
+)
 
 logger = logging.getLogger(__name__)
 
@@ -206,8 +209,8 @@ class ConcurrentBuilder:
         *,
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[ParticipantSpecifier] | None = None,
-        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
+        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the ConcurrentBuilder.
 
@@ -404,7 +407,7 @@ class ConcurrentBuilder:
 
         # Default: only the aggregator is terminal; participant outputs are hidden
         # unless explicitly designated as terminal or intermediate.
-        designated, intermediate_designated = resolve_participant_designation(
+        designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
             output_participants=self._output_participants,
             intermediate_participants=self._intermediate_participants,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -209,17 +209,17 @@ class ConcurrentBuilder:
         *,
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the ConcurrentBuilder.
 
         Args:
             participants: Sequence of agent or executor instances to run in parallel.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_participants: Optional participant names or instances whose ``yield_output`` calls
+            final_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as terminal workflow ``output`` events alongside the aggregator.
-            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+            intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
@@ -227,9 +227,9 @@ class ConcurrentBuilder:
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._output_participants = list(output_participants) if output_participants is not None else None
-        self._intermediate_participants = (
-            list(intermediate_participants) if intermediate_participants is not None else None
+        self._final_output_from = list(final_output_from) if final_output_from is not None else None
+        self._intermediate_output_from = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
         self._set_participants(participants)
@@ -409,8 +409,8 @@ class ConcurrentBuilder:
         # unless explicitly designated as terminal or intermediate.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            output_participants=self._output_participants,
-            intermediate_participants=self._intermediate_participants,
+            final_output_from=self._final_output_from,
+            intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[aggregator],
         )
         builder = WorkflowBuilder(

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -18,6 +18,7 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 from typing_extensions import Never
 
 from ._orchestration_request_info import AgentApprovalExecutor
+from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
 
 logger = logging.getLogger(__name__)
 
@@ -205,23 +206,28 @@ class ConcurrentBuilder:
         *,
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
-        intermediate_outputs: bool = False,
+        output_participants: Sequence[ParticipantSpecifier] | None = None,
+        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
     ) -> None:
         """Initialize the ConcurrentBuilder.
 
         Args:
             participants: Sequence of agent or executor instances to run in parallel.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            intermediate_outputs: If True, every participant's `yield_output` surfaces as a
-                workflow `output` event in addition to the aggregator's. By default
-                (False) only the aggregator's output surfaces.
+            output_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as terminal workflow ``output`` events alongside the aggregator.
+            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._aggregator: Executor | None = None
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._intermediate_outputs: bool = intermediate_outputs
+        self._output_participants = list(output_participants) if output_participants is not None else None
+        self._intermediate_participants = (
+            list(intermediate_participants) if intermediate_participants is not None else None
+        )
 
         self._set_participants(participants)
 
@@ -396,14 +402,13 @@ class ConcurrentBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
-        # Default: only the aggregator is terminal; participants surface as intermediate.
-        # With intermediate_outputs=True, participants are also designated so their yields
-        # surface as type='output' — preserving the legacy "see every participant" contract.
-        designated: list[Executor | SupportsAgentRun] = (
-            [aggregator, *participants] if self._intermediate_outputs else [aggregator]
-        )
-        intermediate_designated: list[Executor | SupportsAgentRun] = (
-            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        # Default: only the aggregator is terminal; participant outputs are hidden
+        # unless explicitly designated as terminal or intermediate.
+        designated, intermediate_designated = resolve_participant_designation(
+            participants=participants,
+            output_participants=self._output_participants,
+            intermediate_participants=self._intermediate_participants,
+            extra_output_executors=[aggregator],
         )
         builder = WorkflowBuilder(
             start_executor=dispatcher,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -214,7 +214,6 @@ class ConcurrentBuilder:
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
         intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the ConcurrentBuilder.
 
@@ -227,14 +226,13 @@ class ConcurrentBuilder:
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
                 not selected by ``output_from``. Unlisted participant outputs are hidden.
-            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._aggregator: Executor | None = None
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._output_from = _coalesce_output_from(output_from=output_from)
         self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -396,16 +396,20 @@ class ConcurrentBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
-        # Default: only the aggregator is designated; participants surface as intermediate.
+        # Default: only the aggregator is terminal; participants surface as intermediate.
         # With intermediate_outputs=True, participants are also designated so their yields
         # surface as type='output' — preserving the legacy "see every participant" contract.
         designated: list[Executor | SupportsAgentRun] = (
             [aggregator, *participants] if self._intermediate_outputs else [aggregator]
         )
+        intermediate_designated: list[Executor | SupportsAgentRun] = (
+            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        )
         builder = WorkflowBuilder(
             start_executor=dispatcher,
             checkpoint_storage=self._checkpoint_storage,
             output_executors=designated,
+            intermediate_executors=intermediate_designated,
         )
         # Fan-out for parallel execution
         builder.add_fan_out_edges(dispatcher, participants)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -22,6 +22,7 @@ from ._participant_output_config import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
     _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
+    _ParticipantIntermediateOutputSelection,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -213,7 +214,7 @@ class ConcurrentBuilder:
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        intermediate_output_from: _ParticipantIntermediateOutputSelection = None,
     ) -> None:
         """Initialize the ConcurrentBuilder.
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal, cast
 
 from agent_framework import AgentResponse, Message, SupportsAgentRun
 from agent_framework._workflows._agent_executor import AgentExecutor, AgentExecutorRequest, AgentExecutorResponse
@@ -19,6 +19,9 @@ from typing_extensions import Never
 
 from ._orchestration_request_info import AgentApprovalExecutor
 from ._participant_output_config import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
+    _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -209,28 +212,30 @@ class ConcurrentBuilder:
         *,
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the ConcurrentBuilder.
 
         Args:
             participants: Sequence of agent or executor instances to run in parallel.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            final_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as terminal workflow ``output`` events alongside the aggregator.
+            output_from: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``output`` events alongside the aggregator. Pass ``"all"`` to select every
+                participant.
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
+                surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
+                not selected by ``output_from``. Unlisted participant outputs are hidden.
+            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._aggregator: Executor | None = None
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._final_output_from = list(final_output_from) if final_output_from is not None else None
-        self._intermediate_output_from = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
-        )
+        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)
 
@@ -409,14 +414,14 @@ class ConcurrentBuilder:
         # unless explicitly designated as terminal or intermediate.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            final_output_from=self._final_output_from,
+            output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[aggregator],
         )
         builder = WorkflowBuilder(
             start_executor=dispatcher,
             checkpoint_storage=self._checkpoint_storage,
-            final_output_from=designated,
+            output_from=designated,
             intermediate_output_from=intermediate_designated,
         )
         # Fan-out for parallel execution

--- a/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_concurrent.py
@@ -416,8 +416,8 @@ class ConcurrentBuilder:
         builder = WorkflowBuilder(
             start_executor=dispatcher,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=designated,
-            intermediate_executors=intermediate_designated,
+            final_output_from=designated,
+            intermediate_output_from=intermediate_designated,
         )
         # Fan-out for parallel execution
         builder.add_fan_out_edges(dispatcher, participants)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -1001,11 +1001,17 @@ class GroupChatBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Build workflow graph
+        # Default: only the orchestrator is designated; participants surface as intermediate.
+        # With intermediate_outputs=True, participants are also designated so their yields
+        # surface as type='output' — preserving the legacy contract.
+        # `group_chat` orchestrator-progress events keep their dedicated event type.
+        designated: list[Executor | SupportsAgentRun] = (
+            [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
+        )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=[orchestrator] if not self._intermediate_outputs else None,
+            output_executors=designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -27,7 +27,7 @@ import sys
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Literal, cast
 
 from agent_framework import Agent, AgentResponse, AgentResponseUpdate, AgentSession, Message, SupportsAgentRun
 from agent_framework._workflows._agent_executor import AgentExecutor, AgentExecutorRequest, AgentExecutorResponse
@@ -52,6 +52,9 @@ from ._base_group_chat_orchestrator import (
 from ._orchestration_request_info import AgentApprovalExecutor
 from ._orchestrator_helpers import clean_conversation_for_handoff
 from ._participant_output_config import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
+    _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -622,8 +625,9 @@ class GroupChatBuilder:
         termination_condition: TerminationCondition | None = None,
         max_rounds: int | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the GroupChatBuilder.
 
@@ -640,10 +644,13 @@ class GroupChatBuilder:
                 True to terminate the conversation, False to continue.
             max_rounds: Optional maximum number of orchestrator rounds to prevent infinite conversations.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            final_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as terminal workflow ``output`` events alongside the orchestrator.
+            output_from: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``output`` events alongside the orchestrator. Pass ``"all"`` to select every
+                participant.
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
+                surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
+                not selected by ``output_from``. Unlisted participant outputs are hidden.
+            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
         self._participant_factories: list[Callable[[], SupportsAgentRun | Executor]] = []
@@ -664,10 +671,8 @@ class GroupChatBuilder:
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] = set()
 
-        self._final_output_from = list(final_output_from) if final_output_from is not None else None
-        self._intermediate_output_from = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
-        )
+        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         if participants is None and participant_factories is None:
             raise ValueError("Either participants or participant_factories must be provided.")
@@ -1015,14 +1020,14 @@ class GroupChatBuilder:
         # `group_chat` orchestrator-progress events keep their dedicated event type.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            final_output_from=self._final_output_from,
+            output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            final_output_from=designated,
+            output_from=designated,
             intermediate_output_from=intermediate_designated,
         )
         for participant in participants:

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -1022,8 +1022,8 @@ class GroupChatBuilder:
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=designated,
-            intermediate_executors=intermediate_designated,
+            final_output_from=designated,
+            intermediate_output_from=intermediate_designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -51,6 +51,7 @@ from ._base_group_chat_orchestrator import (
 )
 from ._orchestration_request_info import AgentApprovalExecutor
 from ._orchestrator_helpers import clean_conversation_for_handoff
+from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -618,7 +619,8 @@ class GroupChatBuilder:
         termination_condition: TerminationCondition | None = None,
         max_rounds: int | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
-        intermediate_outputs: bool = False,
+        output_participants: Sequence[ParticipantSpecifier] | None = None,
+        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
     ) -> None:
         """Initialize the GroupChatBuilder.
 
@@ -635,9 +637,10 @@ class GroupChatBuilder:
                 True to terminate the conversation, False to continue.
             max_rounds: Optional maximum number of orchestrator rounds to prevent infinite conversations.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            intermediate_outputs: If True, every participant's `yield_output` surfaces as a
-                workflow `output` event in addition to the orchestrator's. By default (False)
-                only the orchestrator's output surfaces.
+            output_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as terminal workflow ``output`` events alongside the orchestrator.
+            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
         self._participant_factories: list[Callable[[], SupportsAgentRun | Executor]] = []
@@ -658,7 +661,10 @@ class GroupChatBuilder:
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] = set()
 
-        self._intermediate_outputs: bool = intermediate_outputs
+        self._output_participants = list(output_participants) if output_participants is not None else None
+        self._intermediate_participants = (
+            list(intermediate_participants) if intermediate_participants is not None else None
+        )
 
         if participants is None and participant_factories is None:
             raise ValueError("Either participants or participant_factories must be provided.")
@@ -1001,15 +1007,14 @@ class GroupChatBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Default: only the orchestrator is terminal; participants surface as intermediate.
-        # With intermediate_outputs=True, participants are also designated so their yields
-        # surface as type='output' — preserving the legacy contract.
+        # Default: only the orchestrator is terminal; participant outputs are hidden
+        # unless explicitly designated as terminal or intermediate.
         # `group_chat` orchestrator-progress events keep their dedicated event type.
-        designated: list[Executor | SupportsAgentRun] = (
-            [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
-        )
-        intermediate_designated: list[Executor | SupportsAgentRun] = (
-            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        designated, intermediate_designated = resolve_participant_designation(
+            participants=participants,
+            output_participants=self._output_participants,
+            intermediate_participants=self._intermediate_participants,
+            extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -627,7 +627,6 @@ class GroupChatBuilder:
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
         intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the GroupChatBuilder.
 
@@ -650,7 +649,6 @@ class GroupChatBuilder:
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
                 not selected by ``output_from``. Unlisted participant outputs are hidden.
-            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
         self._participant_factories: list[Callable[[], SupportsAgentRun | Executor]] = []
@@ -671,7 +669,7 @@ class GroupChatBuilder:
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] = set()
 
-        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._output_from = _coalesce_output_from(output_from=output_from)
         self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         if participants is None and participant_factories is None:

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -622,8 +622,8 @@ class GroupChatBuilder:
         termination_condition: TerminationCondition | None = None,
         max_rounds: int | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the GroupChatBuilder.
 
@@ -640,9 +640,9 @@ class GroupChatBuilder:
                 True to terminate the conversation, False to continue.
             max_rounds: Optional maximum number of orchestrator rounds to prevent infinite conversations.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_participants: Optional participant names or instances whose ``yield_output`` calls
+            final_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as terminal workflow ``output`` events alongside the orchestrator.
-            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+            intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
@@ -664,9 +664,9 @@ class GroupChatBuilder:
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] = set()
 
-        self._output_participants = list(output_participants) if output_participants is not None else None
-        self._intermediate_participants = (
-            list(intermediate_participants) if intermediate_participants is not None else None
+        self._final_output_from = list(final_output_from) if final_output_from is not None else None
+        self._intermediate_output_from = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
         if participants is None and participant_factories is None:
@@ -1015,8 +1015,8 @@ class GroupChatBuilder:
         # `group_chat` orchestrator-progress events keep their dedicated event type.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            output_participants=self._output_participants,
-            intermediate_participants=self._intermediate_participants,
+            final_output_from=self._final_output_from,
+            intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -55,6 +55,7 @@ from ._participant_output_config import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
     _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
+    _ParticipantIntermediateOutputSelection,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -626,7 +627,7 @@ class GroupChatBuilder:
         max_rounds: int | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        intermediate_output_from: _ParticipantIntermediateOutputSelection = None,
     ) -> None:
         """Initialize the GroupChatBuilder.
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -1001,17 +1001,21 @@ class GroupChatBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Default: only the orchestrator is designated; participants surface as intermediate.
+        # Default: only the orchestrator is terminal; participants surface as intermediate.
         # With intermediate_outputs=True, participants are also designated so their yields
         # surface as type='output' — preserving the legacy contract.
         # `group_chat` orchestrator-progress events keep their dedicated event type.
         designated: list[Executor | SupportsAgentRun] = (
             [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
         )
+        intermediate_designated: list[Executor | SupportsAgentRun] = (
+            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
             output_executors=designated,
+            intermediate_executors=intermediate_designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_group_chat.py
@@ -51,7 +51,10 @@ from ._base_group_chat_orchestrator import (
 )
 from ._orchestration_request_info import AgentApprovalExecutor
 from ._orchestrator_helpers import clean_conversation_for_handoff
-from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
+from ._participant_output_config import (
+    _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
+    _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
+)
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -619,8 +622,8 @@ class GroupChatBuilder:
         termination_condition: TerminationCondition | None = None,
         max_rounds: int | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[ParticipantSpecifier] | None = None,
-        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
+        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the GroupChatBuilder.
 
@@ -1010,7 +1013,7 @@ class GroupChatBuilder:
         # Default: only the orchestrator is terminal; participant outputs are hidden
         # unless explicitly designated as terminal or intermediate.
         # `group_chat` orchestrator-progress events keep their dedicated event type.
-        designated, intermediate_designated = resolve_participant_designation(
+        designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
             output_participants=self._output_participants,
             intermediate_participants=self._intermediate_participants,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -955,11 +955,15 @@ class HandoffBuilder:
         if self._start_id is None:
             raise ValueError("Must call with_start_agent(...) before building the workflow.")
         start_executor = executors[self._resolve_to_id(resolved_agents[self._start_id])]
+        # Handoff has no separate terminator: every participant's reply is a primary
+        # output (termination is implicit when no handoff fires). All participants are
+        # designated outputs so each yield surfaces as type='output'.
         builder = WorkflowBuilder(
             name=self._name,
             description=self._description,
             start_executor=start_executor,
             checkpoint_storage=self._checkpoint_storage,
+            output_executors=list(executors.values()),
         )
 
         # Add the appropriate edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -53,7 +53,10 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 
 from ._base_group_chat_orchestrator import TerminationCondition
 from ._orchestrator_helpers import clean_conversation_for_handoff
-from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
+from ._participant_output_config import (
+    _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
+    _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
+)
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -590,8 +593,8 @@ class HandoffBuilder:
         description: str | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
         termination_condition: TerminationCondition | None = None,
-        output_participants: Sequence[ParticipantSpecifier] | None = None,
-        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
+        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 
@@ -969,7 +972,7 @@ class HandoffBuilder:
         # Handoff has no separate terminator: every participant's reply is a primary
         # output by default. Explicit participant designation can narrow or reclassify
         # selected speakers.
-        output_executors, intermediate_executors = resolve_participant_designation(
+        output_executors, intermediate_executors = _resolve_participant_output_config(
             participants=list(executors.values()),
             output_participants=self._output_participants,
             intermediate_participants=self._intermediate_participants,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -36,7 +36,7 @@ import sys
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, cast
 
 from agent_framework import Agent, AgentResponse, Message, SupportsAgentRun
 from agent_framework._middleware import FunctionInvocationContext, FunctionMiddleware, MiddlewareTermination
@@ -54,6 +54,9 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 from ._base_group_chat_orchestrator import TerminationCondition
 from ._orchestrator_helpers import clean_conversation_for_handoff
 from ._participant_output_config import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
+    _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -593,8 +596,9 @@ class HandoffBuilder:
         description: str | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
         termination_condition: TerminationCondition | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 
@@ -616,10 +620,13 @@ class HandoffBuilder:
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
             termination_condition: Optional callable that receives the full conversation and returns True
                 (or awaitable True) if the workflow should terminate.
-            final_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as terminal workflow ``output`` events. Defaults to all participants.
+            output_from: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``output`` events. Defaults to all participants; pass ``"all"`` to select every
+                participant explicitly.
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
+                surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
+                not selected by ``output_from``. Unlisted participant outputs are hidden.
+            final_output_from: Deprecated alias for ``output_from``.
         """
         self._name = name
         self._description = description
@@ -645,10 +652,8 @@ class HandoffBuilder:
 
         # Termination related members
         self._termination_condition: Callable[[list[Message]], bool | Awaitable[bool]] | None = termination_condition
-        self._final_output_from = list(final_output_from) if final_output_from is not None else None
-        self._intermediate_output_from = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
-        )
+        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
     def participants(self, participants: Sequence[Agent]) -> "HandoffBuilder":
         """Register the agents that will participate in the handoff workflow.
@@ -974,7 +979,7 @@ class HandoffBuilder:
         # selected speakers.
         final_output, intermediate_output = _resolve_participant_output_config(
             participants=list(executors.values()),
-            final_output_from=self._final_output_from,
+            output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
             default_final_output_from=list(executors.values()),
         )
@@ -983,7 +988,7 @@ class HandoffBuilder:
             description=self._description,
             start_executor=start_executor,
             checkpoint_storage=self._checkpoint_storage,
-            final_output_from=final_output,
+            output_from=final_output,
             intermediate_output_from=intermediate_output,
         )
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -598,7 +598,6 @@ class HandoffBuilder:
         termination_condition: TerminationCondition | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
         intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 
@@ -626,7 +625,6 @@ class HandoffBuilder:
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
                 not selected by ``output_from``. Unlisted participant outputs are hidden.
-            final_output_from: Deprecated alias for ``output_from``.
         """
         self._name = name
         self._description = description
@@ -652,7 +650,7 @@ class HandoffBuilder:
 
         # Termination related members
         self._termination_condition: Callable[[list[Message]], bool | Awaitable[bool]] | None = termination_condition
-        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._output_from = _coalesce_output_from(output_from=output_from)
         self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
     def participants(self, participants: Sequence[Agent]) -> "HandoffBuilder":
@@ -977,18 +975,18 @@ class HandoffBuilder:
         # Handoff has no separate terminator: every participant's reply is a primary
         # output by default. Explicit participant designation can narrow or reclassify
         # selected speakers.
-        final_output, intermediate_output = _resolve_participant_output_config(
+        output, intermediate_output = _resolve_participant_output_config(
             participants=list(executors.values()),
             output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
-            default_final_output_from=list(executors.values()),
+            default_output_from=list(executors.values()),
         )
         builder = WorkflowBuilder(
             name=self._name,
             description=self._description,
             start_executor=start_executor,
             checkpoint_storage=self._checkpoint_storage,
-            output_from=final_output,
+            output_from=output,
             intermediate_output_from=intermediate_output,
         )
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -593,8 +593,8 @@ class HandoffBuilder:
         description: str | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
         termination_condition: TerminationCondition | None = None,
-        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 
@@ -616,9 +616,9 @@ class HandoffBuilder:
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
             termination_condition: Optional callable that receives the full conversation and returns True
                 (or awaitable True) if the workflow should terminate.
-            output_participants: Optional participant names or instances whose ``yield_output`` calls
+            final_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as terminal workflow ``output`` events. Defaults to all participants.
-            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+            intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._name = name
@@ -645,9 +645,9 @@ class HandoffBuilder:
 
         # Termination related members
         self._termination_condition: Callable[[list[Message]], bool | Awaitable[bool]] | None = termination_condition
-        self._output_participants = list(output_participants) if output_participants is not None else None
-        self._intermediate_participants = (
-            list(intermediate_participants) if intermediate_participants is not None else None
+        self._final_output_from = list(final_output_from) if final_output_from is not None else None
+        self._intermediate_output_from = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
     def participants(self, participants: Sequence[Agent]) -> "HandoffBuilder":
@@ -974,9 +974,9 @@ class HandoffBuilder:
         # selected speakers.
         output_executors, intermediate_executors = _resolve_participant_output_config(
             participants=list(executors.values()),
-            output_participants=self._output_participants,
-            intermediate_participants=self._intermediate_participants,
-            default_output_participants=list(executors.values()),
+            final_output_from=self._final_output_from,
+            intermediate_output_from=self._intermediate_output_from,
+            default_final_output_from=list(executors.values()),
         )
         builder = WorkflowBuilder(
             name=self._name,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -972,7 +972,7 @@ class HandoffBuilder:
         # Handoff has no separate terminator: every participant's reply is a primary
         # output by default. Explicit participant designation can narrow or reclassify
         # selected speakers.
-        output_executors, intermediate_executors = _resolve_participant_output_config(
+        final_output, intermediate_output = _resolve_participant_output_config(
             participants=list(executors.values()),
             final_output_from=self._final_output_from,
             intermediate_output_from=self._intermediate_output_from,
@@ -983,8 +983,8 @@ class HandoffBuilder:
             description=self._description,
             start_executor=start_executor,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=output_executors,
-            intermediate_executors=intermediate_executors,
+            final_output_from=final_output,
+            intermediate_output_from=intermediate_output,
         )
 
         # Add the appropriate edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -384,7 +384,7 @@ class HandoffAgentExecutor(AgentExecutor):
 
         # Append the agent response to the full conversation history. This list removes
         # function call related content such that the result stays consistent regardless
-        # of which agent yields the final output.
+        # of which agent yields Workflow Output.
         self._full_conversation.extend(cleaned_response)
 
         # Broadcast only the cleaned response to other agents (without function_calls/results)
@@ -584,7 +584,7 @@ class HandoffBuilder:
 
     Note:
     1. Agents in handoff workflows must be ``Agent`` instances and support local tool calls.
-    2. Because each agent's response is itself a workflow output, handoff has no separate
+    2. Because each agent's response is itself Workflow Output, handoff has no separate
        "intermediate outputs" channel — every per-agent response is the primary output.
     """
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -53,6 +53,7 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 
 from ._base_group_chat_orchestrator import TerminationCondition
 from ._orchestrator_helpers import clean_conversation_for_handoff
+from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -589,6 +590,8 @@ class HandoffBuilder:
         description: str | None = None,
         checkpoint_storage: CheckpointStorage | None = None,
         termination_condition: TerminationCondition | None = None,
+        output_participants: Sequence[ParticipantSpecifier] | None = None,
+        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 
@@ -610,6 +613,10 @@ class HandoffBuilder:
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
             termination_condition: Optional callable that receives the full conversation and returns True
                 (or awaitable True) if the workflow should terminate.
+            output_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as terminal workflow ``output`` events. Defaults to all participants.
+            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._name = name
         self._description = description
@@ -635,6 +642,10 @@ class HandoffBuilder:
 
         # Termination related members
         self._termination_condition: Callable[[list[Message]], bool | Awaitable[bool]] | None = termination_condition
+        self._output_participants = list(output_participants) if output_participants is not None else None
+        self._intermediate_participants = (
+            list(intermediate_participants) if intermediate_participants is not None else None
+        )
 
     def participants(self, participants: Sequence[Agent]) -> "HandoffBuilder":
         """Register the agents that will participate in the handoff workflow.
@@ -956,14 +967,21 @@ class HandoffBuilder:
             raise ValueError("Must call with_start_agent(...) before building the workflow.")
         start_executor = executors[self._resolve_to_id(resolved_agents[self._start_id])]
         # Handoff has no separate terminator: every participant's reply is a primary
-        # output (termination is implicit when no handoff fires). All participants are
-        # designated outputs so each yield surfaces as type='output'.
+        # output by default. Explicit participant designation can narrow or reclassify
+        # selected speakers.
+        output_executors, intermediate_executors = resolve_participant_designation(
+            participants=list(executors.values()),
+            output_participants=self._output_participants,
+            intermediate_participants=self._intermediate_participants,
+            default_output_participants=list(executors.values()),
+        )
         builder = WorkflowBuilder(
             name=self._name,
             description=self._description,
             start_executor=start_executor,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=list(executors.values()),
+            output_executors=output_executors,
+            intermediate_executors=intermediate_executors,
         )
 
         # Add the appropriate edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -57,6 +57,7 @@ from ._participant_output_config import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
     _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
+    _ParticipantIntermediateOutputSelection,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -597,7 +598,7 @@ class HandoffBuilder:
         checkpoint_storage: CheckpointStorage | None = None,
         termination_condition: TerminationCondition | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        intermediate_output_from: _ParticipantIntermediateOutputSelection = None,
     ) -> None:
         r"""Initialize a HandoffBuilder for creating conversational handoff workflows.
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -1762,11 +1762,17 @@ class MagenticBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Build workflow graph
+        # Default: only the manager is designated; worker yields surface as intermediate.
+        # With intermediate_outputs=True, workers are also designated so their yields
+        # surface as type='output' — preserving the legacy contract.
+        # `magentic_orchestrator` events keep their dedicated event type.
+        designated: list[Executor | SupportsAgentRun] = (
+            [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
+        )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=[orchestrator] if not self._intermediate_outputs else None,
+            output_executors=designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -38,6 +38,7 @@ from ._base_group_chat_orchestrator import (
     GroupChatWorkflowContextOutT,
     ParticipantRegistry,
 )
+from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -1409,7 +1410,8 @@ class MagenticBuilder:
         # Existing params
         enable_plan_review: bool = False,
         checkpoint_storage: CheckpointStorage | None = None,
-        intermediate_outputs: bool = False,
+        output_participants: Sequence[ParticipantSpecifier] | None = None,
+        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
     ) -> None:
         """Initialize the Magentic workflow builder.
 
@@ -1432,9 +1434,10 @@ class MagenticBuilder:
             max_round_count: Max total coordination rounds. None means unlimited.
             enable_plan_review: If True, requires human approval of the initial plan before proceeding.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            intermediate_outputs: If True, every participant's `yield_output` surfaces as a
-                workflow `output` event in addition to the orchestrator's. By default (False)
-                only the orchestrator's output surfaces.
+            output_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as terminal workflow ``output`` events alongside the manager.
+            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
 
@@ -1447,7 +1450,10 @@ class MagenticBuilder:
 
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
 
-        self._intermediate_outputs = intermediate_outputs
+        self._output_participants = list(output_participants) if output_participants is not None else None
+        self._intermediate_participants = (
+            list(intermediate_participants) if intermediate_participants is not None else None
+        )
 
         self._set_participants(participants)
 
@@ -1762,15 +1768,14 @@ class MagenticBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Default: only the manager is terminal; worker yields surface as intermediate.
-        # With intermediate_outputs=True, workers are also designated so their yields
-        # surface as type='output' — preserving the legacy contract.
+        # Default: only the manager is terminal; worker outputs are hidden unless
+        # explicitly designated as terminal or intermediate.
         # `magentic_orchestrator` events keep their dedicated event type.
-        designated: list[Executor | SupportsAgentRun] = (
-            [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
-        )
-        intermediate_designated: list[Executor | SupportsAgentRun] = (
-            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        designated, intermediate_designated = resolve_participant_designation(
+            participants=participants,
+            output_participants=self._output_participants,
+            intermediate_participants=self._intermediate_participants,
+            extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -42,6 +42,7 @@ from ._participant_output_config import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
     _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
+    _ParticipantIntermediateOutputSelection,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -1417,7 +1418,7 @@ class MagenticBuilder:
         enable_plan_review: bool = False,
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        intermediate_output_from: _ParticipantIntermediateOutputSelection = None,
     ) -> None:
         """Initialize the Magentic workflow builder.
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -1413,8 +1413,8 @@ class MagenticBuilder:
         # Existing params
         enable_plan_review: bool = False,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the Magentic workflow builder.
 
@@ -1437,9 +1437,9 @@ class MagenticBuilder:
             max_round_count: Max total coordination rounds. None means unlimited.
             enable_plan_review: If True, requires human approval of the initial plan before proceeding.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            output_participants: Optional participant names or instances whose ``yield_output`` calls
+            final_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as terminal workflow ``output`` events alongside the manager.
-            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+            intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
@@ -1453,9 +1453,9 @@ class MagenticBuilder:
 
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
 
-        self._output_participants = list(output_participants) if output_participants is not None else None
-        self._intermediate_participants = (
-            list(intermediate_participants) if intermediate_participants is not None else None
+        self._final_output_from = list(final_output_from) if final_output_from is not None else None
+        self._intermediate_output_from = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
         self._set_participants(participants)
@@ -1776,8 +1776,8 @@ class MagenticBuilder:
         # `magentic_orchestrator` events keep their dedicated event type.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            output_participants=self._output_participants,
-            intermediate_participants=self._intermediate_participants,
+            final_output_from=self._final_output_from,
+            intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, ClassVar, TypeVar, cast
+from typing import Any, ClassVar, Literal, TypeVar, cast
 
 from agent_framework import (
     AgentResponse,
@@ -39,6 +39,9 @@ from ._base_group_chat_orchestrator import (
     ParticipantRegistry,
 )
 from ._participant_output_config import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
+    _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -1413,8 +1416,9 @@ class MagenticBuilder:
         # Existing params
         enable_plan_review: bool = False,
         checkpoint_storage: CheckpointStorage | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the Magentic workflow builder.
 
@@ -1437,10 +1441,13 @@ class MagenticBuilder:
             max_round_count: Max total coordination rounds. None means unlimited.
             enable_plan_review: If True, requires human approval of the initial plan before proceeding.
             checkpoint_storage: Optional checkpoint storage for enabling workflow state persistence.
-            final_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as terminal workflow ``output`` events alongside the manager.
+            output_from: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``output`` events alongside the manager. Pass ``"all"`` to select every
+                participant.
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
+                surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
+                not selected by ``output_from``. Unlisted participant outputs are hidden.
+            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
 
@@ -1453,10 +1460,8 @@ class MagenticBuilder:
 
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
 
-        self._final_output_from = list(final_output_from) if final_output_from is not None else None
-        self._intermediate_output_from = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
-        )
+        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)
 
@@ -1776,14 +1781,14 @@ class MagenticBuilder:
         # `magentic_orchestrator` events keep their dedicated event type.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            final_output_from=self._final_output_from,
+            output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
             extra_output_executors=[orchestrator],
         )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            final_output_from=designated,
+            output_from=designated,
             intermediate_output_from=intermediate_designated,
         )
         for participant in participants:

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -1762,17 +1762,21 @@ class MagenticBuilder:
         participants: list[Executor] = self._resolve_participants()
         orchestrator: Executor = self._resolve_orchestrator(participants)
 
-        # Default: only the manager is designated; worker yields surface as intermediate.
+        # Default: only the manager is terminal; worker yields surface as intermediate.
         # With intermediate_outputs=True, workers are also designated so their yields
         # surface as type='output' — preserving the legacy contract.
         # `magentic_orchestrator` events keep their dedicated event type.
         designated: list[Executor | SupportsAgentRun] = (
             [orchestrator, *participants] if self._intermediate_outputs else [orchestrator]
         )
+        intermediate_designated: list[Executor | SupportsAgentRun] = (
+            [] if self._intermediate_outputs else [p for p in participants if p.workflow_output_types]
+        )
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
             output_executors=designated,
+            intermediate_executors=intermediate_designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -38,7 +38,10 @@ from ._base_group_chat_orchestrator import (
     GroupChatWorkflowContextOutT,
     ParticipantRegistry,
 )
-from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
+from ._participant_output_config import (
+    _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
+    _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
+)
 
 if sys.version_info >= (3, 12):
     from typing import override  # type: ignore # pragma: no cover
@@ -1410,8 +1413,8 @@ class MagenticBuilder:
         # Existing params
         enable_plan_review: bool = False,
         checkpoint_storage: CheckpointStorage | None = None,
-        output_participants: Sequence[ParticipantSpecifier] | None = None,
-        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
+        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the Magentic workflow builder.
 
@@ -1771,7 +1774,7 @@ class MagenticBuilder:
         # Default: only the manager is terminal; worker outputs are hidden unless
         # explicitly designated as terminal or intermediate.
         # `magentic_orchestrator` events keep their dedicated event type.
-        designated, intermediate_designated = resolve_participant_designation(
+        designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
             output_participants=self._output_participants,
             intermediate_participants=self._intermediate_participants,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -1418,7 +1418,6 @@ class MagenticBuilder:
         checkpoint_storage: CheckpointStorage | None = None,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
         intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the Magentic workflow builder.
 
@@ -1447,7 +1446,6 @@ class MagenticBuilder:
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
                 not selected by ``output_from``. Unlisted participant outputs are hidden.
-            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: dict[str, SupportsAgentRun | Executor] = {}
 
@@ -1460,7 +1458,7 @@ class MagenticBuilder:
 
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
 
-        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._output_from = _coalesce_output_from(output_from=output_from)
         self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_magentic.py
@@ -1783,8 +1783,8 @@ class MagenticBuilder:
         workflow_builder = WorkflowBuilder(
             start_executor=orchestrator,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=designated,
-            intermediate_executors=intermediate_designated,
+            final_output_from=designated,
+            intermediate_output_from=intermediate_designated,
         )
         for participant in participants:
             # Orchestrator and participant bi-directional edges

--- a/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
@@ -220,8 +220,14 @@ class AgentApprovalExecutor(WorkflowExecutor):
         request_info_cls = _TerminalAgentRequestInfoExecutor if terminal else AgentRequestInfoExecutor
         request_info_executor = request_info_cls(id="agent_request_info_executor")
 
+        # Both inner executors yield the inner workflow's terminal output (the agent
+        # during its turn; the _TerminalAgentRequestInfoExecutor after approval), so
+        # both must be designated for WorkflowExecutor.get_outputs() to surface them.
         return (
-            WorkflowBuilder(start_executor=agent_executor)
+            WorkflowBuilder(
+                start_executor=agent_executor,
+                output_executors=[agent_executor, request_info_executor],
+            )
             # Create a loop between agent executor and request info executor
             .add_edge(agent_executor, request_info_executor)
             .add_edge(request_info_executor, agent_executor)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
@@ -226,7 +226,7 @@ class AgentApprovalExecutor(WorkflowExecutor):
         return (
             WorkflowBuilder(
                 start_executor=agent_executor,
-                final_output_from=[agent_executor, request_info_executor],
+                output_from=[agent_executor, request_info_executor],
             )
             # Create a loop between agent executor and request info executor
             .add_edge(agent_executor, request_info_executor)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_orchestration_request_info.py
@@ -226,7 +226,7 @@ class AgentApprovalExecutor(WorkflowExecutor):
         return (
             WorkflowBuilder(
                 start_executor=agent_executor,
-                output_executors=[agent_executor, request_info_executor],
+                final_output_from=[agent_executor, request_info_executor],
             )
             # Create a loop between agent executor and request info executor
             .add_edge(agent_executor, request_info_executor)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_designation.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_designation.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Participant-oriented workflow output designation helpers."""
+
+from collections.abc import Sequence
+
+from agent_framework import SupportsAgentRun
+from agent_framework._workflows._agent_utils import resolve_agent_id
+from agent_framework._workflows._executor import Executor
+
+ParticipantSpecifier = str | SupportsAgentRun | Executor
+WorkflowExecutorSpecifier = Executor | SupportsAgentRun
+
+
+def resolve_participant_designation(
+    *,
+    participants: Sequence[Executor],
+    output_participants: Sequence[ParticipantSpecifier] | None,
+    intermediate_participants: Sequence[ParticipantSpecifier] | None,
+    default_output_participants: Sequence[Executor] = (),
+    extra_output_executors: Sequence[Executor] = (),
+) -> tuple[list[WorkflowExecutorSpecifier], list[WorkflowExecutorSpecifier]]:
+    """Resolve public participant designations into workflow executor designations."""
+    explicit_designation = output_participants is not None or intermediate_participants is not None
+    if explicit_designation and not (output_participants or intermediate_participants):
+        raise ValueError("output_participants and intermediate_participants cannot both be empty.")
+
+    participants_by_id = {participant.id: participant for participant in participants}
+    known_participants = sorted(participants_by_id)
+
+    output_designated = (
+        _resolve_designated_participants(
+            output_participants,
+            kind="output",
+            participants_by_id=participants_by_id,
+            known_participants=known_participants,
+        )
+        if output_participants is not None
+        else list(default_output_participants)
+    )
+    intermediate_designated = (
+        _resolve_designated_participants(
+            intermediate_participants,
+            kind="intermediate",
+            participants_by_id=participants_by_id,
+            known_participants=known_participants,
+        )
+        if intermediate_participants is not None
+        else []
+    )
+
+    overlap = sorted(
+        {participant.id for participant in output_designated}.intersection(
+            participant.id for participant in intermediate_designated
+        )
+    )
+    if overlap:
+        raise ValueError(f"Participants cannot be both output and intermediate designated: {overlap}")
+
+    output_executors: list[WorkflowExecutorSpecifier] = [*extra_output_executors, *output_designated]
+    intermediate_executors: list[WorkflowExecutorSpecifier] = list(intermediate_designated)
+    return output_executors, intermediate_executors
+
+
+def _resolve_designated_participants(
+    designations: Sequence[ParticipantSpecifier],
+    *,
+    kind: str,
+    participants_by_id: dict[str, Executor],
+    known_participants: Sequence[str],
+) -> list[Executor]:
+    resolved: list[Executor] = []
+    seen: set[str] = set()
+    for designation in designations:
+        participant_id = _participant_id(designation)
+        if participant_id in seen:
+            raise ValueError(f"Duplicate {kind} participant '{participant_id}' in {kind}_participants.")
+        seen.add(participant_id)
+        try:
+            resolved.append(participants_by_id[participant_id])
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown {kind} participant '{participant_id}'. Known participants: {known_participants}"
+            ) from exc
+    return resolved
+
+
+def _participant_id(participant: ParticipantSpecifier) -> str:
+    if isinstance(participant, str):
+        return participant
+    if isinstance(participant, Executor):
+        return participant.id
+    return resolve_agent_id(participant)

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -28,16 +28,6 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
     participants_by_id = {participant.id: participant for participant in participants}
     known_participants = sorted(participants_by_id)
 
-    output_designated = (
-        _resolve_designated_participants(
-            final_output_from,
-            kind="output",
-            participants_by_id=participants_by_id,
-            known_participants=known_participants,
-        )
-        if final_output_from is not None
-        else list(default_final_output_from)
-    )
     intermediate_designated = (
         _resolve_designated_participants(
             intermediate_output_from,
@@ -48,6 +38,24 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
         if intermediate_output_from is not None
         else []
     )
+
+    if final_output_from is not None:
+        output_designated = _resolve_designated_participants(
+            final_output_from,
+            kind="output",
+            participants_by_id=participants_by_id,
+            known_participants=known_participants,
+        )
+    else:
+        # The caller-supplied default applies only to participants not explicitly designated as
+        # intermediate. Without this subtraction, builders that pre-populate a default-final list
+        # (Handoff defaults to all participants, Sequential defaults to the last) would force
+        # an overlap error whenever a user passed `intermediate_output_from=[X]` for an X in
+        # the default set, contradicting the public docstring contract.
+        intermediate_ids = {participant.id for participant in intermediate_designated}
+        output_designated = [
+            participant for participant in default_final_output_from if participant.id not in intermediate_ids
+        ]
 
     overlap = sorted(
         {participant.id for participant in output_designated}.intersection(

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -2,51 +2,120 @@
 
 """Participant-oriented workflow output configuration helpers."""
 
+import warnings
 from collections.abc import Sequence
+from typing import Any, Literal
 
 from agent_framework import SupportsAgentRun
 from agent_framework._workflows._agent_utils import resolve_agent_id
 from agent_framework._workflows._executor import Executor
 
+_MISSING = object()
+_ALL_OUTPUTS: Literal["all"] = "all"
+_ALL_OTHER_OUTPUTS: Literal["all_other"] = "all_other"
 _ParticipantOutputSpecifier = str | SupportsAgentRun | Executor
+_ParticipantOutputSelection = Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None
+_ParticipantIntermediateOutputSelection = Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None
 _WorkflowExecutorSpecifier = Executor | SupportsAgentRun
+
+
+def _coalesce_output_from(  # pyright: ignore[reportUnusedFunction]
+    *,
+    output_from: Any = _MISSING,
+    final_output_from: Any = _MISSING,
+) -> _ParticipantOutputSelection:
+    """Resolve deprecated orchestration output-selection aliases to ``output_from``."""
+    provided = [
+        name
+        for name, value in (("output_from", output_from), ("final_output_from", final_output_from))
+        if value is not _MISSING
+    ]
+    if len(provided) > 1:
+        raise TypeError(
+            f"Cannot pass multiple orchestration output selection parameters ({', '.join(provided)}); "
+            "use `output_from`."
+        )
+    if final_output_from is not _MISSING:
+        warnings.warn(
+            "`final_output_from` is deprecated and will be removed in a future version; use `output_from` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return _coerce_output_from(final_output_from)
+    if output_from is not _MISSING:
+        return _coerce_output_from(output_from)
+    return None
+
+
+def _coerce_output_from(output_from: Any) -> _ParticipantOutputSelection:
+    """Coerce workflow-output participant selection while preserving the ``"all"`` literal."""
+    if output_from is None:
+        return None
+    if isinstance(output_from, str):
+        if output_from == _ALL_OUTPUTS:
+            return _ALL_OUTPUTS
+        if output_from == _ALL_OTHER_OUTPUTS:
+            raise ValueError("output_from='all_other' is invalid; use intermediate_output_from='all_other' instead.")
+        raise ValueError(f"Unsupported output_from literal {output_from!r}; use 'all' or a list of participants.")
+    return list(output_from)
+
+
+def _coerce_intermediate_output_from(  # pyright: ignore[reportUnusedFunction]
+    intermediate_output_from: Any,
+) -> _ParticipantIntermediateOutputSelection:
+    """Coerce intermediate-output participant selection while preserving ``"all_other"``."""
+    if intermediate_output_from is None:
+        return None
+    if isinstance(intermediate_output_from, str):
+        if intermediate_output_from == _ALL_OUTPUTS:
+            raise ValueError("intermediate_output_from='all' is invalid; use output_from='all' instead.")
+        if intermediate_output_from == _ALL_OTHER_OUTPUTS:
+            return _ALL_OTHER_OUTPUTS
+        raise ValueError(
+            f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; "
+            "use 'all_other' or a list of participants."
+        )
+    return list(intermediate_output_from)
 
 
 def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
     *,
     participants: Sequence[Executor],
-    final_output_from: Sequence[_ParticipantOutputSpecifier] | None,
-    intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None,
+    output_from: _ParticipantOutputSelection,
+    intermediate_output_from: _ParticipantIntermediateOutputSelection,
     default_final_output_from: Sequence[Executor] = (),
     extra_output_executors: Sequence[Executor] = (),
 ) -> tuple[list[_WorkflowExecutorSpecifier], list[_WorkflowExecutorSpecifier]]:
     """Resolve public participant output config into workflow executor config."""
-    explicit_config = final_output_from is not None or intermediate_output_from is not None
-    if explicit_config and not (final_output_from or intermediate_output_from):
-        raise ValueError("final_output_from and intermediate_output_from cannot both be empty.")
+    explicit_config = output_from is not None or intermediate_output_from is not None
+    if explicit_config and not (output_from or intermediate_output_from):
+        raise ValueError("output_from and intermediate_output_from cannot both be empty.")
 
     participants_by_id = {participant.id: participant for participant in participants}
     known_participants = sorted(participants_by_id)
 
-    intermediate_designated = (
-        _resolve_designated_participants(
-            intermediate_output_from,
-            kind="intermediate",
-            participants_by_id=participants_by_id,
-            known_participants=known_participants,
-        )
-        if intermediate_output_from is not None
-        else []
-    )
-
-    if final_output_from is not None:
+    if output_from == _ALL_OUTPUTS:
+        output_designated = list(participants)
+    elif output_from is not None:
         output_designated = _resolve_designated_participants(
-            final_output_from,
+            output_from,
             kind="output",
             participants_by_id=participants_by_id,
             known_participants=known_participants,
         )
+    elif intermediate_output_from == _ALL_OTHER_OUTPUTS:
+        output_designated = []
     else:
+        intermediate_designated = (
+            _resolve_designated_participants(
+                intermediate_output_from,
+                kind="intermediate",
+                participants_by_id=participants_by_id,
+                known_participants=known_participants,
+            )
+            if intermediate_output_from is not None
+            else []
+        )
         # The caller-supplied default applies only to participants not explicitly designated as
         # intermediate. Without this subtraction, builders that pre-populate a default-final list
         # (Handoff defaults to all participants, Sequential defaults to the last) would force
@@ -56,6 +125,19 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
         output_designated = [
             participant for participant in default_final_output_from if participant.id not in intermediate_ids
         ]
+
+    if intermediate_output_from == _ALL_OTHER_OUTPUTS:
+        output_ids = {participant.id for participant in output_designated}
+        intermediate_designated = [participant for participant in participants if participant.id not in output_ids]
+    elif intermediate_output_from is not None:
+        intermediate_designated = _resolve_designated_participants(
+            intermediate_output_from,
+            kind="intermediate",
+            participants_by_id=participants_by_id,
+            known_participants=known_participants,
+        )
+    else:
+        intermediate_designated = []
 
     overlap = sorted(
         {participant.id for participant in output_designated}.intersection(

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -2,7 +2,6 @@
 
 """Participant-oriented workflow output configuration helpers."""
 
-import warnings
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -22,26 +21,8 @@ _WorkflowExecutorSpecifier = Executor | SupportsAgentRun
 def _coalesce_output_from(  # pyright: ignore[reportUnusedFunction]
     *,
     output_from: Any = _MISSING,
-    final_output_from: Any = _MISSING,
 ) -> _ParticipantOutputSelection:
-    """Resolve deprecated orchestration output-selection aliases to ``output_from``."""
-    provided = [
-        name
-        for name, value in (("output_from", output_from), ("final_output_from", final_output_from))
-        if value is not _MISSING
-    ]
-    if len(provided) > 1:
-        raise TypeError(
-            f"Cannot pass multiple orchestration output selection parameters ({', '.join(provided)}); "
-            "use `output_from`."
-        )
-    if final_output_from is not _MISSING:
-        warnings.warn(
-            "`final_output_from` is deprecated and will be removed in a future version; use `output_from` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return _coerce_output_from(final_output_from)
+    """Resolve orchestration output selection to ``output_from``."""
     if output_from is not _MISSING:
         return _coerce_output_from(output_from)
     return None
@@ -83,7 +64,7 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
     participants: Sequence[Executor],
     output_from: _ParticipantOutputSelection,
     intermediate_output_from: _ParticipantIntermediateOutputSelection,
-    default_final_output_from: Sequence[Executor] = (),
+    default_output_from: Sequence[Executor] = (),
     extra_output_executors: Sequence[Executor] = (),
 ) -> tuple[list[_WorkflowExecutorSpecifier], list[_WorkflowExecutorSpecifier]]:
     """Resolve public participant output config into workflow executor config."""
@@ -117,13 +98,13 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
             else []
         )
         # The caller-supplied default applies only to participants not explicitly designated as
-        # intermediate. Without this subtraction, builders that pre-populate a default-final list
+        # intermediate. Without this subtraction, builders that pre-populate a default output list
         # (Handoff defaults to all participants, Sequential defaults to the last) would force
         # an overlap error whenever a user passed `intermediate_output_from=[X]` for an X in
         # the default set, contradicting the public docstring contract.
         intermediate_ids = {participant.id for participant in intermediate_designated}
         output_designated = [
-            participant for participant in default_final_output_from if participant.id not in intermediate_ids
+            participant for participant in default_output_from if participant.id not in intermediate_ids
         ]
 
     if intermediate_output_from == _ALL_OTHER_OUTPUTS:

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Participant-oriented workflow output designation helpers."""
+"""Participant-oriented workflow output configuration helpers."""
 
 from collections.abc import Sequence
 
@@ -8,21 +8,21 @@ from agent_framework import SupportsAgentRun
 from agent_framework._workflows._agent_utils import resolve_agent_id
 from agent_framework._workflows._executor import Executor
 
-ParticipantSpecifier = str | SupportsAgentRun | Executor
-WorkflowExecutorSpecifier = Executor | SupportsAgentRun
+_ParticipantOutputSpecifier = str | SupportsAgentRun | Executor
+_WorkflowExecutorSpecifier = Executor | SupportsAgentRun
 
 
-def resolve_participant_designation(
+def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
     *,
     participants: Sequence[Executor],
-    output_participants: Sequence[ParticipantSpecifier] | None,
-    intermediate_participants: Sequence[ParticipantSpecifier] | None,
+    output_participants: Sequence[_ParticipantOutputSpecifier] | None,
+    intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None,
     default_output_participants: Sequence[Executor] = (),
     extra_output_executors: Sequence[Executor] = (),
-) -> tuple[list[WorkflowExecutorSpecifier], list[WorkflowExecutorSpecifier]]:
-    """Resolve public participant designations into workflow executor designations."""
-    explicit_designation = output_participants is not None or intermediate_participants is not None
-    if explicit_designation and not (output_participants or intermediate_participants):
+) -> tuple[list[_WorkflowExecutorSpecifier], list[_WorkflowExecutorSpecifier]]:
+    """Resolve public participant output config into workflow executor config."""
+    explicit_config = output_participants is not None or intermediate_participants is not None
+    if explicit_config and not (output_participants or intermediate_participants):
         raise ValueError("output_participants and intermediate_participants cannot both be empty.")
 
     participants_by_id = {participant.id: participant for participant in participants}
@@ -57,13 +57,13 @@ def resolve_participant_designation(
     if overlap:
         raise ValueError(f"Participants cannot be both output and intermediate designated: {overlap}")
 
-    output_executors: list[WorkflowExecutorSpecifier] = [*extra_output_executors, *output_designated]
-    intermediate_executors: list[WorkflowExecutorSpecifier] = list(intermediate_designated)
+    output_executors: list[_WorkflowExecutorSpecifier] = [*extra_output_executors, *output_designated]
+    intermediate_executors: list[_WorkflowExecutorSpecifier] = list(intermediate_designated)
     return output_executors, intermediate_executors
 
 
 def _resolve_designated_participants(
-    designations: Sequence[ParticipantSpecifier],
+    designations: Sequence[_ParticipantOutputSpecifier],
     *,
     kind: str,
     participants_by_id: dict[str, Executor],
@@ -85,7 +85,7 @@ def _resolve_designated_participants(
     return resolved
 
 
-def _participant_id(participant: ParticipantSpecifier) -> str:
+def _participant_id(participant: _ParticipantOutputSpecifier) -> str:
     if isinstance(participant, str):
         return participant
     if isinstance(participant, Executor):

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -14,7 +14,7 @@ _ALL_OUTPUTS: Literal["all"] = "all"
 _ALL_OTHER_OUTPUTS: Literal["all_other"] = "all_other"
 _ParticipantOutputSpecifier = str | SupportsAgentRun | Executor
 _ParticipantOutputSelection = Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None
-_ParticipantIntermediateOutputSelection = Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None
+_ParticipantIntermediateOutputSelection = Sequence[_ParticipantOutputSpecifier] | Literal["all", "all_other"] | None
 _WorkflowExecutorSpecifier = Executor | SupportsAgentRun
 
 
@@ -49,12 +49,12 @@ def _coerce_intermediate_output_from(  # pyright: ignore[reportUnusedFunction]
         return None
     if isinstance(intermediate_output_from, str):
         if intermediate_output_from == _ALL_OUTPUTS:
-            raise ValueError("intermediate_output_from='all' is invalid; use output_from='all' instead.")
+            return _ALL_OUTPUTS
         if intermediate_output_from == _ALL_OTHER_OUTPUTS:
             return _ALL_OTHER_OUTPUTS
         raise ValueError(
             f"Unsupported intermediate_output_from literal {intermediate_output_from!r}; "
-            "use 'all_other' or a list of participants."
+            "use 'all', 'all_other', or a list of participants."
         )
     return list(intermediate_output_from)
 
@@ -84,7 +84,7 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
             participants_by_id=participants_by_id,
             known_participants=known_participants,
         )
-    elif intermediate_output_from == _ALL_OTHER_OUTPUTS:
+    elif intermediate_output_from in (_ALL_OTHER_OUTPUTS, _ALL_OUTPUTS):
         output_designated = []
     else:
         intermediate_designated = (
@@ -107,7 +107,9 @@ def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
             participant for participant in default_output_from if participant.id not in intermediate_ids
         ]
 
-    if intermediate_output_from == _ALL_OTHER_OUTPUTS:
+    if intermediate_output_from == _ALL_OUTPUTS:
+        intermediate_designated = list(participants)
+    elif intermediate_output_from == _ALL_OTHER_OUTPUTS:
         output_ids = {participant.id for participant in output_designated}
         intermediate_designated = [participant for participant in participants if participant.id not in output_ids]
     elif intermediate_output_from is not None:

--- a/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_participant_output_config.py
@@ -15,37 +15,37 @@ _WorkflowExecutorSpecifier = Executor | SupportsAgentRun
 def _resolve_participant_output_config(  # pyright: ignore[reportUnusedFunction]
     *,
     participants: Sequence[Executor],
-    output_participants: Sequence[_ParticipantOutputSpecifier] | None,
-    intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None,
-    default_output_participants: Sequence[Executor] = (),
+    final_output_from: Sequence[_ParticipantOutputSpecifier] | None,
+    intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None,
+    default_final_output_from: Sequence[Executor] = (),
     extra_output_executors: Sequence[Executor] = (),
 ) -> tuple[list[_WorkflowExecutorSpecifier], list[_WorkflowExecutorSpecifier]]:
     """Resolve public participant output config into workflow executor config."""
-    explicit_config = output_participants is not None or intermediate_participants is not None
-    if explicit_config and not (output_participants or intermediate_participants):
-        raise ValueError("output_participants and intermediate_participants cannot both be empty.")
+    explicit_config = final_output_from is not None or intermediate_output_from is not None
+    if explicit_config and not (final_output_from or intermediate_output_from):
+        raise ValueError("final_output_from and intermediate_output_from cannot both be empty.")
 
     participants_by_id = {participant.id: participant for participant in participants}
     known_participants = sorted(participants_by_id)
 
     output_designated = (
         _resolve_designated_participants(
-            output_participants,
+            final_output_from,
             kind="output",
             participants_by_id=participants_by_id,
             known_participants=known_participants,
         )
-        if output_participants is not None
-        else list(default_output_participants)
+        if final_output_from is not None
+        else list(default_final_output_from)
     )
     intermediate_designated = (
         _resolve_designated_participants(
-            intermediate_participants,
+            intermediate_output_from,
             kind="intermediate",
             participants_by_id=participants_by_id,
             known_participants=known_participants,
         )
-        if intermediate_participants is not None
+        if intermediate_output_from is not None
         else []
     )
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -234,10 +234,17 @@ class SequentialBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
+        # Default: only the terminator is designated; earlier participants' yields
+        # surface as type='intermediate'. With intermediate_outputs=True, every
+        # participant is designated so all yields surface as type='output' — preserving
+        # the legacy contract for callers who opt in to seeing per-participant outputs.
+        designated: list[Executor | SupportsAgentRun] = (
+            list(participants) if self._intermediate_outputs else [participants[-1]]
+        )
         builder = WorkflowBuilder(
             start_executor=input_conv,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=[participants[-1]] if not self._intermediate_outputs else None,
+            output_executors=designated,
         )
 
         prior: Executor | SupportsAgentRun = input_conv

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -67,7 +67,7 @@ class SequentialBuilder:
     - The workflow wires participants in order, passing a list[Message] down the chain
     - Agents append their assistant messages to the conversation
     - Custom executors can transform/summarize and return a list[Message]
-    - The final output is the conversation produced by the last participant
+    - The default Workflow Output is the conversation produced by the last participant
 
     Usage:
 
@@ -238,8 +238,8 @@ class SequentialBuilder:
             - Custom `Executor`: receives `list[Message]` and forwards `list[Message]`.
               If used as the terminator, it must call `ctx.yield_output(AgentResponse(...))`
               instead of `ctx.send_message(...)` — its yield becomes the workflow's output.
-        - The last participant is registered as the workflow's `output_executor`, so the
-          terminator's own `yield_output` is the workflow's terminal output (`AgentResponse`,
+        - The last participant is selected as Workflow Output by default, so the
+          terminator's own `yield_output` is Workflow Output (`AgentResponse`,
           or per-chunk `AgentResponseUpdate` when streaming).
         """
         input_conv = _InputToConversation(id="input-conversation")

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -95,8 +95,8 @@ class SequentialBuilder:
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
         chain_only_agent_responses: bool = False,
-        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the SequentialBuilder.
 
@@ -106,9 +106,9 @@ class SequentialBuilder:
             chain_only_agent_responses: If True, only agent responses are chained between agents.
                 By default, the full conversation context is passed to the next agent. This also applies
                 to Executor -> Agent transitions if the executor sends `AgentExecutorResponse`.
-            output_participants: Optional participant names or instances whose ``yield_output`` calls
+            final_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as terminal workflow ``output`` events. Defaults to the final participant.
-            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+            intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
@@ -116,9 +116,9 @@ class SequentialBuilder:
         self._chain_only_agent_responses: bool = chain_only_agent_responses
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._output_participants = list(output_participants) if output_participants is not None else None
-        self._intermediate_participants = (
-            list(intermediate_participants) if intermediate_participants is not None else None
+        self._final_output_from = list(final_output_from) if final_output_from is not None else None
+        self._intermediate_output_from = (
+            list(intermediate_output_from) if intermediate_output_from is not None else None
         )
 
         self._set_participants(participants)
@@ -247,9 +247,9 @@ class SequentialBuilder:
         # can surface selected earlier participant outputs as terminal or intermediate.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            output_participants=self._output_participants,
-            intermediate_participants=self._intermediate_participants,
-            default_output_participants=[participants[-1]],
+            final_output_from=self._final_output_from,
+            intermediate_output_from=self._intermediate_output_from,
+            default_final_output_from=[participants[-1]],
         )
         builder = WorkflowBuilder(
             start_executor=input_conv,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -254,8 +254,8 @@ class SequentialBuilder:
         builder = WorkflowBuilder(
             start_executor=input_conv,
             checkpoint_storage=self._checkpoint_storage,
-            output_executors=designated,
-            intermediate_executors=intermediate_designated,
+            final_output_from=designated,
+            intermediate_output_from=intermediate_designated,
         )
 
         prior: Executor | SupportsAgentRun = input_conv

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -36,6 +36,7 @@ from ._participant_output_config import (
     _MISSING,  # pyright: ignore[reportPrivateUsage]
     _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
     _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
+    _ParticipantIntermediateOutputSelection,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -99,7 +100,7 @@ class SequentialBuilder:
         checkpoint_storage: CheckpointStorage | None = None,
         chain_only_agent_responses: bool = False,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        intermediate_output_from: _ParticipantIntermediateOutputSelection = None,
     ) -> None:
         """Initialize the SequentialBuilder.
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -32,7 +32,10 @@ from agent_framework._workflows._workflow_builder import WorkflowBuilder
 from agent_framework._workflows._workflow_context import WorkflowContext
 
 from ._orchestration_request_info import AgentApprovalExecutor
-from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
+from ._participant_output_config import (
+    _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
+    _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,8 +95,8 @@ class SequentialBuilder:
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
         chain_only_agent_responses: bool = False,
-        output_participants: Sequence[ParticipantSpecifier] | None = None,
-        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
+        output_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
+        intermediate_participants: Sequence[_ParticipantOutputSpecifier] | None = None,
     ) -> None:
         """Initialize the SequentialBuilder.
 
@@ -242,7 +245,7 @@ class SequentialBuilder:
 
         # Default: only the terminator is terminal. Explicit participant designation
         # can surface selected earlier participant outputs as terminal or intermediate.
-        designated, intermediate_designated = resolve_participant_designation(
+        designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
             output_participants=self._output_participants,
             intermediate_participants=self._intermediate_participants,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -234,17 +234,21 @@ class SequentialBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
-        # Default: only the terminator is designated; earlier participants' yields
+        # Default: only the terminator is terminal; earlier participants' yields
         # surface as type='intermediate'. With intermediate_outputs=True, every
         # participant is designated so all yields surface as type='output' — preserving
         # the legacy contract for callers who opt in to seeing per-participant outputs.
         designated: list[Executor | SupportsAgentRun] = (
             list(participants) if self._intermediate_outputs else [participants[-1]]
         )
+        intermediate_designated: list[Executor | SupportsAgentRun] = (
+            [] if self._intermediate_outputs else [p for p in participants[:-1] if p.workflow_output_types]
+        )
         builder = WorkflowBuilder(
             start_executor=input_conv,
             checkpoint_storage=self._checkpoint_storage,
             output_executors=designated,
+            intermediate_executors=intermediate_designated,
         )
 
         prior: Executor | SupportsAgentRun = input_conv

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -32,6 +32,7 @@ from agent_framework._workflows._workflow_builder import WorkflowBuilder
 from agent_framework._workflows._workflow_context import WorkflowContext
 
 from ._orchestration_request_info import AgentApprovalExecutor
+from ._participant_designation import ParticipantSpecifier, resolve_participant_designation
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,8 @@ class SequentialBuilder:
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
         chain_only_agent_responses: bool = False,
-        intermediate_outputs: bool = False,
+        output_participants: Sequence[ParticipantSpecifier] | None = None,
+        intermediate_participants: Sequence[ParticipantSpecifier] | None = None,
     ) -> None:
         """Initialize the SequentialBuilder.
 
@@ -101,16 +103,20 @@ class SequentialBuilder:
             chain_only_agent_responses: If True, only agent responses are chained between agents.
                 By default, the full conversation context is passed to the next agent. This also applies
                 to Executor -> Agent transitions if the executor sends `AgentExecutorResponse`.
-            intermediate_outputs: If True, every participant's `yield_output` surfaces as a
-                workflow `output` event in addition to the terminator's. By default (False) only
-                the last participant's output surfaces.
+            output_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as terminal workflow ``output`` events. Defaults to the final participant.
+            intermediate_participants: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._chain_only_agent_responses: bool = chain_only_agent_responses
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._intermediate_outputs: bool = intermediate_outputs
+        self._output_participants = list(output_participants) if output_participants is not None else None
+        self._intermediate_participants = (
+            list(intermediate_participants) if intermediate_participants is not None else None
+        )
 
         self._set_participants(participants)
 
@@ -234,15 +240,13 @@ class SequentialBuilder:
         # Resolve participants and participant factories to executors
         participants: list[Executor] = self._resolve_participants()
 
-        # Default: only the terminator is terminal; earlier participants' yields
-        # surface as type='intermediate'. With intermediate_outputs=True, every
-        # participant is designated so all yields surface as type='output' — preserving
-        # the legacy contract for callers who opt in to seeing per-participant outputs.
-        designated: list[Executor | SupportsAgentRun] = (
-            list(participants) if self._intermediate_outputs else [participants[-1]]
-        )
-        intermediate_designated: list[Executor | SupportsAgentRun] = (
-            [] if self._intermediate_outputs else [p for p in participants[:-1] if p.workflow_output_types]
+        # Default: only the terminator is terminal. Explicit participant designation
+        # can surface selected earlier participant outputs as terminal or intermediate.
+        designated, intermediate_designated = resolve_participant_designation(
+            participants=participants,
+            output_participants=self._output_participants,
+            intermediate_participants=self._intermediate_participants,
+            default_output_participants=[participants[-1]],
         )
         builder = WorkflowBuilder(
             start_executor=input_conv,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -100,7 +100,6 @@ class SequentialBuilder:
         chain_only_agent_responses: bool = False,
         output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
         intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the SequentialBuilder.
 
@@ -115,14 +114,13 @@ class SequentialBuilder:
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
                 surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
                 not selected by ``output_from``. Unlisted participant outputs are hidden.
-            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._chain_only_agent_responses: bool = chain_only_agent_responses
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._output_from = _coalesce_output_from(output_from=output_from)
         self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)
@@ -253,7 +251,7 @@ class SequentialBuilder:
             participants=participants,
             output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
-            default_final_output_from=[participants[-1]],
+            default_output_from=[participants[-1]],
         )
         builder = WorkflowBuilder(
             start_executor=input_conv,

--- a/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_sequential.py
@@ -16,7 +16,7 @@ produces — by convention an `AgentResponse` so downstream consumers see a unif
 
 import logging
 from collections.abc import Sequence
-from typing import Literal
+from typing import Any, Literal, cast
 
 from agent_framework import Message, SupportsAgentRun
 from agent_framework._workflows._agent_executor import AgentExecutor
@@ -33,6 +33,9 @@ from agent_framework._workflows._workflow_context import WorkflowContext
 
 from ._orchestration_request_info import AgentApprovalExecutor
 from ._participant_output_config import (
+    _MISSING,  # pyright: ignore[reportPrivateUsage]
+    _coalesce_output_from,  # pyright: ignore[reportPrivateUsage]
+    _coerce_intermediate_output_from,  # pyright: ignore[reportPrivateUsage]
     _ParticipantOutputSpecifier,  # pyright: ignore[reportPrivateUsage]
     _resolve_participant_output_config,  # pyright: ignore[reportPrivateUsage]
 )
@@ -95,8 +98,9 @@ class SequentialBuilder:
         participants: Sequence[SupportsAgentRun | Executor],
         checkpoint_storage: CheckpointStorage | None = None,
         chain_only_agent_responses: bool = False,
-        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
-        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | None = None,
+        output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all"] | None = cast(Any, _MISSING),
+        intermediate_output_from: Sequence[_ParticipantOutputSpecifier] | Literal["all_other"] | None = None,
+        final_output_from: Sequence[_ParticipantOutputSpecifier] | None = cast(Any, _MISSING),
     ) -> None:
         """Initialize the SequentialBuilder.
 
@@ -106,20 +110,20 @@ class SequentialBuilder:
             chain_only_agent_responses: If True, only agent responses are chained between agents.
                 By default, the full conversation context is passed to the next agent. This also applies
                 to Executor -> Agent transitions if the executor sends `AgentExecutorResponse`.
-            final_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as terminal workflow ``output`` events. Defaults to the final participant.
+            output_from: Optional participant names or instances whose ``yield_output`` calls
+                surface as workflow ``output`` events. Pass ``"all"`` to select every participant.
             intermediate_output_from: Optional participant names or instances whose ``yield_output`` calls
-                surface as workflow ``intermediate`` events. Unlisted participant outputs are hidden.
+                surface as workflow ``intermediate`` events. Pass ``"all_other"`` to select every participant
+                not selected by ``output_from``. Unlisted participant outputs are hidden.
+            final_output_from: Deprecated alias for ``output_from``.
         """
         self._participants: list[SupportsAgentRun | Executor] = []
         self._checkpoint_storage: CheckpointStorage | None = checkpoint_storage
         self._chain_only_agent_responses: bool = chain_only_agent_responses
         self._request_info_enabled: bool = False
         self._request_info_filter: set[str] | None = None
-        self._final_output_from = list(final_output_from) if final_output_from is not None else None
-        self._intermediate_output_from = (
-            list(intermediate_output_from) if intermediate_output_from is not None else None
-        )
+        self._output_from = _coalesce_output_from(output_from=output_from, final_output_from=final_output_from)
+        self._intermediate_output_from = _coerce_intermediate_output_from(intermediate_output_from)
 
         self._set_participants(participants)
 
@@ -247,14 +251,14 @@ class SequentialBuilder:
         # can surface selected earlier participant outputs as terminal or intermediate.
         designated, intermediate_designated = _resolve_participant_output_config(
             participants=participants,
-            final_output_from=self._final_output_from,
+            output_from=self._output_from,
             intermediate_output_from=self._intermediate_output_from,
             default_final_output_from=[participants[-1]],
         )
         builder = WorkflowBuilder(
             start_executor=input_conv,
             checkpoint_storage=self._checkpoint_storage,
-            final_output_from=designated,
+            output_from=designated,
             intermediate_output_from=intermediate_designated,
         )
 

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -632,7 +632,8 @@ async def _collect_agent_responses_setup(participant: SupportsAgentRun) -> list[
 
     wf = MagenticBuilder(participants=[participant], intermediate_outputs=True, manager=InvokeOnceManager()).build()
 
-    # Run a bounded stream to allow one invoke and then completion
+    # With intermediate_outputs=True, participants are designated as outputs alongside
+    # the manager — so their streaming chunks surface as type='output' (not intermediate).
     events: list[WorkflowEvent] = []
     async for ev in wf.run("task", stream=True):
         events.append(ev)

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -630,9 +630,13 @@ class StubAssistantsAgent(BaseAgent):
 async def _collect_agent_responses_setup(participant: SupportsAgentRun) -> list[Message]:
     captured: list[Message] = []
 
-    wf = MagenticBuilder(participants=[participant], intermediate_outputs=True, manager=InvokeOnceManager()).build()
+    wf = MagenticBuilder(
+        participants=[participant],
+        output_participants=[participant],
+        manager=InvokeOnceManager(),
+    ).build()
 
-    # With intermediate_outputs=True, participants are designated as outputs alongside
+    # With output_participants, participants are designated as outputs alongside
     # the manager — so their streaming chunks surface as type='output' (not intermediate).
     events: list[WorkflowEvent] = []
     async for ev in wf.run("task", stream=True):

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -632,11 +632,11 @@ async def _collect_agent_responses_setup(participant: SupportsAgentRun) -> list[
 
     wf = MagenticBuilder(
         participants=[participant],
-        final_output_from=[participant],
+        output_from=[participant],
         manager=InvokeOnceManager(),
     ).build()
 
-    # With final_output_from, participants are designated as outputs alongside
+    # With output_from, participants are designated as outputs alongside
     # the manager — so their streaming chunks surface as type='output' (not intermediate).
     events: list[WorkflowEvent] = []
     async for ev in wf.run("task", stream=True):

--- a/python/packages/orchestrations/tests/test_magentic.py
+++ b/python/packages/orchestrations/tests/test_magentic.py
@@ -632,11 +632,11 @@ async def _collect_agent_responses_setup(participant: SupportsAgentRun) -> list[
 
     wf = MagenticBuilder(
         participants=[participant],
-        output_participants=[participant],
+        final_output_from=[participant],
         manager=InvokeOnceManager(),
     ).build()
 
-    # With output_participants, participants are designated as outputs alongside
+    # With final_output_from, participants are designated as outputs alongside
     # the manager — so their streaming chunks surface as type='output' (not intermediate).
     events: list[WorkflowEvent] = []
     async for ev in wf.run("task", stream=True):

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -1,0 +1,259 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for orchestration intermediate vs terminal output labeling.
+
+Verifies that under the strict-output model:
+  - Sequential / Concurrent / GroupChat / Magentic designate their terminator,
+    aggregator, orchestrator, or manager as the sole output executor; per-step
+    yields from non-designated executors emit `type='intermediate'` events.
+  - Handoff designates ALL participants — every reply is `type='output'`.
+  - When wrapped via `workflow.as_agent()`, intermediate events surface as
+    `text_reasoning` content; terminal events as `text` content; existing
+    `.text` accessors return terminal-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, Awaitable
+from typing import Any, Literal, overload
+
+import pytest
+from agent_framework import (
+    AgentResponse,
+    AgentResponseUpdate,
+    AgentRunInputs,
+    AgentSession,
+    BaseAgent,
+    Content,
+    Message,
+    ResponseStream,
+)
+from agent_framework.orchestrations import ConcurrentBuilder, SequentialBuilder
+
+
+class _EchoAgent(BaseAgent):
+    """Minimal non-streaming agent that returns a single assistant message."""
+
+    @overload
+    def run(
+        self,
+        messages: AgentRunInputs | None = ...,
+        *,
+        stream: Literal[False] = ...,
+        session: AgentSession | None = ...,
+        **kwargs: Any,
+    ) -> Awaitable[AgentResponse[Any]]: ...
+    @overload
+    def run(
+        self,
+        messages: AgentRunInputs | None = ...,
+        *,
+        stream: Literal[True],
+        session: AgentSession | None = ...,
+        **kwargs: Any,
+    ) -> ResponseStream[AgentResponseUpdate, AgentResponse[Any]]: ...
+
+    def run(
+        self,
+        messages: AgentRunInputs | None = None,
+        *,
+        stream: bool = False,
+        session: AgentSession | None = None,
+        **kwargs: Any,
+    ) -> Awaitable[AgentResponse[Any]] | ResponseStream[AgentResponseUpdate, AgentResponse[Any]]:
+        if stream:
+
+            async def _stream() -> AsyncIterable[AgentResponseUpdate]:
+                yield AgentResponseUpdate(
+                    contents=[Content.from_text(text=f"{self.name} reply")], author_name=self.name
+                )
+
+            return ResponseStream(_stream(), finalizer=AgentResponse.from_updates)
+
+        async def _run() -> AgentResponse:
+            return AgentResponse(messages=[Message("assistant", [f"{self.name} reply"], author_name=self.name)])
+
+        return _run()
+
+
+# ---------------------------------------------------------------------------
+# Sequential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sequential_default_only_terminator_is_output() -> None:
+    """Default Sequential (intermediate_outputs=False) designates only the terminator;
+    earlier participants surface as type='intermediate'."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c]).build()
+
+    output_events: list[Any] = []
+    intermediate_events: list[Any] = []
+    async for event in workflow.run("hello", stream=True):
+        if event.type == "output":
+            output_events.append(event)
+        elif event.type == "intermediate":
+            intermediate_events.append(event)
+
+    # Only the terminator (C) emits type='output'.
+    assert len(output_events) == 1
+    assert "C" in {ev.executor_id for ev in output_events}
+
+    # A and B emit type='intermediate'.
+    intermediate_executors = {ev.executor_id for ev in intermediate_events}
+    assert "A" in intermediate_executors
+    assert "B" in intermediate_executors
+
+
+@pytest.mark.asyncio
+async def test_sequential_intermediate_outputs_true_designates_all() -> None:
+    """Sequential with intermediate_outputs=True preserves the legacy contract:
+    every participant's yield surfaces as type='output'."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_outputs=True).build()
+    result = await workflow.run("hello")
+    outputs = result.get_outputs()
+    # All three participants' yields surface in get_outputs() under intermediate_outputs=True.
+    assert len(outputs) == 3
+
+
+@pytest.mark.asyncio
+async def test_sequential_get_outputs_returns_terminator_only() -> None:
+    """WorkflowRunResult.get_outputs() returns only the terminator's yield."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = SequentialBuilder(participants=[a, b]).build()
+    result = await workflow.run("hi")
+    outputs = result.get_outputs()
+    assert len(outputs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Concurrent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_default_only_aggregator_is_output() -> None:
+    """Default Concurrent (intermediate_outputs=False): only the aggregator is
+    designated; participants surface as type='intermediate'."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = ConcurrentBuilder(participants=[a, b]).build()
+
+    output_events: list[Any] = []
+    intermediate_events: list[Any] = []
+    async for event in workflow.run("hello", stream=True):
+        if event.type == "output":
+            output_events.append(event)
+        elif event.type == "intermediate":
+            intermediate_events.append(event)
+
+    # Aggregator is the only designated executor → only it emits type='output'.
+    assert len(output_events) == 1
+
+    # Both participants emit type='intermediate'.
+    intermediate_authors = {ev.executor_id for ev in intermediate_events}
+    assert "A" in intermediate_authors
+    assert "B" in intermediate_authors
+
+
+@pytest.mark.asyncio
+async def test_concurrent_intermediate_outputs_true_designates_all() -> None:
+    """Concurrent with intermediate_outputs=True designates participants alongside the
+    aggregator — every participant's yield surfaces as type='output'."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = ConcurrentBuilder(participants=[a, b], intermediate_outputs=True).build()
+    result = await workflow.run("hello")
+    outputs = result.get_outputs()
+    # Two participants + aggregator → three terminal outputs in get_outputs().
+    assert len(outputs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Sequential wrapped as_agent — text_reasoning mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sequential_default_as_agent_intermediates_are_text_reasoning() -> None:
+    """Default Sequential wrapped as_agent: per-step participant replies become
+    text_reasoning content; the terminator's reply becomes text content.
+    """
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c]).build()
+    agent = workflow.as_agent("seq")
+
+    response = await agent.run("hi")
+
+    # .text returns terminal content only — only C's reply.
+    assert response.text == "C reply"
+
+    text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
+    reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
+
+    assert any("C reply" in c.text for c in text_contents)
+    assert any("A reply" in c.text for c in reasoning_contents)
+    assert any("B reply" in c.text for c in reasoning_contents)
+
+
+@pytest.mark.asyncio
+async def test_sequential_as_agent_intermediate_outputs_true_all_text() -> None:
+    """Sequential with intermediate_outputs=True wrapped as_agent: every participant's
+    reply is now designated terminal, so each surfaces as text content (not reasoning).
+    Existing callers reading .text get all participants' replies concatenated."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_outputs=True).build()
+    agent = workflow.as_agent("seq")
+
+    response = await agent.run("hi")
+    text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
+    text = " ".join(c.text for c in text_contents)
+    assert "A reply" in text
+    assert "B reply" in text
+    assert "C reply" in text
+
+
+# ---------------------------------------------------------------------------
+# Concurrent wrapped as_agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_default_as_agent_participants_are_text_reasoning() -> None:
+    """Default Concurrent wrapped as_agent: participant replies are text_reasoning;
+    aggregator's yield is text content."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = ConcurrentBuilder(participants=[a, b]).build()
+    agent = workflow.as_agent("concurrent")
+
+    response = await agent.run("hi")
+
+    text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
+    reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
+
+    # A's and B's replies are intermediate (text_reasoning).
+    assert any("A reply" in c.text for c in reasoning_contents)
+    assert any("B reply" in c.text for c in reasoning_contents)
+
+    # The aggregator's default-yielded AgentResponse passes through as text content.
+    assert text_contents, "expected at least one terminal text content from the aggregator"

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -14,8 +14,8 @@ Verifies that under the strict-output model:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterable, Awaitable
-from typing import Any, Literal, overload
+from collections.abc import AsyncIterable, Awaitable, Callable
+from typing import Any, ClassVar, Literal, overload
 
 import pytest
 from agent_framework import (
@@ -28,7 +28,18 @@ from agent_framework import (
     Message,
     ResponseStream,
 )
-from agent_framework.orchestrations import ConcurrentBuilder, SequentialBuilder
+from agent_framework.orchestrations import (
+    ConcurrentBuilder,
+    GroupChatBuilder,
+    GroupChatState,
+    HandoffBuilder,
+    MagenticBuilder,
+    MagenticContext,
+    MagenticManagerBase,
+    MagenticProgressLedger,
+    MagenticProgressLedgerItem,
+    SequentialBuilder,
+)
 
 
 class _EchoAgent(BaseAgent):
@@ -257,3 +268,186 @@ async def test_concurrent_default_as_agent_participants_are_text_reasoning() -> 
 
     # The aggregator's default-yielded AgentResponse passes through as text content.
     assert text_contents, "expected at least one terminal text content from the aggregator"
+
+
+# ---------------------------------------------------------------------------
+# GroupChat
+# ---------------------------------------------------------------------------
+
+
+def _two_step_selector() -> Callable[[GroupChatState], str]:
+    """Selector that picks each participant once, then keeps the first to keep tests bounded."""
+    counter = {"n": 0}
+
+    def _select(state: GroupChatState) -> str:
+        participants = list(state.participants.keys())
+        step = counter["n"]
+        counter["n"] = step + 1
+        if step == 0:
+            return participants[0]
+        if step == 1 and len(participants) > 1:
+            return participants[1]
+        return participants[0]
+
+    return _select
+
+
+@pytest.mark.asyncio
+async def test_group_chat_default_only_orchestrator_is_output() -> None:
+    """Default GroupChat: only the orchestrator is designated; participant replies surface
+    as type='intermediate'."""
+    alpha = _EchoAgent(name="alpha")
+    beta = _EchoAgent(name="beta")
+
+    workflow = GroupChatBuilder(
+        participants=[alpha, beta],
+        max_rounds=2,
+        selection_func=_two_step_selector(),
+    ).build()
+
+    output_executors: set[str] = set()
+    intermediate_executors: set[str] = set()
+    async for event in workflow.run("kickoff", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+        elif event.type == "intermediate" and event.executor_id is not None:
+            intermediate_executors.add(event.executor_id)
+
+    assert "group_chat_orchestrator" in output_executors
+    assert "alpha" in intermediate_executors
+    assert "beta" in intermediate_executors
+    # Participants must NOT appear among designated outputs in the default contract.
+    assert "alpha" not in output_executors
+    assert "beta" not in output_executors
+
+
+@pytest.mark.asyncio
+async def test_group_chat_intermediate_outputs_true_designates_all() -> None:
+    """GroupChat with intermediate_outputs=True designates orchestrator + every participant —
+    each reply surfaces as type='output'."""
+    alpha = _EchoAgent(name="alpha")
+    beta = _EchoAgent(name="beta")
+
+    workflow = GroupChatBuilder(
+        participants=[alpha, beta],
+        max_rounds=2,
+        selection_func=_two_step_selector(),
+        intermediate_outputs=True,
+    ).build()
+
+    output_executors: set[str] = set()
+    async for event in workflow.run("kickoff", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+
+    assert {"group_chat_orchestrator", "alpha", "beta"}.issubset(output_executors)
+
+
+# ---------------------------------------------------------------------------
+# Handoff
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_builder_designates_every_participant_as_output() -> None:
+    """Handoff has no intermediate channel — every participant's reply is a primary
+    output. The builder must designate all participants in the workflow's
+    ``_output_executors`` set so each per-agent yield surfaces as type='output'.
+
+    Structural assertion (vs end-to-end) because Handoff agents require a full
+    chat-client/middleware stack that we don't want to reproduce in this contract test.
+    """
+    from agent_framework import Agent
+    from agent_framework._clients import BaseChatClient
+    from agent_framework._middleware import ChatMiddlewareLayer
+    from agent_framework._tools import FunctionInvocationLayer
+
+    class _StubClient(FunctionInvocationLayer[Any], ChatMiddlewareLayer[Any], BaseChatClient[Any]):
+        def __init__(self) -> None:
+            ChatMiddlewareLayer.__init__(self)
+            FunctionInvocationLayer.__init__(self)
+            BaseChatClient.__init__(self)
+
+        def _inner_get_response(self, **kwargs: Any) -> Any:  # pragma: no cover - never called
+            raise NotImplementedError
+
+    alpha = Agent(
+        name="alpha",
+        id="alpha",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+    beta = Agent(
+        name="beta",
+        id="beta",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+
+    workflow = HandoffBuilder(participants=[alpha, beta]).with_start_agent(alpha).build()
+
+    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    assert "alpha" in designated, f"alpha must be designated; got {designated}"
+    assert "beta" in designated, f"beta must be designated; got {designated}"
+
+
+# ---------------------------------------------------------------------------
+# Magentic
+# ---------------------------------------------------------------------------
+
+
+class _StubMagenticManager(MagenticManagerBase):
+    """Deterministic manager that finishes after one round with a fixed final answer."""
+
+    FINAL_ANSWER: ClassVar[str] = "MAGENTIC_FINAL"
+
+    def __init__(self) -> None:
+        super().__init__(max_stall_count=3)
+        self.name = "magentic_manager"
+        self.next_speaker_name = "alpha"
+
+    async def plan(self, magentic_context: MagenticContext) -> Message:
+        return Message("assistant", ["Plan: do the thing."], author_name=self.name)
+
+    async def replan(self, magentic_context: MagenticContext) -> Message:
+        return Message("assistant", ["Replan."], author_name=self.name)
+
+    async def create_progress_ledger(self, magentic_context: MagenticContext) -> MagenticProgressLedger:
+        is_satisfied = len(magentic_context.chat_history) > 1
+        return MagenticProgressLedger(
+            is_request_satisfied=MagenticProgressLedgerItem(reason="t", answer=is_satisfied),
+            is_in_loop=MagenticProgressLedgerItem(reason="t", answer=False),
+            is_progress_being_made=MagenticProgressLedgerItem(reason="t", answer=True),
+            next_speaker=MagenticProgressLedgerItem(reason="t", answer=self.next_speaker_name),
+            instruction_or_question=MagenticProgressLedgerItem(reason="t", answer="Go."),
+        )
+
+    async def prepare_final_answer(self, magentic_context: MagenticContext) -> Message:
+        return Message("assistant", [self.FINAL_ANSWER], author_name=self.name)
+
+
+def test_magentic_builder_default_only_manager_designated() -> None:
+    """Default Magentic: only the orchestrator (manager) is designated for terminal output;
+    participant replies surface as type='intermediate'.
+
+    Structural assertion on ``workflow._output_executors`` because exercising a Magentic
+    plan/replan loop end-to-end is heavy and orthogonal to this contract.
+    """
+    manager = _StubMagenticManager()
+    alpha = _EchoAgent(name="alpha")
+
+    workflow = MagenticBuilder(participants=[alpha], manager=manager).build()
+
+    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    assert "magentic_orchestrator" in designated, f"manager must be designated; got {designated}"
+    assert "alpha" not in designated, f"participant must not be designated by default; got {designated}"
+
+
+def test_magentic_builder_intermediate_outputs_true_designates_all() -> None:
+    """Magentic with intermediate_outputs=True designates orchestrator + every participant."""
+    manager = _StubMagenticManager()
+    alpha = _EchoAgent(name="alpha")
+
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_outputs=True).build()
+
+    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    assert {"magentic_orchestrator", "alpha"}.issubset(designated)

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -351,7 +351,7 @@ async def test_group_chat_intermediate_outputs_true_designates_all() -> None:
 def test_handoff_builder_designates_every_participant_as_output() -> None:
     """Handoff has no intermediate channel — every participant's reply is a primary
     output. The builder must designate all participants in the workflow's
-    ``_output_executors`` set so each per-agent yield surfaces as type='output'.
+    output designation so each per-agent yield surfaces as type='output'.
 
     Structural assertion (vs end-to-end) because Handoff agents require a full
     chat-client/middleware stack that we don't want to reproduce in this contract test.
@@ -385,7 +385,7 @@ def test_handoff_builder_designates_every_participant_as_output() -> None:
 
     workflow = HandoffBuilder(participants=[alpha, beta]).with_start_agent(alpha).build()
 
-    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    designated = {ex.id for ex in workflow.get_output_executors()}
     assert "alpha" in designated, f"alpha must be designated; got {designated}"
     assert "beta" in designated, f"beta must be designated; got {designated}"
 
@@ -429,7 +429,7 @@ def test_magentic_builder_default_only_manager_designated() -> None:
     """Default Magentic: only the orchestrator (manager) is designated for terminal output;
     participant replies surface as type='intermediate'.
 
-    Structural assertion on ``workflow._output_executors`` because exercising a Magentic
+    Structural assertion on the workflow's output designation because exercising a Magentic
     plan/replan loop end-to-end is heavy and orthogonal to this contract.
     """
     manager = _StubMagenticManager()
@@ -437,7 +437,7 @@ def test_magentic_builder_default_only_manager_designated() -> None:
 
     workflow = MagenticBuilder(participants=[alpha], manager=manager).build()
 
-    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    designated = {ex.id for ex in workflow.get_output_executors()}
     assert "magentic_orchestrator" in designated, f"manager must be designated; got {designated}"
     assert "alpha" not in designated, f"participant must not be designated by default; got {designated}"
 
@@ -449,5 +449,5 @@ def test_magentic_builder_intermediate_outputs_true_designates_all() -> None:
 
     workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_outputs=True).build()
 
-    designated = set(workflow._output_executors or [])  # type: ignore[arg-type]
+    designated = {ex.id for ex in workflow.get_output_executors()}
     assert {"magentic_orchestrator", "alpha"}.issubset(designated)

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -117,13 +117,13 @@ async def test_sequential_default_only_terminator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sequential_final_output_from_designates_terminal_participants() -> None:
-    """Sequential final_output_from controls which participant yields surface as terminal output."""
+async def test_sequential_output_from_designates_workflow_output_participants() -> None:
+    """Sequential output_from controls which participant yields surface as workflow output."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], final_output_from=["A", "B", "C"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], output_from=["A", "B", "C"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
     assert len(outputs) == 3
@@ -219,12 +219,12 @@ async def test_concurrent_default_only_aggregator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_concurrent_final_output_from_designates_terminal_participants() -> None:
-    """Concurrent final_output_from designates participant outputs alongside the aggregator."""
+async def test_concurrent_output_from_designates_workflow_output_participants() -> None:
+    """Concurrent output_from designates participant outputs alongside the aggregator."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
-    workflow = ConcurrentBuilder(participants=[a, b], final_output_from=[a, "B"]).build()
+    workflow = ConcurrentBuilder(participants=[a, b], output_from=[a, "B"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
     assert len(outputs) == 3
@@ -278,13 +278,13 @@ async def test_sequential_default_as_agent_intermediates_are_text_reasoning() ->
 
 
 @pytest.mark.asyncio
-async def test_sequential_as_agent_final_output_from_all_text() -> None:
-    """final_output_from makes designated participant replies terminal text content."""
+async def test_sequential_as_agent_output_from_all_text() -> None:
+    """output_from makes designated participant replies normal response text content."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], final_output_from=["A", "B", "C"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], output_from=["A", "B", "C"]).build()
     agent = workflow.as_agent("seq")
 
     response = await agent.run("hi")
@@ -392,8 +392,8 @@ async def test_group_chat_default_only_orchestrator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_group_chat_final_output_from_designates_terminal_participants() -> None:
-    """GroupChat final_output_from designates participants alongside the orchestrator."""
+async def test_group_chat_output_from_designates_workflow_output_participants() -> None:
+    """GroupChat output_from designates participants alongside the orchestrator."""
     alpha = _EchoAgent(name="alpha")
     beta = _EchoAgent(name="beta")
 
@@ -401,7 +401,7 @@ async def test_group_chat_final_output_from_designates_terminal_participants() -
         participants=[alpha, beta],
         max_rounds=2,
         selection_func=_two_step_selector(),
-        final_output_from=[alpha, "beta"],
+        output_from=[alpha, "beta"],
     ).build()
 
     output_executors: set[str] = set()
@@ -483,7 +483,7 @@ def test_handoff_builder_designates_every_participant_as_output() -> None:
     assert "beta" in designated, f"beta must be designated; got {designated}"
 
 
-def test_handoff_builder_final_output_from_can_select_terminal_participants() -> None:
+def test_handoff_builder_output_from_can_select_workflow_output_participants() -> None:
     from agent_framework import Agent
     from agent_framework._clients import BaseChatClient
     from agent_framework._middleware import ChatMiddlewareLayer
@@ -511,7 +511,7 @@ def test_handoff_builder_final_output_from_can_select_terminal_participants() ->
         require_per_service_call_history_persistence=True,
     )
 
-    workflow = HandoffBuilder(participants=[alpha, beta], final_output_from=["alpha"]).with_start_agent(alpha).build()
+    workflow = HandoffBuilder(participants=[alpha, beta], output_from=["alpha"]).with_start_agent(alpha).build()
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"alpha"}
 
@@ -604,12 +604,12 @@ def test_magentic_builder_default_only_manager_designated() -> None:
     assert "alpha" not in designated, f"participant must not be designated by default; got {designated}"
 
 
-def test_magentic_builder_final_output_from_designates_terminal_participants() -> None:
-    """Magentic final_output_from designates workers alongside the orchestrator."""
+def test_magentic_builder_output_from_designates_workflow_output_participants() -> None:
+    """Magentic output_from designates workers alongside the orchestrator."""
     manager = _StubMagenticManager()
     alpha = _EchoAgent(name="alpha")
 
-    workflow = MagenticBuilder(participants=[alpha], manager=manager, final_output_from=["alpha"]).build()
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, output_from=["alpha"]).build()
 
     designated = {ex.id for ex in workflow.get_output_executors()}
     assert {"magentic_orchestrator", "alpha"}.issubset(designated)
@@ -623,6 +623,39 @@ def test_magentic_builder_intermediate_output_from_designates_intermediate_worke
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"magentic_orchestrator"}
     assert {ex.id for ex in workflow.get_intermediate_executors()} == {"alpha"}
+
+
+def test_sequential_output_from_all_selects_all_participants() -> None:
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], output_from="all").build()
+
+    assert {ex.id for ex in workflow.get_output_executors()} == {"A", "B", "C"}
+
+
+def test_sequential_intermediate_output_from_all_other_selects_non_outputs() -> None:
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(
+        participants=[a, b, c], output_from=["C"], intermediate_output_from="all_other"
+    ).build()
+
+    assert {ex.id for ex in workflow.get_output_executors()} == {"C"}
+    assert {ex.id for ex in workflow.get_intermediate_executors()} == {"A", "B"}
+
+
+def test_sequential_all_other_with_omitted_output_from_selects_all_intermediate() -> None:
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = SequentialBuilder(participants=[a, b], intermediate_output_from="all_other").build()
+
+    assert {ex.id for ex in workflow.get_output_executors()} == set()
+    assert {ex.id for ex in workflow.get_intermediate_executors()} == {"A", "B"}
 
 
 # ---------------------------------------------------------------------------
@@ -695,11 +728,29 @@ def _build_handoff_with_designation(**kwargs: Any) -> None:
     ("kwargs", "match"),
     [
         ({"final_output_from": [], "intermediate_output_from": []}, "cannot both be empty"),
-        ({"final_output_from": ["alpha", "alpha"]}, "Duplicate output participant"),
-        ({"final_output_from": ["alpha"], "intermediate_output_from": ["alpha"]}, "cannot be both output"),
-        ({"final_output_from": ["missing"]}, "Unknown output participant"),
+        ({"output_from": [], "intermediate_output_from": []}, "cannot both be empty"),
+        ({"output_from": ["alpha", "alpha"]}, "Duplicate output participant"),
+        ({"output_from": ["alpha"], "intermediate_output_from": ["alpha"]}, "cannot be both output"),
+        ({"output_from": ["missing"]}, "Unknown output participant"),
+        ({"output_from": "all_other"}, "output_from='all_other'"),
+        ({"intermediate_output_from": "all"}, "intermediate_output_from='all'"),
     ],
 )
 def test_participant_output_config_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         build(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        _build_sequential_with_designation,
+        _build_concurrent_with_designation,
+        _build_group_chat_with_designation,
+        _build_magentic_with_designation,
+        _build_handoff_with_designation,
+    ],
+)
+def test_participant_output_config_rejects_output_from_alias_conflict(build: Callable[..., None]) -> None:
+    with pytest.raises(TypeError, match="output_from.*final_output_from"):
+        build(output_from=["alpha"], final_output_from=["beta"])

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -94,8 +94,7 @@ class _EchoAgent(BaseAgent):
 
 @pytest.mark.asyncio
 async def test_sequential_default_only_terminator_is_output() -> None:
-    """Default Sequential (intermediate_outputs=False) designates only the terminator;
-    earlier participants surface as type='intermediate'."""
+    """Default Sequential designates only the terminator; earlier participants are hidden."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
@@ -114,25 +113,40 @@ async def test_sequential_default_only_terminator_is_output() -> None:
     assert len(output_events) == 1
     assert "C" in {ev.executor_id for ev in output_events}
 
-    # A and B emit type='intermediate'.
-    intermediate_executors = {ev.executor_id for ev in intermediate_events}
-    assert "A" in intermediate_executors
-    assert "B" in intermediate_executors
+    assert not intermediate_events
 
 
 @pytest.mark.asyncio
-async def test_sequential_intermediate_outputs_true_designates_all() -> None:
-    """Sequential with intermediate_outputs=True preserves the legacy contract:
-    every participant's yield surfaces as type='output'."""
+async def test_sequential_output_participants_designates_terminal_participants() -> None:
+    """Sequential output_participants controls which participant yields surface as terminal output."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], intermediate_outputs=True).build()
+    workflow = SequentialBuilder(participants=[a, b, c], output_participants=["A", "B", "C"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
-    # All three participants' yields surface in get_outputs() under intermediate_outputs=True.
     assert len(outputs) == 3
+
+
+@pytest.mark.asyncio
+async def test_sequential_intermediate_participants_surface_as_intermediate() -> None:
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_participants=[a, "B"]).build()
+
+    output_executors: set[str] = set()
+    intermediate_executors: set[str] = set()
+    async for event in workflow.run("hello", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+        elif event.type == "intermediate" and event.executor_id is not None:
+            intermediate_executors.add(event.executor_id)
+
+    assert output_executors == {"C"}
+    assert intermediate_executors == {"A", "B"}
 
 
 @pytest.mark.asyncio
@@ -154,8 +168,7 @@ async def test_sequential_get_outputs_returns_terminator_only() -> None:
 
 @pytest.mark.asyncio
 async def test_concurrent_default_only_aggregator_is_output() -> None:
-    """Default Concurrent (intermediate_outputs=False): only the aggregator is
-    designated; participants surface as type='intermediate'."""
+    """Default Concurrent designates only the aggregator; participants are hidden."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
@@ -172,24 +185,38 @@ async def test_concurrent_default_only_aggregator_is_output() -> None:
     # Aggregator is the only designated executor → only it emits type='output'.
     assert len(output_events) == 1
 
-    # Both participants emit type='intermediate'.
-    intermediate_authors = {ev.executor_id for ev in intermediate_events}
-    assert "A" in intermediate_authors
-    assert "B" in intermediate_authors
+    assert not intermediate_events
 
 
 @pytest.mark.asyncio
-async def test_concurrent_intermediate_outputs_true_designates_all() -> None:
-    """Concurrent with intermediate_outputs=True designates participants alongside the
-    aggregator — every participant's yield surfaces as type='output'."""
+async def test_concurrent_output_participants_designates_terminal_participants() -> None:
+    """Concurrent output_participants designates participant outputs alongside the aggregator."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
-    workflow = ConcurrentBuilder(participants=[a, b], intermediate_outputs=True).build()
+    workflow = ConcurrentBuilder(participants=[a, b], output_participants=[a, "B"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
-    # Two participants + aggregator → three terminal outputs in get_outputs().
     assert len(outputs) == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrent_intermediate_participants_surface_as_intermediate() -> None:
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+
+    workflow = ConcurrentBuilder(participants=[a, b], intermediate_participants=["A", b]).build()
+
+    output_executors: set[str] = set()
+    intermediate_executors: set[str] = set()
+    async for event in workflow.run("hello", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+        elif event.type == "intermediate" and event.executor_id is not None:
+            intermediate_executors.add(event.executor_id)
+
+    assert "aggregator" in output_executors
+    assert intermediate_executors == {"A", "B"}
 
 
 # ---------------------------------------------------------------------------
@@ -199,9 +226,7 @@ async def test_concurrent_intermediate_outputs_true_designates_all() -> None:
 
 @pytest.mark.asyncio
 async def test_sequential_default_as_agent_intermediates_are_text_reasoning() -> None:
-    """Default Sequential wrapped as_agent: per-step participant replies become
-    text_reasoning content; the terminator's reply becomes text content.
-    """
+    """Default Sequential wrapped as_agent returns only the terminator's terminal content."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
@@ -218,20 +243,18 @@ async def test_sequential_default_as_agent_intermediates_are_text_reasoning() ->
     reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
 
     assert any("C reply" in c.text for c in text_contents)
-    assert any("A reply" in c.text for c in reasoning_contents)
-    assert any("B reply" in c.text for c in reasoning_contents)
+    assert not any("A reply" in c.text for c in reasoning_contents)
+    assert not any("B reply" in c.text for c in reasoning_contents)
 
 
 @pytest.mark.asyncio
-async def test_sequential_as_agent_intermediate_outputs_true_all_text() -> None:
-    """Sequential with intermediate_outputs=True wrapped as_agent: every participant's
-    reply is now designated terminal, so each surfaces as text content (not reasoning).
-    Existing callers reading .text get all participants' replies concatenated."""
+async def test_sequential_as_agent_output_participants_all_text() -> None:
+    """output_participants makes designated participant replies terminal text content."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], intermediate_outputs=True).build()
+    workflow = SequentialBuilder(participants=[a, b, c], output_participants=["A", "B", "C"]).build()
     agent = workflow.as_agent("seq")
 
     response = await agent.run("hi")
@@ -240,6 +263,25 @@ async def test_sequential_as_agent_intermediate_outputs_true_all_text() -> None:
     assert "A reply" in text
     assert "B reply" in text
     assert "C reply" in text
+
+
+@pytest.mark.asyncio
+async def test_sequential_as_agent_intermediate_participants_are_text_reasoning() -> None:
+    """intermediate_participants maps selected participant replies to reasoning content."""
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_participants=["A", "B"]).build()
+    agent = workflow.as_agent("seq")
+
+    response = await agent.run("hi")
+
+    text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
+    reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
+    assert any("C reply" in c.text for c in text_contents)
+    assert any("A reply" in c.text for c in reasoning_contents)
+    assert any("B reply" in c.text for c in reasoning_contents)
 
 
 # ---------------------------------------------------------------------------
@@ -262,9 +304,8 @@ async def test_concurrent_default_as_agent_participants_are_text_reasoning() -> 
     text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
     reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
 
-    # A's and B's replies are intermediate (text_reasoning).
-    assert any("A reply" in c.text for c in reasoning_contents)
-    assert any("B reply" in c.text for c in reasoning_contents)
+    assert not any("A reply" in c.text for c in reasoning_contents)
+    assert not any("B reply" in c.text for c in reasoning_contents)
 
     # The aggregator's default-yielded AgentResponse passes through as text content.
     assert text_contents, "expected at least one terminal text content from the aggregator"
@@ -294,8 +335,7 @@ def _two_step_selector() -> Callable[[GroupChatState], str]:
 
 @pytest.mark.asyncio
 async def test_group_chat_default_only_orchestrator_is_output() -> None:
-    """Default GroupChat: only the orchestrator is designated; participant replies surface
-    as type='intermediate'."""
+    """Default GroupChat designates only the orchestrator; participant replies are hidden."""
     alpha = _EchoAgent(name="alpha")
     beta = _EchoAgent(name="beta")
 
@@ -314,17 +354,16 @@ async def test_group_chat_default_only_orchestrator_is_output() -> None:
             intermediate_executors.add(event.executor_id)
 
     assert "group_chat_orchestrator" in output_executors
-    assert "alpha" in intermediate_executors
-    assert "beta" in intermediate_executors
+    assert "alpha" not in intermediate_executors
+    assert "beta" not in intermediate_executors
     # Participants must NOT appear among designated outputs in the default contract.
     assert "alpha" not in output_executors
     assert "beta" not in output_executors
 
 
 @pytest.mark.asyncio
-async def test_group_chat_intermediate_outputs_true_designates_all() -> None:
-    """GroupChat with intermediate_outputs=True designates orchestrator + every participant —
-    each reply surfaces as type='output'."""
+async def test_group_chat_output_participants_designates_terminal_participants() -> None:
+    """GroupChat output_participants designates participants alongside the orchestrator."""
     alpha = _EchoAgent(name="alpha")
     beta = _EchoAgent(name="beta")
 
@@ -332,7 +371,7 @@ async def test_group_chat_intermediate_outputs_true_designates_all() -> None:
         participants=[alpha, beta],
         max_rounds=2,
         selection_func=_two_step_selector(),
-        intermediate_outputs=True,
+        output_participants=[alpha, "beta"],
     ).build()
 
     output_executors: set[str] = set()
@@ -341,6 +380,30 @@ async def test_group_chat_intermediate_outputs_true_designates_all() -> None:
             output_executors.add(event.executor_id)
 
     assert {"group_chat_orchestrator", "alpha", "beta"}.issubset(output_executors)
+
+
+@pytest.mark.asyncio
+async def test_group_chat_intermediate_participants_surface_as_intermediate() -> None:
+    alpha = _EchoAgent(name="alpha")
+    beta = _EchoAgent(name="beta")
+
+    workflow = GroupChatBuilder(
+        participants=[alpha, beta],
+        max_rounds=2,
+        selection_func=_two_step_selector(),
+        intermediate_participants=["alpha", beta],
+    ).build()
+
+    output_executors: set[str] = set()
+    intermediate_executors: set[str] = set()
+    async for event in workflow.run("kickoff", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+        elif event.type == "intermediate" and event.executor_id is not None:
+            intermediate_executors.add(event.executor_id)
+
+    assert "group_chat_orchestrator" in output_executors
+    assert intermediate_executors == {"alpha", "beta"}
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +451,39 @@ def test_handoff_builder_designates_every_participant_as_output() -> None:
     designated = {ex.id for ex in workflow.get_output_executors()}
     assert "alpha" in designated, f"alpha must be designated; got {designated}"
     assert "beta" in designated, f"beta must be designated; got {designated}"
+
+
+def test_handoff_builder_output_participants_can_select_terminal_participants() -> None:
+    from agent_framework import Agent
+    from agent_framework._clients import BaseChatClient
+    from agent_framework._middleware import ChatMiddlewareLayer
+    from agent_framework._tools import FunctionInvocationLayer
+
+    class _StubClient(FunctionInvocationLayer[Any], ChatMiddlewareLayer[Any], BaseChatClient[Any]):
+        def __init__(self) -> None:
+            ChatMiddlewareLayer.__init__(self)
+            FunctionInvocationLayer.__init__(self)
+            BaseChatClient.__init__(self)
+
+        def _inner_get_response(self, **kwargs: Any) -> Any:  # pragma: no cover - never called
+            raise NotImplementedError
+
+    alpha = Agent(
+        name="alpha",
+        id="alpha",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+    beta = Agent(
+        name="beta",
+        id="beta",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+
+    workflow = HandoffBuilder(participants=[alpha, beta], output_participants=["alpha"]).with_start_agent(alpha).build()
+
+    assert {ex.id for ex in workflow.get_output_executors()} == {"alpha"}
 
 
 # ---------------------------------------------------------------------------
@@ -442,12 +538,102 @@ def test_magentic_builder_default_only_manager_designated() -> None:
     assert "alpha" not in designated, f"participant must not be designated by default; got {designated}"
 
 
-def test_magentic_builder_intermediate_outputs_true_designates_all() -> None:
-    """Magentic with intermediate_outputs=True designates orchestrator + every participant."""
+def test_magentic_builder_output_participants_designates_terminal_participants() -> None:
+    """Magentic output_participants designates workers alongside the orchestrator."""
     manager = _StubMagenticManager()
     alpha = _EchoAgent(name="alpha")
 
-    workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_outputs=True).build()
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, output_participants=["alpha"]).build()
 
     designated = {ex.id for ex in workflow.get_output_executors()}
     assert {"magentic_orchestrator", "alpha"}.issubset(designated)
+
+
+def test_magentic_builder_intermediate_participants_designates_intermediate_workers() -> None:
+    manager = _StubMagenticManager()
+    alpha = _EchoAgent(name="alpha")
+
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_participants=[alpha]).build()
+
+    assert {ex.id for ex in workflow.get_output_executors()} == {"magentic_orchestrator"}
+    assert {ex.id for ex in workflow.get_intermediate_executors()} == {"alpha"}
+
+
+# ---------------------------------------------------------------------------
+# Participant designation validation
+# ---------------------------------------------------------------------------
+
+
+def _build_sequential_with_designation(**kwargs: Any) -> None:
+    SequentialBuilder(participants=[_EchoAgent(name="alpha"), _EchoAgent(name="beta")], **kwargs).build()
+
+
+def _build_concurrent_with_designation(**kwargs: Any) -> None:
+    ConcurrentBuilder(participants=[_EchoAgent(name="alpha"), _EchoAgent(name="beta")], **kwargs).build()
+
+
+def _build_group_chat_with_designation(**kwargs: Any) -> None:
+    GroupChatBuilder(
+        participants=[_EchoAgent(name="alpha"), _EchoAgent(name="beta")],
+        max_rounds=1,
+        selection_func=_two_step_selector(),
+        **kwargs,
+    ).build()
+
+
+def _build_magentic_with_designation(**kwargs: Any) -> None:
+    MagenticBuilder(participants=[_EchoAgent(name="alpha")], manager=_StubMagenticManager(), **kwargs).build()
+
+
+def _build_handoff_with_designation(**kwargs: Any) -> None:
+    from agent_framework import Agent
+    from agent_framework._clients import BaseChatClient
+    from agent_framework._middleware import ChatMiddlewareLayer
+    from agent_framework._tools import FunctionInvocationLayer
+
+    class _StubClient(FunctionInvocationLayer[Any], ChatMiddlewareLayer[Any], BaseChatClient[Any]):
+        def __init__(self) -> None:
+            ChatMiddlewareLayer.__init__(self)
+            FunctionInvocationLayer.__init__(self)
+            BaseChatClient.__init__(self)
+
+        def _inner_get_response(self, **kwargs: Any) -> Any:  # pragma: no cover - never called
+            raise NotImplementedError
+
+    alpha = Agent(
+        name="alpha",
+        id="alpha",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+    beta = Agent(
+        name="beta",
+        id="beta",
+        client=_StubClient(),
+        require_per_service_call_history_persistence=True,
+    )
+    HandoffBuilder(participants=[alpha, beta], **kwargs).with_start_agent(alpha).build()
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        _build_sequential_with_designation,
+        _build_concurrent_with_designation,
+        _build_group_chat_with_designation,
+        _build_magentic_with_designation,
+        _build_handoff_with_designation,
+    ],
+)
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"output_participants": [], "intermediate_participants": []}, "cannot both be empty"),
+        ({"output_participants": ["alpha", "alpha"]}, "Duplicate output participant"),
+        ({"output_participants": ["alpha"], "intermediate_participants": ["alpha"]}, "cannot be both output"),
+        ({"output_participants": ["missing"]}, "Unknown output participant"),
+    ],
+)
+def test_participant_designation_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        build(**kwargs)

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -727,7 +727,6 @@ def _build_handoff_with_designation(**kwargs: Any) -> None:
         ({"output_from": ["alpha"], "intermediate_output_from": ["alpha"]}, "cannot be both output"),
         ({"output_from": ["missing"]}, "Unknown output participant"),
         ({"output_from": "all_other"}, "output_from='all_other'"),
-        ({"intermediate_output_from": "all"}, "intermediate_output_from='all'"),
     ],
 )
 def test_participant_output_config_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -7,9 +7,8 @@ Verifies that under the strict-output model:
     aggregator, orchestrator, or manager as the sole output executor; per-step
     yields from non-designated executors emit `type='intermediate'` events.
   - Handoff designates ALL participants — every reply is `type='output'`.
-  - When wrapped via `workflow.as_agent()`, intermediate events surface as
-    `text_reasoning` content; terminal events as `text` content; existing
-    `.text` accessors return terminal-only.
+  - When wrapped via `workflow.as_agent()`, caller-facing workflow events surface
+    with their original content types.
 """
 
 from __future__ import annotations
@@ -151,13 +150,13 @@ async def test_sequential_intermediate_output_from_surface_as_intermediate() -> 
 
 @pytest.mark.asyncio
 async def test_sequential_intermediate_can_demote_default_terminator() -> None:
-    """Regression: marking the default-final terminator as intermediate must not raise an overlap error.
+    """Regression: marking the default output terminator as intermediate must not raise an overlap error.
 
-    Sequential's default-final list is `[participants[-1]]`. Before the fix, designating that
+    Sequential's default output list is `[participants[-1]]`. Before the fix, designating that
     same participant via `intermediate_output_from` triggered the
     "Participants cannot be both output and intermediate designated" overlap rejection in
     `_participant_output_config`, contradicting the public contract that
-    `intermediate_output_from` can be used independently of `final_output_from`.
+    `intermediate_output_from` can be used independently of `output_from`.
     """
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
@@ -250,13 +249,13 @@ async def test_concurrent_intermediate_output_from_surface_as_intermediate() -> 
 
 
 # ---------------------------------------------------------------------------
-# Sequential wrapped as_agent — text_reasoning mapping
+# Sequential wrapped as_agent
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_sequential_default_as_agent_intermediates_are_text_reasoning() -> None:
-    """Default Sequential wrapped as_agent returns only the terminator's terminal content."""
+async def test_sequential_default_as_agent_forwards_original_content_types() -> None:
+    """Default Sequential wrapped as_agent forwards original content types."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
@@ -266,15 +265,11 @@ async def test_sequential_default_as_agent_intermediates_are_text_reasoning() ->
 
     response = await agent.run("hi")
 
-    # .text returns terminal content only — only C's reply.
-    assert response.text == "C reply"
-
     text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
     reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
 
     assert any("C reply" in c.text for c in text_contents)
-    assert not any("A reply" in c.text for c in reasoning_contents)
-    assert not any("B reply" in c.text for c in reasoning_contents)
+    assert not reasoning_contents
 
 
 @pytest.mark.asyncio
@@ -296,8 +291,8 @@ async def test_sequential_as_agent_output_from_all_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sequential_as_agent_intermediate_output_from_are_text_reasoning() -> None:
-    """intermediate_output_from maps selected participant replies to reasoning content."""
+async def test_sequential_as_agent_intermediate_output_from_keeps_text_content() -> None:
+    """intermediate_output_from keeps selected participant replies as their original content type."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
@@ -310,8 +305,9 @@ async def test_sequential_as_agent_intermediate_output_from_are_text_reasoning()
     text_contents = [c for m in response.messages for c in m.contents if c.type == "text"]
     reasoning_contents = [c for m in response.messages for c in m.contents if c.type == "text_reasoning"]
     assert any("C reply" in c.text for c in text_contents)
-    assert any("A reply" in c.text for c in reasoning_contents)
-    assert any("B reply" in c.text for c in reasoning_contents)
+    assert any("A reply" in c.text for c in text_contents)
+    assert any("B reply" in c.text for c in text_contents)
+    assert not reasoning_contents
 
 
 # ---------------------------------------------------------------------------
@@ -320,9 +316,8 @@ async def test_sequential_as_agent_intermediate_output_from_are_text_reasoning()
 
 
 @pytest.mark.asyncio
-async def test_concurrent_default_as_agent_participants_are_text_reasoning() -> None:
-    """Default Concurrent wrapped as_agent: participant replies are text_reasoning;
-    aggregator's yield is text content."""
+async def test_concurrent_default_as_agent_participants_keep_text_content() -> None:
+    """Default Concurrent wrapped as_agent keeps original participant content types."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
@@ -516,13 +511,13 @@ def test_handoff_builder_output_from_can_select_workflow_output_participants() -
     assert {ex.id for ex in workflow.get_output_executors()} == {"alpha"}
 
 
-def test_handoff_builder_intermediate_output_from_demotes_from_default_final() -> None:
-    """Regression: `intermediate_output_from` alone must not collide with the default-final list.
+def test_handoff_builder_intermediate_output_from_demotes_from_default_output() -> None:
+    """Regression: `intermediate_output_from` alone must not collide with the default output list.
 
-    Handoff defaults `final_output_from` to every participant. Before the fix, supplying
-    `intermediate_output_from=["alpha"]` without restating `final_output_from` triggered
+    Handoff defaults workflow output to every participant. Before the fix, supplying
+    `intermediate_output_from=["alpha"]` without restating `output_from` triggered
     "Participants cannot be both output and intermediate designated: ['alpha']" because
-    alpha was simultaneously in the default-final list and the explicit intermediate list.
+    alpha was simultaneously in the default output list and the explicit intermediate list.
     The contract documented at `_handoff.py:619-622` promises `intermediate_output_from` is
     usable on its own.
     """
@@ -727,7 +722,6 @@ def _build_handoff_with_designation(**kwargs: Any) -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"final_output_from": [], "intermediate_output_from": []}, "cannot both be empty"),
         ({"output_from": [], "intermediate_output_from": []}, "cannot both be empty"),
         ({"output_from": ["alpha", "alpha"]}, "Duplicate output participant"),
         ({"output_from": ["alpha"], "intermediate_output_from": ["alpha"]}, "cannot be both output"),
@@ -751,6 +745,6 @@ def test_participant_output_config_validation(build: Callable[..., None], kwargs
         _build_handoff_with_designation,
     ],
 )
-def test_participant_output_config_rejects_output_from_alias_conflict(build: Callable[..., None]) -> None:
-    with pytest.raises(TypeError, match="output_from.*final_output_from"):
-        build(output_from=["alpha"], final_output_from=["beta"])
+def test_participant_output_config_rejects_final_output_from_parameter(build: Callable[..., None]) -> None:
+    with pytest.raises(TypeError, match="final_output_from"):
+        build(final_output_from=["beta"])

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -150,6 +150,36 @@ async def test_sequential_intermediate_output_from_surface_as_intermediate() -> 
 
 
 @pytest.mark.asyncio
+async def test_sequential_intermediate_can_demote_default_terminator() -> None:
+    """Regression: marking the default-final terminator as intermediate must not raise an overlap error.
+
+    Sequential's default-final list is `[participants[-1]]`. Before the fix, designating that
+    same participant via `intermediate_output_from` triggered the
+    "Participants cannot be both output and intermediate designated" overlap rejection in
+    `_participant_output_config`, contradicting the public contract that
+    `intermediate_output_from` can be used independently of `final_output_from`.
+    """
+    a = _EchoAgent(name="A")
+    b = _EchoAgent(name="B")
+    c = _EchoAgent(name="C")
+
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_output_from=["C"]).build()
+
+    output_executors: set[str] = set()
+    intermediate_executors: set[str] = set()
+    async for event in workflow.run("hello", stream=True):
+        if event.type == "output" and event.executor_id is not None:
+            output_executors.add(event.executor_id)
+        elif event.type == "intermediate" and event.executor_id is not None:
+            intermediate_executors.add(event.executor_id)
+
+    # The default-final list ([C]) is implicitly narrowed by the intermediate designation,
+    # so no participant surfaces as terminal output and C surfaces as intermediate.
+    assert output_executors == set()
+    assert intermediate_executors == {"C"}
+
+
+@pytest.mark.asyncio
 async def test_sequential_get_outputs_returns_terminator_only() -> None:
     """WorkflowRunResult.get_outputs() returns only the terminator's yield."""
     a = _EchoAgent(name="A")
@@ -484,6 +514,42 @@ def test_handoff_builder_final_output_from_can_select_terminal_participants() ->
     workflow = HandoffBuilder(participants=[alpha, beta], final_output_from=["alpha"]).with_start_agent(alpha).build()
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"alpha"}
+
+
+def test_handoff_builder_intermediate_output_from_demotes_from_default_final() -> None:
+    """Regression: `intermediate_output_from` alone must not collide with the default-final list.
+
+    Handoff defaults `final_output_from` to every participant. Before the fix, supplying
+    `intermediate_output_from=["alpha"]` without restating `final_output_from` triggered
+    "Participants cannot be both output and intermediate designated: ['alpha']" because
+    alpha was simultaneously in the default-final list and the explicit intermediate list.
+    The contract documented at `_handoff.py:619-622` promises `intermediate_output_from` is
+    usable on its own.
+    """
+    from agent_framework import Agent
+    from agent_framework._clients import BaseChatClient
+    from agent_framework._middleware import ChatMiddlewareLayer
+    from agent_framework._tools import FunctionInvocationLayer
+
+    class _StubClient(FunctionInvocationLayer[Any], ChatMiddlewareLayer[Any], BaseChatClient[Any]):
+        def __init__(self) -> None:
+            ChatMiddlewareLayer.__init__(self)
+            FunctionInvocationLayer.__init__(self)
+            BaseChatClient.__init__(self)
+
+        def _inner_get_response(self, **kwargs: Any) -> Any:  # pragma: no cover - never called
+            raise NotImplementedError
+
+    alpha = Agent(name="alpha", id="alpha", client=_StubClient(), require_per_service_call_history_persistence=True)
+    beta = Agent(name="beta", id="beta", client=_StubClient(), require_per_service_call_history_persistence=True)
+
+    workflow = (
+        HandoffBuilder(participants=[alpha, beta], intermediate_output_from=["alpha"]).with_start_agent(alpha).build()
+    )
+
+    # alpha is implicitly removed from the default-final set; beta remains final.
+    assert {ex.id for ex in workflow.get_output_executors()} == {"beta"}
+    assert {ex.id for ex in workflow.get_intermediate_executors()} == {"alpha"}
 
 
 # ---------------------------------------------------------------------------

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -117,25 +117,25 @@ async def test_sequential_default_only_terminator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sequential_output_participants_designates_terminal_participants() -> None:
-    """Sequential output_participants controls which participant yields surface as terminal output."""
+async def test_sequential_final_output_from_designates_terminal_participants() -> None:
+    """Sequential final_output_from controls which participant yields surface as terminal output."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], output_participants=["A", "B", "C"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], final_output_from=["A", "B", "C"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
     assert len(outputs) == 3
 
 
 @pytest.mark.asyncio
-async def test_sequential_intermediate_participants_surface_as_intermediate() -> None:
+async def test_sequential_intermediate_output_from_surface_as_intermediate() -> None:
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], intermediate_participants=[a, "B"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_output_from=[a, "B"]).build()
 
     output_executors: set[str] = set()
     intermediate_executors: set[str] = set()
@@ -189,23 +189,23 @@ async def test_concurrent_default_only_aggregator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_concurrent_output_participants_designates_terminal_participants() -> None:
-    """Concurrent output_participants designates participant outputs alongside the aggregator."""
+async def test_concurrent_final_output_from_designates_terminal_participants() -> None:
+    """Concurrent final_output_from designates participant outputs alongside the aggregator."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
-    workflow = ConcurrentBuilder(participants=[a, b], output_participants=[a, "B"]).build()
+    workflow = ConcurrentBuilder(participants=[a, b], final_output_from=[a, "B"]).build()
     result = await workflow.run("hello")
     outputs = result.get_outputs()
     assert len(outputs) == 3
 
 
 @pytest.mark.asyncio
-async def test_concurrent_intermediate_participants_surface_as_intermediate() -> None:
+async def test_concurrent_intermediate_output_from_surface_as_intermediate() -> None:
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
 
-    workflow = ConcurrentBuilder(participants=[a, b], intermediate_participants=["A", b]).build()
+    workflow = ConcurrentBuilder(participants=[a, b], intermediate_output_from=["A", b]).build()
 
     output_executors: set[str] = set()
     intermediate_executors: set[str] = set()
@@ -248,13 +248,13 @@ async def test_sequential_default_as_agent_intermediates_are_text_reasoning() ->
 
 
 @pytest.mark.asyncio
-async def test_sequential_as_agent_output_participants_all_text() -> None:
-    """output_participants makes designated participant replies terminal text content."""
+async def test_sequential_as_agent_final_output_from_all_text() -> None:
+    """final_output_from makes designated participant replies terminal text content."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], output_participants=["A", "B", "C"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], final_output_from=["A", "B", "C"]).build()
     agent = workflow.as_agent("seq")
 
     response = await agent.run("hi")
@@ -266,13 +266,13 @@ async def test_sequential_as_agent_output_participants_all_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sequential_as_agent_intermediate_participants_are_text_reasoning() -> None:
-    """intermediate_participants maps selected participant replies to reasoning content."""
+async def test_sequential_as_agent_intermediate_output_from_are_text_reasoning() -> None:
+    """intermediate_output_from maps selected participant replies to reasoning content."""
     a = _EchoAgent(name="A")
     b = _EchoAgent(name="B")
     c = _EchoAgent(name="C")
 
-    workflow = SequentialBuilder(participants=[a, b, c], intermediate_participants=["A", "B"]).build()
+    workflow = SequentialBuilder(participants=[a, b, c], intermediate_output_from=["A", "B"]).build()
     agent = workflow.as_agent("seq")
 
     response = await agent.run("hi")
@@ -362,8 +362,8 @@ async def test_group_chat_default_only_orchestrator_is_output() -> None:
 
 
 @pytest.mark.asyncio
-async def test_group_chat_output_participants_designates_terminal_participants() -> None:
-    """GroupChat output_participants designates participants alongside the orchestrator."""
+async def test_group_chat_final_output_from_designates_terminal_participants() -> None:
+    """GroupChat final_output_from designates participants alongside the orchestrator."""
     alpha = _EchoAgent(name="alpha")
     beta = _EchoAgent(name="beta")
 
@@ -371,7 +371,7 @@ async def test_group_chat_output_participants_designates_terminal_participants()
         participants=[alpha, beta],
         max_rounds=2,
         selection_func=_two_step_selector(),
-        output_participants=[alpha, "beta"],
+        final_output_from=[alpha, "beta"],
     ).build()
 
     output_executors: set[str] = set()
@@ -383,7 +383,7 @@ async def test_group_chat_output_participants_designates_terminal_participants()
 
 
 @pytest.mark.asyncio
-async def test_group_chat_intermediate_participants_surface_as_intermediate() -> None:
+async def test_group_chat_intermediate_output_from_surface_as_intermediate() -> None:
     alpha = _EchoAgent(name="alpha")
     beta = _EchoAgent(name="beta")
 
@@ -391,7 +391,7 @@ async def test_group_chat_intermediate_participants_surface_as_intermediate() ->
         participants=[alpha, beta],
         max_rounds=2,
         selection_func=_two_step_selector(),
-        intermediate_participants=["alpha", beta],
+        intermediate_output_from=["alpha", beta],
     ).build()
 
     output_executors: set[str] = set()
@@ -453,7 +453,7 @@ def test_handoff_builder_designates_every_participant_as_output() -> None:
     assert "beta" in designated, f"beta must be designated; got {designated}"
 
 
-def test_handoff_builder_output_participants_can_select_terminal_participants() -> None:
+def test_handoff_builder_final_output_from_can_select_terminal_participants() -> None:
     from agent_framework import Agent
     from agent_framework._clients import BaseChatClient
     from agent_framework._middleware import ChatMiddlewareLayer
@@ -481,7 +481,7 @@ def test_handoff_builder_output_participants_can_select_terminal_participants() 
         require_per_service_call_history_persistence=True,
     )
 
-    workflow = HandoffBuilder(participants=[alpha, beta], output_participants=["alpha"]).with_start_agent(alpha).build()
+    workflow = HandoffBuilder(participants=[alpha, beta], final_output_from=["alpha"]).with_start_agent(alpha).build()
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"alpha"}
 
@@ -538,22 +538,22 @@ def test_magentic_builder_default_only_manager_designated() -> None:
     assert "alpha" not in designated, f"participant must not be designated by default; got {designated}"
 
 
-def test_magentic_builder_output_participants_designates_terminal_participants() -> None:
-    """Magentic output_participants designates workers alongside the orchestrator."""
+def test_magentic_builder_final_output_from_designates_terminal_participants() -> None:
+    """Magentic final_output_from designates workers alongside the orchestrator."""
     manager = _StubMagenticManager()
     alpha = _EchoAgent(name="alpha")
 
-    workflow = MagenticBuilder(participants=[alpha], manager=manager, output_participants=["alpha"]).build()
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, final_output_from=["alpha"]).build()
 
     designated = {ex.id for ex in workflow.get_output_executors()}
     assert {"magentic_orchestrator", "alpha"}.issubset(designated)
 
 
-def test_magentic_builder_intermediate_participants_designates_intermediate_workers() -> None:
+def test_magentic_builder_intermediate_output_from_designates_intermediate_workers() -> None:
     manager = _StubMagenticManager()
     alpha = _EchoAgent(name="alpha")
 
-    workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_participants=[alpha]).build()
+    workflow = MagenticBuilder(participants=[alpha], manager=manager, intermediate_output_from=[alpha]).build()
 
     assert {ex.id for ex in workflow.get_output_executors()} == {"magentic_orchestrator"}
     assert {ex.id for ex in workflow.get_intermediate_executors()} == {"alpha"}
@@ -628,10 +628,10 @@ def _build_handoff_with_designation(**kwargs: Any) -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"output_participants": [], "intermediate_participants": []}, "cannot both be empty"),
-        ({"output_participants": ["alpha", "alpha"]}, "Duplicate output participant"),
-        ({"output_participants": ["alpha"], "intermediate_participants": ["alpha"]}, "cannot be both output"),
-        ({"output_participants": ["missing"]}, "Unknown output participant"),
+        ({"final_output_from": [], "intermediate_output_from": []}, "cannot both be empty"),
+        ({"final_output_from": ["alpha", "alpha"]}, "Duplicate output participant"),
+        ({"final_output_from": ["alpha"], "intermediate_output_from": ["alpha"]}, "cannot be both output"),
+        ({"final_output_from": ["missing"]}, "Unknown output participant"),
     ],
 )
 def test_participant_output_config_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:

--- a/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
+++ b/python/packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py
@@ -634,6 +634,6 @@ def _build_handoff_with_designation(**kwargs: Any) -> None:
         ({"output_participants": ["missing"]}, "Unknown output participant"),
     ],
 )
-def test_participant_designation_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:
+def test_participant_output_config_validation(build: Callable[..., None], kwargs: dict[str, Any], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         build(**kwargs)

--- a/python/samples/03-workflows/README.md
+++ b/python/samples/03-workflows/README.md
@@ -89,6 +89,7 @@ Write workflows as plain Python async functions — no graph concepts, no execut
 | Multi-Selection Edge Group | [control-flow/multi_selection_edge_group.py](./control-flow/multi_selection_edge_group.py) | Select one or many targets dynamically (subset fan-out) |
 | Simple Loop                | [control-flow/simple_loop.py](./control-flow/simple_loop.py)                               | Feedback loop where an agent judges ABOVE/BELOW/MATCHED |
 | Workflow Cancellation      | [control-flow/workflow_cancellation.py](./control-flow/workflow_cancellation.py)           | Cancel a running workflow using asyncio tasks           |
+| Intermediate vs Terminal Outputs | [control-flow/intermediate_vs_terminal_outputs.py](./control-flow/intermediate_vs_terminal_outputs.py) | Designate output executors so non-designated yields surface as `type='intermediate'` events (and `text_reasoning` content via `as_agent`) |
 
 ### human-in-the-loop
 

--- a/python/samples/03-workflows/README.md
+++ b/python/samples/03-workflows/README.md
@@ -149,9 +149,8 @@ Invalid selections fail at construction or build time:
 | Unknown executor selections | Typos and missing participants are rejected |
 | `output_from=[], intermediate_output_from=[]` | Both explicit selections are empty |
 
-Legacy aliases `final_output_from`, `output_executors`, and `intermediate_executors` remain compatibility-only and emit
-deprecation warnings where supported. New samples and applications should use `output_from` and
-`intermediate_output_from`.
+Compatibility aliases such as `output_executors` emit deprecation warnings where supported. New samples and
+applications should use `output_from` and `intermediate_output_from`.
 
 When a workflow is wrapped with `workflow.as_agent()`, Workflow Output becomes normal agent text content. Intermediate
 Output becomes `text_reasoning` content, so `AgentResponse.text` remains focused on the caller-facing answer while

--- a/python/samples/03-workflows/README.md
+++ b/python/samples/03-workflows/README.md
@@ -89,7 +89,7 @@ Write workflows as plain Python async functions — no graph concepts, no execut
 | Multi-Selection Edge Group | [control-flow/multi_selection_edge_group.py](./control-flow/multi_selection_edge_group.py) | Select one or many targets dynamically (subset fan-out) |
 | Simple Loop                | [control-flow/simple_loop.py](./control-flow/simple_loop.py)                               | Feedback loop where an agent judges ABOVE/BELOW/MATCHED |
 | Workflow Cancellation      | [control-flow/workflow_cancellation.py](./control-flow/workflow_cancellation.py)           | Cancel a running workflow using asyncio tasks           |
-| Intermediate vs Terminal Outputs | [control-flow/intermediate_vs_terminal_outputs.py](./control-flow/intermediate_vs_terminal_outputs.py) | Designate output executors so non-designated yields surface as `type='intermediate'` events (and `text_reasoning` content via `as_agent`) |
+| Intermediate vs Terminal Outputs | [control-flow/intermediate_vs_terminal_outputs.py](./control-flow/intermediate_vs_terminal_outputs.py) | Designate terminal and intermediate executors; hide unlisted yields; map intermediate workflow events to `text_reasoning` content via `as_agent` |
 
 ### human-in-the-loop
 
@@ -118,6 +118,22 @@ For additional observability samples in Agent Framework, see the [observability 
 
 Orchestration-focused samples (Sequential, Concurrent, Handoff, GroupChat, Magentic), including builder-based
 `workflow.as_agent(...)` variants, are documented in the [orchestrations](./orchestrations/README.md) directory.
+
+### output designation
+
+Workflow output designation controls which `ctx.yield_output(...)` calls are visible to callers:
+
+- Compatibility mode applies when neither `output_executors` nor `intermediate_executors` is provided. Every
+  executor yield is emitted as a terminal `type='output'` event.
+- Explicit designation mode applies when either list is provided. `output_executors` emit terminal `output`
+  events, `intermediate_executors` emit visible `intermediate` events, and unlisted executor yields are hidden from
+  caller-facing output accessors and streams.
+- Validation rejects empty explicit designation, duplicate executors, overlap between output and intermediate
+  executors, unknown executors, and designated executors that do not yield workflow output.
+
+When a workflow is wrapped with `workflow.as_agent()`, terminal workflow output becomes normal agent text content.
+Intermediate workflow output becomes `text_reasoning` content, so `AgentResponse.text` remains focused on the final
+answer while callers can still inspect progress or supporting work from the response messages.
 
 ### parallelism
 

--- a/python/samples/03-workflows/README.md
+++ b/python/samples/03-workflows/README.md
@@ -123,12 +123,12 @@ Orchestration-focused samples (Sequential, Concurrent, Handoff, GroupChat, Magen
 
 Workflow output designation controls which `ctx.yield_output(...)` calls are visible to callers:
 
-- Compatibility mode applies when neither `output_executors` nor `intermediate_executors` is provided. Every
+- Compatibility mode applies when neither `final_output_from` nor `intermediate_output_from` is provided. Every
   executor yield is emitted as a terminal `type='output'` event.
-- Explicit designation mode applies when either list is provided. `output_executors` emit terminal `output`
-  events, `intermediate_executors` emit visible `intermediate` events, and unlisted executor yields are hidden from
-  caller-facing output accessors and streams.
-- Validation rejects empty explicit designation, duplicate executors, overlap between output and intermediate
+- Explicit designation mode applies when either list is provided. Executors in `final_output_from` emit terminal
+  `output` events, executors in `intermediate_output_from` emit visible `intermediate` events, and unlisted executor
+  yields are hidden from caller-facing output accessors and streams.
+- Validation rejects empty explicit designation, duplicate executors, overlap between final-output and intermediate
   executors, unknown executors, and designated executors that do not yield workflow output.
 
 When a workflow is wrapped with `workflow.as_agent()`, terminal workflow output becomes normal agent text content.

--- a/python/samples/03-workflows/README.md
+++ b/python/samples/03-workflows/README.md
@@ -89,7 +89,7 @@ Write workflows as plain Python async functions — no graph concepts, no execut
 | Multi-Selection Edge Group | [control-flow/multi_selection_edge_group.py](./control-flow/multi_selection_edge_group.py) | Select one or many targets dynamically (subset fan-out) |
 | Simple Loop                | [control-flow/simple_loop.py](./control-flow/simple_loop.py)                               | Feedback loop where an agent judges ABOVE/BELOW/MATCHED |
 | Workflow Cancellation      | [control-flow/workflow_cancellation.py](./control-flow/workflow_cancellation.py)           | Cancel a running workflow using asyncio tasks           |
-| Intermediate vs Terminal Outputs | [control-flow/intermediate_vs_terminal_outputs.py](./control-flow/intermediate_vs_terminal_outputs.py) | Designate terminal and intermediate executors; hide unlisted yields; map intermediate workflow events to `text_reasoning` content via `as_agent` |
+| Workflow and Intermediate Outputs | [control-flow/intermediate_vs_terminal_outputs.py](./control-flow/intermediate_vs_terminal_outputs.py) | Select Workflow Output and Intermediate Output executors; hide unselected yields; map Intermediate Output events to `text_reasoning` content via `as_agent` |
 
 ### human-in-the-loop
 
@@ -119,21 +119,43 @@ For additional observability samples in Agent Framework, see the [observability 
 Orchestration-focused samples (Sequential, Concurrent, Handoff, GroupChat, Magentic), including builder-based
 `workflow.as_agent(...)` variants, are documented in the [orchestrations](./orchestrations/README.md) directory.
 
-### output designation
+### output selection
 
-Workflow output designation controls which `ctx.yield_output(...)` calls are visible to callers:
+Workflow Output selection controls which `ctx.yield_output(...)` calls are visible to callers as `type='output'`
+events and through `WorkflowRunResult.get_outputs()`. The core rule is that `output_from` is an allow-list for
+Workflow Output, not a routing rule for every other executor output. Unselected executor payloads are hidden unless
+`intermediate_output_from` explicitly selects them as Intermediate Output.
 
-- Compatibility mode applies when neither `final_output_from` nor `intermediate_output_from` is provided. Every
-  executor yield is emitted as a terminal `type='output'` event.
-- Explicit designation mode applies when either list is provided. Executors in `final_output_from` emit terminal
-  `output` events, executors in `intermediate_output_from` emit visible `intermediate` events, and unlisted executor
-  yields are hidden from caller-facing output accessors and streams.
-- Validation rejects empty explicit designation, duplicate executors, overlap between final-output and intermediate
-  executors, unknown executors, and designated executors that do not yield workflow output.
+Use `output_from` and `intermediate_output_from` as the canonical API:
 
-When a workflow is wrapped with `workflow.as_agent()`, terminal workflow output becomes normal agent text content.
-Intermediate workflow output becomes `text_reasoning` content, so `AgentResponse.text` remains focused on the final
-answer while callers can still inspect progress or supporting work from the response messages.
+| Selection | Workflow Output | Intermediate Output | Hidden payloads |
+| --- | --- | --- | --- |
+| Omit both selections | Every executor `yield_output`; emits a deprecation warning | None | None |
+| `output_from="all"` | Every executor `yield_output`; no warning | None | None |
+| `output_from=[answerer]` | Only `answerer` | None | All other executor payloads |
+| `output_from=[answerer], intermediate_output_from="all_other"` | Only `answerer` | Every output-capable executor not selected by `output_from` | None |
+| `intermediate_output_from="all_other"` | None | Every output-capable executor | None |
+| `output_from=[], intermediate_output_from="all_other"` | None | Every output-capable executor | None |
+| `output_from=[answerer], intermediate_output_from=[planner, researcher]` | Only `answerer` | `planner` and `researcher` | Any other executor payloads |
+
+Invalid selections fail at construction or build time:
+
+| Invalid selection | Why it fails |
+| --- | --- |
+| `output_from="all_other"` | `"all_other"` is only valid for `intermediate_output_from` |
+| `intermediate_output_from="all"` | `"all"` is only valid for `output_from` |
+| The same executor in both selections | One payload cannot be both Workflow Output and Intermediate Output |
+| Duplicate executor selections | Duplicates are treated as configuration errors |
+| Unknown executor selections | Typos and missing participants are rejected |
+| `output_from=[], intermediate_output_from=[]` | Both explicit selections are empty |
+
+Legacy aliases `final_output_from`, `output_executors`, and `intermediate_executors` remain compatibility-only and emit
+deprecation warnings where supported. New samples and applications should use `output_from` and
+`intermediate_output_from`.
+
+When a workflow is wrapped with `workflow.as_agent()`, Workflow Output becomes normal agent text content. Intermediate
+Output becomes `text_reasoning` content, so `AgentResponse.text` remains focused on the caller-facing answer while
+callers can still inspect progress or supporting work from the response messages.
 
 ### parallelism
 
@@ -191,7 +213,7 @@ Sequential orchestration uses a few small adapter nodes for plumbing:
 
 - "input-conversation" normalizes input to `list[Message]`
 - "to-conversation:<participant>" converts agent responses into the shared conversation
-- "complete" publishes the final output event (type='output')
+- "complete" publishes the Workflow Output event (`type='output'`)
   These may appear in event streams (executor_invoked/executor_completed). They're analogous to
   concurrent’s dispatcher and aggregator and can be ignored if you only care about agent activity.
 

--- a/python/samples/03-workflows/agents/group_chat_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/group_chat_workflow_as_agent.py
@@ -54,11 +54,11 @@ async def main() -> None:
         credential=AzureCliCredential(),
     )
 
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so workflow.as_agent() maps
+    # them to text_reasoning content while the final answer remains normal text.
     workflow = GroupChatBuilder(
         participants=[researcher, writer],
-        intermediate_outputs=True,
+        intermediate_participants=[researcher, writer],
         orchestrator_agent=Agent(
             client=_orch_client,
             name="Orchestrator",

--- a/python/samples/03-workflows/agents/group_chat_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/group_chat_workflow_as_agent.py
@@ -58,7 +58,7 @@ async def main() -> None:
     # them to text_reasoning content while the final answer remains normal text.
     workflow = GroupChatBuilder(
         participants=[researcher, writer],
-        intermediate_participants=[researcher, writer],
+        intermediate_output_from=[researcher, writer],
         orchestrator_agent=Agent(
             client=_orch_client,
             name="Orchestrator",

--- a/python/samples/03-workflows/agents/magentic_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/magentic_workflow_as_agent.py
@@ -76,7 +76,7 @@ async def main() -> None:
     # them to text_reasoning content while the final answer remains normal text.
     workflow = MagenticBuilder(
         participants=[researcher_agent, coder_agent],
-        intermediate_participants=[researcher_agent, coder_agent],
+        intermediate_output_from=[researcher_agent, coder_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=3,

--- a/python/samples/03-workflows/agents/magentic_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/magentic_workflow_as_agent.py
@@ -72,11 +72,11 @@ async def main() -> None:
 
     print("\nBuilding Magentic Workflow...")
 
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so workflow.as_agent() maps
+    # them to text_reasoning content while the final answer remains normal text.
     workflow = MagenticBuilder(
         participants=[researcher_agent, coder_agent],
-        intermediate_outputs=True,
+        intermediate_participants=[researcher_agent, coder_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=3,

--- a/python/samples/03-workflows/agents/sequential_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/sequential_workflow_as_agent.py
@@ -78,7 +78,7 @@ async def main() -> None:
     Note:
     `workflow.as_agent()` returns ONLY the final agent's response (the "answer") — the prior agents' work
     is not included in the response. To preserve earlier participant replies while running as an agent, build with
-    `SequentialBuilder(participants=[...], intermediate_participants=[writer])`; intermediate workflow events become
+    `SequentialBuilder(participants=[...], intermediate_output_from=[writer])`; intermediate workflow events become
     `text_reasoning` content on the AgentResponse, while `.text` remains terminal-output only.
     """
 

--- a/python/samples/03-workflows/agents/sequential_workflow_as_agent.py
+++ b/python/samples/03-workflows/agents/sequential_workflow_as_agent.py
@@ -77,9 +77,9 @@ async def main() -> None:
 
     Note:
     `workflow.as_agent()` returns ONLY the final agent's response (the "answer") — the prior agents' work
-    is not included in the response. To observe intermediate agents while running as an agent, build with
-    `SequentialBuilder(participants=[...], intermediate_outputs=True)`; the intermediate replies are then
-    surfaced as `data` events and merged into the AgentResponse.
+    is not included in the response. To preserve earlier participant replies while running as an agent, build with
+    `SequentialBuilder(participants=[...], intermediate_participants=[writer])`; intermediate workflow events become
+    `text_reasoning` content on the AgentResponse, while `.text` remains terminal-output only.
     """
 
 

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+
+from agent_framework import (
+    Message,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+)
+from typing_extensions import Never
+
+"""
+Sample: Intermediate vs terminal output labeling
+
+What this sample shows
+- How ``WorkflowBuilder(output_executors=[...])`` designates which executors emit
+  the workflow's terminal output.
+- How yields from non-designated executors automatically surface as
+  ``type='intermediate'`` events, while yields from designated executors surface
+  as ``type='output'``.
+- How the same workflow wrapped via ``workflow.as_agent()`` translates intermediate
+  events to ``text_reasoning`` content so existing ``.text`` accessors keep
+  returning terminal-only output.
+
+The contract on ``output_executors``:
+- ``None`` (default, legacy): every ``yield_output`` produces ``type='output'``.
+  Emits a ``DeprecationWarning`` at build() time recommending explicit designation.
+- ``[]`` (explicit empty list): strict mode, no terminals. Every yield is
+  ``type='intermediate'``; ``WorkflowRunResult.get_outputs()`` returns ``[]``.
+- ``[X, ...]`` (explicit list): strict mode. Yields from designated executors
+  produce ``type='output'``; all other yields produce ``type='intermediate'``.
+
+Prerequisites
+- No external services required.
+"""
+
+
+@executor(id="planner")
+async def planner(messages: list[Message], ctx: WorkflowContext[list[Message], str]) -> None:
+    """Non-designated step: emits an intermediate progress note, then forwards."""
+    prompt = messages[0].text if messages else ""
+    await ctx.yield_output(f"plan: starting work on '{prompt}'")
+    await ctx.send_message(messages)
+
+
+@executor(id="researcher")
+async def researcher(messages: list[Message], ctx: WorkflowContext[list[Message], str]) -> None:
+    """Non-designated step: emits intermediate progress, then forwards."""
+    prompt = messages[0].text if messages else ""
+    await ctx.yield_output(f"research: gathering data for '{prompt}'")
+    await ctx.send_message(messages)
+
+
+@executor(id="answerer")
+async def answerer(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
+    """Designated terminal: emits the workflow's final answer."""
+    prompt = messages[0].text if messages else ""
+    await ctx.yield_output(f"final answer to '{prompt}': 42")
+
+
+async def main() -> None:
+    # Build with explicit output_executors=[answerer]. Only `answerer` yields
+    # produce type='output' events; planner and researcher emit type='intermediate'.
+    workflow = (
+        WorkflowBuilder(start_executor=planner, output_executors=[answerer])
+        .add_edge(planner, researcher)
+        .add_edge(researcher, answerer)
+        .build()
+    )
+
+    initial = [Message(role="user", contents=["life, the universe, and everything"])]
+
+    print("=== Streaming events (workflow.run(stream=True)) ===")
+    async for event in workflow.run(initial, stream=True):
+        if event.type == "intermediate":
+            print(f"  [intermediate] {event.executor_id}: {event.data}")
+        elif event.type == "output":
+            print(f"  [output]       {event.executor_id}: {event.data}")
+
+    # WorkflowRunResult.get_outputs() filters to type='output' events, so it
+    # only returns the designated terminal yield.
+    print("\n=== Non-streaming run().get_outputs() ===")
+    result = await workflow.run(initial)
+    print(f"  outputs: {result.get_outputs()}")
+
+    # When the same workflow is wrapped via as_agent(), intermediate events
+    # surface as ``text_reasoning`` content; the terminal event surfaces as
+    # ``text`` content. Existing callers reading ``response.text`` get only
+    # the terminal answer because ``.text`` filters to text content.
+    print("\n=== workflow.as_agent() — intermediate → text_reasoning content ===")
+    agent = workflow.as_agent("planner-agent")
+    response = await agent.run("life, the universe, and everything")
+    print(f"  response.text (terminal only): {response.text!r}")
+    reasoning = " | ".join(
+        c.text for m in response.messages for c in m.contents if c.type == "text_reasoning"
+    )
+    print(f"  reasoning content (intermediates): {reasoning!r}")
+
+    """
+    Sample output:
+
+    === Streaming events (workflow.run(stream=True)) ===
+      [intermediate] planner: plan: starting work on 'life, the universe, and everything'
+      [intermediate] researcher: research: gathering data for 'life, the universe, and everything'
+      [output]       answerer: final answer to 'life, the universe, and everything': 42
+
+    === Non-streaming run().get_outputs() ===
+      outputs: ["final answer to 'life, the universe, and everything': 42"]
+
+    === workflow.as_agent() — intermediate → text_reasoning content ===
+      response.text (terminal only): "final answer to 'life, the universe, and everything': 42"
+      reasoning content (intermediates): "plan: starting work on ... | research: gathering data for ..."
+    """
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -16,20 +16,25 @@ Sample: Intermediate vs terminal output labeling
 What this sample shows
 - How ``WorkflowBuilder(output_executors=[...])`` designates which executors emit
   the workflow's terminal output.
-- How yields from non-designated executors automatically surface as
-  ``type='intermediate'`` events, while yields from designated executors surface
-  as ``type='output'``.
+- How ``WorkflowBuilder(intermediate_executors=[...])`` designates which executor
+  yields surface as ``type='intermediate'`` events.
+- How unlisted executor yields are hidden from caller-facing output/intermediate
+  events in explicit designation mode.
 - How the same workflow wrapped via ``workflow.as_agent()`` translates intermediate
   events to ``text_reasoning`` content so existing ``.text`` accessors keep
   returning terminal-only output.
 
-The contract on ``output_executors``:
-- ``None`` (default, legacy): every ``yield_output`` produces ``type='output'``.
-  Emits a ``DeprecationWarning`` at build() time recommending explicit designation.
-- ``[]`` (explicit empty list): strict mode, no terminals. Every yield is
-  ``type='intermediate'``; ``WorkflowRunResult.get_outputs()`` returns ``[]``.
-- ``[X, ...]`` (explicit list): strict mode. Yields from designated executors
-  produce ``type='output'``; all other yields produce ``type='intermediate'``.
+The output designation contract:
+- Compatibility mode: when neither ``output_executors`` nor ``intermediate_executors``
+  is provided, every ``yield_output`` produces ``type='output'``.
+- Explicit designation mode: provide either ``output_executors`` or
+  ``intermediate_executors``. Designated output executors emit terminal
+  ``type='output'`` events; designated intermediate executors emit
+  ``type='intermediate'`` events; unlisted executor yields are hidden from the
+  stream and ``WorkflowRunResult`` output accessors.
+- Validation: explicit designation must not be empty, duplicate executor entries
+  are rejected, an executor cannot be both output and intermediate, unknown
+  executors are rejected, and designated executors must yield workflow output.
 
 Prerequisites
 - No external services required.
@@ -38,7 +43,7 @@ Prerequisites
 
 @executor(id="planner")
 async def planner(messages: list[Message], ctx: WorkflowContext[list[Message], str]) -> None:
-    """Non-designated step: emits an intermediate progress note, then forwards."""
+    """Intermediate step: emits a visible progress note, then forwards."""
     prompt = messages[0].text if messages else ""
     await ctx.yield_output(f"plan: starting work on '{prompt}'")
     await ctx.send_message(messages)
@@ -46,7 +51,7 @@ async def planner(messages: list[Message], ctx: WorkflowContext[list[Message], s
 
 @executor(id="researcher")
 async def researcher(messages: list[Message], ctx: WorkflowContext[list[Message], str]) -> None:
-    """Non-designated step: emits intermediate progress, then forwards."""
+    """Intermediate step: emits visible progress, then forwards."""
     prompt = messages[0].text if messages else ""
     await ctx.yield_output(f"research: gathering data for '{prompt}'")
     await ctx.send_message(messages)
@@ -60,10 +65,15 @@ async def answerer(messages: list[Message], ctx: WorkflowContext[Never, str]) ->
 
 
 async def main() -> None:
-    # Build with explicit output_executors=[answerer]. Only `answerer` yields
-    # produce type='output' events; planner and researcher emit type='intermediate'.
+    # Build with explicit output and intermediate designations. `answerer`
+    # produces terminal type='output' events; planner and researcher produce
+    # visible type='intermediate' progress events.
     workflow = (
-        WorkflowBuilder(start_executor=planner, output_executors=[answerer])
+        WorkflowBuilder(
+            start_executor=planner,
+            output_executors=[answerer],
+            intermediate_executors=[planner, researcher],
+        )
         .add_edge(planner, researcher)
         .add_edge(researcher, answerer)
         .build()
@@ -92,9 +102,7 @@ async def main() -> None:
     agent = workflow.as_agent("planner-agent")
     response = await agent.run("life, the universe, and everything")
     print(f"  response.text (terminal only): {response.text!r}")
-    reasoning = " | ".join(
-        c.text for m in response.messages for c in m.contents if c.type == "text_reasoning"
-    )
+    reasoning = " | ".join(c.text for m in response.messages for c in m.contents if c.type == "text_reasoning")
     print(f"  reasoning content (intermediates): {reasoning!r}")
 
     """

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -14,9 +14,9 @@ from typing_extensions import Never
 Sample: Intermediate vs terminal output labeling
 
 What this sample shows
-- How ``WorkflowBuilder(output_executors=[...])`` designates which executors emit
+- How ``WorkflowBuilder(final_output_from=[...])`` designates which executors emit
   the workflow's terminal output.
-- How ``WorkflowBuilder(intermediate_executors=[...])`` designates which executor
+- How ``WorkflowBuilder(intermediate_output_from=[...])`` designates which executor
   yields surface as ``type='intermediate'`` events.
 - How unlisted executor yields are hidden from caller-facing output/intermediate
   events in explicit designation mode.
@@ -25,10 +25,10 @@ What this sample shows
   returning terminal-only output.
 
 The output designation contract:
-- Compatibility mode: when neither ``output_executors`` nor ``intermediate_executors``
+- Compatibility mode: when neither ``final_output_from`` nor ``intermediate_output_from``
   is provided, every ``yield_output`` produces ``type='output'``.
-- Explicit designation mode: provide either ``output_executors`` or
-  ``intermediate_executors``. Designated output executors emit terminal
+- Explicit designation mode: provide either ``final_output_from`` or
+  ``intermediate_output_from``. Designated output executors emit terminal
   ``type='output'`` events; designated intermediate executors emit
   ``type='intermediate'`` events; unlisted executor yields are hidden from the
   stream and ``WorkflowRunResult`` output accessors.
@@ -71,8 +71,8 @@ async def main() -> None:
     workflow = (
         WorkflowBuilder(
             start_executor=planner,
-            output_executors=[answerer],
-            intermediate_executors=[planner, researcher],
+            final_output_from=[answerer],
+            intermediate_output_from=[planner, researcher],
         )
         .add_edge(planner, researcher)
         .add_edge(researcher, answerer)

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -12,33 +12,34 @@ from agent_framework import (
 from typing_extensions import Never
 
 """
-Sample: Intermediate vs terminal output labeling
+Sample: Workflow Output vs Intermediate Output labeling
 
 What this sample shows
-- How ``WorkflowBuilder(final_output_from=[...])`` designates which executors emit
-  the workflow's terminal output.
+- How ``WorkflowBuilder(output_from=[...])`` designates which executors emit
+  Workflow Output.
 - How ``WorkflowBuilder(intermediate_output_from=[...])`` designates which executor
-  yields surface as ``type='intermediate'`` events.
+  yields surface as Intermediate Output (``type='intermediate'`` events).
 - How unlisted executor yields are hidden from caller-facing output/intermediate
   events in explicit designation mode.
 - How the same workflow wrapped via ``workflow.as_agent()`` translates intermediate
   events to ``text_reasoning`` content so existing ``.text`` accessors keep
-  returning terminal-only output.
+  returning Workflow Output only.
 - How a sub-workflow embedded via ``WorkflowExecutor`` bubbles its intermediate
   emissions up through the parent's event stream, attributed to the
   ``WorkflowExecutor`` id rather than the child's internal executor ids.
 
-The output designation contract:
-- Compatibility mode: when neither ``final_output_from`` nor ``intermediate_output_from``
-  is provided, every ``yield_output`` produces ``type='output'``.
-- Explicit designation mode: provide either ``final_output_from`` or
-  ``intermediate_output_from``. Designated output executors emit terminal
-  ``type='output'`` events; designated intermediate executors emit
-  ``type='intermediate'`` events; unlisted executor yields are hidden from the
-  stream and ``WorkflowRunResult`` output accessors.
-- Validation: explicit designation must not be empty, duplicate executor entries
-  are rejected, an executor cannot be both output and intermediate, unknown
-  executors are rejected, and designated executors must yield workflow output.
+The output selection contract:
+- Compatibility mode: when neither ``output_from`` nor ``intermediate_output_from``
+  is provided, every ``yield_output`` produces Workflow Output and a deprecation
+  warning points to explicit selection.
+- Explicit selection mode: provide either ``output_from`` or
+  ``intermediate_output_from``. Executors selected by ``output_from`` emit Workflow Output
+  (``type='output'`` events); executors selected by ``intermediate_output_from`` emit
+  Intermediate Output (``type='intermediate'`` events); unselected executor yields are
+  hidden from the stream and ``WorkflowRunResult`` output accessors.
+- Validation: explicit selections must not both be empty; duplicate executor entries,
+  overlap between Workflow Output and Intermediate Output, unknown executors, invalid
+  literals, and selected executors without workflow output types are rejected.
 
 Prerequisites
 - No external services required.
@@ -63,19 +64,19 @@ async def researcher(messages: list[Message], ctx: WorkflowContext[list[Message]
 
 @executor(id="answerer")
 async def answerer(messages: list[Message], ctx: WorkflowContext[Never, str]) -> None:
-    """Designated terminal: emits the workflow's final answer."""
+    """Designated Workflow Output: emits the workflow's answer."""
     prompt = messages[0].text if messages else ""
     await ctx.yield_output(f"final answer to '{prompt}': 42")
 
 
 async def main() -> None:
-    # Build with explicit output and intermediate designations. `answerer`
-    # produces terminal type='output' events; planner and researcher produce
-    # visible type='intermediate' progress events.
+    # Build with explicit Workflow Output and Intermediate Output selections.
+    # `answerer` produces type='output' events; planner and researcher produce
+    # visible type='intermediate' events.
     workflow = (
         WorkflowBuilder(
             start_executor=planner,
-            final_output_from=[answerer],
+            output_from=[answerer],
             intermediate_output_from=[planner, researcher],
         )
         .add_edge(planner, researcher)
@@ -93,19 +94,19 @@ async def main() -> None:
             print(f"  [output]       {event.executor_id}: {event.data}")
 
     # WorkflowRunResult.get_outputs() filters to type='output' events, so it
-    # only returns the designated terminal yield.
+    # only returns the selected Workflow Output yield.
     print("\n=== Non-streaming run().get_outputs() ===")
     result = await workflow.run(initial)
     print(f"  outputs: {result.get_outputs()}")
 
     # When the same workflow is wrapped via as_agent(), intermediate events
-    # surface as ``text_reasoning`` content; the terminal event surfaces as
+    # surface as ``text_reasoning`` content; Workflow Output surfaces as
     # ``text`` content. Existing callers reading ``response.text`` get only
-    # the terminal answer because ``.text`` filters to text content.
+    # the selected Workflow Output because ``.text`` filters to text content.
     print("\n=== workflow.as_agent() -- intermediate -> text_reasoning content ===")
     agent = workflow.as_agent("planner-agent")
     response = await agent.run("life, the universe, and everything")
-    print(f"  response.text (terminal only): {response.text!r}")
+    print(f"  response.text (Workflow Output only): {response.text!r}")
     reasoning = " | ".join(c.text for m in response.messages for c in m.contents if c.type == "text_reasoning")
     print(f"  reasoning content (intermediates): {reasoning!r}")
 
@@ -122,7 +123,7 @@ async def main() -> None:
         await ctx.yield_output(message)
 
     parent_workflow = (
-        WorkflowBuilder(start_executor=sub, final_output_from=[parent_sink])
+        WorkflowBuilder(start_executor=sub, output_from=[parent_sink])
         .add_edge(sub, parent_sink)
         .build()
     )
@@ -145,7 +146,7 @@ async def main() -> None:
       outputs: ["final answer to 'life, the universe, and everything': 42"]
 
     === workflow.as_agent() -- intermediate -> text_reasoning content ===
-      response.text (terminal only): "final answer to 'life, the universe, and everything': 42"
+      response.text (Workflow Output only): "final answer to 'life, the universe, and everything': 42"
       reasoning content (intermediates): "plan: starting work on ... | research: gathering data for ..."
 
     === Embedding as a sub-workflow -- intermediates bubble up ===

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -6,6 +6,7 @@ from agent_framework import (
     Message,
     WorkflowBuilder,
     WorkflowContext,
+    WorkflowExecutor,
     executor,
 )
 from typing_extensions import Never
@@ -23,6 +24,9 @@ What this sample shows
 - How the same workflow wrapped via ``workflow.as_agent()`` translates intermediate
   events to ``text_reasoning`` content so existing ``.text`` accessors keep
   returning terminal-only output.
+- How a sub-workflow embedded via ``WorkflowExecutor`` bubbles its intermediate
+  emissions up through the parent's event stream, attributed to the
+  ``WorkflowExecutor`` id rather than the child's internal executor ids.
 
 The output designation contract:
 - Compatibility mode: when neither ``final_output_from`` nor ``intermediate_output_from``
@@ -98,12 +102,36 @@ async def main() -> None:
     # surface as ``text_reasoning`` content; the terminal event surfaces as
     # ``text`` content. Existing callers reading ``response.text`` get only
     # the terminal answer because ``.text`` filters to text content.
-    print("\n=== workflow.as_agent() — intermediate → text_reasoning content ===")
+    print("\n=== workflow.as_agent() -- intermediate -> text_reasoning content ===")
     agent = workflow.as_agent("planner-agent")
     response = await agent.run("life, the universe, and everything")
     print(f"  response.text (terminal only): {response.text!r}")
     reasoning = " | ".join(c.text for m in response.messages for c in m.contents if c.type == "text_reasoning")
     print(f"  reasoning content (intermediates): {reasoning!r}")
+
+    # Embed the same workflow as a node inside a larger workflow via WorkflowExecutor.
+    # Child intermediate emissions are forwarded to the parent's event stream with the
+    # WorkflowExecutor's id as the source, so outer callers don't have to know the
+    # child's internal executor layout. The 'intermediate' label is preserved across
+    # the boundary regardless of how the parent designates the WorkflowExecutor.
+    print("\n=== Embedding as a sub-workflow -- intermediates bubble up ===")
+    sub = WorkflowExecutor(workflow, id="sub")
+
+    @executor(id="parent_sink")
+    async def parent_sink(message: str, ctx: WorkflowContext[Never, str]) -> None:
+        await ctx.yield_output(message)
+
+    parent_workflow = (
+        WorkflowBuilder(start_executor=sub, final_output_from=[parent_sink])
+        .add_edge(sub, parent_sink)
+        .build()
+    )
+
+    async for event in parent_workflow.run(initial, stream=True):
+        if event.type == "intermediate":
+            print(f"  [intermediate] {event.executor_id}: {event.data}")
+        elif event.type == "output":
+            print(f"  [output]       {event.executor_id}: {event.data}")
 
     """
     Sample output:
@@ -116,9 +144,14 @@ async def main() -> None:
     === Non-streaming run().get_outputs() ===
       outputs: ["final answer to 'life, the universe, and everything': 42"]
 
-    === workflow.as_agent() — intermediate → text_reasoning content ===
+    === workflow.as_agent() -- intermediate -> text_reasoning content ===
       response.text (terminal only): "final answer to 'life, the universe, and everything': 42"
       reasoning content (intermediates): "plan: starting work on ... | research: gathering data for ..."
+
+    === Embedding as a sub-workflow -- intermediates bubble up ===
+      [intermediate] sub: plan: starting work on 'life, the universe, and everything'
+      [intermediate] sub: research: gathering data for 'life, the universe, and everything'
+      [output]       parent_sink: final answer to 'life, the universe, and everything': 42
     """
 
 

--- a/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
+++ b/python/samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py
@@ -122,11 +122,7 @@ async def main() -> None:
     async def parent_sink(message: str, ctx: WorkflowContext[Never, str]) -> None:
         await ctx.yield_output(message)
 
-    parent_workflow = (
-        WorkflowBuilder(start_executor=sub, output_from=[parent_sink])
-        .add_edge(sub, parent_sink)
-        .build()
-    )
+    parent_workflow = WorkflowBuilder(start_executor=sub, output_from=[parent_sink]).add_edge(sub, parent_sink).build()
 
     async for event in parent_workflow.run(initial, stream=True):
         if event.type == "intermediate":

--- a/python/samples/03-workflows/human-in-the-loop/agents_with_approval_requests.py
+++ b/python/samples/03-workflows/human-in-the-loop/agents_with_approval_requests.py
@@ -248,7 +248,7 @@ async def main() -> None:
 
     # Build the workflow
     workflow = (
-        WorkflowBuilder(start_executor=email_processor, final_output_from=[conclude_workflow])
+        WorkflowBuilder(start_executor=email_processor, output_from=[conclude_workflow])
         .add_edge(email_processor, email_writer_agent)
         .add_edge(email_writer_agent, conclude_workflow)
         .build()

--- a/python/samples/03-workflows/human-in-the-loop/agents_with_approval_requests.py
+++ b/python/samples/03-workflows/human-in-the-loop/agents_with_approval_requests.py
@@ -248,7 +248,7 @@ async def main() -> None:
 
     # Build the workflow
     workflow = (
-        WorkflowBuilder(start_executor=email_processor, output_executors=[conclude_workflow])
+        WorkflowBuilder(start_executor=email_processor, final_output_from=[conclude_workflow])
         .add_edge(email_processor, email_writer_agent)
         .add_edge(email_writer_agent, conclude_workflow)
         .build()

--- a/python/samples/03-workflows/orchestrations/README.md
+++ b/python/samples/03-workflows/orchestrations/README.md
@@ -81,6 +81,21 @@ from agent_framework.orchestrations import (
 
 ## Tips
 
+**Participant output designation**: Orchestration builders use participant-oriented names for workflow output
+selection. Use `output_participants=[...]` when participant responses should be terminal `output` events, and
+`intermediate_participants=[...]` when participant responses should be visible progress events. In explicit
+designation mode, unlisted participant responses are hidden from caller-facing output streams. Builders validate
+empty explicit designation, duplicate participants, overlap between output and intermediate participants, and unknown
+participant names.
+
+By default, Sequential keeps the final participant terminal. Concurrent, GroupChat, and Magentic keep their synthetic
+aggregator/orchestrator/manager final executors terminal, while participant responses stay hidden unless designated.
+Handoff keeps participants terminal by default.
+
+When an orchestration workflow is exposed via `workflow.as_agent()`, terminal workflow outputs become normal text
+content in the `AgentResponse`; intermediate participant outputs become `text_reasoning` content. This preserves the
+final answer in `.text` while making designated progress available for callers that inspect message contents.
+
 **Magentic checkpointing tip**: Treat `MagenticBuilder.participants` keys as stable identifiers. When resuming from a checkpoint, the rebuilt workflow must reuse the same participant names; otherwise the checkpoint cannot be applied and the run will fail fast.
 
 **Handoff workflow tip**: Handoff workflows maintain the full conversation history including any `Message.additional_properties` emitted by your agents. This ensures routing metadata remains intact across all agent transitions. For specialist-to-specialist handoffs, use `.add_handoff(source, targets)` to configure which agents can route to which others with a fluent, type-safe API.

--- a/python/samples/03-workflows/orchestrations/README.md
+++ b/python/samples/03-workflows/orchestrations/README.md
@@ -85,8 +85,7 @@ from agent_framework.orchestrations import (
 Use `output_from=[...]` when participant responses should be Workflow Output (`type='output'` events), and
 `intermediate_output_from=[...]` when participant responses should be Intermediate Output (`type='intermediate'`
 events). `output_from` is an allow-list for Workflow Output, not a routing rule for every other participant output.
-Unselected participant responses are hidden unless `intermediate_output_from` selects them. The deprecated
-`final_output_from` alias is compatibility-only.
+Unselected participant responses are hidden unless `intermediate_output_from` selects them.
 
 | Selection | Workflow Output | Intermediate Output | Hidden payloads |
 | --- | --- | --- | --- |

--- a/python/samples/03-workflows/orchestrations/README.md
+++ b/python/samples/03-workflows/orchestrations/README.md
@@ -82,8 +82,8 @@ from agent_framework.orchestrations import (
 ## Tips
 
 **Participant output designation**: Orchestration builders use participant-oriented names for workflow output
-selection. Use `output_participants=[...]` when participant responses should be terminal `output` events, and
-`intermediate_participants=[...]` when participant responses should be visible progress events. In explicit
+selection. Use `final_output_from=[...]` when participant responses should be terminal `output` events, and
+`intermediate_output_from=[...]` when participant responses should be visible progress events. In explicit
 designation mode, unlisted participant responses are hidden from caller-facing output streams. Builders validate
 empty explicit designation, duplicate participants, overlap between output and intermediate participants, and unknown
 participant names.

--- a/python/samples/03-workflows/orchestrations/README.md
+++ b/python/samples/03-workflows/orchestrations/README.md
@@ -81,20 +81,41 @@ from agent_framework.orchestrations import (
 
 ## Tips
 
-**Participant output designation**: Orchestration builders use participant-oriented names for workflow output
-selection. Use `final_output_from=[...]` when participant responses should be terminal `output` events, and
-`intermediate_output_from=[...]` when participant responses should be visible progress events. In explicit
-designation mode, unlisted participant responses are hidden from caller-facing output streams. Builders validate
-empty explicit designation, duplicate participants, overlap between output and intermediate participants, and unknown
-participant names.
+**Participant output selection**: Orchestration builders use participant-oriented names for Workflow Output selection.
+Use `output_from=[...]` when participant responses should be Workflow Output (`type='output'` events), and
+`intermediate_output_from=[...]` when participant responses should be Intermediate Output (`type='intermediate'`
+events). `output_from` is an allow-list for Workflow Output, not a routing rule for every other participant output.
+Unselected participant responses are hidden unless `intermediate_output_from` selects them. The deprecated
+`final_output_from` alias is compatibility-only.
 
-By default, Sequential keeps the final participant terminal. Concurrent, GroupChat, and Magentic keep their synthetic
-aggregator/orchestrator/manager final executors terminal, while participant responses stay hidden unless designated.
-Handoff keeps participants terminal by default.
+| Selection | Workflow Output | Intermediate Output | Hidden payloads |
+| --- | --- | --- | --- |
+| Omit both selections | Builder default Workflow Output contract | None | Builder-specific non-output participant payloads |
+| `output_from="all"` | Every output-capable participant | None | None |
+| `output_from=[writer]` | Only `writer` | None | All other participant payloads |
+| `output_from=[writer], intermediate_output_from="all_other"` | Only `writer` | Every output-capable participant not selected by `output_from` | None |
+| `intermediate_output_from="all_other"` | None, except builder-internal default output executors where applicable | Every output-capable participant | Builder-internal plumbing payloads |
+| `output_from=[], intermediate_output_from="all_other"` | None, except builder-internal default output executors where applicable | Every output-capable participant | Builder-internal plumbing payloads |
+| `output_from=[writer], intermediate_output_from=[researcher, reviewer]` | Only `writer` | `researcher` and `reviewer` | Any other participant payloads |
 
-When an orchestration workflow is exposed via `workflow.as_agent()`, terminal workflow outputs become normal text
-content in the `AgentResponse`; intermediate participant outputs become `text_reasoning` content. This preserves the
-final answer in `.text` while making designated progress available for callers that inspect message contents.
+Invalid selections fail at construction or build time:
+
+| Invalid selection | Why it fails |
+| --- | --- |
+| `output_from="all_other"` | `"all_other"` is only valid for `intermediate_output_from` |
+| `intermediate_output_from="all"` | `"all"` is only valid for `output_from` |
+| The same participant in both selections | One payload cannot be both Workflow Output and Intermediate Output |
+| Duplicate participant selections | Duplicates are treated as configuration errors |
+| Unknown participant selections | Typos and missing participants are rejected |
+| `output_from=[], intermediate_output_from=[]` | Both explicit selections are empty |
+
+By default, Sequential keeps the last participant as Workflow Output. Concurrent, GroupChat, and Magentic keep their
+synthetic aggregator/orchestrator/manager executors as Workflow Output, while participant responses stay hidden unless
+selected. Handoff keeps participants as Workflow Output by default.
+
+When an orchestration workflow is exposed via `workflow.as_agent()`, Workflow Output becomes normal text content in
+the `AgentResponse`; Intermediate Output becomes `text_reasoning` content. This preserves `.text` while making
+selected progress available for callers that inspect message contents.
 
 **Magentic checkpointing tip**: Treat `MagenticBuilder.participants` keys as stable identifiers. When resuming from a checkpoint, the rebuilt workflow must reuse the same participant names; otherwise the checkpoint cannot be applied and the run will fail fast.
 
@@ -105,7 +126,7 @@ final answer in `.text` while making designated progress available for callers t
 **Sequential orchestration note**: Sequential orchestration uses a few small adapter nodes for plumbing:
 - `input-conversation` normalizes input to `list[Message]`
 - `to-conversation:<participant>` converts agent responses into the shared conversation
-- `complete` publishes the final output event (type='output')
+- `complete` publishes the Workflow Output event (`type='output'`)
 
 These may appear in event streams (executor_invoked/executor_completed). They're analogous to concurrent's dispatcher and aggregator and can be ignored if you only care about agent activity.
 

--- a/python/samples/03-workflows/orchestrations/group_chat_agent_manager.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_agent_manager.py
@@ -85,7 +85,7 @@ async def main() -> None:
         GroupChatBuilder(
             participants=[researcher, writer],
             termination_condition=lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 4,
-            intermediate_participants=[researcher, writer],
+            intermediate_output_from=[researcher, writer],
             orchestrator_agent=orchestrator_agent,
         )
         # Set a hard termination condition: stop after 4 assistant messages

--- a/python/samples/03-workflows/orchestrations/group_chat_agent_manager.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_agent_manager.py
@@ -78,13 +78,14 @@ async def main() -> None:
     # Build the group chat workflow
     # termination_condition: stop after 4 assistant messages
     # (The agent orchestrator will intelligently decide when to end before this limit but just in case)
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so the stream shows the
+    # conversation as it unfolds while the orchestrator's transcript remains the
+    # terminal workflow output.
     workflow = (
         GroupChatBuilder(
             participants=[researcher, writer],
             termination_condition=lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 4,
-            intermediate_outputs=True,
+            intermediate_participants=[researcher, writer],
             orchestrator_agent=orchestrator_agent,
         )
         # Set a hard termination condition: stop after 4 assistant messages
@@ -102,7 +103,7 @@ async def main() -> None:
     # Keep track of the last response to format output nicely in streaming mode
     last_response_id: str | None = None
     async for event in workflow.run(task, stream=True):
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             data = event.data
             if isinstance(data, AgentResponseUpdate):
                 rid = data.response_id

--- a/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
@@ -226,7 +226,7 @@ Share your perspective authentically. Feel free to:
         GroupChatBuilder(
             participants=[farmer, developer, teacher, activist, spiritual_leader, artist, immigrant, doctor],
             termination_condition=lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 10,
-            intermediate_participants=[
+            intermediate_output_from=[
                 farmer,
                 developer,
                 teacher,

--- a/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
@@ -219,13 +219,23 @@ Share your perspective authentically. Feel free to:
     )
 
     # termination_condition: stop after 10 assistant messages
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so the stream shows the
+    # conversation as it unfolds while the orchestrator's transcript remains the
+    # terminal workflow output.
     workflow = (
         GroupChatBuilder(
             participants=[farmer, developer, teacher, activist, spiritual_leader, artist, immigrant, doctor],
             termination_condition=lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 10,
-            intermediate_outputs=True,
+            intermediate_participants=[
+                farmer,
+                developer,
+                teacher,
+                activist,
+                spiritual_leader,
+                artist,
+                immigrant,
+                doctor,
+            ],
             orchestrator_agent=moderator,
         )
         .with_termination_condition(lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 10)
@@ -254,7 +264,7 @@ Share your perspective authentically. Feel free to:
     # Keep track of the last response to format output nicely in streaming mode
     last_response_id: str | None = None
     async for event in workflow.run(f"Please begin the discussion on: {topic}", stream=True):
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             data = event.data
             if isinstance(data, AgentResponseUpdate):
                 rid = data.response_id

--- a/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_philosophical_debate.py
@@ -227,14 +227,7 @@ Share your perspective authentically. Feel free to:
             participants=[farmer, developer, teacher, activist, spiritual_leader, artist, immigrant, doctor],
             termination_condition=lambda messages: sum(1 for msg in messages if msg.role == "assistant") >= 10,
             intermediate_output_from=[
-                farmer,
-                developer,
-                teacher,
-                activist,
-                spiritual_leader,
-                artist,
-                immigrant,
-                doctor,
+                "all",
             ],
             orchestrator_agent=moderator,
         )

--- a/python/samples/03-workflows/orchestrations/group_chat_simple_selector.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_simple_selector.py
@@ -103,7 +103,7 @@ async def main() -> None:
         GroupChatBuilder(
             participants=[expert, verifier, clarifier, skeptic],
             termination_condition=lambda conversation: len(conversation) >= 6,
-            intermediate_participants=[expert, verifier, clarifier, skeptic],
+            intermediate_output_from=[expert, verifier, clarifier, skeptic],
             selection_func=round_robin_selector,
         )
         # Set a hard termination condition: stop after 6 messages (user task + one full rounds + 1)

--- a/python/samples/03-workflows/orchestrations/group_chat_simple_selector.py
+++ b/python/samples/03-workflows/orchestrations/group_chat_simple_selector.py
@@ -96,13 +96,14 @@ async def main() -> None:
     # This will end the conversation after the expert has spoken 2 times (one iteration loop)
     # Note: it's possible that the expert gets it right the first time and the other participants
     # have nothing to add, but for demo purposes we want to see at least one full round of interaction.
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so the stream shows the
+    # conversation as it unfolds while the orchestrator's transcript remains the
+    # terminal workflow output.
     workflow = (
         GroupChatBuilder(
             participants=[expert, verifier, clarifier, skeptic],
             termination_condition=lambda conversation: len(conversation) >= 6,
-            intermediate_outputs=True,
+            intermediate_participants=[expert, verifier, clarifier, skeptic],
             selection_func=round_robin_selector,
         )
         # Set a hard termination condition: stop after 6 messages (user task + one full rounds + 1)
@@ -123,7 +124,7 @@ async def main() -> None:
     # Keep track of the last response to format output nicely in streaming mode
     last_response_id: str | None = None
     async for event in workflow.run(task, stream=True):
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             data = event.data
             if isinstance(data, AgentResponseUpdate):
                 rid = data.response_id

--- a/python/samples/03-workflows/orchestrations/magentic.py
+++ b/python/samples/03-workflows/orchestrations/magentic.py
@@ -93,7 +93,7 @@ async def main() -> None:
     # terminal workflow output.
     workflow = MagenticBuilder(
         participants=[researcher_agent, coder_agent],
-        intermediate_participants=[researcher_agent, coder_agent],
+        intermediate_output_from=[researcher_agent, coder_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=3,

--- a/python/samples/03-workflows/orchestrations/magentic.py
+++ b/python/samples/03-workflows/orchestrations/magentic.py
@@ -88,11 +88,12 @@ async def main() -> None:
 
     print("\nBuilding Magentic Workflow...")
 
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # Mark participant responses as intermediate so the stream shows the
+    # conversation as it unfolds while the manager's final answer remains the
+    # terminal workflow output.
     workflow = MagenticBuilder(
         participants=[researcher_agent, coder_agent],
-        intermediate_outputs=True,
+        intermediate_participants=[researcher_agent, coder_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=3,
@@ -115,7 +116,7 @@ async def main() -> None:
     last_response_id: str | None = None
     output_event: WorkflowEvent | None = None
     async for event in workflow.run(task, stream=True):
-        if event.type == "output" and isinstance(event.data, AgentResponseUpdate):
+        if event.type == "intermediate" and isinstance(event.data, AgentResponseUpdate):
             response_id = event.data.response_id
             if response_id != last_response_id:
                 if last_response_id is not None:

--- a/python/samples/03-workflows/orchestrations/magentic.py
+++ b/python/samples/03-workflows/orchestrations/magentic.py
@@ -116,7 +116,7 @@ async def main() -> None:
     last_response_id: str | None = None
     output_event: WorkflowEvent | None = None
     async for event in workflow.run(task, stream=True):
-        if event.type == "intermediate" and isinstance(event.data, AgentResponseUpdate):
+        if event.type in ("intermediate", "output") and isinstance(event.data, AgentResponseUpdate):
             response_id = event.data.response_id
             if response_id != last_response_id:
                 if last_response_id is not None:

--- a/python/samples/03-workflows/orchestrations/magentic_human_plan_review.py
+++ b/python/samples/03-workflows/orchestrations/magentic_human_plan_review.py
@@ -136,7 +136,7 @@ async def main() -> None:
     workflow = MagenticBuilder(
         participants=[researcher_agent, analyst_agent],
         enable_plan_review=True,
-        intermediate_participants=[researcher_agent, analyst_agent],
+        intermediate_output_from=[researcher_agent, analyst_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=1,

--- a/python/samples/03-workflows/orchestrations/magentic_human_plan_review.py
+++ b/python/samples/03-workflows/orchestrations/magentic_human_plan_review.py
@@ -55,7 +55,7 @@ async def process_event_stream(stream: AsyncIterable[WorkflowEvent]) -> dict[str
         if event.type == "request_info" and event.request_type is MagenticPlanReviewRequest:
             requests[event.request_id] = cast(MagenticPlanReviewRequest, event.data)
 
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             data = event.data
             if isinstance(data, AgentResponseUpdate):
                 rid = data.response_id
@@ -129,13 +129,14 @@ async def main() -> None:
 
     print("\nBuilding Magentic Workflow with Human Plan Review...")
 
-    # enable_plan_review=True: Request human input for plan review
-    # intermediate_outputs=True: Enable intermediate outputs to observe the conversation as it unfolds
-    # (Intermediate outputs will be emitted as WorkflowOutputEvent events)
+    # enable_plan_review=True: Request human input for plan review.
+    # Mark participant responses as intermediate so the stream shows the
+    # conversation as it unfolds while the manager's final answer remains the
+    # terminal workflow output.
     workflow = MagenticBuilder(
         participants=[researcher_agent, analyst_agent],
         enable_plan_review=True,
-        intermediate_outputs=True,
+        intermediate_participants=[researcher_agent, analyst_agent],
         manager_agent=manager_agent,
         max_round_count=10,
         max_stall_count=1,

--- a/python/samples/03-workflows/orchestrations/sequential_chain_only_agent_responses.py
+++ b/python/samples/03-workflows/orchestrations/sequential_chain_only_agent_responses.py
@@ -66,13 +66,13 @@ async def main() -> None:
     workflow = SequentialBuilder(
         participants=[writer, translator, reviewer],
         chain_only_agent_responses=True,
-        intermediate_outputs=True,
+        intermediate_participants=[writer, translator],
     ).build()
 
     # 3) Run and collect outputs
     last_agent: str | None = None
     async for event in workflow.run("Write a tagline for a budget-friendly eBike.", stream=True):
-        if event.type == "output" and isinstance(event.data, AgentResponseUpdate):
+        if event.type in ("intermediate", "output") and isinstance(event.data, AgentResponseUpdate):
             if event.data.author_name != last_agent:
                 last_agent = event.data.author_name
                 print()

--- a/python/samples/03-workflows/orchestrations/sequential_chain_only_agent_responses.py
+++ b/python/samples/03-workflows/orchestrations/sequential_chain_only_agent_responses.py
@@ -66,7 +66,7 @@ async def main() -> None:
     workflow = SequentialBuilder(
         participants=[writer, translator, reviewer],
         chain_only_agent_responses=True,
-        intermediate_participants=[writer, translator],
+        intermediate_output_from=[writer, translator],
     ).build()
 
     # 3) Run and collect outputs

--- a/python/samples/04-hosting/foundry-hosted-agents/responses/05_workflows/main.py
+++ b/python/samples/04-hosting/foundry-hosted-agents/responses/05_workflows/main.py
@@ -54,7 +54,7 @@ def main():
             start_executor=writer_executor,
             # Limiting the output to only the final formatted result.
             # If this is not set, all intermediate results will be included in the output.
-            output_executors=[format_executor],
+            final_output_from=[format_executor],
         )
         .add_edge(writer_executor, legal_executor)
         .add_edge(legal_executor, format_executor)

--- a/python/samples/04-hosting/foundry-hosted-agents/responses/05_workflows/main.py
+++ b/python/samples/04-hosting/foundry-hosted-agents/responses/05_workflows/main.py
@@ -52,9 +52,9 @@ def main():
     workflow_agent = (
         WorkflowBuilder(
             start_executor=writer_executor,
-            # Limiting the output to only the final formatted result.
-            # If this is not set, all intermediate results will be included in the output.
-            final_output_from=[format_executor],
+            # Select only the formatted result as Workflow Output.
+            # Unselected executor payloads are hidden unless selected as Intermediate Output.
+            output_from=[format_executor],
         )
         .add_edge(writer_executor, legal_executor)
         .add_edge(legal_executor, format_executor)

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -8,7 +8,7 @@ This directory contains samples demonstrating the capabilities of Microsoft Agen
 |--------|-------------|
 | [`01-get-started/`](./01-get-started/) | Progressive tutorial: hello agent → hosting |
 | [`02-agents/`](./02-agents/) | Deep-dive by concept: tools, middleware, providers, orchestrations |
-| [`03-workflows/`](./03-workflows/) | Workflow patterns: sequential, concurrent, state, declarative |
+| [`03-workflows/`](./03-workflows/) | Workflow patterns: sequential, concurrent, state, declarative, explicit output designation |
 | [`04-hosting/`](./04-hosting/) | Deployment: Azure Functions, Durable Tasks, A2A |
 | [`05-end-to-end/`](./05-end-to-end/) | Full applications, evaluation, demos |
 

--- a/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
@@ -248,13 +248,13 @@ async def run_agent_framework_example(task: str) -> str:
         participants=[researcher, planner],
         orchestrator_agent=Agent(client=client),
         max_rounds=8,
-        intermediate_outputs=True,
+        intermediate_participants=[researcher, planner],
     ).build()
 
     output_messages: list[Message] = []
     last_message_id: str | None = None
     async for event in workflow.run(task, stream=True):
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             if isinstance(event.data, AgentResponseUpdate):
                 if event.data.message_id != last_message_id:
                     last_message_id = event.data.message_id

--- a/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/group_chat.py
@@ -248,7 +248,7 @@ async def run_agent_framework_example(task: str) -> str:
         participants=[researcher, planner],
         orchestrator_agent=Agent(client=client),
         max_rounds=8,
-        intermediate_participants=[researcher, planner],
+        intermediate_output_from=[researcher, planner],
     ).build()
 
     output_messages: list[Message] = []

--- a/python/samples/semantic-kernel-migration/orchestrations/magentic.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/magentic.py
@@ -164,13 +164,13 @@ async def run_agent_framework_example(prompt: str) -> str | None:
     workflow = MagenticBuilder(
         participants=[researcher, coder],
         manager_agent=manager_agent,  # type: ignore
-        intermediate_outputs=True,
+        intermediate_participants=[researcher, coder],
     ).build()
 
     output_messages: list[Message] = []
     last_message_id: str | None = None
     async for event in workflow.run(prompt, stream=True):
-        if event.type == "output":
+        if event.type in ("intermediate", "output"):
             if isinstance(event.data, AgentResponseUpdate):
                 if event.data.message_id != last_message_id:
                     last_message_id = event.data.message_id

--- a/python/samples/semantic-kernel-migration/orchestrations/magentic.py
+++ b/python/samples/semantic-kernel-migration/orchestrations/magentic.py
@@ -164,7 +164,7 @@ async def run_agent_framework_example(prompt: str) -> str | None:
     workflow = MagenticBuilder(
         participants=[researcher, coder],
         manager_agent=manager_agent,  # type: ignore
-        intermediate_participants=[researcher, coder],
+        intermediate_output_from=[researcher, coder],
     ).build()
 
     output_messages: list[Message] = []

--- a/python/scripts/sample_validation/create_dynamic_workflow_executor.py
+++ b/python/scripts/sample_validation/create_dynamic_workflow_executor.py
@@ -17,8 +17,6 @@ from agent_framework.github import GitHubCopilotAgent
 from copilot.generated.session_events import PermissionRequest
 from copilot.session import PermissionRequestResult
 from pydantic import BaseModel
-from typing_extensions import Never
-
 from sample_validation.const import WORKER_COMPLETED
 from sample_validation.discovery import DiscoveryResult
 from sample_validation.models import (
@@ -29,6 +27,7 @@ from sample_validation.models import (
     ValidationConfig,
     WorkflowCreationResult,
 )
+from typing_extensions import Never
 
 logger = logging.getLogger(__name__)
 
@@ -249,7 +248,7 @@ class CollectorExecutor(Executor):
         batch_completion: BatchCompletion,
         ctx: WorkflowContext[Never, ExecutionResult],
     ) -> None:
-        """Receive all results at once and emit final output."""
+        """Receive all results at once and emit Workflow Output."""
         await ctx.yield_output(ExecutionResult(results=self._results))
 
     @handler
@@ -305,9 +304,7 @@ class CreateConcurrentValidationWorkflowExecutor(Executor):
         )
         collector = CollectorExecutor()
 
-        nested_builder = WorkflowBuilder(
-            start_executor=coordinator, output_executors=[collector]
-        )
+        nested_builder = WorkflowBuilder(start_executor=coordinator, output_from=[collector])
         nested_builder.add_edge(coordinator, collector)
         for worker in workers:
             nested_builder.add_edge(coordinator, worker)


### PR DESCRIPTION
### Motivation and Context

Workflows had no first-class way to distinguish a designated terminal output from observational intermediate emissions. Both surfaced as `type='output'` events with no marker, so consumers could not separate "the workflow's answer" from "progress / reasoning along the way" without out-of-band knowledge of the graph. The same gap existed in orchestrations: participant replies and the manager / aggregator / terminator answer were all output, indistinguishable to the caller.

The original kwarg names (`output_executors` / `intermediate_executors`) also read ambiguously. They could be parsed as "the executors that produce output," when their real meaning is "which executors emit which kind of output."

This PR introduces an explicit intermediate output type, designates per-executor finality at build time, and renames the builder kwargs to match how the API is actually read.

> [!IMPORTANT]
> This breaking change is scoped to the experimental `agent_framework_orchestrations` package only; the core `agent_framework` kwarg rename ships with deprecation aliases.

### Description

Core changes:

- New `WorkflowEvent.type == "intermediate"` discriminator alongside `"output"`. Legacy `"data"` becomes a deprecated alias of `"intermediate"`.
- Per-executor designation through `WorkflowBuilder(final_output_from=[...], intermediate_output_from=[...])`. Designation is fixed at build time; `ctx.yield_output(...)` has no per-emission flag and an executor cannot vary the label per yield (documented on the yield_output docstring).
- `WorkflowRunResult` exposes `get_intermediate_outputs()` alongside `get_outputs()`.
- The `workflow.as_agent()` boundary forwards both `output` and `intermediate` events via an explicit allowlist (`AGENT_FORWARDED_EVENT_TYPES`); intermediates render as `text_reasoning` content, so existing `.text` accessors continue to return only the terminal answer.
- `WorkflowExecutor` (sub-workflow embedding) now pipes child intermediate emissions up through the parent's event stream, attributed to the `WorkflowExecutor`'s own id rather than the child's internal executor ids. This preserves encapsulation and keeps the `intermediate` label intact across the boundary regardless of how the parent designates the `WorkflowExecutor`.

Builder kwarg rename:

- Core: `output_executors` -> `final_output_from`, `intermediate_executors` -> `intermediate_output_from`. Both old names are still accepted with `DeprecationWarning` via a small `_coalesce_renamed_kwarg` helper. Supplying both the old and new name for the same slot raises `TypeError`. The serialized form (`Workflow.to_dict()`) deliberately keeps the old wire keys `output_executors` / `intermediate_executors` for checkpoint compatibility, with a test to lock that asymmetry in place.
- Orchestrations: `output_participants` -> `final_output_from`, `intermediate_participants` -> `intermediate_output_from`. Clean break, no shim, because the orchestrations package is still pre-1.0.

Orchestrations fix:

- `HandoffBuilder` defaults `final_output_from` to every participant, and `SequentialBuilder` defaults to the last participant. Before this fix, supplying `intermediate_output_from=[X]` where X was in the default-final list triggered the "Participants cannot be both output and intermediate designated" overlap rejection, contradicting the documented contract that `intermediate_output_from` is usable on its own. The shared `_resolve_participant_output_config` helper now subtracts the explicit intermediates from the default-final list, so intermediate designation implicitly demotes the listed participants out of the default-final set. Regression tests added for both Handoff and Sequential.

Samples and docs:

- `samples/03-workflows/control-flow/intermediate_vs_terminal_outputs.py` walks the full path: explicit designation, streaming consumption, `WorkflowRunResult` accessors, `as_agent()` translation, and now sub-workflow embedding via `WorkflowExecutor` showing child intermediates bubbling up.
- `samples/03-workflows/README.md` and orchestration sample docstrings updated to the new kwarg names.
- Docstrings on `ctx.yield_output`, `WorkflowEvent.output`, and `WorkflowEvent.intermediate` make the per-executor (not per-yield) invariant explicit, so future contributors do not propose a `ctx.yield_intermediate(...)` API.

Test coverage added:

- `WorkflowExecutor` intermediate propagation across the sub-workflow boundary.
- `Workflow.to_dict()` preserves the legacy wire keys after the kwarg rename.
- `WorkflowBuilder` raises `TypeError` when both the deprecated alias and the new canonical kwarg are supplied (both the output and intermediate pairs).
- `HandoffBuilder(intermediate_output_from=[X])` and `SequentialBuilder(intermediate_output_from=[last_participant])` do not collide with the default-final list.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.