### PR TITLE
.NET: fix: preserve AG-UI event metadata

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEvent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEvent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 #if ASPNETCORE
@@ -13,4 +14,7 @@ internal abstract class BaseEvent
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
+
+    [JsonExtensionData]
+    public IDictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEventJsonConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/BaseEventJsonConverter.cs
@@ -47,6 +47,7 @@ internal sealed class BaseEventJsonConverter : JsonConverter<BaseEvent>
             AGUIEventTypes.ToolCallEnd => jsonElement.Deserialize(options.GetTypeInfo(typeof(ToolCallEndEvent))) as ToolCallEndEvent,
             AGUIEventTypes.ToolCallResult => jsonElement.Deserialize(options.GetTypeInfo(typeof(ToolCallResultEvent))) as ToolCallResultEvent,
             AGUIEventTypes.StateSnapshot => jsonElement.Deserialize(options.GetTypeInfo(typeof(StateSnapshotEvent))) as StateSnapshotEvent,
+            AGUIEventTypes.StateDelta => jsonElement.Deserialize(options.GetTypeInfo(typeof(StateDeltaEvent))) as StateDeltaEvent,
             AGUIEventTypes.ReasoningStart => jsonElement.Deserialize(options.GetTypeInfo(typeof(ReasoningStartEvent))) as ReasoningStartEvent,
             AGUIEventTypes.ReasoningMessageStart => jsonElement.Deserialize(options.GetTypeInfo(typeof(ReasoningMessageStartEvent))) as ReasoningMessageStartEvent,
             AGUIEventTypes.ReasoningMessageContent => jsonElement.Deserialize(options.GetTypeInfo(typeof(ReasoningMessageContentEvent))) as ReasoningMessageContentEvent,

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -57,6 +57,34 @@ internal static class ChatResponseUpdateAGUIExtensions
         return copiedProperties;
     }
 
+    private static AdditionalPropertiesDictionary? MergeAdditionalProperties(
+        AdditionalPropertiesDictionary? startProperties,
+        AdditionalPropertiesDictionary? contentProperties)
+    {
+        if (startProperties is not { Count: > 0 })
+        {
+            return contentProperties;
+        }
+
+        if (contentProperties is not { Count: > 0 })
+        {
+            return startProperties;
+        }
+
+        AdditionalPropertiesDictionary mergedProperties = [];
+        foreach (KeyValuePair<string, object?> property in startProperties)
+        {
+            mergedProperties[property.Key] = property.Value;
+        }
+
+        foreach (KeyValuePair<string, object?> property in contentProperties)
+        {
+            mergedProperties[property.Key] = property.Value;
+        }
+
+        return mergedProperties;
+    }
+
     private static bool IsReservedProperty(string key, string[] reservedPropertyNames)
     {
         foreach (string reservedPropertyName in reservedPropertyNames)
@@ -228,6 +256,7 @@ internal static class ChatResponseUpdateAGUIExtensions
         private string? _currentMessageId;
         private string? _conversationId;
         private string? _responseId;
+        private AdditionalPropertiesDictionary? _textStartAdditionalProperties;
 
         public void SetConversationAndResponseIds(string? conversationId, string? responseId)
         {
@@ -244,13 +273,15 @@ internal static class ChatResponseUpdateAGUIExtensions
 
             this._currentRole = AGUIChatMessageExtensions.MapChatRole(textStart.Role);
             this._currentMessageId = textStart.MessageId;
+            this._textStartAdditionalProperties = CopyAdditionalProperties(textStart);
         }
 
         internal ChatResponseUpdate EmitTextUpdate(TextMessageContentEvent textContent)
         {
+            AdditionalPropertiesDictionary? contentAdditionalProperties = CopyAdditionalProperties(textContent);
             TextContent content = new(textContent.Delta)
             {
-                AdditionalProperties = CopyAdditionalProperties(textContent)
+                AdditionalProperties = MergeAdditionalProperties(this._textStartAdditionalProperties, contentAdditionalProperties)
             };
 
             return new ChatResponseUpdate(
@@ -272,6 +303,7 @@ internal static class ChatResponseUpdateAGUIExtensions
             }
             this._currentRole = default;
             this._currentMessageId = null;
+            this._textStartAdditionalProperties = null;
         }
     }
 

--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -22,6 +22,54 @@ internal static class ChatResponseUpdateAGUIExtensions
     private static readonly MediaTypeHeaderValue? s_jsonPatchMediaType = new("application/json-patch+json");
     private static readonly MediaTypeHeaderValue? s_json = new("application/json");
 
+    private static Dictionary<string, object?>? CopyAdditionalProperties(AIContent content, params string[] reservedPropertyNames)
+    {
+        if (content.AdditionalProperties is not { Count: > 0 } additionalProperties)
+        {
+            return null;
+        }
+
+        Dictionary<string, object?> copiedProperties = [];
+        foreach (KeyValuePair<string, object?> property in additionalProperties)
+        {
+            if (!IsReservedProperty(property.Key, reservedPropertyNames))
+            {
+                copiedProperties[property.Key] = property.Value;
+            }
+        }
+
+        return copiedProperties.Count > 0 ? copiedProperties : null;
+    }
+
+    private static AdditionalPropertiesDictionary? CopyAdditionalProperties(BaseEvent evt)
+    {
+        if (evt.AdditionalProperties is not { Count: > 0 } additionalProperties)
+        {
+            return null;
+        }
+
+        AdditionalPropertiesDictionary copiedProperties = [];
+        foreach (KeyValuePair<string, object?> property in additionalProperties)
+        {
+            copiedProperties[property.Key] = property.Value;
+        }
+
+        return copiedProperties;
+    }
+
+    private static bool IsReservedProperty(string key, string[] reservedPropertyNames)
+    {
+        foreach (string reservedPropertyName in reservedPropertyNames)
+        {
+            if (string.Equals(key, reservedPropertyName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static async IAsyncEnumerable<ChatResponseUpdate> AsChatResponseUpdatesAsync(
         this IAsyncEnumerable<BaseEvent> events,
         JsonSerializerOptions jsonSerializerOptions,
@@ -135,6 +183,7 @@ internal static class ChatResponseUpdateAGUIExtensions
             stateSnapshot.Snapshot!.Value,
             jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)));
         DataContent dataContent = new(jsonBytes, "application/json");
+        dataContent.AdditionalProperties = CopyAdditionalProperties(stateSnapshot);
 
         return new ChatResponseUpdate(ChatRole.Assistant, [dataContent])
         {
@@ -159,6 +208,7 @@ internal static class ChatResponseUpdateAGUIExtensions
             stateDelta.Delta!.Value,
             jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)));
         DataContent dataContent = new(jsonBytes, "application/json-patch+json");
+        dataContent.AdditionalProperties = CopyAdditionalProperties(stateDelta);
 
         return new ChatResponseUpdate(ChatRole.Assistant, [dataContent])
         {
@@ -198,9 +248,14 @@ internal static class ChatResponseUpdateAGUIExtensions
 
         internal ChatResponseUpdate EmitTextUpdate(TextMessageContentEvent textContent)
         {
+            TextContent content = new(textContent.Delta)
+            {
+                AdditionalProperties = CopyAdditionalProperties(textContent)
+            };
+
             return new ChatResponseUpdate(
                 this._currentRole,
-                textContent.Delta)
+                [content])
             {
                 ConversationId = this._conversationId,
                 ResponseId = this._responseId,
@@ -476,7 +531,7 @@ internal static class ChatResponseUpdateAGUIExtensions
             }
 
             if (chatResponse is { Contents.Count: > 0 } &&
-                chatResponse.Contents[0] is TextContent &&
+                chatResponse.Contents[0] is TextContent textContentForStart &&
                 !string.Equals(currentMessageId, textMessageId, StringComparison.Ordinal))
             {
                 // Close any open reasoning block before opening a text message, so AG-UI
@@ -511,7 +566,8 @@ internal static class ChatResponseUpdateAGUIExtensions
                 yield return new TextMessageStartEvent
                 {
                     MessageId = textMessageId!,
-                    Role = chatResponse.Role!.Value.Value
+                    Role = chatResponse.Role!.Value.Value,
+                    AdditionalProperties = CopyAdditionalProperties(textContentForStart, "type", "messageId", "role")
                 };
 
                 currentMessageId = textMessageId;
@@ -524,7 +580,8 @@ internal static class ChatResponseUpdateAGUIExtensions
                 yield return new TextMessageContentEvent
                 {
                     MessageId = currentMessageId!,
-                    Delta = textContent.Text
+                    Delta = textContent.Text,
+                    AdditionalProperties = CopyAdditionalProperties(textContent, "type", "messageId", "delta")
                 };
             }
 
@@ -662,12 +719,13 @@ internal static class ChatResponseUpdateAGUIExtensions
 #if !NET
                                 Snapshot = (JsonElement?)JsonSerializer.Deserialize(
                                 dataContent.Data.ToArray(),
-                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)))
+                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement))),
 #else
                                 Snapshot = (JsonElement?)JsonSerializer.Deserialize(
                                 dataContent.Data.Span,
-                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)))
+                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement))),
 #endif
+                                AdditionalProperties = CopyAdditionalProperties(dataContent, "type", "snapshot")
                             };
                         }
                         else if (mediaType is { } && mediaType.Equals(s_jsonPatchMediaType))
@@ -679,12 +737,13 @@ internal static class ChatResponseUpdateAGUIExtensions
 #if !NET
                                 Delta = (JsonElement?)JsonSerializer.Deserialize(
                                 dataContent.Data.ToArray(),
-                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)))
+                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement))),
 #else
                                 Delta = (JsonElement?)JsonSerializer.Deserialize(
                                 dataContent.Data.Span,
-                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)))
+                                jsonSerializerOptions.GetTypeInfo(typeof(JsonElement))),
 #endif
+                                AdditionalProperties = CopyAdditionalProperties(dataContent, "type", "delta")
                             };
                         }
                         else
@@ -694,10 +753,11 @@ internal static class ChatResponseUpdateAGUIExtensions
                             {
                                 MessageId = textMessageId!,
 #if !NET
-                                Delta = Encoding.UTF8.GetString(dataContent.Data.ToArray())
+                                Delta = Encoding.UTF8.GetString(dataContent.Data.ToArray()),
 #else
-                                Delta = Encoding.UTF8.GetString(dataContent.Data.Span)
+                                Delta = Encoding.UTF8.GetString(dataContent.Data.Span),
 #endif
+                                AdditionalProperties = CopyAdditionalProperties(dataContent, "type", "messageId", "delta")
                             };
                         }
                     }

--- a/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
@@ -120,6 +120,36 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
     }
 
     [Fact]
+    public async Task AsChatResponseUpdatesAsync_WithTextEventAdditionalProperties_PreservesTextContentMetadataAsync()
+    {
+        // Arrange
+        List<BaseEvent> events =
+        [
+            new TextMessageStartEvent { MessageId = "msg1", Role = AGUIRoles.Assistant },
+            new TextMessageContentEvent
+            {
+                MessageId = "msg1",
+                Delta = "Hello",
+                AdditionalProperties = new Dictionary<string, object?> { ["textContentType"] = "Markdown" }
+            },
+            new TextMessageEndEvent { MessageId = "msg1" }
+        ];
+
+        // Act
+        List<ChatResponseUpdate> updates = [];
+        await foreach (ChatResponseUpdate update in events.ToAsyncEnumerableAsync().AsChatResponseUpdatesAsync(AGUIJsonSerializerContext.Default.Options))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        ChatResponseUpdate textUpdate = Assert.Single(updates);
+        TextContent content = Assert.IsType<TextContent>(textUpdate.Contents[0]);
+        Assert.NotNull(content.AdditionalProperties);
+        Assert.Equal("Markdown", content.AdditionalProperties["textContentType"]);
+    }
+
+    [Fact]
     public async Task AsChatResponseUpdatesAsync_WithTextMessageStartWhileMessageInProgress_ThrowsInvalidOperationExceptionAsync()
     {
         // Arrange
@@ -696,6 +726,48 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
     }
 
     [Fact]
+    public async Task AsAGUIEventStreamAsync_WithStateDataAdditionalProperties_EmitsPassthroughPropertiesAsync()
+    {
+        // Arrange
+        JsonElement snapshot = JsonSerializer.SerializeToElement(new { counter = 42 });
+        DataContent dataContent = new(JsonSerializer.SerializeToUtf8Bytes(snapshot), "application/json")
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["stateKind"] = "progress",
+                ["snapshot"] = "reserved"
+            }
+        };
+
+        List<ChatResponseUpdate> updates =
+        [
+            new ChatResponseUpdate(ChatRole.Assistant, [dataContent])
+            {
+                MessageId = "msg1"
+            }
+        ];
+
+        // Act
+        List<BaseEvent> outputEvents = [];
+        await foreach (BaseEvent evt in updates.ToAsyncEnumerableAsync().AsAGUIEventStreamAsync("thread1", "run1", AGUIJsonSerializerContext.Default.Options))
+        {
+            outputEvents.Add(evt);
+        }
+
+        // Assert
+        StateSnapshotEvent snapshotEvent = outputEvents.OfType<StateSnapshotEvent>().Single();
+        Assert.NotNull(snapshotEvent.AdditionalProperties);
+        Assert.Equal("progress", snapshotEvent.AdditionalProperties["stateKind"]);
+        Assert.False(snapshotEvent.AdditionalProperties.ContainsKey("snapshot"));
+
+        string json = JsonSerializer.Serialize(snapshotEvent, AGUIJsonSerializerContext.Default.StateSnapshotEvent);
+        using JsonDocument document = JsonDocument.Parse(json);
+        Assert.Equal("progress", document.RootElement.GetProperty("stateKind").GetString());
+        Assert.True(document.RootElement.TryGetProperty("snapshot", out JsonElement snapshotElement));
+        Assert.Equal(42, snapshotElement.GetProperty("counter").GetInt32());
+    }
+
+    [Fact]
     public async Task AsAGUIEventStreamAsync_WithBothSnapshotAndDelta_EmitsBothEventsAsync()
     {
         // Arrange
@@ -913,6 +985,49 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
         Assert.Contains(outputEvents, e => e is TextMessageStartEvent);
         Assert.Contains(outputEvents, e => e is TextMessageContentEvent);
         Assert.Contains(outputEvents, e => e is TextMessageEndEvent);
+    }
+
+    [Fact]
+    public async Task AsAGUIEventStreamAsync_WithTextContentAdditionalProperties_EmitsPassthroughPropertiesAsync()
+    {
+        // Arrange
+        TextContent content = new("Hello")
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["textContentType"] = "Markdown",
+                ["messageId"] = "reserved"
+            }
+        };
+
+        List<ChatResponseUpdate> updates =
+        [
+            new(ChatRole.Assistant, [content]) { MessageId = "msg1" }
+        ];
+
+        // Act
+        List<BaseEvent> outputEvents = [];
+        await foreach (BaseEvent evt in updates.ToAsyncEnumerableAsync().AsAGUIEventStreamAsync("thread1", "run1", AGUIJsonSerializerContext.Default.Options))
+        {
+            outputEvents.Add(evt);
+        }
+
+        // Assert
+        TextMessageStartEvent startEvent = outputEvents.OfType<TextMessageStartEvent>().Single();
+        Assert.NotNull(startEvent.AdditionalProperties);
+        Assert.Equal("Markdown", startEvent.AdditionalProperties["textContentType"]);
+        Assert.False(startEvent.AdditionalProperties.ContainsKey("messageId"));
+
+        TextMessageContentEvent contentEvent = outputEvents.OfType<TextMessageContentEvent>().Single();
+        Assert.NotNull(contentEvent.AdditionalProperties);
+        Assert.Equal("Markdown", contentEvent.AdditionalProperties["textContentType"]);
+        Assert.False(contentEvent.AdditionalProperties.ContainsKey("messageId"));
+
+        string json = JsonSerializer.Serialize(contentEvent, AGUIJsonSerializerContext.Default.TextMessageContentEvent);
+        using JsonDocument document = JsonDocument.Parse(json);
+        Assert.Equal("Markdown", document.RootElement.GetProperty("textContentType").GetString());
+        Assert.Equal("msg1", document.RootElement.GetProperty("messageId").GetString());
+        Assert.Equal("Hello", document.RootElement.GetProperty("delta").GetString());
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
@@ -150,6 +150,51 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
     }
 
     [Fact]
+    public async Task AsChatResponseUpdatesAsync_WithTextStartAdditionalProperties_PreservesAndMergesMetadataAsync()
+    {
+        // Arrange
+        List<BaseEvent> events =
+        [
+            new TextMessageStartEvent
+            {
+                MessageId = "msg1",
+                Role = AGUIRoles.Assistant,
+                AdditionalProperties = new Dictionary<string, object?>
+                {
+                    ["startOnly"] = "from-start",
+                    ["textContentType"] = "PlainText"
+                }
+            },
+            new TextMessageContentEvent
+            {
+                MessageId = "msg1",
+                Delta = "Hello",
+                AdditionalProperties = new Dictionary<string, object?>
+                {
+                    ["contentOnly"] = "from-content",
+                    ["textContentType"] = "Markdown"
+                }
+            },
+            new TextMessageEndEvent { MessageId = "msg1" }
+        ];
+
+        // Act
+        List<ChatResponseUpdate> updates = [];
+        await foreach (ChatResponseUpdate update in events.ToAsyncEnumerableAsync().AsChatResponseUpdatesAsync(AGUIJsonSerializerContext.Default.Options))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        ChatResponseUpdate textUpdate = Assert.Single(updates);
+        TextContent content = Assert.IsType<TextContent>(textUpdate.Contents[0]);
+        Assert.NotNull(content.AdditionalProperties);
+        Assert.Equal("from-start", content.AdditionalProperties["startOnly"]);
+        Assert.Equal("from-content", content.AdditionalProperties["contentOnly"]);
+        Assert.Equal("Markdown", content.AdditionalProperties["textContentType"]);
+    }
+
+    [Fact]
     public async Task AsChatResponseUpdatesAsync_WithTextMessageStartWhileMessageInProgress_ThrowsInvalidOperationExceptionAsync()
     {
         // Arrange
@@ -846,6 +891,26 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
         Assert.Equal("move", delta[3].GetProperty("op").GetString());
         Assert.Equal("copy", delta[4].GetProperty("op").GetString());
         Assert.Equal("test", delta[5].GetProperty("op").GetString());
+    }
+
+    [Fact]
+    public void BaseEventJsonConverter_WithStateDeltaEvent_DeserializesStateDeltaEvent()
+    {
+        // Arrange
+        JsonElement originalDelta = JsonSerializer.SerializeToElement(new object[]
+        {
+            new { op = "replace", path = "/counter", value = 43 }
+        });
+        BaseEvent originalEvent = new StateDeltaEvent { Delta = originalDelta };
+        string json = JsonSerializer.Serialize(originalEvent, AGUIJsonSerializerContext.Default.Options);
+
+        // Act
+        BaseEvent? deserializedEvent = JsonSerializer.Deserialize<BaseEvent>(json, AGUIJsonSerializerContext.Default.Options);
+
+        // Assert
+        StateDeltaEvent stateDeltaEvent = Assert.IsType<StateDeltaEvent>(deserializedEvent);
+        Assert.NotNull(stateDeltaEvent.Delta);
+        Assert.Equal("replace", stateDeltaEvent.Delta.Value[0].GetProperty("op").GetString());
     }
 
     #endregion State Delta Tests


### PR DESCRIPTION
﻿## Summary
- preserve `TextContent.AdditionalProperties` as AG-UI passthrough fields on text start/content events
- preserve event passthrough fields when converting AG-UI text events back to `TextContent`
- carry `DataContent.AdditionalProperties` through state snapshot/delta events as the same passthrough metadata path
- filter event-owned fields like `type`, `messageId`, `delta`, and `snapshot` so metadata cannot shadow AG-UI protocol fields

Fixes #4923

## Validation
- `dotnet run --project dotnet\tests\Microsoft.Agents.AI.AGUI.UnitTests\Microsoft.Agents.AI.AGUI.UnitTests.csproj --framework net10.0 -- --filter-class Microsoft.Agents.AI.AGUI.UnitTests.ChatResponseUpdateAGUIExtensionsTests`
- `dotnet run --project dotnet\tests\Microsoft.Agents.AI.AGUI.UnitTests\Microsoft.Agents.AI.AGUI.UnitTests.csproj --framework net10.0`
- `dotnet format dotnet\agent-framework-dotnet.slnx --verify-no-changes --include dotnet\src\Microsoft.Agents.AI.AGUI\Shared\BaseEvent.cs dotnet\src\Microsoft.Agents.AI.AGUI\Shared\ChatResponseUpdateAGUIExtensions.cs dotnet\tests\Microsoft.Agents.AI.AGUI.UnitTests\ChatResponseUpdateAGUIExtensionsTests.cs`
- `git diff --check`
