### PR TITLE
.NET: Add observer for OpenAIWebSearch

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
@@ -31,6 +31,10 @@ public sealed class ToolCallDisplayObserver : ConsoleObserver
         {
             await ux.WriteInfoLineAsync($"🔧 Calling tool: {ToolCallFormatter.Format(this._formatters, functionCall)}...", ConsoleColor.DarkYellow);
         }
+        else if (content is WebSearchToolCallContent)
+        {
+            // Handled by WebSearchDisplayObserver when present; skip here to avoid duplication.
+        }
         else if (content is ToolCallContent toolCall)
         {
             await ux.WriteInfoLineAsync($"🔧 Calling tool: {toolCall}...", ConsoleColor.DarkYellow);

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ToolCallDisplayObserver.cs
@@ -33,7 +33,7 @@ public sealed class ToolCallDisplayObserver : ConsoleObserver
         }
         else if (content is WebSearchToolCallContent)
         {
-            // Handled by WebSearchDisplayObserver when present; skip here to avoid duplication.
+            // Handled by OpenAIResponsesWebSearchDisplayObserver when present; skip here to avoid duplication.
         }
         else if (content is ToolCallContent toolCall)
         {

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/OpenAIResponsesWebSearchDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/OpenAIResponsesWebSearchDisplayObserver.cs
@@ -48,19 +48,22 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
                 await WriteOpenPageAsync(ux, openPage);
                 break;
 
+            case WebSearchSearchAction search:
+                await WriteSearchAsync(ux, search, outputs);
+                break;
+
             default:
-                // "search" action type — the concrete class is internal to the SDK,
-                // so we extract queries from the raw JSON representation.
-                await WriteSearchAsync(ux, wscri, outputs);
+                await ux.WriteInfoLineAsync("🌐 Web Search Tool (unknown action)", ConsoleColor.DarkCyan);
                 break;
         }
     }
 
-    private static async Task WriteSearchAsync(IUXStateDriver ux, WebSearchCallResponseItem wscri, IList<AIContent>? outputs)
+    private static async Task WriteSearchAsync(IUXStateDriver ux, WebSearchSearchAction search, IList<AIContent>? outputs)
     {
-        var queries = GetQueriesFromItem(wscri);
+        // Read queries directly from the typed action.
+        IList<string> queries = search.Queries;
 
-        if (queries is null || queries.Count == 0)
+        if (queries.Count == 0)
         {
             await ux.WriteInfoLineAsync("🌐 Web Search Tool: search", ConsoleColor.DarkCyan);
             return;
@@ -79,8 +82,8 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
         }
 
         // Show search result sources (URLs + titles) when available.
-        // This requires IncludedResponseProperty.WebSearchCallActionSources on the request options,
-        // which is only supported by the direct OpenAI API — Azure AI Foundry does not currently return sources.
+        // Sources come from M.E.AI's Outputs when IncludedResponseProperty.WebSearchCallActionSources is set,
+        // or directly from the SDK's WebSearchSearchAction.Sources.
         if (hasResults)
         {
             sb.Append("\n   │");
@@ -88,6 +91,16 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
             {
                 string connector = i < outputs.Count - 1 ? "├─" : "└─";
                 string line = FormatOutput(outputs[i]);
+                sb.Append($"\n   {connector} {line}");
+            }
+        }
+        else if (search.Sources is { Count: > 0 } sources)
+        {
+            sb.Append("\n   │");
+            for (int i = 0; i < sources.Count; i++)
+            {
+                string connector = i < sources.Count - 1 ? "├─" : "└─";
+                string line = FormatSource(sources[i]);
                 sb.Append($"\n   {connector} {line}");
             }
         }
@@ -114,7 +127,28 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
     }
 
     /// <summary>
-    /// Formats a single search result output for display.
+    /// Formats a single search result source from the SDK's <see cref="WebSearchActionSource"/> for display.
+    /// </summary>
+    private static string FormatSource(WebSearchActionSource source)
+    {
+        if (source is WebSearchActionUriSource uriSource)
+        {
+            string url = uriSource.Uri?.AbsoluteUri ?? "(unknown)";
+
+            // WebSearchActionUriSource doesn't expose a title property,
+            // but the API may include one in the raw response JSON.
+            string? title = GetTitleFromRawRepresentation(uriSource);
+
+            return title is not null
+                ? $"{Truncate(title, MaxQueryDisplayLength)} — {url}"
+                : url;
+        }
+
+        return source.ToString() ?? "(unknown source)";
+    }
+
+    /// <summary>
+    /// Formats a single search result output from M.E.AI's <see cref="AIContent"/> for display.
     /// </summary>
     private static string FormatOutput(AIContent output)
     {
@@ -138,6 +172,9 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
 
     /// <summary>
     /// Attempts to extract a "title" field from a raw representation object by serializing it to JSON.
+    /// The SDK's <see cref="WebSearchActionUriSource"/> doesn't expose a title property,
+    /// but the API may include one in the raw JSON — this is forward-compatible for when
+    /// the SDK adds title support.
     /// </summary>
     private static string? GetTitleFromRawRepresentation(object? rawRepresentation)
     {
@@ -159,56 +196,6 @@ internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
         catch
         {
             // Serialization may not be supported for this object type.
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Extracts query strings from a <see cref="WebSearchCallResponseItem"/> by
-    /// reading the "queries" array from the serialized JSON, since the search
-    /// action type is internal to the OpenAI SDK.
-    /// </summary>
-    private static List<string>? GetQueriesFromItem(WebSearchCallResponseItem wscri)
-    {
-        try
-        {
-            var data = System.ClientModel.Primitives.ModelReaderWriter.Write(wscri);
-            using var doc = System.Text.Json.JsonDocument.Parse(data);
-
-            if (!doc.RootElement.TryGetProperty("action", out var actionEl))
-            {
-                return null;
-            }
-
-            // Try the "queries" array first (multiple search queries).
-            if (actionEl.TryGetProperty("queries", out var queriesEl)
-                && queriesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
-            {
-                var queries = new List<string>();
-                foreach (var q in queriesEl.EnumerateArray())
-                {
-                    string? text = q.GetString();
-                    if (text is not null)
-                    {
-                        queries.Add(text);
-                    }
-                }
-
-                return queries;
-            }
-
-            // Fall back to the single "query" field.
-            if (actionEl.TryGetProperty("query", out var queryEl)
-                && queryEl.ValueKind == System.Text.Json.JsonValueKind.String)
-            {
-                string? text = queryEl.GetString();
-                return text is not null ? [text] : null;
-            }
-        }
-        catch
-        {
-            // Serialization may fail (e.g. the null-URI bug on find_in_page actions).
         }
 
         return null;

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/OpenAIResponsesWebSearchDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/OpenAIResponsesWebSearchDisplayObserver.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable OPENAI001 // Suppress experimental API warnings for Responses API usage.
+
+using System.Text;
+using Harness.Shared.Console;
+using Harness.Shared.Console.Observers;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using OpenAI.Responses;
+
+namespace SampleApp;
+
+/// <summary>
+/// Displays web search activity in the scroll area. Shows search queries,
+/// page opens, and find-in-page actions as they stream in from the API.
+/// </summary>
+internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
+{
+    private const int MaxQueryDisplayLength = 120;
+
+    /// <inheritdoc/>
+    public override async Task OnContentAsync(IUXStateDriver ux, AIContent content, AIAgent agent, AgentSession session)
+    {
+        if (content is WebSearchToolResultContent resultContent
+            && resultContent.RawRepresentation is WebSearchCallResponseItem wscri)
+        {
+            await WriteActionAsync(ux, wscri, resultContent.Outputs);
+        }
+    }
+
+    private static async Task WriteActionAsync(IUXStateDriver ux, WebSearchCallResponseItem wscri, IList<AIContent>? outputs)
+    {
+        WebSearchAction? action = wscri.Action;
+        if (action is null)
+        {
+            await ux.WriteInfoLineAsync("🌐 Web Search Tool (no action details)", ConsoleColor.DarkCyan);
+            return;
+        }
+
+        switch (action)
+        {
+            case WebSearchFindInPageAction findInPage:
+                await WriteFindInPageAsync(ux, findInPage);
+                break;
+
+            case WebSearchOpenPageAction openPage:
+                await WriteOpenPageAsync(ux, openPage);
+                break;
+
+            default:
+                // "search" action type — the concrete class is internal to the SDK,
+                // so we extract queries from the raw JSON representation.
+                await WriteSearchAsync(ux, wscri, outputs);
+                break;
+        }
+    }
+
+    private static async Task WriteSearchAsync(IUXStateDriver ux, WebSearchCallResponseItem wscri, IList<AIContent>? outputs)
+    {
+        var queries = GetQueriesFromItem(wscri);
+
+        if (queries is null || queries.Count == 0)
+        {
+            await ux.WriteInfoLineAsync("🌐 Web Search Tool: search", ConsoleColor.DarkCyan);
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("🌐 Web Search Tool: search");
+
+        // Show the search queries.
+        bool hasResults = outputs is { Count: > 0 };
+        for (int i = 0; i < queries.Count; i++)
+        {
+            string connector = (i < queries.Count - 1 || hasResults) ? "├─" : "└─";
+            string query = Truncate(queries[i], MaxQueryDisplayLength);
+            sb.Append($"\n   {connector} \"{query}\"");
+        }
+
+        // Show search result sources (URLs + titles) when available.
+        // This requires IncludedResponseProperty.WebSearchCallActionSources on the request options,
+        // which is only supported by the direct OpenAI API — Azure AI Foundry does not currently return sources.
+        if (hasResults)
+        {
+            sb.Append("\n   │");
+            for (int i = 0; i < outputs!.Count; i++)
+            {
+                string connector = i < outputs.Count - 1 ? "├─" : "└─";
+                string line = FormatOutput(outputs[i]);
+                sb.Append($"\n   {connector} {line}");
+            }
+        }
+
+        await ux.WriteInfoLineAsync(sb.ToString(), ConsoleColor.DarkCyan);
+    }
+
+    private static async Task WriteOpenPageAsync(IUXStateDriver ux, WebSearchOpenPageAction openPage)
+    {
+        string url = openPage.Uri?.AbsoluteUri ?? "(unknown)";
+        await ux.WriteInfoLineAsync(
+            $"🌐 Web Search Tool: open page\n   └─ {url}",
+            ConsoleColor.DarkCyan);
+    }
+
+    private static async Task WriteFindInPageAsync(IUXStateDriver ux, WebSearchFindInPageAction findInPage)
+    {
+        string url = findInPage.Uri?.AbsoluteUri ?? "(unknown)";
+        string pattern = findInPage.Pattern ?? "(unknown)";
+
+        await ux.WriteInfoLineAsync(
+            $"🌐 Web Search Tool: find in page\n   ├─ \"{Truncate(pattern, MaxQueryDisplayLength)}\"\n   └─ {url}",
+            ConsoleColor.DarkCyan);
+    }
+
+    /// <summary>
+    /// Formats a single search result output for display.
+    /// </summary>
+    private static string FormatOutput(AIContent output)
+    {
+        if (output is UriContent uriContent)
+        {
+            string url = uriContent.Uri?.AbsoluteUri ?? "(unknown)";
+
+            // Try to extract a title from the raw JSON of the source.
+            // The SDK's WebSearchActionUriSource doesn't expose a title property,
+            // but the API may include one in the raw response.
+            string? title = GetTitleFromRawRepresentation(uriContent.RawRepresentation)
+                ?? (uriContent.AdditionalProperties?.TryGetValue("title", out var t) is true ? t?.ToString() : null);
+
+            return title is not null
+                ? $"{Truncate(title, MaxQueryDisplayLength)} — {url}"
+                : url;
+        }
+
+        return output.ToString() ?? "(unknown output)";
+    }
+
+    /// <summary>
+    /// Attempts to extract a "title" field from a raw representation object by serializing it to JSON.
+    /// </summary>
+    private static string? GetTitleFromRawRepresentation(object? rawRepresentation)
+    {
+        if (rawRepresentation is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var data = System.ClientModel.Primitives.ModelReaderWriter.Write(rawRepresentation);
+            using var doc = System.Text.Json.JsonDocument.Parse(data);
+            if (doc.RootElement.TryGetProperty("title", out var titleEl)
+                && titleEl.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                return titleEl.GetString();
+            }
+        }
+        catch
+        {
+            // Serialization may not be supported for this object type.
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts query strings from a <see cref="WebSearchCallResponseItem"/> by
+    /// reading the "queries" array from the serialized JSON, since the search
+    /// action type is internal to the OpenAI SDK.
+    /// </summary>
+    private static List<string>? GetQueriesFromItem(WebSearchCallResponseItem wscri)
+    {
+        try
+        {
+            var data = System.ClientModel.Primitives.ModelReaderWriter.Write(wscri);
+            using var doc = System.Text.Json.JsonDocument.Parse(data);
+
+            if (!doc.RootElement.TryGetProperty("action", out var actionEl))
+            {
+                return null;
+            }
+
+            // Try the "queries" array first (multiple search queries).
+            if (actionEl.TryGetProperty("queries", out var queriesEl)
+                && queriesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+            {
+                var queries = new List<string>();
+                foreach (var q in queriesEl.EnumerateArray())
+                {
+                    string? text = q.GetString();
+                    if (text is not null)
+                    {
+                        queries.Add(text);
+                    }
+                }
+
+                return queries;
+            }
+
+            // Fall back to the single "query" field.
+            if (actionEl.TryGetProperty("query", out var queryEl)
+                && queryEl.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                string? text = queryEl.GetString();
+                return text is not null ? [text] : null;
+            }
+        }
+        catch
+        {
+            // Serialization may fail (e.g. the null-URI bug on find_in_page actions).
+        }
+
+        return null;
+    }
+
+    private static string Truncate(string text, int maxLength)
+        => text.Length <= maxLength ? text : string.Concat(text.AsSpan(0, maxLength - 1), "…");
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -163,12 +163,14 @@ await HarnessConsole.RunAgentAsync(
     userPrompt: "Enter a research topic to get started.",
     new HarnessConsoleOptions
     {
-        Observers = HarnessConsoleOptions.BuildObserversWithPlanning(
-            agent,
-            planModeName: "plan",
-            executionModeName: "execute",
-            maxContextWindowTokens: MaxContextWindowTokens,
-            maxOutputTokens: MaxOutputTokens,
-            toolFormatters: [new DownloadUriToolFormatter(), .. ToolCallFormatter.BuildDefaultToolFormatters()]),
+        Observers = [
+            new OpenAIResponsesWebSearchDisplayObserver(),
+            .. HarnessConsoleOptions.BuildObserversWithPlanning(
+                agent,
+                planModeName: "plan",
+                executionModeName: "execute",
+                maxContextWindowTokens: MaxContextWindowTokens,
+                maxOutputTokens: MaxOutputTokens,
+                toolFormatters: [new DownloadUriToolFormatter(), .. ToolCallFormatter.BuildDefaultToolFormatters()])],
         CommandHandlers = HarnessConsoleOptions.BuildDefaultCommandHandlers(agent),
     });


### PR DESCRIPTION
### Motivation and Context

### Description

Updating the console samples with an observer that allows displaying more detail of calls to the OpenAIResponses web_search tool.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.