### PR TITLE
Python: Remove duplicate pop in InMemoryCacheProvider.remove

### DIFF
--- a/python/packages/purview/agent_framework_purview/_cache.py
+++ b/python/packages/purview/agent_framework_purview/_cache.py
@@ -161,7 +161,6 @@ class InMemoryCacheProvider:
         entry = self._cache.pop(key, None)
         if entry is not None:
             self._current_size_bytes -= entry[2]
-        self._cache.pop(key, None)
 
 
 def create_protection_scopes_cache_key(request: ProtectionScopesRequest) -> str:


### PR DESCRIPTION
### Motivation and Context

 The `remove` method in `InMemoryCacheProvider` (purview package) contains a duplicate `self._cache.pop(key, None)`
call. The second call is dead code: the first `pop` has already either removed the key or returned `None`, and there
is no `await` between the two statements that could allow another coroutine to re-add the key. The redundant line is
misleading to readers (suggests it's guarding against something it isn't) and adds noise to the diff history.

 ### Description

 Removes the second `self._cache.pop(key, None)` call in `InMemoryCacheProvider.remove`.

 Behavior is identical before and after for every input:
 - If the key was present, the first `pop` removes it and decrements `_current_size_bytes`. The second `pop` (now
removed) found nothing.
 - If the key was absent, both `pop` calls were no-ops.

 No public API change. No test changes required — existing `test_cache.py` tests continue to pass.

 ### Contribution Checklist

 - [x] The code builds clean without any errors or warnings
 - [x] The PR follows the [Contribution 
Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
 - [x] All unit tests pass, and I have added new tests where possible
 - [] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.