### PR TITLE
Python: forward Foundry context instructions

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -338,10 +338,17 @@ class RawFoundryAgentChatClient(  # type: ignore[misc]
                     )
 
         # Prepare messages: extract system/developer messages as instructions
-        prepared_messages, _instructions = self._prepare_messages_for_azure_ai(messages)
+        prepared_messages, context_instructions = self._prepare_messages_for_azure_ai(messages)
+        prepare_options = dict(options)
+        base_instructions = cast(str | None, prepare_options.pop("instructions", None))
+        instructions = "\n".join(
+            instruction for instruction in (base_instructions, context_instructions) if instruction
+        )
 
         # Call parent prepare_options (OpenAI Responses API format)
-        run_options = await super()._prepare_options(prepared_messages, options, **kwargs)
+        run_options = await super()._prepare_options(prepared_messages, prepare_options, **kwargs)
+        if instructions:
+            run_options["instructions"] = instructions
 
         # Apply Azure AI schema transforms
         if "input" in run_options and isinstance(run_options["input"], list):

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -17,6 +17,7 @@ from agent_framework import (
     ChatMiddleware,
     ChatResponse,
     ChatResponseUpdate,
+    Content,
     Message,
     tool,
 )
@@ -200,6 +201,34 @@ async def test_raw_foundry_agent_chat_client_prepare_options_accepts_function_to
     assert result == {
         "extra_body": {"agent_reference": {"name": "test-agent", "type": "agent_reference"}},
     }
+
+
+async def test_raw_foundry_agent_chat_client_prepare_options_forwards_context_instructions() -> None:
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+    )
+
+    result = await client._prepare_options(
+        messages=[
+            Message(role="system", contents=[Content.from_text("Use available skills.")]),
+            Message(role="developer", contents=[Content.from_text("Prefer deterministic answers.")]),
+            Message(role="user", contents=[Content.from_text("run cats-name")]),
+        ],
+        options={"instructions": "Base instructions."},
+    )
+
+    assert result["instructions"] == "Base instructions.\nUse available skills.\nPrefer deterministic answers."
+    assert result["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "run cats-name"}],
+        }
+    ]
 
 
 async def test_raw_foundry_agent_chat_client_prepare_options_strips_client_side_fields() -> None:


### PR DESCRIPTION
## Summary
- forward system/developer messages from Foundry context providers as request instructions
- keep agent-level instructions and skills/context instructions together instead of dropping the context side
- add a regression test for SkillsProvider-style context instructions

Fixes #5883.

## To verify
- `uv run pytest packages\foundry\tests\foundry\test_foundry_agent.py::test_raw_foundry_agent_chat_client_prepare_options_forwards_context_instructions packages\foundry\tests\foundry\test_foundry_agent.py::test_raw_foundry_agent_chat_client_prepare_options_accepts_function_tools packages\foundry\tests\foundry\test_foundry_agent.py::test_raw_foundry_agent_chat_client_prepare_options_strips_client_side_fields -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check packages\foundry\agent_framework_foundry\_agent.py packages\foundry\tests\foundry\test_foundry_agent.py`
- `uv run ruff format --check packages\foundry\agent_framework_foundry\_agent.py packages\foundry\tests\foundry\test_foundry_agent.py`
- `uv run pyright packages\foundry\agent_framework_foundry\_agent.py packages\foundry\tests\foundry\test_foundry_agent.py`
- `uv run python -m py_compile packages\foundry\agent_framework_foundry\_agent.py packages\foundry\tests\foundry\test_foundry_agent.py`
- `git diff --check`
