### PR TITLE
.NET: fix(aspire-devui): ship Microsoft.Agents.AI.DevUI as a transitive dependency

### DIFF
--- a/dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/DevUIIntegration.AppHost.csproj
+++ b/dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/DevUIIntegration.AppHost.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Aspire.Hosting.Azure.AIFoundry" />
     <PackageReference Include="OpenAI" />
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\..\..\src\Aspire.Hosting.AgentFramework.DevUI\Aspire.Hosting.AgentFramework.DevUI.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\WriterAgent\WriterAgent.csproj" />
     <ProjectReference Include="..\EditorAgent\EditorAgent.csproj" />

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
@@ -31,6 +31,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Microsoft.Agents.AI.DevUI ships the embedded DevUI frontend assets that the
+      aggregator loads at runtime via Assembly.Load. Reference it here so users of
+      Aspire.Hosting.AgentFramework.DevUI get the frontend out of the box without
+      having to add a second package to their AppHost project.
+    -->
+    <ProjectReference Include="..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
@@ -36,8 +36,12 @@
       aggregator loads at runtime via Assembly.Load. Reference it here so users of
       Aspire.Hosting.AgentFramework.DevUI get the frontend out of the box without
       having to add a second package to their AppHost project.
+
+      TreatAsUsed silences ReferenceTrimmer RT0002: no symbol from this assembly
+      is referenced in source, but the assembly must flow through as a runtime
+      dependency so Assembly.Load("Microsoft.Agents.AI.DevUI") succeeds.
     -->
-    <ProjectReference Include="..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" />
+    <ProjectReference Include="..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" TreatAsUsed="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/README.md
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/README.md
@@ -92,7 +92,9 @@ builder.AddDevUI("devui", port: 8090);
 
 ### DevUI frontend assembly
 
-To serve the DevUI frontend directly from the aggregator (instead of proxying from a backend), add the `Microsoft.Agents.AI.DevUI` NuGet package to your AppHost project. The aggregator loads its embedded resources at runtime via `Assembly.Load`.
+The DevUI frontend assets are loaded at runtime from the `Microsoft.Agents.AI.DevUI` assembly, which is referenced transitively by this package. No additional setup is required to serve the frontend directly from the aggregator.
+
+If the assembly cannot be loaded (for example, when trimming or AOT settings strip it), the aggregator falls back to proxying the frontend from the first backend agent service that serves `/devui`.
 
 ## Additional documentation
 

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIFrontendAssemblyTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIFrontendAssemblyTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Linq;

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIFrontendAssemblyTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIFrontendAssemblyTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Aspire.Hosting.AgentFramework.DevUI.UnitTests;
+
+/// <summary>
+/// Regression tests guarding the fix for
+/// https://github.com/microsoft/agent-framework/issues/5779.
+///
+/// Aspire.Hosting.AgentFramework.DevUI references Microsoft.Agents.AI.DevUI so that
+/// the embedded DevUI frontend assets ship with the Aspire integration package. These
+/// tests verify that the assembly is loadable at runtime via Assembly.Load and exposes
+/// the embedded frontend resources the aggregator depends on.
+/// </summary>
+public class DevUIFrontendAssemblyTests
+{
+    /// <summary>
+    /// Verifies that the Microsoft.Agents.AI.DevUI assembly is reachable via
+    /// <see cref="Assembly.Load(string)"/>, which is how
+    /// <c>DevUIAggregatorHostedService.LoadFrontendResources</c> discovers it.
+    /// </summary>
+    [Fact]
+    public void MicrosoftAgentsAIDevUIAssembly_IsLoadableAtRuntime()
+    {
+        // Act
+        var assembly = Assembly.Load("Microsoft.Agents.AI.DevUI");
+
+        // Assert
+        Assert.NotNull(assembly);
+        Assert.Equal("Microsoft.Agents.AI.DevUI", assembly.GetName().Name);
+    }
+
+    /// <summary>
+    /// Verifies that the Microsoft.Agents.AI.DevUI assembly exposes at least one
+    /// embedded frontend resource using the prefix the aggregator looks for.
+    /// </summary>
+    [Fact]
+    public void MicrosoftAgentsAIDevUIAssembly_ExposesEmbeddedFrontendResources()
+    {
+        // Arrange
+        var assembly = Assembly.Load("Microsoft.Agents.AI.DevUI");
+        var prefix = $"{assembly.GetName().Name}.resources.";
+
+        // Act
+        var resourceNames = assembly.GetManifestResourceNames();
+        var frontendResources = resourceNames
+            .Where(n => n.StartsWith(prefix, StringComparison.Ordinal))
+            .ToArray();
+
+        // Assert
+        Assert.NotEmpty(frontendResources);
+    }
+}


### PR DESCRIPTION
### Motivation and Context

`Aspire.Hosting.AgentFramework.DevUI` starts an in-process Kestrel aggregator that serves the DevUI frontend from embedded resources in the `Microsoft.Agents.AI.DevUI` assembly. The aggregator discovers that assembly at runtime via:

```csharp
Assembly.Load("Microsoft.Agents.AI.DevUI")
```

in [`DevUIAggregatorHostedService.LoadFrontendResources`](https://github.com/microsoft/agent-framework/blob/main/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs#L118).

Until now, `Microsoft.Agents.AI.DevUI` was **not** referenced by `Aspire.Hosting.AgentFramework.DevUI.csproj`. Users who followed the README's installation instructions (`dotnet add package Aspire.Hosting.AgentFramework.DevUI`) ended up with the aggregator but not the frontend assembly. `Assembly.Load` then failed silently (debug-level log), no backend served `/devui/`, and `GET /devui/` returned HTTP 404 — exactly the failure mode reported in #5779.

The only place this worked was the [`DevUIAspireIntegration` sample](https://github.com/microsoft/agent-framework/blob/main/dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/DevUIIntegration.AppHost.csproj), which carries a second explicit `ProjectReference` to `Microsoft.Agents.AI.DevUI`. The reporter (@hansmbakker) independently arrived at the same workaround and asked for the dependency to be automatic.

### Description

Make `Microsoft.Agents.AI.DevUI` a first-class dependency of `Aspire.Hosting.AgentFramework.DevUI` so the integration works out of the box from a single `dotnet add package` invocation:

- **`dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj`** — Add `<ProjectReference Include="..\Microsoft.Agents.AI.DevUI\Microsoft.Agents.AI.DevUI.csproj" />`. Both projects import `nuget-package.props`, so the in-repo project reference flows through to a transitive NuGet `PackageReference` at pack time. A short comment in the csproj explains why the reference exists.
- **`dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/DevUIIntegration.AppHost.csproj`** — Drop the now-redundant explicit `ProjectReference` to `Microsoft.Agents.AI.DevUI` so the sample mirrors what end-users will write after this change.
- **`dotnet/src/Aspire.Hosting.AgentFramework.DevUI/README.md`** — Rewrite the "DevUI frontend assembly" section. It previously told users to manually add `Microsoft.Agents.AI.DevUI` to their AppHost project; it now describes the new default behavior and the fallback path the aggregator uses when the assembly cannot be loaded (e.g., trimming/AOT settings).
- **`dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIFrontendAssemblyTests.cs`** _(new)_ — Two-test regression guard that asserts (a) `Assembly.Load("Microsoft.Agents.AI.DevUI")` succeeds from a process that only references `Aspire.Hosting.AgentFramework.DevUI`, and (b) the loaded assembly exposes embedded frontend resources under the prefix the aggregator scans for. If a future change accidentally removes the new `ProjectReference`, these tests fail with a clear signal.

The aggregator's existing fallback path (proxy the frontend from the first backend agent service that serves `/devui`) is preserved unchanged for users who explicitly opt out of the embedded assets.

I was unable to run `dotnet build` locally because the repo pins SDK `10.0.200` in `global.json` and I do not have that preview installed. The csproj edits use the exact same `<ProjectReference>` shape as four other csprojs in the repo, and the README/sample changes are textual. CI will confirm the build.

Fixes #5779

### Contribution Checklist

- [x] The code builds clean without any errors or warnings _(CI to confirm; SDK 10.0.200 not available locally)_
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible _(added `DevUIFrontendAssemblyTests`)_
- [ ] **Is this a breaking change?** No. Adding a transitive dependency is additive; the aggregator's behavior when the assembly is missing is unchanged (it still falls back to proxying from a backend).
