### PR TITLE
.NET: Fix QuestionExecutor looping after GotoAction re-entry in declarative workflows

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
@@ -43,8 +43,6 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
 
     protected override async ValueTask<object?> ExecuteAsync(IWorkflowContext context, CancellationToken cancellationToken = default)
     {
-        await this._promptCount.WriteAsync(context, 0).ConfigureAwait(false);
-
         InitializablePropertyPath variable = Throw.IfNull(this.Model.Variable);
         bool isValueUndefined = context.ReadState(variable.Path) is BlankValue;
         // Snapshot prior-execution state before we mutate it below so the SkipQuestionMode
@@ -72,7 +70,9 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
 
         if (proceed)
         {
-            await this.PromptAsync(context, cancellationToken).ConfigureAwait(false);
+            // Initial prompt: count is 0 because no responses have been received yet for this turn.
+            // _promptCount itself is tracked in CaptureResponseAsync's scope (see comment on _promptCount).
+            await this.PromptAsync(context, actualCount: 0, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -84,14 +84,18 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
 
     public async ValueTask PrepareResponseAsync(IWorkflowContext context, ActionExecutorResult message, CancellationToken cancellationToken)
     {
-        int count = await this._promptCount.ReadAsync(context).ConfigureAwait(false);
         ExternalInputRequest inputRequest = new(this.FormatPrompt(this.Model.Prompt));
         await context.SendMessageAsync(inputRequest, cancellationToken).ConfigureAwait(false);
-        await this._promptCount.WriteAsync(context, count + 1).ConfigureAwait(false);
     }
 
     public async ValueTask CaptureResponseAsync(IWorkflowContext context, ExternalInputResponse response, CancellationToken cancellationToken)
     {
+        // _promptCount is tracked in this (Capture) executor's scope so reads and writes are coherent.
+        // Each Capture invocation represents an attempt to satisfy the question; increment up front
+        // and pass the value to PromptAsync explicitly so the retry/default decision is scope-independent.
+        int promptCount = await this._promptCount.ReadAsync(context).ConfigureAwait(false) + 1;
+        await this._promptCount.WriteAsync(context, promptCount).ConfigureAwait(false);
+
         FormulaValue? extractedValue = null;
         if (!response.HasMessages)
         {
@@ -114,10 +118,12 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
 
         if (extractedValue is null)
         {
-            await this.PromptAsync(context, cancellationToken).ConfigureAwait(false);
+            await this.PromptAsync(context, promptCount, cancellationToken).ConfigureAwait(false);
         }
         else
         {
+            // Reset for any subsequent Question turn (e.g. via GotoAction re-entry) so the next attempt starts fresh.
+            await this._promptCount.WriteAsync(context, 0).ConfigureAwait(false);
             bool autoSend = true;
 
             if (this.Model.ExtensionData?.Properties.TryGetValue("autoSend", out DataValue? autoSendValue) ?? false)
@@ -150,10 +156,9 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
         await context.RaiseCompletionEventAsync(this.Model, cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask PromptAsync(IWorkflowContext context, CancellationToken cancellationToken)
+    private async ValueTask PromptAsync(IWorkflowContext context, int actualCount, CancellationToken cancellationToken)
     {
         long repeatCount = this.Evaluator.GetValue(this.Model.RepeatCount).Value;
-        int actualCount = await this._promptCount.ReadAsync(context).ConfigureAwait(false);
         if (actualCount >= repeatCount)
         {
             DataValue defaultValue = DataValue.Blank();
@@ -165,6 +170,8 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
             await this.AssignAsync(Throw.IfNull(this.Model.Variable).Path, defaultValue.ToFormula(), context).ConfigureAwait(false);
             string defaultValueResponse = this.FormatPrompt(this.Model.DefaultValueResponse);
             await context.AddEventAsync(new MessageActivityEvent(defaultValueResponse.Trim()), cancellationToken).ConfigureAwait(false);
+            // Reset for any subsequent Question turn (e.g. via GotoAction re-entry) so the next attempt starts fresh.
+            await this._promptCount.WriteAsync(context, 0).ConfigureAwait(false);
             await context.SendResultMessageAsync(this.Id, cancellationToken).ConfigureAwait(false);
         }
         else

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/QuestionExecutor.cs
@@ -47,6 +47,9 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
 
         InitializablePropertyPath variable = Throw.IfNull(this.Model.Variable);
         bool isValueUndefined = context.ReadState(variable.Path) is BlankValue;
+        // Snapshot prior-execution state before we mutate it below so the SkipQuestionMode
+        // evaluation reflects whether this is the first time the action has run.
+        bool hasExecutedPreviously = await this._hasExecuted.ReadAsync(context).ConfigureAwait(false);
         bool proceed = this.Evaluator.GetValue(this.Model.AlwaysPrompt).Value;
 
         if (!proceed)
@@ -55,12 +58,17 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
             proceed =
                 mode switch
                 {
-                    SkipQuestionMode.SkipOnFirstExecutionIfVariableHasValue => isValueUndefined && !await this._hasExecuted.ReadAsync(context).ConfigureAwait(false),
+                    SkipQuestionMode.SkipOnFirstExecutionIfVariableHasValue => isValueUndefined || hasExecutedPreviously,
                     SkipQuestionMode.AlwaysSkipIfVariableHasValue => isValueUndefined,
                     SkipQuestionMode.AlwaysAsk => true,
                     _ => true,
                 };
         }
+
+        // Record that the action has executed in the same executor scope as the read above.
+        // (CaptureResponseAsync runs in a different executor's state scope, so writing it there
+        // would not be visible to subsequent ExecuteAsync invocations triggered by GotoAction.)
+        await this._hasExecuted.WriteAsync(context, true).ConfigureAwait(false);
 
         if (proceed)
         {
@@ -133,7 +141,6 @@ internal sealed class QuestionExecutor(Question model, ResponseAgentProvider age
             }
 
             await this.AssignAsync(Throw.IfNull(this.Model.Variable).Path, extractedValue, context).ConfigureAwait(false);
-            await this._hasExecuted.WriteAsync(context, true).ConfigureAwait(false);
             await context.SendResultMessageAsync(this.Id, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeWorkflowTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/DeclarativeWorkflowTest.cs
@@ -33,7 +33,7 @@ public sealed class DeclarativeWorkflowTest(ITestOutputHelper output) : Workflow
     public Task ValidateScenarioAsync(string workflowFileName, string testcaseFileName, bool externalConveration = false) =>
         this.RunWorkflowAsync(GetWorkflowPath(workflowFileName, isSample: true), testcaseFileName, externalConveration);
 
-    [Theory(Skip = "Multi-turn tests hang in CI - needs investigation")]
+    [Theory]
     [InlineData("ConfirmInput.yaml", "ConfirmInput.json", false)]
     [InlineData("RequestExternalInput.yaml", "RequestExternalInput.json", false)]
     public Task ValidateMultiTurnAsync(string workflowFileName, string testcaseFileName, bool isSample) =>

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConfirmInput.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConfirmInput.json
@@ -20,7 +20,10 @@
     "conversation_count": 1,
     "min_action_count": 6,
     "max_action_count": -1,
-    "min_response_count": 0,
+    "min_response_count": 2,
+    "max_response_count": -1,
+    "min_message_count": 0,
+    "max_message_count": -1,
     "actions": {
       "start": [
         "set_project",

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConfirmInput.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/ConfirmInput.json
@@ -1,5 +1,5 @@
 ﻿{
-  "description": "Human in the loop sample - RequestExternalInput.yaml.",
+  "description": "Human in the loop sample - ConfirmInput.yaml. First response mismatches to exercise the GotoAction re-prompt path; second response matches and completes the workflow.",
   "setup": {
     "input": {
       "type": "String",
@@ -8,18 +8,28 @@
     "responses": [
       {
         "type": "String",
+        "value": "9999"
+      },
+      {
+        "type": "String",
         "value": "1234"
       }
     ]
   },
   "validation": {
     "conversation_count": 1,
-    "min_action_count": 4,
+    "min_action_count": 6,
     "max_action_count": -1,
     "min_response_count": 0,
     "actions": {
       "start": [
-        "set_project"
+        "set_project",
+        "question_confirm"
+      ],
+      "repeat": [
+        "sendActivity_mismatch",
+        "goto_again",
+        "question_confirm"
       ],
       "final": [
         "sendActivity_confirmed"

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/RequestExternalInput.json
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.IntegrationTests/Testcases/RequestExternalInput.json
@@ -15,7 +15,7 @@
   "validation": {
     "conversation_count": 1,
     "min_action_count": 2,
-    "min_response_count": 0,
+    "min_response_count": 1,
     "min_message_count":  1,
     "actions": {
       "start": [


### PR DESCRIPTION
### Motivation and Context

The `ConfirmInput` declarative workflow sample (and any workflow combining a Question action with a `GotoAction` loopback) entered an infinite loop on re-entry: the question would never re-prompt, so the mismatch branch would fire repeatedly without giving the user a chance to retry. Fixed the bug and re-enabled (and extended) the previously disabled integration test to capture this regression.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.