### PR TITLE
.NET: fix: align Anthropic Extensions AI version

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire.* -->
-    <PackageVersion Include="Anthropic" Version="12.13.0" />
+    <PackageVersion Include="Anthropic" Version="12.20.0" />
     <PackageVersion Include="Anthropic.Foundry" Version="0.5.0" />
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireAppHostSdkVersion)" />
     <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.0.0-preview.1.25560.3" />

--- a/dotnet/tests/AnthropicChatCompletion.IntegrationTests/AnthropicChatCompletionFixture.cs
+++ b/dotnet/tests/AnthropicChatCompletion.IntegrationTests/AnthropicChatCompletionFixture.cs
@@ -102,11 +102,6 @@ public class AnthropicChatCompletionFixture : IChatClientAgentFixture
 
     public async ValueTask InitializeAsync()
     {
-        // Temporarily disabled: Anthropic SDK has a binary incompatibility with the current
-        // Microsoft.Extensions.AI version (WebSearchToolResultContent.Results method not found).
-        // See: https://github.com/microsoft/agent-framework/pull/5515
-        Assert.Skip("Anthropic integration tests temporarily disabled due to SDK incompatibility with Microsoft.Extensions.AI");
-
         try
         {
             _ = TestConfiguration.GetRequiredValue(TestSettings.AnthropicApiKey);

--- a/dotnet/tests/AnthropicChatCompletion.IntegrationTests/AnthropicSkillsIntegrationTests.cs
+++ b/dotnet/tests/AnthropicChatCompletion.IntegrationTests/AnthropicSkillsIntegrationTests.cs
@@ -18,11 +18,7 @@ namespace AnthropicChatCompletion.IntegrationTests;
 /// Integration tests for Anthropic Skills functionality.
 /// These tests are designed to be run locally with a valid Anthropic API key.
 /// </summary>
-/// <remarks>
-/// Temporarily disabled due to Anthropic SDK binary incompatibility with
-/// the current Microsoft.Extensions.AI version (WebSearchToolResultContent.Results).
-/// </remarks>
-[Trait("Category", "IntegrationDisabled")]
+[Trait("Category", "Integration")]
 public sealed class AnthropicSkillsIntegrationTests
 {
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicBetaServiceExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicBetaServiceExtensionsTests.cs
@@ -442,6 +442,7 @@ public sealed class AnthropicBetaServiceExtensionsTests
         public TimeSpan? Timeout { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
         public string? ApiKey { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
         public string? AuthToken { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
+        public string? WebhookKey { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
 
         public IAnthropicClientWithRawResponse WithRawResponse => throw new NotImplementedException();
 
@@ -490,6 +491,12 @@ public sealed class AnthropicBetaServiceExtensionsTests
             public global::Anthropic.Services.Beta.ISessionService Sessions => throw new NotImplementedException();
 
             public global::Anthropic.Services.Beta.IVaultService Vaults => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.IMemoryStoreService MemoryStores => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.IWebhookService Webhooks => throw new NotImplementedException();
+
+            public global::Anthropic.Services.Beta.IUserProfileService UserProfiles => throw new NotImplementedException();
 
             public IBetaService WithOptions(Func<ClientOptions, ClientOptions> modifier)
             {

--- a/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Anthropic.UnitTests/Extensions/AnthropicClientExtensionsTests.cs
@@ -72,6 +72,7 @@ public sealed class AnthropicClientExtensionsTests
         public TimeSpan? Timeout { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
         public string? ApiKey { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
         public string? AuthToken { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
+        public string? WebhookKey { get => throw new NotImplementedException(); init => throw new NotImplementedException(); }
 
         public IAnthropicClientWithRawResponse WithRawResponse => throw new NotImplementedException();
 


### PR DESCRIPTION
## Summary

Related to #5707.

Addresses the Anthropic side of a regression where provider usage could fail with `MissingMethodException` around `Microsoft.Extensions.AI.WebSearchToolResultContent.Results`.

This PR does not change the repo-pinned `Google.GenAI` dependency. During investigation, the latest available `Google.GenAI` package I found was `1.6.1`, and it still appeared to reference `WebSearchToolResultContent.set_Results`, so the Google.GenAI side likely needs an upstream package update or a broader dependency strategy.

## Changes

- Bumped `Anthropic` from `12.13.0` to `12.20.0`
- Re-enabled Anthropic integration coverage that was disabled for the binary incompatibility
- Confirmed `Anthropic` `12.20.0` no longer references the removed `Results` accessor

## Validation

- [x] `git diff --check HEAD~1..HEAD`
- [x] Metadata scan confirmed `Anthropic` `12.20.0` no longer references the removed `WebSearchToolResultContent.Results` accessor
- [x] Confirmed the repo-pinned `Google.GenAI` `1.6.0` is not changed by this PR
- [x] Separately checked the latest available `Google.GenAI` package found during investigation, `1.6.1`, and it still appears to reference `WebSearchToolResultContent.set_Results`
- [ ] `dotnet restore` blocked locally because repo requires .NET SDK `10.0.200`; installed SDK is `9.0.313`
- [ ] `dotnet build` blocked locally for the same SDK reason
- [ ] `dotnet test` blocked locally for the same SDK reason

Related to #5707