### PR TITLE
.NET: DevUI: quarantine flaky discovery integration test (#5845)

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.DevUI.UnitTests/DevUIIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DevUI.UnitTests/DevUIIntegrationTests.cs
@@ -218,7 +218,7 @@ public class DevUIIntegrationTests
         Assert.Contains(discoveryResponse.Entities, e => e.Name == "default-workflow" && e.Type == "workflow");
     }
 
-    [Fact]
+    [Fact(Skip = "Flaky in merge_group; see https://github.com/microsoft/agent-framework/issues/5845")]
     public async Task TestServerWithDevUI_ResolvesMixedAgentsAndWorkflows_AllRegistrationsAsync()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Quarantines the flaky DevUI integration test `TestServerWithDevUI_ResolvesMixedAgentsAndWorkflows_AllRegistrationsAsync` so the merge_group queue stops blocking on it. Tracking issue: #5845.

## Why

Across the last 30 `dotnet-build-and-test` merge_group runs, this test failed 5 times with `System.NullReferenceException` on the deserialized discovery response (`DevUIIntegrationTests.cs:273`). 4 of the 5 failed runs are on PRs that do not touch DevUI source:

| Run | PR |
| --- | --- |
| 25853165883 | #5702 (Hosted-MemoryAgent) |
| 25830222281 | #5831 (DevUI CA1873 logger fix) |
| 25818514390 | #5755 (eval ground_truth) |
| 25749422776 | #5748 (OpenAIResponsesAgentClient) |
| 25743614853 | #5702 (Hosted-MemoryAgent) |

Suspected race between `app.StartAsync()` and the test's `GetTestClient().GetAsync(""/v1/entities"")` discovery enumeration. See #5845 for the full hypothesis and reproduction steps.

## Change

Replace `[Fact]` with `[Fact(Skip = ""Flaky in merge_group; see https://github.com/microsoft/agent-framework/issues/5845"")]` on the affected test.

## Validation

`dotnet build dotnet/tests/Microsoft.Agents.AI.DevUI.UnitTests --tl:off` succeeds with 0 warnings, 0 errors.

## Follow-up

Owner of the DevUI integration surface should investigate the race in #5845 and re-enable the test once fixed.
