### PR TITLE
.NET: Fix bug in store-false helper to ensure addition rather than replacement

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.OpenAI/Extensions/OpenAIResponseClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.OpenAI/Extensions/OpenAIResponseClientExtensions.cs
@@ -120,9 +120,24 @@ public static class OpenAIResponseClientExtensions
         return Throw.IfNull(responseClient)
             .AsIChatClient(model)
             .AsBuilder()
-            .ConfigureOptions(x => x.RawRepresentationFactory = _ => includeReasoningEncryptedContent
-                ? new CreateResponseOptions() { StoredOutputEnabled = false, IncludedProperties = { IncludedResponseProperty.ReasoningEncryptedContent } }
-                : new CreateResponseOptions() { StoredOutputEnabled = false })
+            .ConfigureOptions(x =>
+            {
+                var previousFactory = x.RawRepresentationFactory;
+                x.RawRepresentationFactory = state =>
+                {
+                    var responseOptions = previousFactory?.Invoke(state) as CreateResponseOptions ?? new CreateResponseOptions();
+
+                    responseOptions.StoredOutputEnabled = false;
+
+                    if (includeReasoningEncryptedContent &&
+                        !responseOptions.IncludedProperties.Contains(IncludedResponseProperty.ReasoningEncryptedContent))
+                    {
+                        responseOptions.IncludedProperties.Add(IncludedResponseProperty.ReasoningEncryptedContent);
+                    }
+
+                    return responseOptions;
+                };
+            })
             .Build();
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/ProjectResponsesClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/ProjectResponsesClientExtensionsTests.cs
@@ -151,25 +151,13 @@ public sealed class ProjectResponsesClientExtensionsTests
             },
         };
 
-        // Act - invoke the configure action from the pipeline on the options
-        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(configureField);
-        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
-        Assert.NotNull(configureAction);
-        configureAction(options);
+        // Act
+        var createResponseOptions = GetCreateResponseOptionsFromPipeline(chatClient, options);
 
-        // Assert - invoke the resulting factory and verify all properties are present
-        Assert.NotNull(options.RawRepresentationFactory);
-        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        // Assert
         Assert.NotNull(createResponseOptions);
-
-        // The extension method should have set StoredOutputEnabled to false
         Assert.False(createResponseOptions.StoredOutputEnabled);
-
-        // The extension method should have added ReasoningEncryptedContent
         Assert.Contains(IncludedResponseProperty.ReasoningEncryptedContent, createResponseOptions.IncludedProperties);
-
-        // The caller's original IncludedProperty should still be present
         Assert.Contains(IncludedResponseProperty.WebSearchCallActionSources, createResponseOptions.IncludedProperties);
     }
 
@@ -194,17 +182,10 @@ public sealed class ProjectResponsesClientExtensionsTests
         };
 
         // Act
-        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(configureField);
-        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
-        Assert.NotNull(configureAction);
-        configureAction(options);
-
-        Assert.NotNull(options.RawRepresentationFactory);
-        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
-        Assert.NotNull(createResponseOptions);
+        var createResponseOptions = GetCreateResponseOptionsFromPipeline(chatClient, options);
 
         // Assert - ReasoningEncryptedContent should appear exactly once
+        Assert.NotNull(createResponseOptions);
         int count = 0;
         foreach (var prop in createResponseOptions.IncludedProperties)
         {
@@ -242,13 +223,21 @@ public sealed class ProjectResponsesClientExtensionsTests
     /// </summary>
     private static CreateResponseOptions? GetCreateResponseOptionsFromPipeline(IChatClient chatClient)
     {
+        return GetCreateResponseOptionsFromPipeline(chatClient, new ChatOptions());
+    }
+
+    /// <summary>
+    /// Overload that runs the configure action on caller-supplied <see cref="ChatOptions"/>,
+    /// useful for testing that existing factories are preserved.
+    /// </summary>
+    private static CreateResponseOptions? GetCreateResponseOptionsFromPipeline(IChatClient chatClient, ChatOptions options)
+    {
         var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(configureField);
 
         var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
         Assert.NotNull(configureAction);
 
-        var options = new ChatOptions();
         configureAction(options);
 
         Assert.NotNull(options.RawRepresentationFactory);

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/ProjectResponsesClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/ProjectResponsesClientExtensionsTests.cs
@@ -130,6 +130,94 @@ public sealed class ProjectResponsesClientExtensionsTests
     }
 
     /// <summary>
+    /// Verify that AsIChatClientWithStoredOutputDisabled preserves an existing RawRepresentationFactory
+    /// set on ChatOptions, augmenting it with StoredOutputEnabled and ReasoningEncryptedContent
+    /// rather than replacing it.
+    /// </summary>
+    [Fact]
+    public void AsIChatClientWithStoredOutputDisabled_PreservesExistingRawRepresentationFactory()
+    {
+        // Arrange
+        var responseClient = CreateTestClient();
+        var chatClient = responseClient.AsIChatClientWithStoredOutputDisabled();
+
+        // Simulate a caller setting their own RawRepresentationFactory on ChatOptions
+        // (e.g., to add WebSearchCallActionSources).
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new CreateResponseOptions
+            {
+                IncludedProperties = { IncludedResponseProperty.WebSearchCallActionSources },
+            },
+        };
+
+        // Act - invoke the configure action from the pipeline on the options
+        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(configureField);
+        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
+        Assert.NotNull(configureAction);
+        configureAction(options);
+
+        // Assert - invoke the resulting factory and verify all properties are present
+        Assert.NotNull(options.RawRepresentationFactory);
+        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        Assert.NotNull(createResponseOptions);
+
+        // The extension method should have set StoredOutputEnabled to false
+        Assert.False(createResponseOptions.StoredOutputEnabled);
+
+        // The extension method should have added ReasoningEncryptedContent
+        Assert.Contains(IncludedResponseProperty.ReasoningEncryptedContent, createResponseOptions.IncludedProperties);
+
+        // The caller's original IncludedProperty should still be present
+        Assert.Contains(IncludedResponseProperty.WebSearchCallActionSources, createResponseOptions.IncludedProperties);
+    }
+
+    /// <summary>
+    /// Verify that AsIChatClientWithStoredOutputDisabled does not duplicate ReasoningEncryptedContent
+    /// when the existing factory already includes it.
+    /// </summary>
+    [Fact]
+    public void AsIChatClientWithStoredOutputDisabled_DoesNotDuplicateReasoningEncryptedContent()
+    {
+        // Arrange
+        var responseClient = CreateTestClient();
+        var chatClient = responseClient.AsIChatClientWithStoredOutputDisabled();
+
+        // Simulate a caller that already includes ReasoningEncryptedContent
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new CreateResponseOptions
+            {
+                IncludedProperties = { IncludedResponseProperty.ReasoningEncryptedContent },
+            },
+        };
+
+        // Act
+        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(configureField);
+        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
+        Assert.NotNull(configureAction);
+        configureAction(options);
+
+        Assert.NotNull(options.RawRepresentationFactory);
+        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        Assert.NotNull(createResponseOptions);
+
+        // Assert - ReasoningEncryptedContent should appear exactly once
+        int count = 0;
+        foreach (var prop in createResponseOptions.IncludedProperties)
+        {
+            if (prop == IncludedResponseProperty.ReasoningEncryptedContent)
+            {
+                count++;
+            }
+        }
+
+        Assert.Equal(1, count);
+    }
+
+    /// <summary>
     /// Verify that AsIChatClientWithStoredOutputDisabled works with an optional deployment name.
     /// </summary>
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Extensions/OpenAIResponseClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Extensions/OpenAIResponseClientExtensionsTests.cs
@@ -392,25 +392,13 @@ public sealed class OpenAIResponseClientExtensionsTests
             },
         };
 
-        // Act - invoke the configure action from the pipeline on the options
-        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(configureField);
-        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
-        Assert.NotNull(configureAction);
-        configureAction(options);
+        // Act
+        var createResponseOptions = GetCreateResponseOptionsFromPipeline(chatClient, options);
 
-        // Assert - invoke the resulting factory and verify all properties are present
-        Assert.NotNull(options.RawRepresentationFactory);
-        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        // Assert
         Assert.NotNull(createResponseOptions);
-
-        // The extension method should have set StoredOutputEnabled to false
         Assert.False(createResponseOptions.StoredOutputEnabled);
-
-        // The extension method should have added ReasoningEncryptedContent
         Assert.Contains(IncludedResponseProperty.ReasoningEncryptedContent, createResponseOptions.IncludedProperties);
-
-        // The caller's original IncludedProperty should still be present
         Assert.Contains(IncludedResponseProperty.WebSearchCallActionSources, createResponseOptions.IncludedProperties);
     }
 
@@ -435,17 +423,10 @@ public sealed class OpenAIResponseClientExtensionsTests
         };
 
         // Act
-        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(configureField);
-        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
-        Assert.NotNull(configureAction);
-        configureAction(options);
-
-        Assert.NotNull(options.RawRepresentationFactory);
-        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
-        Assert.NotNull(createResponseOptions);
+        var createResponseOptions = GetCreateResponseOptionsFromPipeline(chatClient, options);
 
         // Assert - ReasoningEncryptedContent should appear exactly once
+        Assert.NotNull(createResponseOptions);
         int count = 0;
         foreach (var prop in createResponseOptions.IncludedProperties)
         {
@@ -483,6 +464,15 @@ public sealed class OpenAIResponseClientExtensionsTests
     /// </summary>
     private static CreateResponseOptions? GetCreateResponseOptionsFromPipeline(IChatClient chatClient)
     {
+        return GetCreateResponseOptionsFromPipeline(chatClient, new ChatOptions());
+    }
+
+    /// <summary>
+    /// Overload that runs the configure action on caller-supplied <see cref="ChatOptions"/>,
+    /// useful for testing that existing factories are preserved.
+    /// </summary>
+    private static CreateResponseOptions? GetCreateResponseOptionsFromPipeline(IChatClient chatClient, ChatOptions options)
+    {
         // The ConfigureOptionsChatClient stores the configure action in a private field.
         var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(configureField);
@@ -490,7 +480,6 @@ public sealed class OpenAIResponseClientExtensionsTests
         var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
         Assert.NotNull(configureAction);
 
-        var options = new ChatOptions();
         configureAction(options);
 
         Assert.NotNull(options.RawRepresentationFactory);

--- a/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Extensions/OpenAIResponseClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Extensions/OpenAIResponseClientExtensionsTests.cs
@@ -371,6 +371,94 @@ public sealed class OpenAIResponseClientExtensionsTests
     }
 
     /// <summary>
+    /// Verify that AsIChatClientWithStoredOutputDisabled preserves an existing RawRepresentationFactory
+    /// set on ChatOptions, augmenting it with StoredOutputEnabled and ReasoningEncryptedContent
+    /// rather than replacing it.
+    /// </summary>
+    [Fact]
+    public void AsIChatClientWithStoredOutputDisabled_PreservesExistingRawRepresentationFactory()
+    {
+        // Arrange
+        var responseClient = new TestOpenAIResponseClient();
+        var chatClient = responseClient.AsIChatClientWithStoredOutputDisabled();
+
+        // Simulate a caller setting their own RawRepresentationFactory on ChatOptions
+        // (e.g., to add WebSearchCallActionSources).
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new CreateResponseOptions
+            {
+                IncludedProperties = { IncludedResponseProperty.WebSearchCallActionSources },
+            },
+        };
+
+        // Act - invoke the configure action from the pipeline on the options
+        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(configureField);
+        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
+        Assert.NotNull(configureAction);
+        configureAction(options);
+
+        // Assert - invoke the resulting factory and verify all properties are present
+        Assert.NotNull(options.RawRepresentationFactory);
+        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        Assert.NotNull(createResponseOptions);
+
+        // The extension method should have set StoredOutputEnabled to false
+        Assert.False(createResponseOptions.StoredOutputEnabled);
+
+        // The extension method should have added ReasoningEncryptedContent
+        Assert.Contains(IncludedResponseProperty.ReasoningEncryptedContent, createResponseOptions.IncludedProperties);
+
+        // The caller's original IncludedProperty should still be present
+        Assert.Contains(IncludedResponseProperty.WebSearchCallActionSources, createResponseOptions.IncludedProperties);
+    }
+
+    /// <summary>
+    /// Verify that AsIChatClientWithStoredOutputDisabled does not duplicate ReasoningEncryptedContent
+    /// when the existing factory already includes it.
+    /// </summary>
+    [Fact]
+    public void AsIChatClientWithStoredOutputDisabled_DoesNotDuplicateReasoningEncryptedContent()
+    {
+        // Arrange
+        var responseClient = new TestOpenAIResponseClient();
+        var chatClient = responseClient.AsIChatClientWithStoredOutputDisabled();
+
+        // Simulate a caller that already includes ReasoningEncryptedContent
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new CreateResponseOptions
+            {
+                IncludedProperties = { IncludedResponseProperty.ReasoningEncryptedContent },
+            },
+        };
+
+        // Act
+        var configureField = chatClient.GetType().GetField("_configureOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(configureField);
+        var configureAction = configureField.GetValue(chatClient) as Action<ChatOptions>;
+        Assert.NotNull(configureAction);
+        configureAction(options);
+
+        Assert.NotNull(options.RawRepresentationFactory);
+        var createResponseOptions = options.RawRepresentationFactory(chatClient) as CreateResponseOptions;
+        Assert.NotNull(createResponseOptions);
+
+        // Assert - ReasoningEncryptedContent should appear exactly once
+        int count = 0;
+        foreach (var prop in createResponseOptions.IncludedProperties)
+        {
+            if (prop == IncludedResponseProperty.ReasoningEncryptedContent)
+            {
+                count++;
+            }
+        }
+
+        Assert.Equal(1, count);
+    }
+
+    /// <summary>
     /// A simple test IServiceProvider implementation for testing.
     /// </summary>
     private sealed class TestServiceProvider : IServiceProvider


### PR DESCRIPTION
### Motivation and Context

Currently using AsIChatClientWithStoredOutputDisabled causes any other raw representation factory to be ignored when using the ResponsesClient.  However when using the ProjectClient, it appends, which is the correct behavior.

### Description

- Fix bug in responses client store-false helper to ensure addition rather than replacement
- Add unit tests for both clients to guard against future regression.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.