### PR TITLE
Trigger issue triage on bug-labeled issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,12 +1,8 @@
 name: Issue Triage
 
 on:
-  workflow_dispatch:
-    inputs:
-      issue_number:
-        description: Issue number to triage
-        required: true
-        type: string
+  issues:
+    types: [opened, labeled]
 
 permissions:
   contents: read
@@ -14,7 +10,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: issue-triage-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
+  group: issue-triage-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -26,6 +22,7 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug') || github.event.action == 'labeled' && github.event.label.name == 'bug' }}
     outputs:
       is_team_member: ${{ steps.check.outputs.is_team_member }}
       issue_number: ${{ steps.issue.outputs.issue_number }}
@@ -36,18 +33,13 @@ jobs:
         shell: bash
         env:
           ISSUE_NUMBER_EVENT: ${{ github.event.issue.number }}
-          ISSUE_NUMBER_INPUT: ${{ inputs.issue_number }}
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_EVENT_NAME}" == "issues" ]]; then
-            issue_number="${ISSUE_NUMBER_EVENT}"
-          else
-            issue_number="${ISSUE_NUMBER_INPUT}"
-          fi
+          issue_number="${ISSUE_NUMBER_EVENT}"
 
           if [[ ! "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Could not determine issue number; for workflow_dispatch runs, the 'issue_number' input is required." >&2
+            echo "Could not determine issue number from event payload." >&2
             exit 1
           fi
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,7 +10,13 @@ permissions:
   id-token: write
 
 concurrency:
-  group: issue-triage-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+  group: >-
+    issue-triage-${{ github.repository }}-${{
+      ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug'))
+       || (github.event.action == 'labeled' && github.event.label.name == 'bug'))
+      && github.event.issue.number
+      || github.run_id
+    }}
   cancel-in-progress: true
 
 env:
@@ -22,7 +28,7 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug') || github.event.action == 'labeled' && github.event.label.name == 'bug' }}
+    if: ${{ (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug')) || (github.event.action == 'labeled' && github.event.label.name == 'bug') }}
     outputs:
       is_team_member: ${{ steps.check.outputs.is_team_member }}
       issue_number: ${{ steps.issue.outputs.issue_number }}


### PR DESCRIPTION
### Motivation and Context

The Issue Triage workflow previously only ran via `workflow_dispatch`, which required a maintainer to manually enter an issue number. We want triage to kick off automatically when a community bug report lands so the spam gate and repro steps run without manual intervention.

### Description

- Replace the `workflow_dispatch` trigger with `issues: [opened, labeled]`.
- Gate the `team_check` job so it only runs when an issue is opened already carrying the `bug` label, or when the `bug` label is added later.
- Simplify the issue-number resolution step (and the concurrency group key) now that the manual input is gone; the issue number always comes from the event payload.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.