### PR TITLE
Python: preserve MCP connection errors during cleanup

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -642,6 +642,11 @@ class MCPTool:
                 )
             else:
                 raise
+        except Exception as e:
+            if type(e).__name__ == "ExceptionGroup":
+                logger.warning("Could not cleanly close MCP exit stack: %s", e)
+            else:
+                raise
         except asyncio.CancelledError:
             logger.warning("Could not cleanly close MCP exit stack because the lifecycle owner task was cancelled.")
 

--- a/python/packages/core/tests/core/test_mcp_exception_group.py
+++ b/python/packages/core/tests/core/test_mcp_exception_group.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from agent_framework import MCPStreamableHTTPTool
+from agent_framework.exceptions import ToolException
+
+
+async def test_connect_initialization_failure_keeps_original_error_when_cleanup_raises_exception_group():
+    exception_group_type = getattr(sys.modules["builtins"], "ExceptionGroup", None)
+    if exception_group_type is None:
+        pytest.skip("ExceptionGroup is only available on Python 3.11+")
+
+    tool = MCPStreamableHTTPTool(name="test", url="http://example.com")
+
+    mock_transport = (Mock(), Mock())
+    mock_context_manager = Mock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_context_manager.__aexit__ = AsyncMock(
+        side_effect=exception_group_type("unhandled errors in a TaskGroup", [ConnectionError("cleanup failed")])
+    )
+    tool.get_mcp_client = Mock(return_value=mock_context_manager)
+
+    mock_session = Mock()
+    mock_session.initialize = AsyncMock(side_effect=ConnectionError("Server not ready"))
+
+    with patch("mcp.client.session.ClientSession") as mock_session_class:
+        mock_session_class.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with pytest.raises(ToolException) as exc_info:
+            await tool.connect()
+
+    assert "MCP server failed to initialize" in str(exc_info.value)
+    assert "Server not ready" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- keep MCP connection/setup failures as `ToolException` when exit-stack cleanup raises an `ExceptionGroup`
- add a regression test for streamable HTTP cleanup masking the original initialization error

Fixes #5876.

## To verify
- `uv run pytest packages\core\tests\core\test_mcp_exception_group.py packages\core\tests\core\test_mcp.py::test_connect_initialization_failure_http_no_command -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check packages\core\agent_framework\_mcp.py packages\core\tests\core\test_mcp_exception_group.py`
- `uv run ruff format --check packages\core\agent_framework\_mcp.py packages\core\tests\core\test_mcp_exception_group.py`
- `uv run pyright packages\core\agent_framework\_mcp.py packages\core\tests\core\test_mcp_exception_group.py`
- `uv run python -m py_compile packages\core\agent_framework\_mcp.py packages\core\tests\core\test_mcp_exception_group.py`
- `git diff --check`
