### PR TITLE
Python: fix: add logging to silent exception handlers (ag-ui + purview)

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
@@ -199,6 +199,7 @@ def _coerce_content(value: Any) -> Content | None:
     try:
         return Content.from_dict(content_payload)
     except Exception:
+        logger.debug("Failed to coerce candidate content from dict", exc_info=True)
         return None
 
 
@@ -218,6 +219,7 @@ def _coerce_message_content(content_payload: Any) -> Content | None:
         try:
             return Content.from_dict(content_dict)
         except Exception:
+            logger.debug("Failed to coerce message content from dict", exc_info=True)
             return None
     return None
 

--- a/python/packages/purview/agent_framework_purview/_models.py
+++ b/python/packages/purview/agent_framework_purview/_models.py
@@ -89,6 +89,7 @@ def deserialize_flag(
         try:
             return enum_cls(value)
         except Exception:
+            logger.warning("Failed to convert int %s to %s", value, enum_cls.__name__)
             return None
 
     flag_value = enum_cls(0)

--- a/python/packages/purview/agent_framework_purview/_models.py
+++ b/python/packages/purview/agent_framework_purview/_models.py
@@ -89,7 +89,7 @@ def deserialize_flag(
         try:
             return enum_cls(value)
         except Exception:
-            logger.warning("Failed to convert int %s to %s", value, enum_cls.__name__)
+            logger.warning("Failed to convert int %s to %s", value, enum_cls.__name__, exc_info=True)
             return None
 
     flag_value = enum_cls(0)
@@ -113,7 +113,7 @@ def deserialize_flag(
                 try:
                     flag_value |= enum_cls(item)
                 except Exception:
-                    logger.warning(f"Failed to convert int {item} to {enum_cls.__name__}")
+                    logger.warning(f"Failed to convert int {item} to {enum_cls.__name__}", exc_info=True)
 
     for part in parts:
         member = mapping.get(part)


### PR DESCRIPTION
## Problem

3 `except Exception` blocks silently swallow failures with no diagnostic output:

| File | Location | What fails silently |
|------|----------|---------------------|
| `_workflow_run.py` | `_coerce_candidate_content` | AG-UI content coercion fails |
| `_workflow_run.py` | `_coerce_message_content` | Message content coercion fails |
| `_models.py` | enum conversion | Purview int→enum conversion fails |

## Fix

Each catch now logs at the appropriate level using the existing module-level `logger = logging.getLogger(__name__)`:

- Content coercion failures → `logger.debug()` (best-effort conversion, not an error)
- Enum conversion failure → `logger.warning()` (indicates malformed data)

## Changes

- 2 files, 3 lines added
- No behavioral changes — all functions still return `None` on failure
