### PR TITLE
.NET: test: add AgentResponse edge case coverage

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
@@ -292,7 +292,7 @@ public class AgentResponseTests
     public void Constructor_WithNullChatResponse_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new AgentResponse((ChatResponse)null!));
+        Assert.Throws<ArgumentNullException>("response", () => new AgentResponse((ChatResponse)null!));
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
@@ -287,4 +287,67 @@ public class AgentResponseTests
         Assert.NotNull(update.AdditionalProperties);
         Assert.Equal("value", update.AdditionalProperties!["key"]);
     }
+
+    [Fact]
+    public void Constructor_WithNullChatResponse_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new AgentResponse((ChatResponse)null!));
+    }
+
+    [Fact]
+    public void Text_WithOnlyNonTextContent_ReturnsEmptyString()
+    {
+        // Arrange
+        AgentResponse response = new(
+        [
+            new ChatMessage(
+                ChatRole.Assistant,
+                [
+                    new DataContent("data:image/png;base64,aGVsbG8="),
+                    new FunctionCallContent("callId1", "fc1"),
+                    new FunctionResultContent("callId1", "result"),
+                ])
+        ]);
+
+        // Act & Assert
+        Assert.Equal(string.Empty, response.Text);
+    }
+
+    [Fact]
+    public void Text_AfterSettingMessagesToNull_ReturnsEmptyString()
+    {
+        // Arrange
+        AgentResponse response = new(new ChatMessage(ChatRole.Assistant, "hello"));
+
+        // Act
+        response.Messages = null!;
+
+        // Assert
+        Assert.Equal(string.Empty, response.Text);
+    }
+
+    [Fact]
+    public void ToAgentResponseUpdates_WithMultipleMessages_PreservesOrder()
+    {
+        // Arrange
+        AgentResponse response = new(
+        [
+            new ChatMessage(ChatRole.Assistant, "first") { MessageId = "msg1" },
+            new ChatMessage(ChatRole.Assistant, "second") { MessageId = "msg2" },
+            new ChatMessage(ChatRole.Assistant, "third") { MessageId = "msg3" },
+        ]);
+
+        // Act
+        AgentResponseUpdate[] updates = response.ToAgentResponseUpdates();
+
+        // Assert
+        Assert.Equal(3, updates.Length);
+        Assert.Equal("msg1", updates[0].MessageId);
+        Assert.Equal("first", updates[0].Text);
+        Assert.Equal("msg2", updates[1].MessageId);
+        Assert.Equal("second", updates[1].Text);
+        Assert.Equal("msg3", updates[2].MessageId);
+        Assert.Equal("third", updates[2].Text);
+    }
 }


### PR DESCRIPTION
### Motivation and Context

  AgentResponse had no tests covering null ChatResponse construction,
  Text property behavior with non-text content, Text after Messages
  is set to null, or message order preservation in ToAgentResponseUpdates.
  These are gaps in critical response handling paths.
-->

### Description

  - Add test verifying null ChatResponse constructor throws ArgumentNullException
  - Add test verifying Text returns empty string when all content is non-text
  - Add test verifying Text returns empty string after Messages is set to null
  - Add test verifying ToAgentResponseUpdates preserves message order across multiple messages

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
 - [x] The PR follows the Contribution Guidelines
 - [x] All unit tests pass, and I have added new tests where possible
 - No breaking change test only, no production code modified