### PR TITLE
.NET: Add Microsoft.Agents.AI.DevUI as dependency of the Aspire integration

### DIFF
--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
@@ -31,6 +31,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      DevUIAggregatorHostedService loads the Microsoft.Agents.AI.DevUI assembly at runtime via
+      Assembly.Load to serve the DevUI frontend, so the assembly must be present in the AppHost's
+      published output. Referencing the project here flows the dependency to consumers of the
+      Aspire.Hosting.AgentFramework.DevUI NuGet package.
+    -->
+    <ProjectReference Include="..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Fixes #5779.

`Aspire.Hosting.AgentFramework.DevUI` serves the DevUI frontend by loading the `Microsoft.Agents.AI.DevUI` assembly at runtime via `Assembly.Load` (in [`DevUIAggregatorHostedService.ServeDevUIFrontendAsync`](https://github.com/microsoft/agent-framework/blob/main/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs)), but the package's `.csproj` did not declare that assembly as a dependency. Users following the package README ended up with `/devui/` returning 404 because the assembly wasn't in the AppHost's published output.

The matching working sample at `dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost.csproj` references both projects explicitly, which is why it works.

This adds a sibling `<ProjectReference>` from the Aspire integration to `Microsoft.Agents.AI.DevUI` so the dependency flows transitively to consumers of the NuGet package.

## Change

One `<ItemGroup>` added to `dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj`:

\`\`\`xml
<ItemGroup>
  <ProjectReference Include=\"..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj\" />
</ItemGroup>
\`\`\`

Pattern is consistent with how the test project and the working sample reference the same csproj.

## Test plan

- [x] XML well-formed (validated locally)
- [ ] Repo builds with the change (relying on CI — .NET SDK was not available locally, so this PR is open to confirm via the build/test workflow)
- [ ] DevUI 404 reproduction from #5779 no longer occurs after building against this branch