### PR TITLE
Python: fix: reject service storage history conflict

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -804,7 +804,12 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
             else cast(str | None, (options or {}).get("conversation_id") or self.default_options.get("conversation_id"))
         )
         if service_stores_history:
-            return []
+            raise AgentInvalidRequestException(
+                "require_per_service_call_history_persistence cannot be used "
+                "when the chat client is configured to store history. Set "
+                "store=False to persist each service call through the configured "
+                "HistoryProvider."
+            )
 
         if conversation_id is not None:
             raise AgentInvalidRequestException(

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -607,65 +607,36 @@ async def test_streaming_per_service_call_persistence_hides_response_id_from_aft
     assert provider_state["response_ids"] == [None, None]
 
 
-async def test_per_service_call_persistence_uses_real_service_storage_when_client_stores_by_default(
+async def test_per_service_call_persistence_rejects_service_storage_when_client_stores_by_default(
     chat_client_base: SupportsChatGetResponse,
 ) -> None:
     provider = _RecordingHistoryProvider()
-
-    @tool(name="lookup_weather", approval_mode="never_require")
-    def lookup_weather(location: str) -> str:
-        return f"Weather in {location}: sunny"
 
     chat_client_base.STORES_BY_DEFAULT = True  # type: ignore[attr-defined]
 
     session = AgentSession()
     session.state[provider.source_id] = {"messages": []}
-    chat_client_base.run_responses = [
-        ChatResponse(
-            messages=Message(
-                role="assistant",
-                contents=[
-                    Content.from_function_call(
-                        call_id="call_1",
-                        name="lookup_weather",
-                        arguments='{"location": "Seattle"}',
-                    )
-                ],
-            ),
-            conversation_id="resp_service_managed",
-            response_id="resp_call_1",
-        ),
-        ChatResponse(
-            messages=Message(role="assistant", contents=["It is sunny in Seattle."]),
-            conversation_id="resp_service_managed",
-            response_id="resp_call_2",
-        ),
-    ]
 
     agent = Agent(
         client=chat_client_base,
-        tools=[lookup_weather],
         context_providers=[provider],
         require_per_service_call_history_persistence=True,
     )
 
-    result = await agent.run("What's the weather in Seattle?", session=session)
+    with pytest.raises(AgentInvalidRequestException, match="store=False"):
+        await agent.run("Hello", session=session)
 
     provider_state = session.state[provider.source_id]
 
-    assert result.text == "It is sunny in Seattle."
-    assert result.response_id == "resp_call_2"
-    assert chat_client_base.call_count == 2
+    assert chat_client_base.call_count == 0
     assert "get_call_count" not in provider_state
     assert "save_call_count" not in provider_state
-    assert session.service_session_id == "resp_service_managed"
+    assert session.service_session_id is None
 
 
-async def test_service_storage_updates_session_handle_per_service_call_before_non_streaming_failure(
+async def test_service_storage_updates_session_handle_before_non_streaming_failure(
     chat_client_base: SupportsChatGetResponse,
 ) -> None:
-    provider = _RecordingHistoryProvider()
-
     @tool(name="lookup_weather", approval_mode="never_require")
     def lookup_weather(location: str) -> str:
         return f"Weather in {location}: sunny"
@@ -673,7 +644,6 @@ async def test_service_storage_updates_session_handle_per_service_call_before_no
     chat_client_base.STORES_BY_DEFAULT = True  # type: ignore[attr-defined]
 
     session = AgentSession()
-    session.state[provider.source_id] = {"messages": []}
     first_response = ChatResponse(
         messages=Message(
             role="assistant",
@@ -695,8 +665,6 @@ async def test_service_storage_updates_session_handle_per_service_call_before_no
     agent = Agent(
         client=chat_client_base,
         tools=[lookup_weather],
-        context_providers=[provider],
-        require_per_service_call_history_persistence=True,
     )
 
     with (
@@ -709,11 +677,9 @@ async def test_service_storage_updates_session_handle_per_service_call_before_no
     assert session.service_session_id == "resp_call_1"
 
 
-async def test_service_storage_updates_session_handle_per_service_call_before_streaming_failure(
+async def test_service_storage_updates_session_handle_before_streaming_failure(
     chat_client_base: SupportsChatGetResponse,
 ) -> None:
-    provider = _RecordingHistoryProvider()
-
     @tool(name="lookup_weather", approval_mode="never_require")
     def lookup_weather(location: str) -> str:
         return f"Weather in {location}: sunny"
@@ -721,7 +687,6 @@ async def test_service_storage_updates_session_handle_per_service_call_before_st
     chat_client_base.STORES_BY_DEFAULT = True  # type: ignore[attr-defined]
 
     session = AgentSession()
-    session.state[provider.source_id] = {"messages": []}
 
     async def _first_stream_updates() -> AsyncIterable[ChatResponseUpdate]:
         yield ChatResponseUpdate(
@@ -758,8 +723,6 @@ async def test_service_storage_updates_session_handle_per_service_call_before_st
     agent = Agent(
         client=chat_client_base,
         tools=[lookup_weather],
-        context_providers=[provider],
-        require_per_service_call_history_persistence=True,
     )
 
     with (


### PR DESCRIPTION
﻿Fixes #5798.

## Summary
- reject `require_per_service_call_history_persistence=True` when the effective chat options still use service-side history storage
- point users to `store=False` so the configured `HistoryProvider` owns per-service-call persistence
- keep the existing service-storage session-handle tests, but separate them from external history-provider persistence

## Tests
- `python -m py_compile python\packages\core\agent_framework\_agents.py python\packages\core\tests\core\test_agents.py`
- `uv run ruff check packages\core\agent_framework\_agents.py packages\core\tests\core\test_agents.py`
- `uv run pytest packages\core\tests\core\test_agents.py -q -k "per_service_call_persistence or service_storage_updates_session_handle" --basetemp .tmp\pytest -p no:cacheprovider`
- `git diff --check`
- `Select-String -Path python\packages\core\agent_framework\_agents.py,python\packages\core\tests\core\test_agents.py -Pattern 'sk-[A-Za-z0-9_-]+'`
