### PR TITLE
Python: Add regression tests for MCPStreamableHTTPTool GET stream resilience (#5317)

### DIFF
--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -4238,11 +4238,13 @@ async def test_streamable_http_get_stream_405_does_not_crash_session():
                         "jsonrpc": "2.0",
                         "id": body["id"],
                         "result": {
-                            "tools": [{
-                                "name": "search_docs",
-                                "description": "Search documentation",
-                                "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
-                            }]
+                            "tools": [
+                                {
+                                    "name": "search_docs",
+                                    "description": "Search documentation",
+                                    "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                                }
+                            ]
                         },
                     }).encode(),
                 )
@@ -4257,26 +4259,28 @@ async def test_streamable_http_get_stream_405_does_not_crash_session():
     transport = httpx.MockTransport(handle_request)
     http_client = httpx.AsyncClient(transport=transport)
 
-    async with http_client:
-        async with streamable_http_client(
+    async with (
+        http_client,
+        streamable_http_client(
             url="http://test-server/mcp",
             http_client=http_client,
             terminate_on_close=False,
-        ) as (read_stream, write_stream, get_session_id):
-            async with ClientSession(
-                read_stream=read_stream,
-                write_stream=write_stream,
-            ) as session:
-                result = await session.initialize()
-                assert result.serverInfo.name == "learn-mcp"
+        ) as (read_stream, write_stream, get_session_id),
+        ClientSession(
+            read_stream=read_stream,
+            write_stream=write_stream,
+        ) as session,
+    ):
+        result = await session.initialize()
+        assert result.serverInfo.name == "learn-mcp"
 
-                # Allow time for the background GET stream attempt to fail
-                await asyncio.sleep(0.5)
+        # Allow time for the background GET stream attempt to fail
+        await asyncio.sleep(0.5)
 
-                # Session must remain usable after the GET stream failure
-                tools = await session.list_tools()
-                assert len(tools.tools) == 1
-                assert tools.tools[0].name == "search_docs"
+        # Session must remain usable after the GET stream failure
+        tools = await session.list_tools()
+        assert len(tools.tools) == 1
+        assert tools.tools[0].name == "search_docs"
 
 
 async def test_streamable_http_get_stream_connection_error_does_not_crash_session():
@@ -4340,25 +4344,27 @@ async def test_streamable_http_get_stream_connection_error_does_not_crash_sessio
     transport = httpx.MockTransport(handle_request)
     http_client = httpx.AsyncClient(transport=transport)
 
-    async with http_client:
-        async with streamable_http_client(
+    async with (
+        http_client,
+        streamable_http_client(
             url="http://test-server/mcp",
             http_client=http_client,
             terminate_on_close=False,
-        ) as (read_stream, write_stream, get_session_id):
-            async with ClientSession(
-                read_stream=read_stream,
-                write_stream=write_stream,
-            ) as session:
-                result = await session.initialize()
-                assert result.serverInfo.name == "d365-server"
+        ) as (read_stream, write_stream, get_session_id),
+        ClientSession(
+            read_stream=read_stream,
+            write_stream=write_stream,
+        ) as session,
+    ):
+        result = await session.initialize()
+        assert result.serverInfo.name == "d365-server"
 
-                # Allow time for the background GET stream reconnection attempts
-                await asyncio.sleep(1.0)
+        # Allow time for the background GET stream reconnection attempts
+        await asyncio.sleep(1.0)
 
-                # Session must remain usable after the GET stream failure
-                tools = await session.list_tools()
-                assert tools.tools is not None
+        # Session must remain usable after the GET stream failure
+        tools = await session.list_tools()
+        assert tools.tools is not None
 
 
 # endregion

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -4178,3 +4178,187 @@ async def test_mcp_streamable_http_tool_header_provider_via_invoke_with_context(
 
 
 # endregion
+
+
+# region: MCPStreamableHTTPTool GET stream resilience
+
+
+async def test_streamable_http_get_stream_405_does_not_crash_session():
+    """Test that a 405 response on the GET SSE notification stream is handled gracefully.
+
+    Some MCP servers (e.g. Learn MCP) reject GET requests with 405 because they only
+    support the modern Streamable HTTP transport. The background GET notification task
+    must not propagate that failure to the main session.
+    """
+    import asyncio
+
+    import httpx
+    from mcp.client.streamable_http import streamable_http_client
+
+    session_id = "test-session-resilience"
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(
+                status_code=405,
+                headers={"content-type": "text/plain"},
+                content=b"This endpoint does not support SSE transport.",
+            )
+
+        if request.method == "POST":
+            body = json.loads(request.content)
+            method = body.get("method")
+
+            if method == "initialize":
+                return httpx.Response(
+                    status_code=200,
+                    headers={
+                        "content-type": "application/json",
+                        "mcp-session-id": session_id,
+                    },
+                    content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": body["id"],
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {"tools": {"listChanged": True}},
+                            "serverInfo": {"name": "learn-mcp", "version": "1.0.0"},
+                        },
+                    }).encode(),
+                )
+
+            if method == "notifications/initialized":
+                return httpx.Response(status_code=202)
+
+            if method == "tools/list":
+                return httpx.Response(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": body["id"],
+                        "result": {
+                            "tools": [{
+                                "name": "search_docs",
+                                "description": "Search documentation",
+                                "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                            }]
+                        },
+                    }).encode(),
+                )
+
+            return httpx.Response(status_code=202)
+
+        if request.method == "DELETE":
+            return httpx.Response(status_code=200)
+
+        return httpx.Response(status_code=404)
+
+    transport = httpx.MockTransport(handle_request)
+    http_client = httpx.AsyncClient(transport=transport)
+
+    async with http_client:
+        async with streamable_http_client(
+            url="http://test-server/mcp",
+            http_client=http_client,
+            terminate_on_close=False,
+        ) as (read_stream, write_stream, get_session_id):
+            async with ClientSession(
+                read_stream=read_stream,
+                write_stream=write_stream,
+            ) as session:
+                result = await session.initialize()
+                assert result.serverInfo.name == "learn-mcp"
+
+                # Allow time for the background GET stream attempt to fail
+                await asyncio.sleep(0.5)
+
+                # Session must remain usable after the GET stream failure
+                tools = await session.list_tools()
+                assert len(tools.tools) == 1
+                assert tools.tools[0].name == "search_docs"
+
+
+async def test_streamable_http_get_stream_connection_error_does_not_crash_session():
+    """Test that a connection error on GET SSE notification stream is handled gracefully.
+
+    Some MCP servers only accept POST and the background GET either resets or refuses
+    the connection. This must not cancel the main session task.
+    """
+    import asyncio
+
+    import httpx
+    from mcp.client.streamable_http import streamable_http_client
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            raise httpx.ConnectError("Connection reset by peer")
+
+        if request.method == "POST":
+            body = json.loads(request.content)
+            method = body.get("method")
+
+            if method == "initialize":
+                return httpx.Response(
+                    status_code=200,
+                    headers={
+                        "content-type": "application/json",
+                        "mcp-session-id": "d365-session",
+                    },
+                    content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": body["id"],
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "d365-server", "version": "1.0.0"},
+                        },
+                    }).encode(),
+                )
+
+            if method == "notifications/initialized":
+                return httpx.Response(status_code=202)
+
+            if method == "tools/list":
+                return httpx.Response(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": body["id"],
+                        "result": {"tools": []},
+                    }).encode(),
+                )
+
+            return httpx.Response(status_code=202)
+
+        if request.method == "DELETE":
+            return httpx.Response(status_code=200)
+
+        return httpx.Response(status_code=404)
+
+    transport = httpx.MockTransport(handle_request)
+    http_client = httpx.AsyncClient(transport=transport)
+
+    async with http_client:
+        async with streamable_http_client(
+            url="http://test-server/mcp",
+            http_client=http_client,
+            terminate_on_close=False,
+        ) as (read_stream, write_stream, get_session_id):
+            async with ClientSession(
+                read_stream=read_stream,
+                write_stream=write_stream,
+            ) as session:
+                result = await session.initialize()
+                assert result.serverInfo.name == "d365-server"
+
+                # Allow time for the background GET stream reconnection attempts
+                await asyncio.sleep(1.0)
+
+                # Session must remain usable after the GET stream failure
+                tools = await session.list_tools()
+                assert tools.tools is not None
+
+
+# endregion

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -4196,9 +4196,11 @@ async def test_streamable_http_get_stream_405_does_not_crash_session():
     from mcp.client.streamable_http import streamable_http_client
 
     session_id = "test-session-resilience"
+    get_attempted = asyncio.Event()
 
     async def handle_request(request: httpx.Request) -> httpx.Response:
         if request.method == "GET":
+            get_attempted.set()
             return httpx.Response(
                 status_code=405,
                 headers={"content-type": "text/plain"},
@@ -4274,8 +4276,8 @@ async def test_streamable_http_get_stream_405_does_not_crash_session():
         result = await session.initialize()
         assert result.serverInfo.name == "learn-mcp"
 
-        # Allow time for the background GET stream attempt to fail
-        await asyncio.sleep(0.5)
+        # Wait for the background GET stream to be attempted
+        await asyncio.wait_for(get_attempted.wait(), timeout=5.0)
 
         # Session must remain usable after the GET stream failure
         tools = await session.list_tools()
@@ -4294,8 +4296,11 @@ async def test_streamable_http_get_stream_connection_error_does_not_crash_sessio
     import httpx
     from mcp.client.streamable_http import streamable_http_client
 
+    get_attempted = asyncio.Event()
+
     async def handle_request(request: httpx.Request) -> httpx.Response:
         if request.method == "GET":
+            get_attempted.set()
             raise httpx.ConnectError("Connection reset by peer")
 
         if request.method == "POST":
@@ -4359,8 +4364,8 @@ async def test_streamable_http_get_stream_connection_error_does_not_crash_sessio
         result = await session.initialize()
         assert result.serverInfo.name == "d365-server"
 
-        # Allow time for the background GET stream reconnection attempts
-        await asyncio.sleep(1.0)
+        # Wait for the background GET stream to be attempted
+        await asyncio.wait_for(get_attempted.wait(), timeout=5.0)
 
         # Session must remain usable after the GET stream failure
         tools = await session.list_tools()


### PR DESCRIPTION
### Motivation and Context

The bug where a failing background GET SSE notification stream crashed the entire agent was already fixed by upgrading to mcp ≥ 1.27.0 (which gracefully handles 405 and connection errors in `handle_get_stream`). These regression tests ensure the fix is not accidentally reverted.

Fixes #5317

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adds two tests to `test_mcp.py` that simulate the exact failure modes reported in the issue: a 405 response (Learn MCP behavior) and a connection reset (D365 F&O behavior) on the background GET SSE stream. Both tests verify that the `ClientSession` remains fully usable after the background notification stream fails — confirming the MCP library upgrade resolved the crash without requiring changes to `agent_framework/_mcp.py`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by giles17's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5317,"repo":"microsoft/agent-framework","rid":"1c1a40c6178345f4ab15b1ff1b8e6dee","rt":"fix","sf":"pr","ts":"2026-05-04T21:48:27.695075+00:00","u":"giles17","v":1}
-->
