### PR TITLE
.NET: add AgentSession StateBag edge case coverage

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentSessionTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentSessionTests.cs
@@ -24,6 +24,45 @@ public class AgentSessionTests
         Assert.Equal("value1", session.StateBag.GetValue<string>("key1"));
     }
 
+    [Fact]
+    public void StateBag_Default_IsEmpty()
+    {
+        // Arrange & Act
+        var session = new TestAgentSession();
+
+        // Assert
+        Assert.Equal(0, session.StateBag.Count);
+    }
+
+    [Fact]
+    public void StateBag_MultipleKeys_StoreAndRetrieveIndependently()
+    {
+        // Arrange
+        var session = new TestAgentSession();
+
+        // Act
+        session.StateBag.SetValue("key1", "value1");
+        session.StateBag.SetValue("key2", "value2");
+
+        // Assert
+        Assert.Equal("value1", session.StateBag.GetValue<string>("key1"));
+        Assert.Equal("value2", session.StateBag.GetValue<string>("key2"));
+    }
+
+    [Fact]
+    public void StateBag_OverwriteValue_ReturnsUpdatedValue()
+    {
+        // Arrange
+        var session = new TestAgentSession();
+        session.StateBag.SetValue("key1", "original");
+
+        // Act
+        session.StateBag.SetValue("key1", "updated");
+
+        // Assert
+        Assert.Equal("updated", session.StateBag.GetValue<string>("key1"));
+    }
+
     #endregion
 
     #region GetService Method Tests


### PR DESCRIPTION
### Motivation and Context
  `AgentSession.StateBag` had only one existing test covering a basic set/get roundtrip.
  Edge cases such as empty initial state, independent multi-key storage, and value overwrite  behavior were not tested through the `AgentSession` layer, even though they are critical for session state correctness.

### Description
  - Add test to verify `AgentSession.StateBag` is empty on initialization
  - Add test to verify multiple keys store and retrieve independently without interference
  - Add test to verify overwriting an existing key returns the updated value


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

  - [x] The code builds clean without any errors or warnings
  - [x] The PR follows the Contribution Guidelines
  - [x] All unit tests pass, and I have added new tests where possible
  - [x] `dotnet test` — 1141 tests, 0 failed 
  - **Is this a breaking change?** No — this PR only adds new tests, no production code was modified.