### PR TITLE
Python: Fix OTLP HTTP base-endpoint losing /v1/{signal} auto-append

### DIFF
--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -498,13 +498,30 @@ def _get_exporters_from_env(
     # Get base endpoint
     base_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 
-    # Get signal-specific endpoints (these override base endpoint)
-    traces_endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or base_endpoint
-    metrics_endpoint = os.getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") or base_endpoint
-    logs_endpoint = os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") or base_endpoint
+    # Get signal-specific endpoints (these override base endpoint and are used verbatim)
+    traces_endpoint_specific = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    metrics_endpoint_specific = os.getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+    logs_endpoint_specific = os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
 
     # Get protocol (default is grpc)
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").lower()
+
+    # Per the OTel spec, OTEL_EXPORTER_OTLP_ENDPOINT is a *base* URL for HTTP — the SDK
+    # auto-appends /v1/{traces,metrics,logs} when it reads the env var directly. The
+    # signal-specific endpoint env vars are *full* URLs used verbatim. Because we read
+    # the env vars here and forward them as the ``endpoint=`` constructor argument
+    # (which the SDK always treats as a full URL), we must replicate the auto-append
+    # ourselves for HTTP when falling back to the base endpoint. For gRPC, the base
+    # endpoint is used as-is.
+    if protocol in ("http/protobuf", "http") and base_endpoint:
+        base_for_http = base_endpoint.rstrip("/")
+        traces_endpoint = traces_endpoint_specific or f"{base_for_http}/v1/traces"
+        metrics_endpoint = metrics_endpoint_specific or f"{base_for_http}/v1/metrics"
+        logs_endpoint = logs_endpoint_specific or f"{base_for_http}/v1/logs"
+    else:
+        traces_endpoint = traces_endpoint_specific or base_endpoint
+        metrics_endpoint = metrics_endpoint_specific or base_endpoint
+        logs_endpoint = logs_endpoint_specific or base_endpoint
 
     # Get base headers
     base_headers_str = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -513,6 +513,9 @@ def _get_exporters_from_env(
     # (which the SDK always treats as a full URL), we must replicate the auto-append
     # ourselves for HTTP when falling back to the base endpoint. For gRPC, the base
     # endpoint is used as-is.
+    traces_endpoint: str | None
+    metrics_endpoint: str | None
+    logs_endpoint: str | None
     if protocol in ("http/protobuf", "http") and base_endpoint:
         base_for_http = base_endpoint.rstrip("/")
         traces_endpoint = traces_endpoint_specific or f"{base_for_http}/v1/traces"

--- a/python/packages/core/tests/core/test_observability.py
+++ b/python/packages/core/tests/core/test_observability.py
@@ -761,6 +761,115 @@ def test_get_exporters_from_env_missing_grpc_dependency(monkeypatch):
         _get_exporters_from_env()
 
 
+# region Test OTLP endpoint computation (base-URL auto-append for HTTP)
+
+
+def test_get_exporters_from_env_http_base_endpoint_appends_signal_paths(monkeypatch):
+    """OTEL_EXPORTER_OTLP_ENDPOINT is a base URL for HTTP; SDK auto-appends
+    /v1/{traces,metrics,logs}. Because we read the env var and forward it as the
+    constructor ``endpoint=`` arg (which the SDK treats as a full URL), we must
+    replicate the auto-append ourselves.
+    """
+    from unittest.mock import patch
+
+    from agent_framework import observability
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    for key in (
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch.object(observability, "_create_otlp_exporters", return_value=[]) as create:
+        observability._get_exporters_from_env()
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["protocol"] == "http/protobuf"
+    assert kwargs["traces_endpoint"] == "http://localhost:4318/v1/traces"
+    assert kwargs["metrics_endpoint"] == "http://localhost:4318/v1/metrics"
+    assert kwargs["logs_endpoint"] == "http://localhost:4318/v1/logs"
+
+
+def test_get_exporters_from_env_http_base_endpoint_trailing_slash(monkeypatch):
+    """A trailing slash on the base endpoint should not produce a doubled slash."""
+    from unittest.mock import patch
+
+    from agent_framework import observability
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    for key in (
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch.object(observability, "_create_otlp_exporters", return_value=[]) as create:
+        observability._get_exporters_from_env()
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["traces_endpoint"] == "http://localhost:4318/v1/traces"
+    assert kwargs["metrics_endpoint"] == "http://localhost:4318/v1/metrics"
+    assert kwargs["logs_endpoint"] == "http://localhost:4318/v1/logs"
+
+
+def test_get_exporters_from_env_http_signal_specific_used_verbatim(monkeypatch):
+    """Signal-specific endpoint env vars are full URLs and must be used verbatim,
+    even when a base endpoint is also set.
+    """
+    from unittest.mock import patch
+
+    from agent_framework import observability
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces.example.com/custom/path")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    for key in (
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch.object(observability, "_create_otlp_exporters", return_value=[]) as create:
+        observability._get_exporters_from_env()
+
+    kwargs = create.call_args.kwargs
+    # Signal-specific is verbatim — no path appended
+    assert kwargs["traces_endpoint"] == "http://traces.example.com/custom/path"
+    # Others fall back to base, with path appended
+    assert kwargs["metrics_endpoint"] == "http://localhost:4318/v1/metrics"
+    assert kwargs["logs_endpoint"] == "http://localhost:4318/v1/logs"
+
+
+def test_get_exporters_from_env_grpc_base_endpoint_unchanged(monkeypatch):
+    """For gRPC, the base endpoint applies to all signals as-is (no path append)."""
+    from unittest.mock import patch
+
+    from agent_framework import observability
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    for key in (
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch.object(observability, "_create_otlp_exporters", return_value=[]) as create:
+        observability._get_exporters_from_env()
+
+    kwargs = create.call_args.kwargs
+    assert kwargs["protocol"] == "grpc"
+    assert kwargs["traces_endpoint"] == "http://localhost:4317"
+    assert kwargs["metrics_endpoint"] == "http://localhost:4317"
+    assert kwargs["logs_endpoint"] == "http://localhost:4317"
+
+
 # region Test create_resource
 
 


### PR DESCRIPTION
## Summary

Fixes #5912

Per the [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp), `OTEL_EXPORTER_OTLP_ENDPOINT` is a **base URL** for HTTP transport — the SDK automatically appends `/v1/traces`, `/v1/metrics`, and `/v1/logs` when it reads the env var directly. Signal-specific env vars (e.g. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) are **full URLs** used verbatim.

`_get_exporters_from_env` in `observability.py` was reading the base endpoint and passing it directly as the `endpoint=` constructor argument to the exporters. The OTel SDK always treats a programmatically-provided `endpoint=` as a **full signal URL** (no auto-append). This silently dropped the `/v1/{signal}` path suffix, causing all HTTP telemetry to be sent to the wrong URL (e.g. `http://localhost:4318` instead of `http://localhost:4318/v1/traces`).

## Changes

**`python/packages/core/agent_framework/observability.py`**

- Read signal-specific endpoint env vars separately from the base endpoint.
- When using HTTP protocol (`http/protobuf` or `http`) and falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`, auto-append `/v1/traces`, `/v1/metrics`, `/v1/logs` to replicate the OTel spec behaviour.
- Signal-specific env vars continue to be forwarded verbatim (no path appended).
- gRPC behaviour is **unchanged** — the base endpoint is used as-is.

**`python/packages/core/tests/core/test_observability.py`**

- Added test cases covering:
  - HTTP protocol with base endpoint → signal paths are auto-appended.
  - HTTP protocol with signal-specific endpoints → used verbatim (no double-append).
  - gRPC protocol with base endpoint → base URL used as-is (no path appended).

## Before / After

| Scenario | Before | After |
|---|---|---|
| `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`, `PROTOCOL=http/protobuf` | Sends to `http://localhost:4318` ❌ | Sends to `http://localhost:4318/v1/traces` ✅ |
| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces`, `PROTOCOL=http/protobuf` | Sends to `http://localhost:4318/v1/traces` ✅ | Sends to `http://localhost:4318/v1/traces` ✅ |
| `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`, `PROTOCOL=grpc` | Sends to `http://localhost:4317` ✅ | Sends to `http://localhost:4317` ✅ |

## Testing

Unit tests added in `test_observability.py` covering all three scenarios above. No integration-level changes required.
