### PR TITLE
.NET: Issue 5662

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
@@ -233,29 +233,19 @@ internal static class InputConverter
 
     /// <summary>
     /// Converts an inbound <c>mcp_approval_response</c> wire item to a
-    /// <see cref="ToolApprovalResponseContent"/>. Looks up the full original
+    /// <see cref="ToolApprovalResponseContent"/>. Looks up the original
     /// <see cref="FunctionCallContent"/> via <see cref="ToolApprovalIdMap"/> so the
-    /// reconstructed approval response carries the original tool name, call id, and
-    /// arguments — which FICC needs to actually invoke the function on the next turn,
-    /// and which the backend Conversations API needs to pair the resulting
-    /// <c>function_call_output</c> with its previously-stored <c>function_call</c>.
+    /// reconstructed response carries the original tool name, call id, and arguments.
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when no mapping is recorded for <paramref name="approvalRequestId"/>.
-    /// Without the mapping we cannot reconstruct the original call faithfully, and any
-    /// placeholder we return would still fail downstream (FICC has no tool to invoke;
-    /// Azure's stored <c>function_call</c> can't pair with the synthetic id) — so we
-    /// fail fast here with a clear, actionable message rather than continuing into a
-    /// confusing HTTP 400 deep inside the agent loop.
+    /// Without the mapping the original call cannot be reconstructed, so we fail the request.
     /// </exception>
     private static ChatMessage ConvertMcpApprovalResponse(string approvalRequestId, bool approve, AgentSessionStateBag? stateBag)
     {
         var entry = ToolApprovalIdMap.ResolveEntry(stateBag, approvalRequestId)
             ?? throw new InvalidOperationException(
-                $"No approval mapping recorded for wire id '{approvalRequestId}'. " +
-                "This typically indicates the outbound mcp_approval_request was emitted " +
-                "by a different process, the session state was not persisted between turns, " +
-                "or the response was synthesized without a corresponding request.");
+                $"No approval mapping recorded for wire id '{approvalRequestId}'.");
 
         var functionCall = new FunctionCallContent(
             entry.CallId,

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
@@ -233,18 +233,41 @@ internal static class InputConverter
 
     /// <summary>
     /// Converts an inbound <c>mcp_approval_response</c> wire item to a
-    /// <see cref="ToolApprovalResponseContent"/>. Looks up the original AF request id
-    /// via <see cref="ToolApprovalIdMap"/>; falls back to the wire id when the mapping
-    /// is unavailable. Carries a placeholder <see cref="FunctionCallContent"/> because
-    /// the original tool-call details are not echoed by clients in the response item.
+    /// <see cref="ToolApprovalResponseContent"/>. Looks up the full original
+    /// <see cref="FunctionCallContent"/> via <see cref="ToolApprovalIdMap"/> so the
+    /// reconstructed approval response carries the original tool name, call id, and
+    /// arguments — which FICC needs to actually invoke the function on the next turn,
+    /// and which the backend Conversations API needs to pair the resulting
+    /// <c>function_call_output</c> with its previously-stored <c>function_call</c>.
+    /// Falls back to a minimal placeholder when no mapping is available (e.g.
+    /// out-of-band test inputs), preserving the previous best-effort behavior.
     /// </summary>
     private static ChatMessage ConvertMcpApprovalResponse(string approvalRequestId, bool approve, AgentSessionStateBag? stateBag)
     {
-        var afRequestId = ToolApprovalIdMap.Resolve(stateBag, approvalRequestId);
-        var placeholderFunctionCall = new FunctionCallContent(afRequestId, "mcp_approval");
+        var entry = ToolApprovalIdMap.ResolveEntry(stateBag, approvalRequestId);
+
+        FunctionCallContent functionCall;
+        string afRequestId;
+        if (entry is not null)
+        {
+            afRequestId = entry.AfRequestId;
+            functionCall = new FunctionCallContent(
+                entry.CallId,
+                entry.Name,
+                ParseFunctionArgumentsObject(entry.Arguments));
+        }
+        else
+        {
+            // No mapping recorded — keep the legacy fallback so converters stay total.
+            // The wire id becomes both the AF request id and the placeholder call id; the
+            // synthetic name signals to downstream code that the original details are unknown.
+            afRequestId = approvalRequestId;
+            functionCall = new FunctionCallContent(approvalRequestId, "mcp_approval");
+        }
+
         return new ChatMessage(
             ChatRole.User,
-            [new ToolApprovalResponseContent(afRequestId, approve, placeholderFunctionCall)]);
+            [new ToolApprovalResponseContent(afRequestId, approve, functionCall)]);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Deserializing tool-call arguments from SDK input.")]

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
@@ -239,35 +239,32 @@ internal static class InputConverter
     /// arguments — which FICC needs to actually invoke the function on the next turn,
     /// and which the backend Conversations API needs to pair the resulting
     /// <c>function_call_output</c> with its previously-stored <c>function_call</c>.
-    /// Falls back to a minimal placeholder when no mapping is available (e.g.
-    /// out-of-band test inputs), preserving the previous best-effort behavior.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no mapping is recorded for <paramref name="approvalRequestId"/>.
+    /// Without the mapping we cannot reconstruct the original call faithfully, and any
+    /// placeholder we return would still fail downstream (FICC has no tool to invoke;
+    /// Azure's stored <c>function_call</c> can't pair with the synthetic id) — so we
+    /// fail fast here with a clear, actionable message rather than continuing into a
+    /// confusing HTTP 400 deep inside the agent loop.
+    /// </exception>
     private static ChatMessage ConvertMcpApprovalResponse(string approvalRequestId, bool approve, AgentSessionStateBag? stateBag)
     {
-        var entry = ToolApprovalIdMap.ResolveEntry(stateBag, approvalRequestId);
+        var entry = ToolApprovalIdMap.ResolveEntry(stateBag, approvalRequestId)
+            ?? throw new InvalidOperationException(
+                $"No approval mapping recorded for wire id '{approvalRequestId}'. " +
+                "This typically indicates the outbound mcp_approval_request was emitted " +
+                "by a different process, the session state was not persisted between turns, " +
+                "or the response was synthesized without a corresponding request.");
 
-        FunctionCallContent functionCall;
-        string afRequestId;
-        if (entry is not null)
-        {
-            afRequestId = entry.AfRequestId;
-            functionCall = new FunctionCallContent(
-                entry.CallId,
-                entry.Name,
-                ParseFunctionArgumentsObject(entry.Arguments));
-        }
-        else
-        {
-            // No mapping recorded — keep the legacy fallback so converters stay total.
-            // The wire id becomes both the AF request id and the placeholder call id; the
-            // synthetic name signals to downstream code that the original details are unknown.
-            afRequestId = approvalRequestId;
-            functionCall = new FunctionCallContent(approvalRequestId, "mcp_approval");
-        }
+        var functionCall = new FunctionCallContent(
+            entry.CallId,
+            entry.Name,
+            ParseFunctionArgumentsObject(entry.Arguments));
 
         return new ChatMessage(
             ChatRole.User,
-            [new ToolApprovalResponseContent(afRequestId, approve, functionCall)]);
+            [new ToolApprovalResponseContent(entry.AfRequestId, approve, functionCall)]);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Deserializing tool-call arguments from SDK input.")]

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -48,10 +48,6 @@ internal static class OutputConverter
         string? previousMessageId = null;
         bool hasTerminalEvent = false;
         var executorItemIds = new Dictionary<string, string>();
-        // Function call emission is deferred until the matching FunctionResultContent arrives.
-        // Without a matching result, the function_call would be an orphan in Azure's stored
-        // conversation and break resume via previous_response_id (issue #5662).
-        var pendingFunctionCalls = new Dictionary<string, (string Name, string Arguments)>(StringComparer.Ordinal);
 
         await foreach (var update in updates.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -143,9 +139,11 @@ internal static class OutputConverter
                             ? JsonSerializer.Serialize(functionCall.Arguments)
                             : "{}";
 
-                        // Buffer name+arguments; only build/emit when the matching
-                        // FunctionResultContent arrives (issue #5662).
-                        pendingFunctionCalls[functionCall.CallId] = (functionCall.Name, arguments);
+                        var fcBuilder = stream.AddOutputItemFunctionCall(functionCall.Name, functionCall.CallId);
+                        yield return fcBuilder.EmitAdded();
+                        yield return fcBuilder.EmitArgumentsDelta(arguments);
+                        yield return fcBuilder.EmitArgumentsDone(arguments);
+                        yield return fcBuilder.EmitDone();
                         break;
                     }
 
@@ -259,16 +257,10 @@ internal static class OutputConverter
 
                     case FunctionResultContent functionResult:
                     {
-                        // Pair this result with a previously-buffered function_call. If none
-                        // exists, drop the result — it likely belongs to an approval flow
-                        // (paired on the wire by mcp_approval_request) and would otherwise
-                        // leave an orphan function_call_output (issue #5662).
-                        if (!pendingFunctionCalls.TryGetValue(functionResult.CallId, out var pending))
+                        if (functionResult.CallId is not { Length: > 0 })
                         {
                             break;
                         }
-
-                        pendingFunctionCalls.Remove(functionResult.CallId);
 
                         foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
                         {
@@ -279,12 +271,6 @@ internal static class OutputConverter
                         currentMessageBuilder = null;
                         accumulatedText = null;
                         previousMessageId = null;
-
-                        var fcBuilder = stream.AddOutputItemFunctionCall(pending.Name, functionResult.CallId);
-                        yield return fcBuilder.EmitAdded();
-                        yield return fcBuilder.EmitArgumentsDelta(pending.Arguments);
-                        yield return fcBuilder.EmitArgumentsDone(pending.Arguments);
-                        yield return fcBuilder.EmitDone();
 
                         var outputJson = functionResult.Result switch
                         {

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -191,7 +191,7 @@ internal static class OutputConverter
                         // wireId↔afRequestId mapping in the session state bag for later lookup
                         // when the matching `mcp_approval_response` arrives on a subsequent turn.
                         var wireId = ToolApprovalIdMap.ComputeWireId(approvalRequest.RequestId);
-                        ToolApprovalIdMap.Record(stateBag, wireId, approvalRequest.RequestId);
+                        ToolApprovalIdMap.Record(stateBag, wireId, approvalRequest.RequestId, approvalFunctionCall);
 
                         var approvalArguments = approvalFunctionCall.Arguments is not null
                             ? JsonSerializer.Serialize(approvalFunctionCall.Arguments)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -120,18 +120,10 @@ internal static class OutputConverter
 
                     case FunctionCallContent:
                     {
-                        // Function calls are internal to the agent's tool-calling loop.
-                        // FICC auto-invokes the function and produces a FunctionResultContent
-                        // (which we also drop, see below) — neither side of the pair belongs
-                        // on the wire. Emitting only the call would leave an orphan
-                        // `function_call` in the response store and break resume on the next
-                        // turn (HTTP 400: "No tool output found for function call ...").
-                        // Approval-required calls surface separately via
-                        // ToolApprovalRequestContent → mcp_approval_request below.
-                        //
-                        // We still close any in-flight assistant message here so that
-                        // pre-tool text cannot accidentally concatenate with post-tool text
-                        // under the same message id.
+                        // Function call/result pairs are internal to the agent's tool-calling
+                        // loop and are not emitted to the wire. Approval-required calls surface
+                        // separately via ToolApprovalRequestContent below. Close any in-flight
+                        // assistant message so pre-tool and post-tool text stay separate.
                         foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
                         {
                             yield return evt;

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -48,6 +48,10 @@ internal static class OutputConverter
         string? previousMessageId = null;
         bool hasTerminalEvent = false;
         var executorItemIds = new Dictionary<string, string>();
+        // Function call emission is deferred until the matching FunctionResultContent arrives.
+        // Without a matching result, the function_call would be an orphan in Azure's stored
+        // conversation and break resume via previous_response_id (issue #5662).
+        var pendingFunctionCalls = new Dictionary<string, (string Name, string Arguments)>(StringComparer.Ordinal);
 
         await foreach (var update in updates.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
@@ -118,12 +122,8 @@ internal static class OutputConverter
                         break;
                     }
 
-                    case FunctionCallContent:
+                    case FunctionCallContent functionCall:
                     {
-                        // Function call/result pairs are internal to the agent's tool-calling
-                        // loop and are not emitted to the wire. Approval-required calls surface
-                        // separately via ToolApprovalRequestContent below. Close any in-flight
-                        // assistant message so pre-tool and post-tool text stay separate.
                         foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
                         {
                             yield return evt;
@@ -133,6 +133,19 @@ internal static class OutputConverter
                         currentMessageBuilder = null;
                         accumulatedText = null;
                         previousMessageId = null;
+
+                        if (functionCall.CallId is not { Length: > 0 })
+                        {
+                            break;
+                        }
+
+                        var arguments = functionCall.Arguments is not null
+                            ? JsonSerializer.Serialize(functionCall.Arguments)
+                            : "{}";
+
+                        // Buffer name+arguments; only build/emit when the matching
+                        // FunctionResultContent arrives (issue #5662).
+                        pendingFunctionCalls[functionCall.CallId] = (functionCall.Name, arguments);
                         break;
                     }
 
@@ -244,10 +257,52 @@ internal static class OutputConverter
                         // These would need to be serialized as base64 or URL references.
                         break;
 
-                    case FunctionResultContent:
-                        // Function results are internal to the agent's tool-calling loop
-                        // and are not emitted as output items in the response stream.
+                    case FunctionResultContent functionResult:
+                    {
+                        // Pair this result with a previously-buffered function_call. If none
+                        // exists, drop the result — it likely belongs to an approval flow
+                        // (paired on the wire by mcp_approval_request) and would otherwise
+                        // leave an orphan function_call_output (issue #5662).
+                        if (!pendingFunctionCalls.TryGetValue(functionResult.CallId, out var pending))
+                        {
+                            break;
+                        }
+
+                        pendingFunctionCalls.Remove(functionResult.CallId);
+
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        {
+                            yield return evt;
+                        }
+
+                        currentTextBuilder = null;
+                        currentMessageBuilder = null;
+                        accumulatedText = null;
+                        previousMessageId = null;
+
+                        var fcBuilder = stream.AddOutputItemFunctionCall(pending.Name, functionResult.CallId);
+                        yield return fcBuilder.EmitAdded();
+                        yield return fcBuilder.EmitArgumentsDelta(pending.Arguments);
+                        yield return fcBuilder.EmitArgumentsDone(pending.Arguments);
+                        yield return fcBuilder.EmitDone();
+
+                        var outputJson = functionResult.Result switch
+                        {
+                            null => "null",
+                            string s => JsonSerializer.Serialize(s),
+                            _ => JsonSerializer.Serialize(functionResult.Result),
+                        };
+
+                        var itemId = GenerateItemId("fc");
+                        var outputItem = new OutputItemFunctionToolCallOutput(
+                            functionResult.CallId,
+                            BinaryData.FromString(outputJson));
+
+                        var outputBuilder = stream.AddOutputItem<OutputItemFunctionToolCallOutput>(itemId);
+                        yield return outputBuilder.EmitAdded(outputItem);
+                        yield return outputBuilder.EmitDone(outputItem);
                         break;
+                    }
 
                     default:
                         break;

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -118,8 +118,20 @@ internal static class OutputConverter
                         break;
                     }
 
-                    case FunctionCallContent funcCall:
+                    case FunctionCallContent:
                     {
+                        // Function calls are internal to the agent's tool-calling loop.
+                        // FICC auto-invokes the function and produces a FunctionResultContent
+                        // (which we also drop, see below) — neither side of the pair belongs
+                        // on the wire. Emitting only the call would leave an orphan
+                        // `function_call` in the response store and break resume on the next
+                        // turn (HTTP 400: "No tool output found for function call ...").
+                        // Approval-required calls surface separately via
+                        // ToolApprovalRequestContent → mcp_approval_request below.
+                        //
+                        // We still close any in-flight assistant message here so that
+                        // pre-tool text cannot accidentally concatenate with post-tool text
+                        // under the same message id.
                         foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
                         {
                             yield return evt;
@@ -129,18 +141,6 @@ internal static class OutputConverter
                         currentMessageBuilder = null;
                         accumulatedText = null;
                         previousMessageId = null;
-
-                        var callId = funcCall.CallId ?? Guid.NewGuid().ToString("N");
-                        var funcBuilder = stream.AddOutputItemFunctionCall(funcCall.Name, callId);
-                        yield return funcBuilder.EmitAdded();
-
-                        var arguments = funcCall.Arguments is not null
-                            ? JsonSerializer.Serialize(funcCall.Arguments)
-                            : "{}";
-
-                        yield return funcBuilder.EmitArgumentsDelta(arguments);
-                        yield return funcBuilder.EmitArgumentsDone(arguments);
-                        yield return funcBuilder.EmitDone();
                         break;
                     }
 

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -120,6 +120,11 @@ internal static class OutputConverter
 
                     case FunctionCallContent functionCall:
                     {
+                        if (functionCall.CallId is not { Length: > 0 })
+                        {
+                            break;
+                        }
+
                         foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
                         {
                             yield return evt;
@@ -129,11 +134,6 @@ internal static class OutputConverter
                         currentMessageBuilder = null;
                         accumulatedText = null;
                         previousMessageId = null;
-
-                        if (functionCall.CallId is not { Length: > 0 })
-                        {
-                            break;
-                        }
 
                         var arguments = functionCall.Arguments is not null
                             ? JsonSerializer.Serialize(functionCall.Arguments)
@@ -194,11 +194,18 @@ internal static class OutputConverter
                         // wireId↔afRequestId mapping in the session state bag for later lookup
                         // when the matching `mcp_approval_response` arrives on a subsequent turn.
                         var wireId = ToolApprovalIdMap.ComputeWireId(approvalRequest.RequestId);
-                        ToolApprovalIdMap.Record(stateBag, wireId, approvalRequest.RequestId, approvalFunctionCall);
 
                         var approvalArguments = approvalFunctionCall.Arguments is not null
                             ? JsonSerializer.Serialize(approvalFunctionCall.Arguments)
                             : "{}";
+
+                        ToolApprovalIdMap.Record(
+                            stateBag,
+                            wireId,
+                            approvalRequest.RequestId,
+                            approvalFunctionCall.CallId,
+                            approvalFunctionCall.Name,
+                            approvalArguments);
 
                         var approvalItem = new OutputItemMcpApprovalRequest(
                             wireId,
@@ -272,17 +279,17 @@ internal static class OutputConverter
                         accumulatedText = null;
                         previousMessageId = null;
 
-                        var outputJson = functionResult.Result switch
+                        var outputText = functionResult.Result switch
                         {
-                            null => "null",
-                            string s => JsonSerializer.Serialize(s),
+                            null => string.Empty,
+                            string s => s,
                             _ => JsonSerializer.Serialize(functionResult.Result),
                         };
 
                         var itemId = GenerateItemId("fc");
                         var outputItem = new OutputItemFunctionToolCallOutput(
                             functionResult.CallId,
-                            BinaryData.FromString(outputJson));
+                            BinaryData.FromString(outputText));
 
                         var outputBuilder = stream.AddOutputItem<OutputItemFunctionToolCallOutput>(itemId);
                         yield return outputBuilder.EmitAdded(outputItem);

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
@@ -1,25 +1,49 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.Foundry.Hosting;
 
 /// <summary>
 /// Helper for translating between agent-framework tool-approval request ids and the
 /// strict-format wire ids required by the Responses Server SDK <c>mcp_approval_request</c>
-/// item type. The mapping is persisted in <see cref="AgentSessionStateBag"/> so an
-/// approval request emitted on one HTTP turn can be matched to the response posted
-/// back on the next turn.
+/// item type, and for preserving the original <see cref="FunctionCallContent"/> across
+/// the request/response round trip. The mapping is persisted in
+/// <see cref="AgentSessionStateBag"/> so an approval request emitted on one HTTP turn can
+/// be matched to the response posted back on the next turn — and the original tool-call
+/// details (name, arguments, call id) can be faithfully reconstructed on the inbound
+/// side, since the wire <c>mcp_approval_response</c> only echoes the approval id.
 /// </summary>
 internal static class ToolApprovalIdMap
 {
     /// <summary>
-    /// State-bag key used to store the wire-id ↔ AF-request-id mapping.
+    /// State-bag key used to store the wire-id ↔ approval-entry mapping.
     /// </summary>
     public const string StateBagKey = "Microsoft.Agents.AI.Foundry.Hosting.ToolApprovalIdMap";
+
+    /// <summary>
+    /// Captures everything needed to faithfully reconstruct the original
+    /// <see cref="FunctionCallContent"/> on the inbound (response) side.
+    /// </summary>
+    /// <remarks>
+    /// FICC composes <c>RequestId</c> as <c>"ficc_{CallId}"</c>; we therefore store
+    /// <c>CallId</c> independently so the reconstructed function-call id matches what
+    /// the model originally emitted (and what the backend Conversations API persisted),
+    /// enabling the resulting <c>function_call_output</c> to pair correctly.
+    /// </remarks>
+    internal sealed class ApprovalEntry
+    {
+        public string AfRequestId { get; set; } = string.Empty;
+        public string CallId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? Arguments { get; set; }
+    }
 
     /// <summary>
     /// SDK item-id format constraints: <c>{prefix}_{50_or_48_chars}</c>. We use the
@@ -41,18 +65,31 @@ internal static class ToolApprovalIdMap
     }
 
     /// <summary>
-    /// Records the wire-id → AF-request-id mapping in the supplied state bag.
+    /// Records the wire-id → approval-entry mapping in the supplied state bag,
+    /// preserving the original <see cref="FunctionCallContent"/> details so the inbound
+    /// <c>mcp_approval_response</c> handler can reconstruct it losslessly.
     /// </summary>
-    public static void Record(AgentSessionStateBag? stateBag, string wireId, string afRequestId)
+    [RequiresUnreferencedCode("FunctionCallContent.Arguments serialization may require types that cannot be statically analyzed.")]
+    [RequiresDynamicCode("FunctionCallContent.Arguments serialization may require runtime code generation.")]
+    public static void Record(AgentSessionStateBag? stateBag, string wireId, string afRequestId, FunctionCallContent functionCall)
     {
         if (stateBag is null)
         {
             return;
         }
 
-        var map = stateBag.GetValue<Dictionary<string, string>>(StateBagKey)
-            ?? new Dictionary<string, string>(StringComparer.Ordinal);
-        map[wireId] = afRequestId;
+        ArgumentNullException.ThrowIfNull(functionCall);
+
+        var map = LoadMap(stateBag);
+        map[wireId] = new ApprovalEntry
+        {
+            AfRequestId = afRequestId,
+            CallId = functionCall.CallId,
+            Name = functionCall.Name,
+            Arguments = functionCall.Arguments is not null
+                ? JsonSerializer.Serialize(functionCall.Arguments)
+                : null,
+        };
         stateBag.SetValue(StateBagKey, map);
     }
 
@@ -62,12 +99,55 @@ internal static class ToolApprovalIdMap
     /// </summary>
     public static string Resolve(AgentSessionStateBag? stateBag, string wireId)
     {
-        if (stateBag?.GetValue<Dictionary<string, string>>(StateBagKey) is { } map
-            && map.TryGetValue(wireId, out var afRequestId))
+        if (TryLoadMap(stateBag, out var map)
+            && map.TryGetValue(wireId, out var entry))
         {
-            return afRequestId;
+            return entry.AfRequestId;
         }
 
         return wireId;
+    }
+
+    /// <summary>
+    /// Looks up the full approval entry for a given wire id, or <see langword="null"/>
+    /// when no mapping is present.
+    /// </summary>
+    public static ApprovalEntry? ResolveEntry(AgentSessionStateBag? stateBag, string wireId)
+    {
+        if (TryLoadMap(stateBag, out var map)
+            && map.TryGetValue(wireId, out var entry))
+        {
+            return entry;
+        }
+
+        return null;
+    }
+
+    private static Dictionary<string, ApprovalEntry> LoadMap(AgentSessionStateBag stateBag)
+        => TryLoadMap(stateBag, out var map) ? map : new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
+
+    private static bool TryLoadMap(AgentSessionStateBag? stateBag, out Dictionary<string, ApprovalEntry> map)
+    {
+        if (stateBag is null)
+        {
+            map = null!;
+            return false;
+        }
+
+        try
+        {
+            map = stateBag.GetValue<Dictionary<string, ApprovalEntry>>(StateBagKey)
+                ?? new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
+            return true;
+        }
+        catch (JsonException)
+        {
+            // Defensive: if a state bag carries an older-format value we cannot deserialize,
+            // start fresh rather than failing the whole request. This only loses the ability
+            // to round-trip an in-flight approval, which the caller already gracefully handles
+            // via the wire-id fallback path.
+            map = new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
+            return true;
+        }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// strict-format wire ids required by the Responses Server SDK <c>mcp_approval_request</c>
 /// item type, and for preserving the original <see cref="FunctionCallContent"/> across
 /// the request/response round trip. The mapping is persisted in
-/// <see cref="AgentSessionStateBag"/> so an approval request emitted on one HTTP turn can
-/// be matched to the response posted back on the next turn — and the original tool-call
-/// details (name, arguments, call id) can be faithfully reconstructed on the inbound
-/// side, since the wire <c>mcp_approval_response</c> only echoes the approval id.
+/// <see cref="AgentSessionStateBag"/>.
 /// </summary>
 internal static class ToolApprovalIdMap
 {
@@ -28,14 +25,13 @@ internal static class ToolApprovalIdMap
     public const string StateBagKey = "Microsoft.Agents.AI.Foundry.Hosting.ToolApprovalIdMap";
 
     /// <summary>
-    /// Captures everything needed to faithfully reconstruct the original
+    /// Captures the data needed to reconstruct the original
     /// <see cref="FunctionCallContent"/> on the inbound (response) side.
     /// </summary>
     /// <remarks>
-    /// FICC composes <c>RequestId</c> as <c>"ficc_{CallId}"</c>; we therefore store
-    /// <c>CallId</c> independently so the reconstructed function-call id matches what
-    /// the model originally emitted (and what the backend Conversations API persisted),
-    /// enabling the resulting <c>function_call_output</c> to pair correctly.
+    /// FICC composes <c>RequestId</c> as <c>"ficc_{CallId}"</c>; <c>CallId</c> is stored
+    /// independently so the reconstructed function-call id matches the one the model
+    /// emitted and the backend Conversations API persisted.
     /// </remarks>
     internal sealed class ApprovalEntry
     {
@@ -65,9 +61,7 @@ internal static class ToolApprovalIdMap
     }
 
     /// <summary>
-    /// Records the wire-id → approval-entry mapping in the supplied state bag,
-    /// preserving the original <see cref="FunctionCallContent"/> details so the inbound
-    /// <c>mcp_approval_response</c> handler can reconstruct it losslessly.
+    /// Records the wire-id → approval-entry mapping in the supplied state bag.
     /// </summary>
     [RequiresUnreferencedCode("FunctionCallContent.Arguments serialization may require types that cannot be statically analyzed.")]
     [RequiresDynamicCode("FunctionCallContent.Arguments serialization may require runtime code generation.")]
@@ -95,7 +89,7 @@ internal static class ToolApprovalIdMap
 
     /// <summary>
     /// Looks up the AF request id for a given wire id. Returns the wire id verbatim
-    /// when no mapping is present (best-effort fallback that keeps converters total).
+    /// when no mapping is present.
     /// </summary>
     public static string Resolve(AgentSessionStateBag? stateBag, string wireId)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.Foundry.Hosting;
@@ -62,27 +60,31 @@ internal static class ToolApprovalIdMap
 
     /// <summary>
     /// Records the wire-id → approval-entry mapping in the supplied state bag.
+    /// Arguments are passed as already-serialized JSON to keep this method
+    /// trim/AOT-friendly (no polymorphic <c>object</c> serialization here).
+    /// No-op when <paramref name="callId"/> or <paramref name="name"/> is empty —
+    /// without those fields the entry cannot be used to faithfully reconstruct
+    /// the original <see cref="FunctionCallContent"/> on the inbound side.
     /// </summary>
-    [RequiresUnreferencedCode("FunctionCallContent.Arguments serialization may require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("FunctionCallContent.Arguments serialization may require runtime code generation.")]
-    public static void Record(AgentSessionStateBag? stateBag, string wireId, string afRequestId, FunctionCallContent functionCall)
+    public static void Record(AgentSessionStateBag? stateBag, string wireId, string afRequestId, string? callId, string? name, string? argumentsJson)
     {
         if (stateBag is null)
         {
             return;
         }
 
-        ArgumentNullException.ThrowIfNull(functionCall);
+        if (string.IsNullOrEmpty(callId) || string.IsNullOrEmpty(name))
+        {
+            return;
+        }
 
         var map = LoadMap(stateBag);
         map[wireId] = new ApprovalEntry
         {
             AfRequestId = afRequestId,
-            CallId = functionCall.CallId,
-            Name = functionCall.Name,
-            Arguments = functionCall.Arguments is not null
-                ? JsonSerializer.Serialize(functionCall.Arguments)
-                : null,
+            CallId = callId!,
+            Name = name!,
+            Arguments = argumentsJson,
         };
         stateBag.SetValue(StateBagKey, map);
     }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Collections.Generic;
@@ -128,20 +128,10 @@ internal static class ToolApprovalIdMap
             return false;
         }
 
-        try
-        {
-            map = stateBag.GetValue<Dictionary<string, ApprovalEntry>>(StateBagKey)
-                ?? new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
-            return true;
-        }
-        catch (JsonException)
-        {
-            // Defensive: if a state bag carries an older-format value we cannot deserialize,
-            // start fresh rather than failing the whole request. This only loses the ability
-            // to round-trip an in-flight approval, which the caller already gracefully handles
-            // via the wire-id fallback path.
-            map = new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
-            return true;
-        }
+        // Don't swallow JsonException: ConvertMcpApprovalResponse fails fast on a missing entry,
+        // so an empty map here would just turn a clear deserialization error into a confusing one.
+        map = stateBag.GetValue<Dictionary<string, ApprovalEntry>>(StateBagKey)
+            ?? new Dictionary<string, ApprovalEntry>(StringComparer.Ordinal);
+        return true;
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Azure.AI.AgentServer.Responses.Models;
 using Microsoft.Extensions.AI;
@@ -783,6 +782,11 @@ public class InputConverterTests
     [Fact]
     public void ConvertItemsToMessages_McpApprovalResponse_ThrowsWhenNoMapping()
     {
+        // Without a recorded ApprovalEntry the converter cannot reconstruct the original
+        // function call faithfully — any placeholder it produced would still fail downstream
+        // (FICC has no tool to invoke; Azure's stored function_call can't pair with the
+        // synthetic id). Fail fast with a clear error instead of continuing into a confusing
+        // HTTP 400 deep inside the agent loop.
         var wireId = "mcpr_" + new string('a', 50);
         var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: true);
 
@@ -800,7 +804,9 @@ public class InputConverterTests
             stateBag,
             wireId,
             AfRequestId,
-            new FunctionCallContent("call_xyz", "issue_refund", new Dictionary<string, object?> { ["order_id"] = 123 }));
+            "call_xyz",
+            "issue_refund",
+            "{\"order_id\":123}");
 
         var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: false);
 
@@ -848,7 +854,9 @@ public class InputConverterTests
             stateBag,
             wireId,
             AfRequestId,
-            new FunctionCallContent("call_history", "delete_file", new Dictionary<string, object?> { ["path"] = "/tmp/x" }));
+            "call_history",
+            "delete_file",
+            "{\"path\":\"/tmp/x\"}");
 
         var item = new OutputItemMcpApprovalResponseResource(
             id: "ar_history_id",
@@ -867,21 +875,6 @@ public class InputConverterTests
     }
 
     [Fact]
-    public void ConvertItemsToMessages_McpApprovalResponse_NoMapping_Throws()
-    {
-        // Without a recorded ApprovalEntry the converter cannot reconstruct the original
-        // function call faithfully — any placeholder it produced would still fail downstream
-        // (FICC has no tool to invoke; Azure's stored function_call can't pair with the
-        // synthetic id). Fail fast with a clear error instead of continuing into a confusing
-        // HTTP 400 deep inside the agent loop.
-        var wireId = "mcpr_" + new string('c', 50);
-        var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: true);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => InputConverter.ConvertItemsToMessages([item]));
-        Assert.Contains(wireId, ex.Message);
-    }
-
-    [Fact]
     public void ConvertItemsToMessages_McpApprovalRequest_MalformedArguments_PreservesRaw()
     {
         var item = new ItemMcpApprovalRequest(
@@ -896,6 +889,28 @@ public class InputConverterTests
         var fc = Assert.IsType<FunctionCallContent>(content.ToolCall);
         Assert.NotNull(fc.Arguments);
         Assert.Equal("not valid json", fc.Arguments!["_raw"]?.ToString());
+    }
+
+    [Fact]
+    public void ToolApprovalIdMap_Record_EmptyCallId_IsNoOp()
+    {
+        var stateBag = new AgentSessionStateBag();
+        var wireId = "mcpr_" + new string('d', 50);
+
+        ToolApprovalIdMap.Record(stateBag, wireId, "ficc_x", callId: string.Empty, name: "tool", argumentsJson: "{}");
+
+        Assert.Null(ToolApprovalIdMap.ResolveEntry(stateBag, wireId));
+    }
+
+    [Fact]
+    public void ToolApprovalIdMap_Record_EmptyName_IsNoOp()
+    {
+        var stateBag = new AgentSessionStateBag();
+        var wireId = "mcpr_" + new string('e', 50);
+
+        ToolApprovalIdMap.Record(stateBag, wireId, "ficc_x", callId: "call_xyz", name: string.Empty, argumentsJson: "{}");
+
+        Assert.Null(ToolApprovalIdMap.ResolveEntry(stateBag, wireId));
     }
 
     // ── input_file data-URI decoding (TryDecodeTextDataUri) ──

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Azure.AI.AgentServer.Responses.Models;
 using Microsoft.Extensions.AI;
@@ -795,10 +796,14 @@ public class InputConverterTests
     [Fact]
     public void ConvertItemsToMessages_McpApprovalResponse_ResolvesAfRequestIdFromStateBag()
     {
-        const string AfRequestId = "af_request_xyz";
+        const string AfRequestId = "ficc_call_xyz";
         var wireId = ToolApprovalIdMap.ComputeWireId(AfRequestId);
         var stateBag = new AgentSessionStateBag();
-        ToolApprovalIdMap.Record(stateBag, wireId, AfRequestId);
+        ToolApprovalIdMap.Record(
+            stateBag,
+            wireId,
+            AfRequestId,
+            new FunctionCallContent("call_xyz", "issue_refund", new Dictionary<string, object?> { ["order_id"] = 123 }));
 
         var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: false);
 
@@ -807,6 +812,17 @@ public class InputConverterTests
         var content = Assert.IsType<ToolApprovalResponseContent>(Assert.Single(messages[0].Contents));
         Assert.Equal(AfRequestId, content.RequestId);
         Assert.False(content.Approved);
+
+        // Verify the original FunctionCallContent is reconstructed losslessly:
+        // - CallId matches the model-issued id (without FICC's "ficc_" prefix), so the
+        //   resulting function_call_output pairs with Azure's stored function_call.
+        // - Name matches the original tool, so FICC can invoke the right function on resume.
+        // - Arguments are preserved.
+        var fcc = Assert.IsType<FunctionCallContent>(content.ToolCall);
+        Assert.Equal("call_xyz", fcc.CallId);
+        Assert.Equal("issue_refund", fcc.Name);
+        Assert.NotNull(fcc.Arguments);
+        Assert.Equal(123, ((System.Text.Json.JsonElement)fcc.Arguments!["order_id"]!).GetInt32());
     }
 
     [Fact]
@@ -828,10 +844,14 @@ public class InputConverterTests
     [Fact]
     public void ConvertOutputItemsToMessages_McpApprovalResponse_ProducesToolApprovalResponse()
     {
-        const string AfRequestId = "af_request_history";
+        const string AfRequestId = "ficc_call_history";
         var wireId = ToolApprovalIdMap.ComputeWireId(AfRequestId);
         var stateBag = new AgentSessionStateBag();
-        ToolApprovalIdMap.Record(stateBag, wireId, AfRequestId);
+        ToolApprovalIdMap.Record(
+            stateBag,
+            wireId,
+            AfRequestId,
+            new FunctionCallContent("call_history", "delete_file", new Dictionary<string, object?> { ["path"] = "/tmp/x" }));
 
         var item = new OutputItemMcpApprovalResponseResource(
             id: "ar_history_id",
@@ -843,6 +863,28 @@ public class InputConverterTests
         var content = Assert.IsType<ToolApprovalResponseContent>(Assert.Single(messages[0].Contents));
         Assert.Equal(AfRequestId, content.RequestId);
         Assert.True(content.Approved);
+
+        var fcc = Assert.IsType<FunctionCallContent>(content.ToolCall);
+        Assert.Equal("call_history", fcc.CallId);
+        Assert.Equal("delete_file", fcc.Name);
+    }
+
+    [Fact]
+    public void ConvertItemsToMessages_McpApprovalResponse_NoMapping_FallsBackToPlaceholder()
+    {
+        // Without a recorded entry the converter must still produce a usable message — the
+        // legacy placeholder behavior is preserved so out-of-band callers (e.g. tests that
+        // bypass OutputConverter) continue to work.
+        var wireId = "mcpr_" + new string('c', 50);
+        var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: true);
+
+        var messages = InputConverter.ConvertItemsToMessages([item]);
+
+        var content = Assert.IsType<ToolApprovalResponseContent>(Assert.Single(messages[0].Contents));
+        Assert.Equal(wireId, content.RequestId);
+        var fcc = Assert.IsType<FunctionCallContent>(content.ToolCall);
+        Assert.Equal(wireId, fcc.CallId);
+        Assert.Equal("mcp_approval", fcc.Name);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
@@ -781,16 +781,13 @@ public class InputConverterTests
     }
 
     [Fact]
-    public void ConvertItemsToMessages_McpApprovalResponse_ProducesToolApprovalResponse_FallsBackToWireIdWhenNoMapping()
+    public void ConvertItemsToMessages_McpApprovalResponse_ThrowsWhenNoMapping()
     {
         var wireId = "mcpr_" + new string('a', 50);
         var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: true);
 
-        var messages = InputConverter.ConvertItemsToMessages([item]);
-
-        var content = Assert.IsType<ToolApprovalResponseContent>(Assert.Single(messages[0].Contents));
-        Assert.Equal(wireId, content.RequestId);
-        Assert.True(content.Approved);
+        var ex = Assert.Throws<InvalidOperationException>(() => InputConverter.ConvertItemsToMessages([item]));
+        Assert.Contains(wireId, ex.Message);
     }
 
     [Fact]
@@ -870,21 +867,18 @@ public class InputConverterTests
     }
 
     [Fact]
-    public void ConvertItemsToMessages_McpApprovalResponse_NoMapping_FallsBackToPlaceholder()
+    public void ConvertItemsToMessages_McpApprovalResponse_NoMapping_Throws()
     {
-        // Without a recorded entry the converter must still produce a usable message — the
-        // legacy placeholder behavior is preserved so out-of-band callers (e.g. tests that
-        // bypass OutputConverter) continue to work.
+        // Without a recorded ApprovalEntry the converter cannot reconstruct the original
+        // function call faithfully — any placeholder it produced would still fail downstream
+        // (FICC has no tool to invoke; Azure's stored function_call can't pair with the
+        // synthetic id). Fail fast with a clear error instead of continuing into a confusing
+        // HTTP 400 deep inside the agent loop.
         var wireId = "mcpr_" + new string('c', 50);
         var item = new MCPApprovalResponse(approvalRequestId: wireId, approve: true);
 
-        var messages = InputConverter.ConvertItemsToMessages([item]);
-
-        var content = Assert.IsType<ToolApprovalResponseContent>(Assert.Single(messages[0].Contents));
-        Assert.Equal(wireId, content.RequestId);
-        var fcc = Assert.IsType<FunctionCallContent>(content.ToolCall);
-        Assert.Equal(wireId, fcc.CallId);
-        Assert.Equal("mcp_approval", fcc.Name);
+        var ex = Assert.Throws<InvalidOperationException>(() => InputConverter.ConvertItemsToMessages([item]));
+        Assert.Contains(wireId, ex.Message);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -84,7 +84,7 @@ public class OutputConverterTests
     }
 
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionCall_IsSuppressedAtWireAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionCallWithoutResult_IsBufferedAndDroppedAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate
@@ -99,11 +99,9 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // FunctionCallContent is internal to the agent's auto-invoke loop and must
-        // NOT surface to the wire. Otherwise the response store keeps an orphan
-        // function_call (no paired function_call_output), and the next turn that
-        // reuses this response as previous_response_id fails with HTTP 400
-        // "No tool output found for function call ...". (issue #5662)
+        // Issue #5662: an FCC without a paired FRC would orphan a function_call in
+        // the response store and break resume via previous_response_id. The FCC is
+        // buffered and only flushed when its FunctionResultContent arrives.
         Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
         Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
@@ -306,9 +304,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // FCC is suppressed at the wire (see issue #5662). Only the text message
-        // remains as a wire item, but the FCC handler still closes the open
-        // message before being suppressed so the message item terminates cleanly.
+        // FCC closes any in-flight assistant message. The FCC itself is buffered
+        // (no matching FRC arrives), so only the text message surfaces (issue #5662).
         Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
         Assert.Single(events.OfType<ResponseOutputItemDoneEvent>());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
@@ -349,14 +346,14 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // FCC suppressed at the wire (issue #5662) regardless of CallId state.
+        // Empty CallId is invalid for the wire format; emission is skipped.
         Assert.DoesNotContain(events, e => e is ResponseOutputItemAddedEvent);
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
     // G-05
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCalls_AreAllSuppressedAsync()
+    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCallsWithoutResults_AreAllBufferedAndDroppedAsync()
     {
         var (stream, _) = CreateTestStream();
         var updates = new[]
@@ -371,7 +368,7 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Both FCCs suppressed at the wire (issue #5662).
+        // No matching FRCs arrive, so both FCCs are dropped (issue #5662).
         Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
@@ -548,7 +545,7 @@ public class OutputConverterTests
 
     // K-03
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionResultContent_IsSkippedWithNoEventsAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultWithoutMatchingCall_IsSkippedAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", "result data")] };
@@ -559,8 +556,37 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
+        // FRC whose CallId we never wire-emitted (e.g. the result of an approval-flow
+        // tool invocation, paired on the wire by mcp_approval_request not function_call)
+        // is dropped to avoid creating an orphan function_call_output (issue #5662).
         Assert.Single(events);
         Assert.IsType<ResponseCompletedEvent>(events[0]);
+    }
+
+    // K-04
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionCallThenResult_EmitsPairedItemsAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var updates = new[]
+        {
+            new AgentResponseUpdate { Contents = [new FunctionCallContent("call_1", "search", new Dictionary<string, object?> { ["q"] = "weather" })] },
+            new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", "sunny")] },
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(updates), stream))
+        {
+            events.Add(evt);
+        }
+
+        // Issue #5662: function_call and function_call_output must both surface as
+        // wire items so Azure's stored conversation has a paired call+output and
+        // resume via previous_response_id works.
+        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Equal(2, events.OfType<ResponseOutputItemDoneEvent>().Count());
+        Assert.Single(events.OfType<ResponseFunctionCallArgumentsDoneEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
     // L-01
@@ -677,6 +703,7 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
+        // Two text messages surface; the FCC is buffered (no FRC) so dropped (issue #5662).
         Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
     }
 
@@ -740,8 +767,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Both FCCs suppressed at the wire (issue #5662). Only the single text
-        // message between them surfaces.
+        // Both FCCs buffered & dropped (no FRCs) leaving only the single text message
+        // between them (issue #5662).
         Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
     }
 
@@ -834,8 +861,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Workflow actions: 4. FCC suppressed at wire (issue #5662). Text message: 1.
-        // Total output items: 5
+        // Workflow actions: 4. FCC buffered (no FRC) and dropped (issue #5662).
+        // Text message: 1. Total output items: 5.
         Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
         Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         Assert.Contains(events, e => e is ResponseTextDeltaEvent);
@@ -974,9 +1001,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Workflow actions: invoked triage, completed triage, invoked expert, completed expert = 4
-        // Content items: FCC suppressed at wire (issue #5662), 1 text message = 1
-        // Total output items: 5
+        // Workflow actions: 4. FCC buffered (no FRC) and dropped (issue #5662).
+        // Content items: 1 text message = 1. Total output items: 5.
         Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
         Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         // Two text deltas for the two streaming chunks

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -590,6 +590,51 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
+    // K-05: An FCC with an empty CallId is dropped without disturbing in-flight text.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionCallEmptyCallIdMidText_PreservesTextBoundaryAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var updates = new[]
+        {
+            new AgentResponseUpdate { MessageId = "msg_1", Contents = [new MeaiTextContent("Hello, ")] },
+            new AgentResponseUpdate { Contents = [new FunctionCallContent(string.Empty, "skipped", new Dictionary<string, object?>())] },
+            new AgentResponseUpdate { MessageId = "msg_1", Contents = [new MeaiTextContent("world!")] },
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(updates), stream))
+        {
+            events.Add(evt);
+        }
+
+        // The FCC is skipped (no CallId), and because we now validate CallId before
+        // closing the in-flight assistant message, both text deltas land in the same
+        // output item — only one message-added event is emitted.
+        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.Equal(2, events.OfType<ResponseTextDeltaEvent>().Count());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // K-06: FRC string results are emitted as raw text on the wire (not JSON-quoted).
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultStringPayload_EmittedAsRawTextAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", "sunny")] };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var added = Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        var output = Assert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
+        // String FRC payloads must not be double-encoded — `sunny`, not `"sunny"`.
+        Assert.Equal("sunny", output.Output.ToString());
+    }
+
     // L-01
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_ExecutorInvokedEvent_EmitsWorkflowActionItemAsync()

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -84,7 +84,7 @@ public class OutputConverterTests
     }
 
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionCallWithoutResult_IsBufferedAndDroppedAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionCallWithoutResult_EmitsFunctionCallWireItemAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate
@@ -99,11 +99,11 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Issue #5662: an FCC without a paired FRC would orphan a function_call in
-        // the response store and break resume via previous_response_id. The FCC is
-        // buffered and only flushed when its FunctionResultContent arrives.
-        Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
-        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // A lone FunctionCallContent (no paired FunctionResultContent) is the
+        // OpenAI Responses encoding of a HITL request: the caller is expected to
+        // resume with a function_call_output for this call_id.
+        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.Single(events.OfType<ResponseFunctionCallArgumentsDoneEvent>());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
@@ -304,10 +304,10 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // FCC closes any in-flight assistant message. The FCC itself is buffered
-        // (no matching FRC arrives), so only the text message surfaces (issue #5662).
-        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
-        Assert.Single(events.OfType<ResponseOutputItemDoneEvent>());
+        // FCC closes any in-flight assistant message, then emits its own function_call
+        // wire item. Result: 2 output items (text message + function_call).
+        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Equal(2, events.OfType<ResponseOutputItemDoneEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
@@ -353,7 +353,7 @@ public class OutputConverterTests
 
     // G-05
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCallsWithoutResults_AreAllBufferedAndDroppedAsync()
+    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCallsWithoutResults_EachEmitsWireItemAsync()
     {
         var (stream, _) = CreateTestStream();
         var updates = new[]
@@ -368,8 +368,9 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // No matching FRCs arrive, so both FCCs are dropped (issue #5662).
-        Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
+        // Each lone FCC surfaces as its own function_call wire item (HITL request shape).
+        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Equal(2, events.OfType<ResponseFunctionCallArgumentsDoneEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
@@ -545,7 +546,7 @@ public class OutputConverterTests
 
     // K-03
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionResultWithoutMatchingCall_IsSkippedAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultWithoutMatchingCall_EmitsFunctionCallOutputAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", "result data")] };
@@ -556,11 +557,11 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // FRC whose CallId we never wire-emitted (e.g. the result of an approval-flow
-        // tool invocation, paired on the wire by mcp_approval_request not function_call)
-        // is dropped to avoid creating an orphan function_call_output (issue #5662).
-        Assert.Single(events);
-        Assert.IsType<ResponseCompletedEvent>(events[0]);
+        // A FunctionResultContent always emits a function_call_output wire item; pairing
+        // with a function_call (if any) is established by call_id at the wire layer.
+        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.Single(events.OfType<ResponseOutputItemDoneEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
     // K-04
@@ -703,8 +704,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Two text messages surface; the FCC is buffered (no FRC) so dropped (issue #5662).
-        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        // text(msg_1) → function_call(call_1) → text(msg_2): three output items.
+        Assert.Equal(3, events.OfType<ResponseOutputItemAddedEvent>().Count());
     }
 
     // M-02
@@ -767,9 +768,8 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Both FCCs buffered & dropped (no FRCs) leaving only the single text message
-        // between them (issue #5662).
-        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        // Three output items: function_call(call_1), text(msg_1), function_call(call_2).
+        Assert.Equal(3, events.OfType<ResponseOutputItemAddedEvent>().Count());
     }
 
     // ===== Workflow content flow tests (W series) =====
@@ -861,10 +861,10 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Workflow actions: 4. FCC buffered (no FRC) and dropped (issue #5662).
-        // Text message: 1. Total output items: 5.
-        Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Workflow actions: 4. Lone FCC: 1 (function_call wire item).
+        // Text message: 1. Total output items: 6.
+        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Single(events.OfType<ResponseFunctionCallArgumentsDoneEvent>());
         Assert.Contains(events, e => e is ResponseTextDeltaEvent);
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
@@ -1001,10 +1001,10 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Workflow actions: 4. FCC buffered (no FRC) and dropped (issue #5662).
-        // Content items: 1 text message = 1. Total output items: 5.
-        Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Workflow actions: 4. Lone FCC: 1 (function_call wire item).
+        // Text message: 1. Total output items: 6.
+        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Single(events.OfType<ResponseFunctionCallArgumentsDoneEvent>());
         // Two text deltas for the two streaming chunks
         Assert.Equal(2, events.OfType<ResponseTextDeltaEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -84,7 +84,7 @@ public class OutputConverterTests
     }
 
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionCall_EmitsFunctionCallEventsAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionCall_IsSuppressedAtWireAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate
@@ -99,10 +99,14 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Should have: FuncAdded, ArgsDelta, ArgsDone, FuncDone, Completed
-        Assert.IsType<ResponseOutputItemAddedEvent>(events[0]);
+        // FunctionCallContent is internal to the agent's auto-invoke loop and must
+        // NOT surface to the wire. Otherwise the response store keeps an orphan
+        // function_call (no paired function_call_output), and the next turn that
+        // reuses this response as previous_response_id fails with HTTP 400
+        // "No tool output found for function call ...". (issue #5662)
+        Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
-        Assert.True(events.Count >= 4, $"Expected at least 4 events for function call, got {events.Count}");
     }
 
     [Fact]
@@ -302,8 +306,11 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.Equal(2, events.OfType<ResponseOutputItemDoneEvent>().Count());
+        // FCC is suppressed at the wire (see issue #5662). Only the text message
+        // remains as a wire item, but the FCC handler still closes the open
+        // message before being suppressed so the message item terminates cleanly.
+        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.Single(events.OfType<ResponseOutputItemDoneEvent>());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
@@ -328,7 +335,7 @@ public class OutputConverterTests
 
     // G-04
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionCallWithEmptyCallId_GeneratesCallIdAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionCallWithEmptyCallId_DoesNotEmitWireItemAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate
@@ -342,12 +349,14 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        Assert.Contains(events, e => e is ResponseOutputItemAddedEvent);
+        // FCC suppressed at the wire (issue #5662) regardless of CallId state.
+        Assert.DoesNotContain(events, e => e is ResponseOutputItemAddedEvent);
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
     // G-05
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCalls_EmitsSeparateBuildersAsync()
+    public async Task ConvertUpdatesToEventsAsync_MultipleFunctionCalls_AreAllSuppressedAsync()
     {
         var (stream, _) = CreateTestStream();
         var updates = new[]
@@ -362,7 +371,9 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        // Both FCCs suppressed at the wire (issue #5662).
+        Assert.Empty(events.OfType<ResponseOutputItemAddedEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
     // H-02
@@ -666,7 +677,7 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        Assert.Equal(3, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Equal(2, events.OfType<ResponseOutputItemAddedEvent>().Count());
     }
 
     // M-02
@@ -729,7 +740,9 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        Assert.Equal(3, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        // Both FCCs suppressed at the wire (issue #5662). Only the single text
+        // message between them surfaces.
+        Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
     }
 
     // ===== Workflow content flow tests (W series) =====
@@ -821,9 +834,10 @@ public class OutputConverterTests
             events.Add(evt);
         }
 
-        // Should have: 4 workflow actions + 1 function call + 1 text message = 6 output items
-        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.Contains(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Workflow actions: 4. FCC suppressed at wire (issue #5662). Text message: 1.
+        // Total output items: 5
+        Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         Assert.Contains(events, e => e is ResponseTextDeltaEvent);
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
@@ -961,10 +975,10 @@ public class OutputConverterTests
         }
 
         // Workflow actions: invoked triage, completed triage, invoked expert, completed expert = 4
-        // Content items: 1 function call, 1 text message = 2
-        // Total output items: 6
-        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.Contains(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Content items: FCC suppressed at wire (issue #5662), 1 text message = 1
+        // Total output items: 5
+        Assert.Equal(5, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         // Two text deltas for the two streaming chunks
         Assert.Equal(2, events.OfType<ResponseTextDeltaEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
@@ -185,10 +185,10 @@ public class OutputConverterWorkflowTests
         }
 
         // Workflow actions: 4 (2 invoked + 2 completed)
-        // Content: 1 reasoning + FCC buffered (no FRC) and dropped + 1 text message = 2 (issue #5662)
-        // Total: 6 output items
-        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Content: 1 reasoning + 1 function_call (lone FCC = HITL request) + 1 text = 3
+        // Total: 7 output items
+        Assert.Equal(7, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.Single(events.OfType<ResponseFunctionCallArgumentsDoneEvent>());
         Assert.Equal(2, events.OfType<ResponseTextDeltaEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
@@ -185,7 +185,7 @@ public class OutputConverterWorkflowTests
         }
 
         // Workflow actions: 4 (2 invoked + 2 completed)
-        // Content: 1 reasoning + FCC suppressed at wire (issue #5662) + 1 text message = 2
+        // Content: 1 reasoning + FCC buffered (no FRC) and dropped + 1 text message = 2 (issue #5662)
         // Total: 6 output items
         Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
         Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterWorkflowTests.cs
@@ -185,10 +185,10 @@ public class OutputConverterWorkflowTests
         }
 
         // Workflow actions: 4 (2 invoked + 2 completed)
-        // Content: 1 reasoning + 1 function call + 1 text message = 3
-        // Total: 7 output items
-        Assert.Equal(7, events.OfType<ResponseOutputItemAddedEvent>().Count());
-        Assert.Contains(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
+        // Content: 1 reasoning + FCC suppressed at wire (issue #5662) + 1 text message = 2
+        // Total: 6 output items
+        Assert.Equal(6, events.OfType<ResponseOutputItemAddedEvent>().Count());
+        Assert.DoesNotContain(events, e => e is ResponseFunctionCallArgumentsDoneEvent);
         Assert.Equal(2, events.OfType<ResponseTextDeltaEvent>().Count());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }


### PR DESCRIPTION
This pull request makes significant improvements to how tool approval requests and responses are handled, ensuring that function call details are preserved and correctly reconstructed across HTTP turns. It also updates the logic to suppress internal function call events from being emitted on the wire, preventing orphaned function calls and related errors. Comprehensive tests are added and updated to validate these behaviors.

Closes #5662 