### PR TITLE
.NET: Fix function_call_output.output to be a JSON string on the wire

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InputConverter.cs
@@ -190,7 +190,7 @@ internal static class InputConverter
 
     private static ChatMessage ConvertFunctionCallOutput(FunctionCallOutputItemParam funcOutput)
     {
-        var output = funcOutput.Output?.ToString() ?? string.Empty;
+        var output = DecodeFunctionResultPayload(funcOutput.Output);
         return new ChatMessage(
             ChatRole.Tool,
             [new FunctionResultContent(funcOutput.CallId, output)]);
@@ -482,9 +482,54 @@ internal static class InputConverter
 
     private static ChatMessage ConvertFunctionToolCallOutput(OutputItemFunctionToolCallOutput funcOutput)
     {
+        var output = DecodeFunctionResultPayload(funcOutput.Output);
         return new ChatMessage(
             ChatRole.Tool,
-            [new FunctionResultContent(funcOutput.CallId, funcOutput.Output)]);
+            [new FunctionResultContent(funcOutput.CallId, output)]);
+    }
+
+    /// <summary>
+    /// Decodes the wire payload of a <c>function_call_output.output</c> field back into the
+    /// underlying tool-result text suitable for replay as <see cref="FunctionResultContent.Result"/>.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>OutputConverter.EncodeFunctionResultAsJsonStringPayload</c>. Per the OpenAI
+    /// Responses spec, <c>output</c> is a JSON string; we extract its underlying value. Legacy
+    /// producers that emitted raw JSON values (arrays/objects) are tolerated by passing the raw
+    /// bytes through unchanged.
+    /// </remarks>
+    private static string DecodeFunctionResultPayload(BinaryData? rawOutput)
+    {
+        if (rawOutput is null)
+        {
+            return string.Empty;
+        }
+
+        var raw = rawOutput.ToString();
+        if (string.IsNullOrEmpty(raw))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            if (doc.RootElement.ValueKind == JsonValueKind.String)
+            {
+                return doc.RootElement.GetString() ?? string.Empty;
+            }
+
+            // Legacy/non-conforming producers may have emitted a raw JSON value
+            // (array/object/number/bool/null). Pass the raw text through as the
+            // payload so the replayed FunctionResultContent.Result preserves the
+            // original tool output shape.
+            return raw;
+        }
+        catch (JsonException)
+        {
+            // Not valid JSON — treat the bytes as a literal string payload.
+            return raw;
+        }
     }
 
     private static ChatRole ConvertMessageRole(MessageRole role)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -279,12 +279,24 @@ internal static class OutputConverter
                         accumulatedText = null;
                         previousMessageId = null;
 
-                        var outputText = functionResult.Result switch
+                        // The OpenAI Responses spec requires `function_call_output.output` to
+                        // be a JSON string. The Responses SDK's OutputItemFunctionToolCallOutput
+                        // accepts a BinaryData containing the *raw JSON value* for the field, so
+                        // we must always wrap the payload as a JSON string literal:
+                        //   - string s   → JSON-encode s (quoted, with escapes)
+                        //   - object o   → JSON-serialize o, then JSON-encode the resulting text
+                        // Without this wrapping, complex tool results (e.g. List<TodoItem>)
+                        // would land on the wire as an unquoted JSON array, which the strict-
+                        // parsing OpenAI .NET client (FunctionCallOutputResponseItem) rejects
+                        // with "requires an element of type 'String', but the target element
+                        // has type 'Array'".
+                        string innerText = functionResult.Result switch
                         {
                             null => string.Empty,
                             string s => s,
                             _ => JsonSerializer.Serialize(functionResult.Result),
                         };
+                        string outputText = JsonSerializer.Serialize(innerText);
 
                         var itemId = GenerateItemId("fc");
                         var outputItem = new OutputItemFunctionToolCallOutput(

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -279,24 +279,7 @@ internal static class OutputConverter
                         accumulatedText = null;
                         previousMessageId = null;
 
-                        // The OpenAI Responses spec requires `function_call_output.output` to
-                        // be a JSON string. The Responses SDK's OutputItemFunctionToolCallOutput
-                        // accepts a BinaryData containing the *raw JSON value* for the field, so
-                        // we must always wrap the payload as a JSON string literal:
-                        //   - string s   → JSON-encode s (quoted, with escapes)
-                        //   - object o   → JSON-serialize o, then JSON-encode the resulting text
-                        // Without this wrapping, complex tool results (e.g. List<TodoItem>)
-                        // would land on the wire as an unquoted JSON array, which the strict-
-                        // parsing OpenAI .NET client (FunctionCallOutputResponseItem) rejects
-                        // with "requires an element of type 'String', but the target element
-                        // has type 'Array'".
-                        string innerText = functionResult.Result switch
-                        {
-                            null => string.Empty,
-                            string s => s,
-                            _ => JsonSerializer.Serialize(functionResult.Result),
-                        };
-                        string outputText = JsonSerializer.Serialize(innerText);
+                        var outputText = EncodeFunctionResultAsJsonStringPayload(functionResult.Result);
 
                         var itemId = GenerateItemId("fc");
                         var outputItem = new OutputItemFunctionToolCallOutput(
@@ -459,5 +442,45 @@ internal static class OutputConverter
         var bytes = RandomNumberGenerator.GetBytes(25);
         var body = Convert.ToHexString(bytes); // 50 hex chars, uppercase
         return $"{prefix}_{body}";
+    }
+
+    /// <summary>
+    /// Encodes a <see cref="FunctionResultContent.Result"/> value into the wire payload for
+    /// the OpenAI Responses <c>function_call_output.output</c> field.
+    /// </summary>
+    /// <remarks>
+    /// The OpenAI Responses spec requires <c>output</c> to be a JSON string. The Responses
+    /// SDK's <see cref="OutputItemFunctionToolCallOutput"/> accepts a <see cref="BinaryData"/>
+    /// containing the *raw JSON value* for the field, so the returned text is always a JSON
+    /// string literal (quoted, with escapes). This avoids two bugs:
+    /// <list type="bullet">
+    ///   <item>Complex results (e.g. <c>List&lt;TodoItem&gt;</c>) landing on the wire as an
+    ///   unquoted JSON array, which the strict-parsing OpenAI .NET client
+    ///   (<c>FunctionCallOutputResponseItem</c>) rejects with
+    ///   "requires an element of type 'String', but the target element has type 'Array'".</item>
+    ///   <item>Numeric- or JSON-shaped string results (e.g. <c>"42"</c> or <c>"{\"k\":1}"</c>)
+    ///   silently changing type on the wire because <c>BinaryData</c> auto-detects JSON.</item>
+    /// </list>
+    /// <see cref="JsonElement"/> / <see cref="JsonDocument"/> values are unwrapped first so
+    /// a string-kind element does not get double-encoded into <c>"\"value\""</c>.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Serializing function call result payload.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Serializing function call result payload.")]
+    private static string EncodeFunctionResultAsJsonStringPayload(object? result)
+    {
+        string innerText = result switch
+        {
+            null => string.Empty,
+            string s => s,
+            JsonElement je => je.ValueKind == JsonValueKind.String
+                ? (je.GetString() ?? string.Empty)
+                : je.GetRawText(),
+            JsonDocument jd => jd.RootElement.ValueKind == JsonValueKind.String
+                ? (jd.RootElement.GetString() ?? string.Empty)
+                : jd.RootElement.GetRawText(),
+            _ => JsonSerializer.Serialize(result),
+        };
+
+        return JsonSerializer.Serialize(innerText);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/InputConverterTests.cs
@@ -207,9 +207,10 @@ public class InputConverterTests
     [Fact]
     public void ConvertOutputItemsToMessages_FunctionToolCallOutput_ReturnsToolMessage()
     {
+        // Spec-compliant payload: a JSON string literal.
         var funcOutput = new OutputItemFunctionToolCallOutput(
             callId: "call_def",
-            output: BinaryData.FromString("result data"));
+            output: BinaryData.FromString("\"result data\""));
 
         var messages = InputConverter.ConvertOutputItemsToMessages([funcOutput]);
 
@@ -218,6 +219,52 @@ public class InputConverterTests
         var result = messages[0].Contents.OfType<FunctionResultContent>().FirstOrDefault();
         Assert.NotNull(result);
         Assert.Equal("call_def", result.CallId);
+        // Round-trip: the JSON-string wire payload is unwrapped to the original tool result text.
+        Assert.Equal("result data", result.Result as string);
+    }
+
+    [Fact]
+    public void ConvertOutputItemsToMessages_FunctionToolCallOutput_LegacyRawJsonArray_PassesThrough()
+    {
+        // Legacy/non-conforming producers that emitted a raw JSON value (array/object) in
+        // `output` are tolerated: the raw text is forwarded as the FunctionResultContent.Result
+        // so the model still sees the original tool-output shape on replay.
+        var funcOutput = new OutputItemFunctionToolCallOutput(
+            callId: "call_legacy",
+            output: BinaryData.FromString("[{\"id\":1}]"));
+
+        var messages = InputConverter.ConvertOutputItemsToMessages([funcOutput]);
+
+        var result = messages[0].Contents.OfType<FunctionResultContent>().FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Equal("[{\"id\":1}]", result.Result as string);
+    }
+
+    [Fact]
+    public void ConvertInputToMessages_FunctionCallOutput_JsonStringPayload_Unwraps()
+    {
+        // Spec-compliant inbound payload — a JSON string literal — must be unwrapped so
+        // FunctionResultContent.Result is the original tool result text, not the JSON-encoded form.
+        var input = new[]
+        {
+            new
+            {
+                type = "function_call_output",
+                id = "fc_out_002",
+                call_id = "call_456",
+                output = "sunny"
+            }
+        };
+
+        var request = new CreateResponse();
+        request.Input = BinaryData.FromObjectAsJson(input);
+
+        var messages = InputConverter.ConvertInputToMessages(request);
+
+        Assert.Single(messages);
+        var funcResult = messages[0].Contents.OfType<FunctionResultContent>().FirstOrDefault();
+        Assert.NotNull(funcResult);
+        Assert.Equal("sunny", funcResult.Result as string);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -616,9 +616,10 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // K-06: FRC string results are emitted as raw text on the wire (not JSON-quoted).
+    // K-06: FRC payloads are wrapped as JSON string literals on the wire so the field is
+    // always a spec-compliant OpenAI Responses `function_call_output.output` string value.
     [Fact]
-    public async Task ConvertUpdatesToEventsAsync_FunctionResultStringPayload_EmittedAsRawTextAsync()
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultStringPayload_EmittedAsJsonStringAsync()
     {
         var (stream, _) = CreateTestStream();
         var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", "sunny")] };
@@ -631,8 +632,76 @@ public class OutputConverterTests
 
         var added = Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
         var output = Assert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
-        // String FRC payloads must not be double-encoded — `sunny`, not `"sunny"`.
-        Assert.Equal("sunny", output.Output.ToString());
+        // The wire payload is a JSON string literal — `"sunny"`, not the bare bytes `sunny`.
+        Assert.Equal("\"sunny\"", output.Output.ToString());
+    }
+
+    // K-06b: List/object FRC payloads must be JSON-stringified into a JSON string value
+    // so the OpenAI .NET client (FunctionCallOutputResponseItem.Output: string) can parse them.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultObjectPayload_EmittedAsJsonStringAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var todoList = new[] { new { id = 1, text = "Buy milk" } };
+        var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", todoList)] };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var added = Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        var output = Assert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
+        // The wire payload must be a quoted JSON string containing the JSON-serialized object.
+        var raw = output.Output.ToString();
+        Assert.StartsWith("\"", raw);
+        Assert.EndsWith("\"", raw);
+        // The unwrapped value must round-trip back to the original JSON.
+        var inner = System.Text.Json.JsonSerializer.Deserialize<string>(raw);
+        Assert.Equal("[{\"id\":1,\"text\":\"Buy milk\"}]", inner);
+    }
+
+    // K-06c: A JsonElement of kind String must not be double-encoded.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultJsonElementStringPayload_NotDoubleEncodedAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        using var doc = System.Text.Json.JsonDocument.Parse("\"sunny\"");
+        var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", doc.RootElement.Clone())] };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var added = Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        var output = Assert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
+        // Must be `"sunny"`, not `"\"sunny\""`.
+        Assert.Equal("\"sunny\"", output.Output.ToString());
+    }
+
+    // K-06d: A JsonElement of non-string kind (e.g. array) must be JSON-stringified, not
+    // emitted as a raw JSON array on the wire.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_FunctionResultJsonElementArrayPayload_EmittedAsJsonStringAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        using var doc = System.Text.Json.JsonDocument.Parse("[{\"id\":1}]");
+        var update = new AgentResponseUpdate { Contents = [new FunctionResultContent("call_1", doc.RootElement.Clone())] };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var added = Assert.Single(events.OfType<ResponseOutputItemAddedEvent>());
+        var output = Assert.IsType<OutputItemFunctionToolCallOutput>(added.Item);
+        var raw = output.Output.ToString();
+        var inner = System.Text.Json.JsonSerializer.Deserialize<string>(raw);
+        Assert.Equal("[{\"id\":1}]", inner);
     }
 
     // L-01


### PR DESCRIPTION
This pull request updates the way function call outputs are serialized to ensure compatibility with the OpenAI Responses specification and the .NET client. The main change is that all function call outputs are now wrapped as JSON string literals, preventing parsing errors when handling complex types.