### PR TITLE
Python: fix: skip orphan Anthropic thinking signatures

### DIFF
--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -803,6 +803,15 @@ class RawAnthropicClient(
                     }
                     a_content.append(mcp_result)
                 case "text_reasoning":
+                    if content.text is None:
+                        if (
+                            content.protected_data
+                            and a_content
+                            and a_content[-1].get("type") == "thinking"
+                            and "signature" not in a_content[-1]
+                        ):
+                            a_content[-1]["signature"] = content.protected_data
+                        continue
                     thinking_block: dict[str, Any] = {"type": "thinking", "thinking": content.text}
                     if content.protected_data:
                         thinking_block["signature"] = content.protected_data

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -485,6 +485,48 @@ def test_prepare_message_for_anthropic_text_reasoning_with_signature(
     assert result["content"][0]["signature"] == "sig_abc123"
 
 
+def test_prepare_message_for_anthropic_attaches_signature_only_reasoning(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    client = create_test_anthropic_client(mock_anthropic_client)
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_text_reasoning(text="Let me think about this..."),
+            Content.from_text_reasoning(text=None, protected_data="sig_abc123"),
+        ],
+    )
+
+    result = client._prepare_message_for_anthropic(message)
+
+    assert result["content"] == [
+        {"type": "thinking", "thinking": "Let me think about this...", "signature": "sig_abc123"}
+    ]
+
+
+def test_prepare_message_for_anthropic_skips_orphan_signature_only_reasoning(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    client = create_test_anthropic_client(mock_anthropic_client)
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_text_reasoning(text=None, protected_data="sig_abc123"),
+            Content.from_function_call(
+                call_id="call_123",
+                name="get_weather",
+                arguments={"location": "San Francisco"},
+            ),
+        ],
+    )
+
+    result = client._prepare_message_for_anthropic(message)
+
+    assert len(result["content"]) == 1
+    assert result["content"][0]["type"] == "tool_use"
+    assert result["content"][0]["id"] == "call_123"
+
+
 def test_prepare_message_for_anthropic_mcp_server_tool_call(
     mock_anthropic_client: MagicMock,
 ) -> None:


### PR DESCRIPTION
Fixes #5783. The Anthropic message serializer no longer emits thinking blocks with thinking set to null when a text_reasoning item only carries protected_data. If the signature immediately follows a thinking block, it is attached to that block; otherwise the orphan signature-only item is skipped before replay. Validation: uv run pytest packages/anthropic/tests/test_anthropic_client.py -k 'text_reasoning or signature_delta' -q; uv run ruff check packages/anthropic/agent_framework_anthropic/_chat_client.py packages/anthropic/tests/test_anthropic_client.py; uv run ruff format --check packages/anthropic/agent_framework_anthropic/_chat_client.py packages/anthropic/tests/test_anthropic_client.py; uv run pyright packages/anthropic/agent_framework_anthropic/_chat_client.py packages/anthropic/tests/test_anthropic_client.py; uv run mypy --config-file pyproject.toml packages/anthropic/agent_framework_anthropic; python -m py_compile; git diff --check. I also tried mypy on the full test file, but it reports existing unrelated type errors in packages/anthropic/tests/test_anthropic_client.py.