### PR TITLE
Python: Add Python parity sample for invoking Foundry Toolbox tools from declarative workflows

### DIFF
--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import locale
 import logging
+import os
 import sys
 import uuid
 from collections.abc import Mapping
@@ -709,6 +710,8 @@ class DeclarativeWorkflowState:
             "Agent": agent_data,
             "Conversation": conversation_data,
             "System": system_data,
+            # Match .NET declarative workflows that use =Env.VAR_NAME.
+            "Env": dict(os.environ),
             # Also expose inputs at top level for backward compatibility with =inputs.X syntax
             "inputs": inputs_data,
             # Custom namespaces

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -32,7 +32,7 @@ import re
 import sys
 import uuid
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal as _Decimal
 from enum import Enum
 from types import MappingProxyType
@@ -93,7 +93,7 @@ class DeclarativeEnvConfig:
             unrelated environment variables never enter the PowerFx scope.
     """
 
-    values: Mapping[str, str] = _EMPTY_ENV_VALUES
+    values: Mapping[str, str] = field(default_factory=lambda: _EMPTY_ENV_VALUES)
     restrict_to_configuration: bool = True
     referenced_names: frozenset[str] = _EMPTY_ENV_REFERENCES
 
@@ -126,11 +126,11 @@ def discover_env_references(node: Any) -> set[str]:
                 names.update(_ENV_REFERENCE_RE.findall(value))
             return
         if isinstance(value, Mapping):
-            for inner in cast(Mapping[Any, Any], value).values():
+            for inner in cast(Mapping[Any, Any], value).values():  # type: ignore[redundant-cast]
                 visit(inner)
             return
         if isinstance(value, list):
-            for item in cast(list[Any], value):
+            for item in cast(list[Any], value):  # type: ignore[redundant-cast]
                 visit(item)
 
     visit(node)

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -63,24 +63,19 @@ logger = logging.getLogger(__name__)
 
 _ENV_REFERENCE_RE = re.compile(r"\bEnv\.([A-Za-z_][A-Za-z0-9_]*)")
 
-_EMPTY_ENV_VALUES: Mapping[str, str] = MappingProxyType({})
-_EMPTY_ENV_REFERENCES: frozenset[str] = frozenset()
-
 
 @dataclass(frozen=True)
 class DeclarativeEnvConfig:
     """Configuration that populates the PowerFx ``Env`` symbol for a workflow.
 
-    Mirrors the .NET ``IConfiguration``-driven environment binding in
-    ``Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowDiagnostics.cs``.
-    The configuration values are always exposed under ``Env.<name>`` (matching
-    ``IConfiguration`` semantics), and ``os.environ`` is consulted only when
-    ``restrict_to_configuration`` is ``False`` and the YAML literally
-    references the name in a PowerFx expression.
+    Configuration values are always exposed under ``Env.<name>``;
+    ``os.environ`` is consulted only when ``restrict_to_configuration``
+    is ``False`` AND the YAML literally references the name in a PowerFx
+    expression (the allowlist enforced via ``referenced_names``).
 
     Attributes:
-        values: Caller-supplied configuration values resolved by name when
-            the workflow YAML references ``=Env.NAME``. Always exposed in
+        values: Caller-supplied configuration resolved by name when the
+            workflow YAML references ``=Env.NAME``. Always exposed in
             the ``Env`` symbol regardless of ``restrict_to_configuration``.
         restrict_to_configuration: When ``True`` (default), the ``Env``
             symbol is populated exclusively from ``values``; ``os.environ``
@@ -93,12 +88,35 @@ class DeclarativeEnvConfig:
             unrelated environment variables never enter the PowerFx scope.
     """
 
-    values: Mapping[str, str] = field(default_factory=lambda: _EMPTY_ENV_VALUES)
+    values: Mapping[str, str] = field(default_factory=lambda: MappingProxyType({}))
     restrict_to_configuration: bool = True
-    referenced_names: frozenset[str] = _EMPTY_ENV_REFERENCES
+    referenced_names: frozenset[str] = field(default_factory=lambda: frozenset[str]())
 
+    def __post_init__(self) -> None:
+        # Defensive snapshots so the frozen guarantee extends to the
+        # contents of ``values`` / ``referenced_names``: caller mutations
+        # to the original objects after construction cannot leak into
+        # ``resolve()``.
+        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+        object.__setattr__(self, "referenced_names", frozenset(self.referenced_names))
 
-_EMPTY_ENV_CONFIG = DeclarativeEnvConfig()
+    def resolve(self) -> dict[str, str]:
+        """Return the resolved ``Env`` symbol mapping for the workflow.
+
+        Configuration values are always included (stringified).
+        ``os.environ`` is consulted only when ``restrict_to_configuration``
+        is ``False`` and the name appears in ``referenced_names``, so
+        unrelated environment variables never enter the PowerFx scope.
+        Configuration values always win over the environment fallback.
+        """
+        resolved = {name: str(value) for name, value in self.values.items()}
+        if self.restrict_to_configuration:
+            return resolved
+        for name in self.referenced_names.difference(resolved):
+            env_value = os.environ.get(name)
+            if env_value is not None:
+                resolved[name] = env_value
+        return resolved
 
 
 def discover_env_references(node: Any) -> set[str]:
@@ -248,7 +266,7 @@ class DeclarativeWorkflowState:
     - Conversation: Conversation history
     """
 
-    def __init__(self, state: State, env_config: DeclarativeEnvConfig = _EMPTY_ENV_CONFIG):
+    def __init__(self, state: State, env_config: DeclarativeEnvConfig | None = None):
         """Initialize with a State instance.
 
         Args:
@@ -259,7 +277,7 @@ class DeclarativeWorkflowState:
                 matching the safe default of the :class:`WorkflowFactory`.
         """
         self._state = state
-        self._env_config = env_config
+        self._env_config = env_config if env_config is not None else DeclarativeEnvConfig()
 
     def initialize(self, inputs: Mapping[str, Any] | None = None) -> None:
         """Initialize the declarative state with inputs.
@@ -798,25 +816,12 @@ class DeclarativeWorkflowState:
             # Custom namespaces
             **state_data.get("Custom", {}),
         }
-        # Populate the ``Env`` symbol from the workflow-level
-        # :class:`DeclarativeEnvConfig`. Caller-supplied configuration
-        # values are always exposed (matching .NET ``IConfiguration``
-        # semantics); ``os.environ`` is consulted only when
-        # ``restrict_to_configuration`` is ``False`` and the YAML explicitly
-        # references the name in a PowerFx expression. When both sources
-        # produce no values the ``Env`` symbol is omitted entirely so
-        # ``=Env.X`` resolves to the literal expression string (preserving
-        # the legacy "unbound identifier" fallback behaviour).
-        env_bound: dict[str, str] = {}
-        for name, value in self._env_config.values.items():
-            env_bound[name] = str(value)
-        if not self._env_config.restrict_to_configuration:
-            for name in self._env_config.referenced_names:
-                if name in env_bound:
-                    continue
-                env_value = os.environ.get(name)
-                if env_value is not None:
-                    env_bound[name] = env_value
+        # Resolve the ``Env`` symbol from the workflow-level
+        # :class:`DeclarativeEnvConfig`. When both ``values`` and the
+        # ``os.environ`` allowlist produce no entries the symbol is
+        # omitted so ``=Env.X`` falls back to the literal expression
+        # string (preserving the legacy "unbound identifier" behaviour).
+        env_bound = self._env_config.resolve()
         if env_bound:
             symbols["Env"] = env_bound
         # Debug log the Local symbols to help diagnose type issues
@@ -976,7 +981,7 @@ class DeclarativeActionExecutor(Executor):
         # executor by :class:`DeclarativeWorkflowBuilder` after construction.
         # Defaults to an empty configuration so direct ``DeclarativeActionExecutor``
         # construction (e.g. in unit tests) doesn't expose ``os.environ``.
-        self._declarative_env_config: DeclarativeEnvConfig = _EMPTY_ENV_CONFIG
+        self._declarative_env_config: DeclarativeEnvConfig = DeclarativeEnvConfig()
 
         # Manually register handlers after initialization
         self._handlers = {}

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -28,12 +28,14 @@ from __future__ import annotations
 import locale
 import logging
 import os
+import re
 import sys
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal as _Decimal
 from enum import Enum
+from types import MappingProxyType
 from typing import Any, Literal, cast
 
 from agent_framework import (
@@ -42,8 +44,6 @@ from agent_framework import (
     WorkflowContext,
 )
 from agent_framework._workflows._state import State
-
-from .._models import _safe_mode_context  # type: ignore[reportPrivateUsage]
 
 try:
     from powerfx import Engine
@@ -59,6 +59,82 @@ else:
 
 
 logger = logging.getLogger(__name__)
+
+
+_ENV_REFERENCE_RE = re.compile(r"\bEnv\.([A-Za-z_][A-Za-z0-9_]*)")
+
+_EMPTY_ENV_VALUES: Mapping[str, str] = MappingProxyType({})
+_EMPTY_ENV_REFERENCES: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class DeclarativeEnvConfig:
+    """Configuration that populates the PowerFx ``Env`` symbol for a workflow.
+
+    Mirrors the .NET ``IConfiguration``-driven environment binding in
+    ``Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowDiagnostics.cs``.
+    The configuration values are always exposed under ``Env.<name>`` (matching
+    ``IConfiguration`` semantics), and ``os.environ`` is consulted only when
+    ``restrict_to_configuration`` is ``False`` and the YAML literally
+    references the name in a PowerFx expression.
+
+    Attributes:
+        values: Caller-supplied configuration values resolved by name when
+            the workflow YAML references ``=Env.NAME``. Always exposed in
+            the ``Env`` symbol regardless of ``restrict_to_configuration``.
+        restrict_to_configuration: When ``True`` (default), the ``Env``
+            symbol is populated exclusively from ``values``; ``os.environ``
+            is never consulted. Set to ``False`` to additionally fall back
+            to ``os.environ`` for names absent from ``values`` that the
+            workflow YAML explicitly references.
+        referenced_names: The set of ``Env.NAME`` symbols discovered in
+            PowerFx expressions inside the workflow definition. The
+            ``os.environ`` fallback is constrained to this allowlist so
+            unrelated environment variables never enter the PowerFx scope.
+    """
+
+    values: Mapping[str, str] = _EMPTY_ENV_VALUES
+    restrict_to_configuration: bool = True
+    referenced_names: frozenset[str] = _EMPTY_ENV_REFERENCES
+
+
+_EMPTY_ENV_CONFIG = DeclarativeEnvConfig()
+
+
+def discover_env_references(node: Any) -> set[str]:
+    """Discover ``Env.NAME`` references in PowerFx expressions inside ``node``.
+
+    Walks any nested ``Mapping``/``list``/scalar structure and inspects every
+    string value. To avoid false positives from doc/description fields that
+    happen to mention ``Env.SOMETHING`` as plain text, the scan only inspects
+    strings that begin with ``=`` (PowerFx expression marker, matching the
+    convention enforced by :meth:`DeclarativeWorkflowState.eval`).
+
+    Args:
+        node: A parsed workflow definition (typically the dict produced by
+            ``yaml.safe_load``).
+
+    Returns:
+        The set of ``Env`` identifier names referenced in PowerFx
+        expressions inside ``node``.
+    """
+    names: set[str] = set()
+
+    def visit(value: Any) -> None:
+        if isinstance(value, str):
+            if value.startswith("="):
+                names.update(_ENV_REFERENCE_RE.findall(value))
+            return
+        if isinstance(value, Mapping):
+            for inner in cast(Mapping[Any, Any], value).values():
+                visit(inner)
+            return
+        if isinstance(value, list):
+            for item in cast(list[Any], value):
+                visit(item)
+
+    visit(node)
+    return names
 
 
 class ConversationData(TypedDict):
@@ -172,13 +248,18 @@ class DeclarativeWorkflowState:
     - Conversation: Conversation history
     """
 
-    def __init__(self, state: State):
+    def __init__(self, state: State, env_config: DeclarativeEnvConfig = _EMPTY_ENV_CONFIG):
         """Initialize with a State instance.
 
         Args:
             state: The workflow's state for persistence
+            env_config: Configuration that populates the PowerFx ``Env``
+                symbol when ``_to_powerfx_symbols`` is called. Defaults to
+                an empty configuration which results in no ``Env`` binding,
+                matching the safe default of the :class:`WorkflowFactory`.
         """
         self._state = state
+        self._env_config = env_config
 
     def initialize(self, inputs: Mapping[str, Any] | None = None) -> None:
         """Initialize the declarative state with inputs.
@@ -717,13 +798,27 @@ class DeclarativeWorkflowState:
             # Custom namespaces
             **state_data.get("Custom", {}),
         }
-        # Expose ``Env`` ONLY when the active workflow factory has explicitly
-        # opted out of safe mode. Matches the policy enforced by
-        # ``_try_powerfx_eval`` in ``_models.py`` and the AgentFactory
-        # ``safe_mode`` flag. Treat the default as safe even when no factory
-        # is in scope (e.g. in unit tests) so opt-in is required.
-        if not _safe_mode_context.get():
-            symbols["Env"] = dict(os.environ)
+        # Populate the ``Env`` symbol from the workflow-level
+        # :class:`DeclarativeEnvConfig`. Caller-supplied configuration
+        # values are always exposed (matching .NET ``IConfiguration``
+        # semantics); ``os.environ`` is consulted only when
+        # ``restrict_to_configuration`` is ``False`` and the YAML explicitly
+        # references the name in a PowerFx expression. When both sources
+        # produce no values the ``Env`` symbol is omitted entirely so
+        # ``=Env.X`` resolves to the literal expression string (preserving
+        # the legacy "unbound identifier" fallback behaviour).
+        env_bound: dict[str, str] = {}
+        for name, value in self._env_config.values.items():
+            env_bound[name] = str(value)
+        if not self._env_config.restrict_to_configuration:
+            for name in self._env_config.referenced_names:
+                if name in env_bound:
+                    continue
+                env_value = os.environ.get(name)
+                if env_value is not None:
+                    env_bound[name] = env_value
+        if env_bound:
+            symbols["Env"] = env_bound
         # Debug log the Local symbols to help diagnose type issues
         if local_data:
             for key, value in local_data.items():
@@ -877,12 +972,27 @@ class DeclarativeActionExecutor(Executor):
         action_id = id or action_def.get("id") or f"{action_def.get('kind', 'action')}_{hash(str(action_def)) % 10000}"
         super().__init__(id=action_id, defer_discovery=True)
         self._action_def = action_def
+        # The active :class:`DeclarativeEnvConfig` is stamped onto the
+        # executor by :class:`DeclarativeWorkflowBuilder` after construction.
+        # Defaults to an empty configuration so direct ``DeclarativeActionExecutor``
+        # construction (e.g. in unit tests) doesn't expose ``os.environ``.
+        self._declarative_env_config: DeclarativeEnvConfig = _EMPTY_ENV_CONFIG
 
         # Manually register handlers after initialization
         self._handlers = {}
         self._handler_specs = []
         self._discover_handlers()
         self._discover_response_handlers()
+
+    def set_declarative_env_config(self, env_config: DeclarativeEnvConfig) -> None:
+        """Set the workflow-level :class:`DeclarativeEnvConfig` for this executor.
+
+        Called by :class:`DeclarativeWorkflowBuilder` after each executor is
+        created so that ``_to_powerfx_symbols`` populates the ``Env`` symbol
+        according to the caller-supplied configuration on the
+        :class:`WorkflowFactory`.
+        """
+        self._declarative_env_config = env_config
 
     @property
     def action_def(self) -> dict[str, Any]:
@@ -896,7 +1006,7 @@ class DeclarativeActionExecutor(Executor):
 
     def _get_state(self, state: State) -> DeclarativeWorkflowState:
         """Get the declarative workflow state wrapper."""
-        return DeclarativeWorkflowState(state)
+        return DeclarativeWorkflowState(state, env_config=self._declarative_env_config)
 
     async def _ensure_state_initialized(
         self,

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -43,7 +43,7 @@ from agent_framework import (
 )
 from agent_framework._workflows._state import State
 
-from .._models import _safe_mode_context
+from .._models import _safe_mode_context  # type: ignore[reportPrivateUsage]
 
 try:
     from powerfx import Engine

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -43,6 +43,8 @@ from agent_framework import (
 )
 from agent_framework._workflows._state import State
 
+from .._models import _safe_mode_context
+
 try:
     from powerfx import Engine
 except (ImportError, RuntimeError):
@@ -710,13 +712,18 @@ class DeclarativeWorkflowState:
             "Agent": agent_data,
             "Conversation": conversation_data,
             "System": system_data,
-            # Match .NET declarative workflows that use =Env.VAR_NAME.
-            "Env": dict(os.environ),
             # Also expose inputs at top level for backward compatibility with =inputs.X syntax
             "inputs": inputs_data,
             # Custom namespaces
             **state_data.get("Custom", {}),
         }
+        # Expose ``Env`` ONLY when the active workflow factory has explicitly
+        # opted out of safe mode. Matches the policy enforced by
+        # ``_try_powerfx_eval`` in ``_models.py`` and the AgentFactory
+        # ``safe_mode`` flag. Treat the default as safe even when no factory
+        # is in scope (e.g. in unit tests) so opt-in is required.
+        if not _safe_mode_context.get():
+            symbols["Env"] = dict(os.environ)
         # Debug log the Local symbols to help diagnose type issues
         if local_data:
             for key, value in local_data.items():

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_builder.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_builder.py
@@ -22,8 +22,10 @@ from agent_framework import (
 )
 
 from ._declarative_base import (
+    _EMPTY_ENV_CONFIG,  # type: ignore[reportPrivateUsage]
     ConditionResult,
     DeclarativeActionExecutor,
+    DeclarativeEnvConfig,
     LoopIterationResult,
 )
 from ._errors import DeclarativeWorkflowError
@@ -140,6 +142,7 @@ class DeclarativeWorkflowBuilder:
         max_iterations: int | None = None,
         http_request_handler: HttpRequestHandler | None = None,
         mcp_tool_handler: MCPToolHandler | None = None,
+        env_config: DeclarativeEnvConfig | None = None,
     ):
         """Initialize the builder.
 
@@ -158,6 +161,10 @@ class DeclarativeWorkflowBuilder:
             mcp_tool_handler: Handler used to dispatch InvokeMcpTool calls.
                 Must be supplied when the workflow contains any InvokeMcpTool;
                 otherwise build raises ``DeclarativeWorkflowError``.
+            env_config: Optional :class:`DeclarativeEnvConfig` controlling
+                how the ``Env`` PowerFx symbol is populated for every
+                executor built by this builder. Defaults to an empty
+                configuration (``Env`` not exposed).
         """
         self._yaml_def = yaml_definition
         self._workflow_id = workflow_id or yaml_definition.get("name", "declarative_workflow")
@@ -171,6 +178,7 @@ class DeclarativeWorkflowBuilder:
         self._seen_explicit_ids: set[str] = set()  # Track explicit IDs for duplicate detection
         self._http_request_handler = http_request_handler
         self._mcp_tool_handler = mcp_tool_handler
+        self._env_config: DeclarativeEnvConfig = env_config if env_config is not None else _EMPTY_ENV_CONFIG
         # Resolve max_iterations: explicit arg > YAML maxTurns > core default
         resolved = max_iterations if max_iterations is not None else yaml_definition.get("maxTurns")
         if resolved is not None and (not isinstance(resolved, int) or resolved <= 0):
@@ -220,6 +228,15 @@ class DeclarativeWorkflowBuilder:
 
         # Resolve pending gotos (back-edges for loops, forward-edges for jumps)
         self._resolve_pending_gotos(builder)
+
+        # Stamp the resolved DeclarativeEnvConfig onto every executor so they
+        # expose the configured Env binding through their _get_state(). This
+        # happens after _create_executors_for_actions and _resolve_pending_gotos
+        # so it covers the entry node, join nodes, evaluators, foreach
+        # init/next/exit nodes, and goto placeholders.
+        for executor in self._executors.values():
+            if isinstance(executor, DeclarativeActionExecutor):
+                executor.set_declarative_env_config(self._env_config)
 
         return builder.build()
 

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_builder.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_builder.py
@@ -22,7 +22,6 @@ from agent_framework import (
 )
 
 from ._declarative_base import (
-    _EMPTY_ENV_CONFIG,  # type: ignore[reportPrivateUsage]
     ConditionResult,
     DeclarativeActionExecutor,
     DeclarativeEnvConfig,
@@ -178,7 +177,7 @@ class DeclarativeWorkflowBuilder:
         self._seen_explicit_ids: set[str] = set()  # Track explicit IDs for duplicate detection
         self._http_request_handler = http_request_handler
         self._mcp_tool_handler = mcp_tool_handler
-        self._env_config: DeclarativeEnvConfig = env_config if env_config is not None else _EMPTY_ENV_CONFIG
+        self._env_config: DeclarativeEnvConfig = env_config if env_config is not None else DeclarativeEnvConfig()
         # Resolve max_iterations: explicit arg > YAML maxTurns > core default
         resolved = max_iterations if max_iterations is not None else yaml_definition.get("maxTurns")
         if resolved is not None and (not isinstance(resolved, int) or resolved <= 0):

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
@@ -26,7 +26,7 @@ from agent_framework import (
 )
 
 from .._loader import AgentFactory
-from .._models import _safe_mode_context
+from .._models import _safe_mode_context  # type: ignore[reportPrivateUsage]
 from ._declarative_builder import DeclarativeWorkflowBuilder
 from ._errors import DeclarativeWorkflowError
 from ._http_handler import HttpRequestHandler

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
@@ -26,7 +26,7 @@ from agent_framework import (
 )
 
 from .._loader import AgentFactory
-from .._models import _safe_mode_context  # type: ignore[reportPrivateUsage]
+from ._declarative_base import DeclarativeEnvConfig, discover_env_references
 from ._declarative_builder import DeclarativeWorkflowBuilder
 from ._errors import DeclarativeWorkflowError
 from ._http_handler import HttpRequestHandler
@@ -94,7 +94,8 @@ class WorkflowFactory:
         max_iterations: int | None = None,
         http_request_handler: HttpRequestHandler | None = None,
         mcp_tool_handler: MCPToolHandler | None = None,
-        safe_mode: bool = True,
+        configuration: Mapping[str, str] | None = None,
+        restrict_env_to_configuration: bool = True,
     ) -> None:
         """Initialize the workflow factory.
 
@@ -121,15 +122,25 @@ class WorkflowFactory:
                 for a default backed by :class:`agent_framework.MCPStreamableHTTPTool`,
                 or supply your own implementation to enforce SSRF guards, allowlisting,
                 or auth/connection resolution.
-            safe_mode: Whether to run in safe mode, default is True.
-                When safe_mode is True, environment variables are NOT accessible from
-                PowerFx expressions in the workflow YAML (e.g. ``=Env.SOME_VAR`` will
-                fail to resolve and the original expression string is preserved).
-                When safe_mode is False, the full ``os.environ`` snapshot is exposed
-                via the ``Env`` symbol in every PowerFx evaluation. Set safe_mode to
-                False ONLY when you fully trust the YAML source. The flag is also
-                forwarded to the internally-constructed :class:`AgentFactory` so
-                inline agent definitions follow the same policy.
+            configuration: Optional mapping that populates the PowerFx ``Env``
+                symbol referenced from workflow YAML expressions (e.g.
+                ``=Env.MY_KEY``). Mirrors the .NET ``IConfiguration``-based
+                pattern in
+                ``dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowDiagnostics.cs``.
+                Keys supplied here are always exposed under ``Env.<key>``; the
+                process ``os.environ`` is consulted only when
+                ``restrict_env_to_configuration`` is ``False``. When neither
+                source produces a value the ``Env`` symbol is omitted so
+                ``=Env.X`` evaluates to the literal expression string.
+            restrict_env_to_configuration: When ``True`` (default), the
+                ``Env`` PowerFx symbol is populated exclusively from
+                ``configuration``; ``os.environ`` is never consulted. Set to
+                ``False`` to additionally fall back to ``os.environ`` for
+                names absent from ``configuration`` that the workflow YAML
+                explicitly references. The fallback is constrained to names
+                discovered in PowerFx expressions inside the workflow
+                definition so unrelated environment variables never enter
+                the PowerFx scope.
 
         Examples:
             .. code-block:: python
@@ -162,9 +173,20 @@ class WorkflowFactory:
                     checkpoint_storage=FileCheckpointStorage("./checkpoints"),
                     env_file=".env",
                 )
+
+            .. code-block:: python
+
+                from agent_framework.declarative import WorkflowFactory
+
+                # Inject named values for =Env.* references in the workflow YAML
+                factory = WorkflowFactory(
+                    configuration={
+                        "MY_SERVER_URL": "https://example.com",
+                        "MY_TOOL_NAME": "search",
+                    },
+                )
         """
-        self.safe_mode = safe_mode
-        self._agent_factory = agent_factory or AgentFactory(env_file_path=env_file, safe_mode=safe_mode)
+        self._agent_factory = agent_factory or AgentFactory(env_file_path=env_file)
         self._agents: dict[str, SupportsAgentRun | AgentExecutor] = dict(agents) if agents else {}
         self._bindings: dict[str, Any] = dict(bindings) if bindings else {}
         self._tools: dict[str, Any] = {}  # Tool registry for InvokeFunctionTool actions
@@ -172,6 +194,8 @@ class WorkflowFactory:
         self._max_iterations = max_iterations
         self._http_request_handler = http_request_handler
         self._mcp_tool_handler = mcp_tool_handler
+        self._configuration: dict[str, str] = dict(configuration) if configuration else {}
+        self._restrict_env_to_configuration = restrict_env_to_configuration
 
     def create_workflow_from_yaml_path(
         self,
@@ -350,15 +374,6 @@ class WorkflowFactory:
         # Validate the workflow definition
         self._validate_workflow_def(workflow_def)
 
-        # Set safe_mode context before evaluating any PowerFx expressions. The
-        # contextvar gates ``Env`` exposure inside ``DeclarativeWorkflowState``
-        # symbols and inside ``_try_powerfx_eval``; both check
-        # ``_safe_mode_context.get()`` at evaluation time. Because the
-        # contextvar propagates through asyncio tasks spawned from the current
-        # context, this value persists into ``workflow.run(...)`` invocations
-        # made on the same coroutine.
-        _safe_mode_context.set(self.safe_mode)
-
         # Extract workflow metadata
         # Support both "name" field and trigger.id for workflow name
         name: str = workflow_def.get("name", "")
@@ -415,6 +430,16 @@ class WorkflowFactory:
         if description:
             normalized_def["description"] = description
 
+        # Build the DeclarativeEnvConfig from the factory's configuration and the
+        # set of Env references actually used in the workflow PowerFx expressions.
+        # The referenced-name allowlist constrains ``os.environ`` fallback (when
+        # enabled) so unrelated variables never enter the PowerFx scope.
+        env_config = DeclarativeEnvConfig(
+            values=dict(self._configuration),
+            restrict_to_configuration=self._restrict_env_to_configuration,
+            referenced_names=frozenset(discover_env_references(normalized_def)),
+        )
+
         # Build the graph-based workflow, passing agents and tools for specialized executors
         try:
             graph_builder = DeclarativeWorkflowBuilder(
@@ -426,6 +451,7 @@ class WorkflowFactory:
                 max_iterations=self._max_iterations,
                 http_request_handler=self._http_request_handler,
                 mcp_tool_handler=self._mcp_tool_handler,
+                env_config=env_config,
             )
             workflow = graph_builder.build()
         except ValueError as e:

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
@@ -26,6 +26,7 @@ from agent_framework import (
 )
 
 from .._loader import AgentFactory
+from .._models import _safe_mode_context
 from ._declarative_builder import DeclarativeWorkflowBuilder
 from ._errors import DeclarativeWorkflowError
 from ._http_handler import HttpRequestHandler
@@ -93,6 +94,7 @@ class WorkflowFactory:
         max_iterations: int | None = None,
         http_request_handler: HttpRequestHandler | None = None,
         mcp_tool_handler: MCPToolHandler | None = None,
+        safe_mode: bool = True,
     ) -> None:
         """Initialize the workflow factory.
 
@@ -119,6 +121,15 @@ class WorkflowFactory:
                 for a default backed by :class:`agent_framework.MCPStreamableHTTPTool`,
                 or supply your own implementation to enforce SSRF guards, allowlisting,
                 or auth/connection resolution.
+            safe_mode: Whether to run in safe mode, default is True.
+                When safe_mode is True, environment variables are NOT accessible from
+                PowerFx expressions in the workflow YAML (e.g. ``=Env.SOME_VAR`` will
+                fail to resolve and the original expression string is preserved).
+                When safe_mode is False, the full ``os.environ`` snapshot is exposed
+                via the ``Env`` symbol in every PowerFx evaluation. Set safe_mode to
+                False ONLY when you fully trust the YAML source. The flag is also
+                forwarded to the internally-constructed :class:`AgentFactory` so
+                inline agent definitions follow the same policy.
 
         Examples:
             .. code-block:: python
@@ -152,7 +163,8 @@ class WorkflowFactory:
                     env_file=".env",
                 )
         """
-        self._agent_factory = agent_factory or AgentFactory(env_file_path=env_file)
+        self.safe_mode = safe_mode
+        self._agent_factory = agent_factory or AgentFactory(env_file_path=env_file, safe_mode=safe_mode)
         self._agents: dict[str, SupportsAgentRun | AgentExecutor] = dict(agents) if agents else {}
         self._bindings: dict[str, Any] = dict(bindings) if bindings else {}
         self._tools: dict[str, Any] = {}  # Tool registry for InvokeFunctionTool actions
@@ -337,6 +349,15 @@ class WorkflowFactory:
         """
         # Validate the workflow definition
         self._validate_workflow_def(workflow_def)
+
+        # Set safe_mode context before evaluating any PowerFx expressions. The
+        # contextvar gates ``Env`` exposure inside ``DeclarativeWorkflowState``
+        # symbols and inside ``_try_powerfx_eval``; both check
+        # ``_safe_mode_context.get()`` at evaluation time. Because the
+        # contextvar propagates through asyncio tasks spawned from the current
+        # context, this value persists into ``workflow.run(...)`` invocations
+        # made on the same coroutine.
+        _safe_mode_context.set(self.safe_mode)
 
         # Extract workflow metadata
         # Support both "name" field and trigger.id for workflow name

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_factory.py
@@ -124,14 +124,12 @@ class WorkflowFactory:
                 or auth/connection resolution.
             configuration: Optional mapping that populates the PowerFx ``Env``
                 symbol referenced from workflow YAML expressions (e.g.
-                ``=Env.MY_KEY``). Mirrors the .NET ``IConfiguration``-based
-                pattern in
-                ``dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/PowerFx/WorkflowDiagnostics.cs``.
-                Keys supplied here are always exposed under ``Env.<key>``; the
-                process ``os.environ`` is consulted only when
-                ``restrict_env_to_configuration`` is ``False``. When neither
-                source produces a value the ``Env`` symbol is omitted so
-                ``=Env.X`` evaluates to the literal expression string.
+                ``=Env.MY_KEY``). Keys supplied here are always exposed
+                under ``Env.<key>``; the process ``os.environ`` is consulted
+                only when ``restrict_env_to_configuration`` is ``False``.
+                When neither source produces a value the ``Env`` symbol is
+                omitted so ``=Env.X`` evaluates to the literal expression
+                string.
             restrict_env_to_configuration: When ``True`` (default), the
                 ``Env`` PowerFx symbol is populated exclusively from
                 ``configuration``; ``os.environ`` is never consulted. Set to

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_mcp_handler.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_mcp_handler.py
@@ -33,7 +33,7 @@ import logging
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast, runtime_checkable
 
 import httpx
 
@@ -194,6 +194,20 @@ class DefaultMCPToolHandler:
             Defaults to ``32``.
     """
 
+    LIST_TOOLS_TOOL_NAME: ClassVar[str] = "tools/list"
+    """Reserved ``tool_name`` that maps an :class:`MCPToolHandler` invocation
+    to the MCP protocol ``tools/list`` discovery operation.
+
+    Mirrors the .NET ``DefaultMcpToolHandler.ListToolsToolName`` public
+    constant for cross-language discoverability. When this handler receives
+    an invocation with this name it pages through ``session.list_tools()``
+    and returns the catalog as a single ``TextContent`` containing JSON of
+    shape ``{"tools": [{name, description, inputSchema, outputSchema}, ...]}``.
+    Workflows can reference this name from an ``InvokeMcpTool`` declarative
+    action to introspect a server's tool surface without an extra round-trip
+    from host code.
+    """
+
     def __init__(
         self,
         *,
@@ -217,9 +231,28 @@ class DefaultMCPToolHandler:
         self._closed = False
 
     async def invoke_tool(self, invocation: MCPToolInvocation) -> MCPToolResult:
-        """Invoke ``invocation.tool_name`` on the cached MCP client for the server."""
+        """Invoke ``invocation.tool_name`` on the cached MCP client for the server.
+
+        The reserved name :attr:`LIST_TOOLS_TOOL_NAME` (``"tools/list"``) is
+        intercepted client-side: instead of being forwarded as a tool call,
+        it is translated to an MCP ``session.list_tools()`` discovery
+        operation (paginated automatically) and returned as a single
+        ``TextContent`` containing a JSON tool catalog. Matches the .NET
+        ``DefaultMcpToolHandler`` behaviour so the same YAML works
+        cross-language.
+        """
         from agent_framework import Content
         from agent_framework.exceptions import ToolExecutionException
+
+        # Reserved-name args validation runs before connect: rejecting bad
+        # input shouldn't require establishing an MCP session.
+        if invocation.tool_name == self.LIST_TOOLS_TOOL_NAME and invocation.arguments:
+            message = f"The reserved MCP '{self.LIST_TOOLS_TOOL_NAME}' operation does not accept tool arguments."
+            return MCPToolResult(
+                outputs=[Content.from_text(f"Error: {message}")],
+                is_error=True,
+                error_message=message,
+            )
 
         try:
             entry = await self._get_or_create_entry(invocation)
@@ -240,6 +273,8 @@ class DefaultMCPToolHandler:
             )
 
         try:
+            if invocation.tool_name == self.LIST_TOOLS_TOOL_NAME:
+                return await self._invoke_list_tools(entry)
             raw = await entry.tool.call_tool(invocation.tool_name, **invocation.arguments)
         except ToolExecutionException as exc:
             logger.info(
@@ -283,6 +318,60 @@ class DefaultMCPToolHandler:
         else:
             outputs = list(raw)
         return MCPToolResult(outputs=outputs)
+
+    @staticmethod
+    async def _invoke_list_tools(entry: _CacheEntry) -> MCPToolResult:
+        """Handle the reserved :attr:`LIST_TOOLS_TOOL_NAME` invocation.
+
+        Pages through ``session.list_tools()`` (mirroring the pagination loop
+        in :meth:`agent_framework.MCPTool.load_tools`) and serialises the
+        full catalog as a single ``TextContent`` containing JSON of shape
+        ``{"tools": [{name, description, inputSchema, outputSchema}, ...]}``.
+
+        The output shape, property names, and property order match
+        ``DefaultMcpToolHandler.SerializeToolsList`` in the .NET reference
+        implementation so the same workflow YAML can consume the result
+        cross-language. ``indent=2`` matches ``Utf8JsonWriter`` ``Indented``
+        mode; ``allow_nan=False`` guards against producing non-conformant
+        JSON ``NaN``/``Infinity`` tokens if a misbehaving server returns
+        such values in a schema.
+        """
+        from agent_framework import Content
+
+        session = getattr(entry.tool, "session", None)
+        if session is None:
+            message = "MCP session is not connected; cannot list tools."
+            return MCPToolResult(
+                outputs=[Content.from_text(f"Error: {message}")],
+                is_error=True,
+                error_message=message,
+            )
+
+        # Lazy import keeps ``mcp`` types out of module import time.
+        from mcp import types as mcp_types
+
+        collected: list[Any] = []
+        params: mcp_types.PaginatedRequestParams | None = None
+        while True:
+            tool_list = await session.list_tools(params=params)
+            collected.extend(tool_list.tools)
+            next_cursor = getattr(tool_list, "nextCursor", None)
+            if not next_cursor:
+                break
+            params = mcp_types.PaginatedRequestParams(cursor=next_cursor)
+
+        payload = {
+            "tools": [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": tool.inputSchema,
+                    "outputSchema": tool.outputSchema,
+                }
+                for tool in collected
+            ],
+        }
+        return MCPToolResult(outputs=[Content.from_text(json.dumps(payload, indent=2, allow_nan=False))])
 
     async def aclose(self) -> None:
         """Close all cached MCP clients and the owned httpx clients.

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_mcp_handler.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_mcp_handler.py
@@ -198,11 +198,12 @@ class DefaultMCPToolHandler:
     """Reserved ``tool_name`` that maps an :class:`MCPToolHandler` invocation
     to the MCP protocol ``tools/list`` discovery operation.
 
-    Mirrors the .NET ``DefaultMcpToolHandler.ListToolsToolName`` public
-    constant for cross-language discoverability. When this handler receives
-    an invocation with this name it pages through ``session.list_tools()``
-    and returns the catalog as a single ``TextContent`` containing JSON of
-    shape ``{"tools": [{name, description, inputSchema, outputSchema}, ...]}``.
+    The constant matches the underlying MCP method name so a single
+    string travels unchanged through host code, YAML, and the protocol
+    wire. When this handler receives an invocation with this name it
+    pages through ``session.list_tools()`` and returns the catalog as a
+    single ``TextContent`` containing JSON of shape
+    ``{"tools": [{name, description, inputSchema, outputSchema}, ...]}``.
     Workflows can reference this name from an ``InvokeMcpTool`` declarative
     action to introspect a server's tool surface without an extra round-trip
     from host code.
@@ -237,9 +238,7 @@ class DefaultMCPToolHandler:
         intercepted client-side: instead of being forwarded as a tool call,
         it is translated to an MCP ``session.list_tools()`` discovery
         operation (paginated automatically) and returned as a single
-        ``TextContent`` containing a JSON tool catalog. Matches the .NET
-        ``DefaultMcpToolHandler`` behaviour so the same YAML works
-        cross-language.
+        ``TextContent`` containing a JSON tool catalog.
         """
         from agent_framework import Content
         from agent_framework.exceptions import ToolExecutionException
@@ -328,13 +327,12 @@ class DefaultMCPToolHandler:
         full catalog as a single ``TextContent`` containing JSON of shape
         ``{"tools": [{name, description, inputSchema, outputSchema}, ...]}``.
 
-        The output shape, property names, and property order match
-        ``DefaultMcpToolHandler.SerializeToolsList`` in the .NET reference
-        implementation so the same workflow YAML can consume the result
-        cross-language. ``indent=2`` matches ``Utf8JsonWriter`` ``Indented``
-        mode; ``allow_nan=False`` guards against producing non-conformant
-        JSON ``NaN``/``Infinity`` tokens if a misbehaving server returns
-        such values in a schema.
+        The output shape, property names, and property order are stable so
+        downstream PowerFx expressions can rely on the schema. ``indent=2``
+        produces human-readable JSON for the conversation log;
+        ``allow_nan=False`` guards against producing non-conformant JSON
+        ``NaN``/``Infinity`` tokens if a misbehaving server returns such
+        values in a schema.
         """
         from agent_framework import Content
 

--- a/python/packages/declarative/tests/test_default_mcp_tool_handler.py
+++ b/python/packages/declarative/tests/test_default_mcp_tool_handler.py
@@ -644,8 +644,8 @@ class TestListTools:
         }
 
     @pytest.mark.asyncio
-    async def test_list_tools_property_order_matches_dotnet(self) -> None:
-        """The JSON property order must match .NET SerializeToolsList: name, description, inputSchema, outputSchema."""
+    async def test_list_tools_property_order_is_stable(self) -> None:
+        """JSON property order is stable: name, description, inputSchema, outputSchema."""
         handler = DefaultMCPToolHandler()
         with _patch_tool():
             await handler.invoke_tool(_invocation())
@@ -662,7 +662,7 @@ class TestListTools:
 
     @pytest.mark.asyncio
     async def test_list_tools_indented_output(self) -> None:
-        """Output is indented with 2-space indent (matches .NET ``Indented=true``)."""
+        """Output is JSON with a 2-space indent so the conversation log is human-readable."""
         handler = DefaultMCPToolHandler()
         with _patch_tool():
             await handler.invoke_tool(_invocation())
@@ -774,6 +774,6 @@ class TestListTools:
         assert result.is_error is False
 
     def test_class_attribute_value(self) -> None:
-        # Constant name MUST be the MCP protocol method name for cross-language parity
-        # with .NET ``DefaultMcpToolHandler.ListToolsToolName``.
+        # Constant must equal the MCP protocol method name so a single
+        # string travels unchanged through host code, YAML, and the wire.
         assert DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME == "tools/list"

--- a/python/packages/declarative/tests/test_default_mcp_tool_handler.py
+++ b/python/packages/declarative/tests/test_default_mcp_tool_handler.py
@@ -13,6 +13,7 @@ owned-vs-caller httpx close semantics.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from typing import Any
 from unittest.mock import patch
@@ -33,6 +34,55 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+class FakeListToolsResult:  # noqa: B903 - mimics ``mcp.types.ListToolsResult`` shape, not a value type
+    """Stand-in for ``mcp.types.ListToolsResult`` returned by ``session.list_tools()``."""
+
+    def __init__(self, tools: list[Any], next_cursor: str | None = None) -> None:
+        self.tools = tools
+        self.nextCursor = next_cursor
+
+
+class FakeMcpTool:
+    """Stand-in for an MCP ``Tool`` (subset used by ``_invoke_list_tools``)."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str | None = None,
+        inputSchema: dict[str, Any] | None = None,
+        outputSchema: dict[str, Any] | None = None,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema if inputSchema is not None else {"type": "object", "properties": {}}
+        self.outputSchema = outputSchema
+
+
+class FakeMcpSession:
+    """Stand-in for ``mcp.ClientSession``.
+
+    ``list_tools_pages`` lets a test enqueue multiple paginated responses;
+    when None (default), an empty single-page result is returned. ``list_tools_error``
+    raises a synthetic error on the next call when set.
+    """
+
+    def __init__(self) -> None:
+        self.list_tools_pages: list[FakeListToolsResult] | None = None
+        self.list_tools_calls: list[Any] = []
+        self.list_tools_error: BaseException | None = None
+
+    async def list_tools(self, params: Any = None) -> FakeListToolsResult:
+        self.list_tools_calls.append(params)
+        if self.list_tools_error is not None:
+            raise self.list_tools_error
+        if self.list_tools_pages is None:
+            return FakeListToolsResult(tools=[])
+        index = len(self.list_tools_calls) - 1
+        if index >= len(self.list_tools_pages):
+            return FakeListToolsResult(tools=[])
+        return self.list_tools_pages[index]
+
+
 class FakeTool:
     """Stand-in for ``MCPStreamableHTTPTool``.
 
@@ -50,6 +100,7 @@ class FakeTool:
         self.connect_error: BaseException | None = None
         self.call_handler: Any = lambda **_a: [Content.from_text("ok")]
         self._httpx_client: httpx.AsyncClient | None = None
+        self.session: FakeMcpSession | None = None
         # Mimic MCPStreamableHTTPTool: when no caller client AND header_provider
         # is set, lazily allocate an owned httpx client during connect.
         FakeTool.instances.append(self)
@@ -63,6 +114,9 @@ class FakeTool:
         # Mimic lazy httpx allocation when no client provided AND header_provider set.
         if self.kwargs.get("http_client") is None and self.kwargs.get("header_provider") is not None:
             self._httpx_client = httpx.AsyncClient()
+        # Mimic MCPStreamableHTTPTool: a live session becomes available after connect.
+        if self.session is None:
+            self.session = FakeMcpSession()
 
     async def close(self) -> None:
         self.close_count += 1
@@ -541,3 +595,185 @@ class TestCacheKey:
         k1 = DefaultMCPToolHandler._cache_key("https://x/", None, None, {"X": "Bearer-A"})
         k2 = DefaultMCPToolHandler._cache_key("https://x/", None, None, {"X": "bearer-a"})
         assert k1 != k2
+
+
+# ---------- tools/list reserved name --------------------------------------
+
+
+class TestListTools:
+    """Exercise the reserved :attr:`DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME` interception path."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_json_catalog(self) -> None:
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            # Prime the cache so the FakeTool session exists.
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session.list_tools_pages = [  # type: ignore[union-attr]
+                FakeListToolsResult(
+                    tools=[
+                        FakeMcpTool(
+                            name="search",
+                            description="Search docs",
+                            inputSchema={"type": "object", "properties": {"q": {"type": "string"}}},
+                            outputSchema={"type": "object"},
+                        ),
+                        FakeMcpTool(name="echo", description=None, outputSchema=None),
+                    ],
+                ),
+            ]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        assert result.is_error is False
+        assert len(result.outputs) == 1
+        payload = json.loads(result.outputs[0].text)  # type: ignore[reportAttributeAccessIssue]
+        assert payload == {
+            "tools": [
+                {
+                    "name": "search",
+                    "description": "Search docs",
+                    "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}},
+                    "outputSchema": {"type": "object"},
+                },
+                {
+                    "name": "echo",
+                    "description": None,
+                    "inputSchema": {"type": "object", "properties": {}},
+                    "outputSchema": None,
+                },
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_tools_property_order_matches_dotnet(self) -> None:
+        """The JSON property order must match .NET SerializeToolsList: name, description, inputSchema, outputSchema."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session.list_tools_pages = [  # type: ignore[union-attr]
+                FakeListToolsResult(tools=[FakeMcpTool(name="t1", description="d")]),
+            ]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        text = result.outputs[0].text  # type: ignore[reportAttributeAccessIssue]
+        name_idx = text.find('"name"')
+        desc_idx = text.find('"description"')
+        input_idx = text.find('"inputSchema"')
+        output_idx = text.find('"outputSchema"')
+        assert 0 <= name_idx < desc_idx < input_idx < output_idx
+
+    @pytest.mark.asyncio
+    async def test_list_tools_indented_output(self) -> None:
+        """Output is indented with 2-space indent (matches .NET ``Indented=true``)."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session.list_tools_pages = [  # type: ignore[union-attr]
+                FakeListToolsResult(tools=[FakeMcpTool(name="t1")]),
+            ]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        text = result.outputs[0].text  # type: ignore[reportAttributeAccessIssue]
+        # Indented output contains newlines and a 2-space indented key.
+        assert "\n  " in text
+
+    @pytest.mark.asyncio
+    async def test_list_tools_rejects_arguments(self) -> None:
+        """Reserved name does NOT accept tool arguments. Fails fast before connect."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            result = await handler.invoke_tool(
+                _invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME, arguments={"q": "test"}),
+            )
+        assert result.is_error is True
+        assert "does not accept tool arguments" in (result.error_message or "")
+        # Args validation runs before connect, so no tool was instantiated.
+        assert FakeTool.instances == []
+
+    @pytest.mark.asyncio
+    async def test_list_tools_empty_args_dict_is_accepted(self) -> None:
+        """An empty arguments dict is equivalent to no arguments."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            result = await handler.invoke_tool(
+                _invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME, arguments={}),
+            )
+        assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_list_tools_paginates(self) -> None:
+        """Pagination loop calls list_tools repeatedly until nextCursor is empty."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session.list_tools_pages = [  # type: ignore[union-attr]
+                FakeListToolsResult(tools=[FakeMcpTool(name="a")], next_cursor="cursor1"),
+                FakeListToolsResult(tools=[FakeMcpTool(name="b")], next_cursor="cursor2"),
+                FakeListToolsResult(tools=[FakeMcpTool(name="c")], next_cursor=None),
+            ]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        payload = json.loads(result.outputs[0].text)  # type: ignore[reportAttributeAccessIssue]
+        assert [t["name"] for t in payload["tools"]] == ["a", "b", "c"]
+        session = FakeTool.instances[0].session
+        assert session is not None
+        assert len(session.list_tools_calls) == 3
+        # First call has no cursor; second/third use the cursor from the prior page.
+        assert session.list_tools_calls[0] is None
+        assert getattr(session.list_tools_calls[1], "cursor", None) == "cursor1"
+        assert getattr(session.list_tools_calls[2], "cursor", None) == "cursor2"
+
+    @pytest.mark.asyncio
+    async def test_list_tools_shares_cache_with_call_tool(self) -> None:
+        """tools/list reuses the same cached MCP session as a regular call_tool."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation(tool_name="search"))
+            await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        assert len(FakeTool.instances) == 1
+        assert FakeTool.instances[0].connect_count == 1
+
+    @pytest.mark.asyncio
+    async def test_list_tools_propagates_session_errors_as_error_result(self) -> None:
+        """Errors raised by session.list_tools become MCPToolResult(is_error=True), not crashes."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session.list_tools_error = httpx.ReadTimeout("read timed out")  # type: ignore[union-attr]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        assert result.is_error is True
+        assert "ReadTimeout" in (result.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_error_when_session_is_none(self) -> None:
+        """If somehow the cached tool has no session, return a clear error rather than crashing."""
+        handler = DefaultMCPToolHandler()
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].session = None
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        assert result.is_error is True
+        assert "not connected" in (result.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_list_tools_does_not_call_call_tool(self) -> None:
+        """The reserved name is intercepted; the inner call_tool path is bypassed."""
+        handler = DefaultMCPToolHandler()
+        call_tool_invoked = False
+
+        def fail(**_a: Any) -> Any:
+            nonlocal call_tool_invoked
+            call_tool_invoked = True
+            raise AssertionError("call_tool should not run for tools/list")
+
+        with _patch_tool():
+            await handler.invoke_tool(_invocation())
+            FakeTool.instances[0].call_handler = fail
+            FakeTool.instances[0].session.list_tools_pages = [  # type: ignore[union-attr]
+                FakeListToolsResult(tools=[]),
+            ]
+            result = await handler.invoke_tool(_invocation(tool_name=DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME))
+        assert call_tool_invoked is False
+        assert result.is_error is False
+
+    def test_class_attribute_value(self) -> None:
+        # Constant name MUST be the MCP protocol method name for cross-language parity
+        # with .NET ``DefaultMcpToolHandler.ListToolsToolName``.
+        assert DefaultMCPToolHandler.LIST_TOOLS_TOOL_NAME == "tools/list"

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/__init__.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Microsoft. All rights reserved.

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -1,0 +1,513 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Invoke Foundry Toolbox MCP sample — combines an MCP server tool and a
+Foundry built-in tool through a single Foundry **toolbox** endpoint.
+
+A Foundry toolbox bundles multiple tool definitions (MCP servers, built-in
+Foundry tools such as ``web_search``, etc.) behind a single MCP-compatible
+proxy URL. Calling MCP-server-backed tools through the toolbox returns
+results namespaced as ``<server_label>___<tool_name>``; calling built-in
+tools (e.g. ``web_search``) returns the tool under its plain name.
+
+This sample mirrors the .NET sample
+``dotnet/samples/03-workflows/Declarative/InvokeFoundryToolboxMcp/`` and
+shows how to:
+
+  1. Provision a toolbox in a Foundry project (delete-then-create_version,
+     so the sample can be re-run without manual cleanup).
+  2. Configure a ``WorkflowFactory`` with a custom :class:`MCPToolHandler`
+     that:
+       * routes every MCP request through a single
+         :class:`httpx.AsyncClient` carrying an Azure AD bearer token
+         (the toolbox endpoint requires AAD auth), and
+       * intercepts the reserved tool name ``"tools/list"`` so the YAML
+         can introspect the toolbox tool set without an extra Python
+         round-trip (matching the .NET ``DefaultMcpToolHandler``
+         behaviour).
+  3. Invoke ``microsoft_docs_search`` (from the Microsoft Learn Docs MCP
+     server surfaced by the toolbox) and ``web_search`` (Foundry built-in)
+     from a single declarative workflow.
+  4. Hand both result sets to a local :class:`Agent` registered with the
+     factory by name so the workflow's ``InvokeAzureAgent`` action can
+     summarise them.
+
+Security note:
+    The default ``DefaultMCPToolHandler`` performs no URL allowlisting or
+    SSRF protection. This sample wraps it with a project-scoped handler
+    that pins outbound requests to ``Authorization: Bearer …`` via Azure
+    AD; for production deployments, additionally constrain the workflow
+    YAML to a known toolbox URL and reject any other server URL before
+    delegating to the inner handler. MCP outputs flow back into agent
+    conversations and share the prompt-injection risk surface of any
+    other tool output.
+
+Run with:
+    python samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+
+Required environment variables:
+    FOUNDRY_PROJECT_ENDPOINT
+        Azure AI Foundry project endpoint.
+    FOUNDRY_MODEL
+        Deployed Foundry model name used by ``FoundryChatClient``.
+
+Optional environment variables:
+    FOUNDRY_TOOLBOX_NAME
+        Name of the toolbox to (re)create. Defaults to
+        ``declarative_foundry_toolbox_mcp``.
+    FOUNDRY_TOOLBOX_API_VERSION
+        Toolbox MCP API version used when building the endpoint URL.
+        Defaults to ``v1``.
+    FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL
+        The ``server_label`` registered for the Microsoft Learn Docs MCP
+        server in the toolbox. Tool names from that server get the
+        ``<server_label>___`` prefix on the toolbox MCP proxy.
+        Defaults to ``microsoft_docs``.
+    FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME
+        Name of the Foundry built-in web-search tool surfaced by the
+        toolbox. Defaults to ``web_search``.
+    FOUNDRY_TOOLBOX_ENDPOINT
+        Explicit toolbox MCP endpoint URL. When set, overrides the URL
+        computed from ``FOUNDRY_PROJECT_ENDPOINT``,
+        ``FOUNDRY_TOOLBOX_NAME``, and ``FOUNDRY_TOOLBOX_API_VERSION``.
+
+Sample output:
+
+    ============================================================
+    Invoke Foundry Toolbox MCP Workflow Demo
+    ============================================================
+    Provisioning toolbox 'declarative_foundry_toolbox_mcp' in Foundry...
+    Toolbox endpoint: https://<account>.services.ai.azure.com/api/projects/<project>/toolboxes/declarative_foundry_toolbox_mcp/mcp?api-version=v1
+
+    Ask one question that benefits from both Microsoft Learn docs and a web search.
+
+    You: How do I configure logging in the Agent Framework?
+    [Listing toolbox tools...]
+    [Searching Microsoft Learn docs...]
+    [Searching the web...]
+    [Summarizing results...]
+
+    Agent: The Agent Framework declarative workflow runtime ...
+"""
+
+import asyncio
+import contextlib
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+from agent_framework import Agent, Content, MCPStreamableHTTPTool
+from agent_framework.declarative import (
+    DefaultMCPToolHandler,
+    MCPToolInvocation,
+    MCPToolResult,
+    WorkflowFactory,
+)
+from agent_framework.foundry import FoundryChatClient
+from azure.core.credentials import TokenCredential
+from azure.identity import AzureCliCredential, get_bearer_token_provider
+
+DEFAULT_TOOLBOX_NAME = "declarative_foundry_toolbox_mcp"
+DEFAULT_TOOLBOX_API_VERSION = "v1"
+DEFAULT_DOCS_SERVER_LABEL = "microsoft_docs"
+DEFAULT_WEB_SEARCH_TOOL_NAME = "web_search"
+DEFAULT_DOCS_MCP_SERVER_URL = "https://learn.microsoft.com/api/mcp"
+
+AGENT_NAME = "FoundryToolboxMcpAgent"
+
+# YAML action ids — kept in sync with ``workflow.yaml`` so the host can
+# render progress markers as each step starts. Long-running MCP calls
+# and a slow Foundry agent invocation can otherwise look like a hang.
+LIST_TOOLS_ACTION_ID = "list_toolbox_tools"
+DOCS_SEARCH_ACTION_ID = "search_docs_with_toolbox"
+WEB_SEARCH_ACTION_ID = "search_web_with_toolbox"
+SUMMARIZE_ACTION_ID = "summarize_toolbox_result"
+
+_ACTION_PROGRESS_LABELS: dict[str, str] = {
+    LIST_TOOLS_ACTION_ID: "Listing toolbox tools...",
+    DOCS_SEARCH_ACTION_ID: "Searching Microsoft Learn docs...",
+    WEB_SEARCH_ACTION_ID: "Searching the web...",
+    SUMMARIZE_ACTION_ID: "Summarizing results...",
+}
+
+# Reserved tool name that the YAML uses to ask the handler for the toolbox
+# tool list. Mirrors .NET ``DefaultMcpToolHandler.ListToolsToolName``.
+LIST_TOOLS_TOOL_NAME = "tools/list"
+
+# AAD audience for the toolbox MCP proxy. Same scope used by the existing
+# Foundry hosted-toolbox samples.
+TOOLBOX_AAD_SCOPE = "https://ai.azure.com/.default"
+
+# Toolbox administration is gated by an Azure AI Foundry preview feature
+# flag. The .NET sample injects this header via a pipeline policy on the
+# ``AgentAdministrationClient``; the Python ``AIProjectClient`` doesn't
+# add it automatically, so we pass it as a per-call header on every
+# toolbox admin operation (delete + create_version) to make sure the
+# toolbox is actually provisioned in the V1Preview routing path that the
+# MCP proxy serves. Without this header, the calls can succeed at the
+# HTTP layer but the toolbox is never wired up to the MCP endpoint —
+# which surfaces at runtime as "MCP server failed to initialize:
+# Session terminated" on the first ``InvokeMcpTool`` call.
+FOUNDRY_FEATURES_HEADER_NAME = "Foundry-Features"
+FOUNDRY_FEATURES_HEADER_VALUE = "Toolboxes=V1Preview"
+FOUNDRY_FEATURES_HEADERS: dict[str, str] = {
+    FOUNDRY_FEATURES_HEADER_NAME: FOUNDRY_FEATURES_HEADER_VALUE,
+}
+
+# Bump the ``az.cmd`` subprocess timeout from the default 10s. On Windows
+# the Azure CLI batch wrapper can take noticeably longer than 10s to
+# return a token (cold-start + ``az`` self-update checks + AAD round-trip),
+# which surfaces as ``CredentialUnavailableError: Failed to invoke the
+# Azure CLI`` after a ``subprocess.TimeoutExpired`` from the credential's
+# internal call.
+AZ_CLI_PROCESS_TIMEOUT_SECONDS = 60
+
+# Match the MCP-recommended httpx timeouts (``mcp.shared._httpx_utils``:
+# 30s connect/write/pool, 5min SSE read). httpx's default ``Timeout(5.0)``
+# is far too aggressive for MCP streaming responses — long-running
+# tool calls through the Foundry toolbox MCP proxy (e.g. the built-in
+# ``web_search``) can take longer than 5s, and a read-timeout fired
+# mid-stream leaves the upper-level ``call_tool`` awaiting a future that
+# never resolves, surfacing as an indefinite hang.
+MCP_CONNECT_TIMEOUT_SECONDS = 30.0
+MCP_READ_TIMEOUT_SECONDS = 300.0
+
+AGENT_INSTRUCTIONS = """\
+You combine results from two tool calls in the conversation:
+
+  - ``microsoft_docs_search`` from the Microsoft Learn Docs MCP server
+    (authoritative Microsoft documentation), and
+  - ``web_search`` (Foundry built-in) for general web context.
+
+Answer the user's question using ONLY the information present in the
+conversation. Prefer Microsoft Learn results for any product or API
+question and cite document titles or URLs when available. If neither
+result set contains an answer, say so plainly rather than guessing.
+"""
+
+
+def build_toolbox_mcp_server_url(project_endpoint: str, name: str, api_version: str) -> str:
+    """Compose the Foundry toolbox MCP proxy URL.
+
+    Toolboxes provisioned via ``AIProjectClient.beta.toolboxes`` live under
+    the ``/toolboxes/{name}`` resource path (the Python SDK's
+    ``BetaToolboxesOperations`` routes POST/GET/DELETE there — see
+    ``azure/ai/projects/operations/_operations.py``). Their MCP proxy URL
+    is ``<project_endpoint>/toolboxes/{name}/mcp?api-version=<api_version>``,
+    matching the .NET sample.
+    """
+    base = project_endpoint.rstrip("/")
+    return f"{base}/toolboxes/{name}/mcp?api-version={api_version}"
+
+
+def create_sample_toolbox(
+    *,
+    name: str,
+    docs_server_label: str,
+    project_endpoint: str,
+    docs_server_url: str = DEFAULT_DOCS_MCP_SERVER_URL,
+) -> None:
+    """Provision a toolbox version in the Foundry project (idempotent).
+
+    Toolboxes are normally provisioned through the Foundry portal or a
+    deployment script; this helper exists so the sample can be re-run
+    end-to-end without manual cleanup. It deletes any toolbox under
+    ``name`` and then creates a new version that bundles:
+
+    - the Microsoft Learn Docs MCP server (``server_label=docs_server_label``),
+      and
+    - the Foundry built-in ``web_search`` tool.
+    """
+    from azure.ai.projects import AIProjectClient
+    from azure.ai.projects.models import MCPTool, Tool, WebSearchTool
+    from azure.core.exceptions import ResourceNotFoundError
+
+    with (
+        AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS) as credential,
+        AIProjectClient(credential=credential, endpoint=project_endpoint) as project_client,
+    ):
+        try:
+            project_client.beta.toolboxes.delete(name, headers=FOUNDRY_FEATURES_HEADERS)
+            print(f"Toolbox '{name}' deleted (replacing with a fresh version).")
+        except ResourceNotFoundError:
+            pass
+
+        tools: list[Tool] = [
+            MCPTool(
+                server_label=docs_server_label,
+                server_url=docs_server_url,
+                require_approval="never",
+            ),
+            WebSearchTool(),
+        ]
+
+        created = project_client.beta.toolboxes.create_version(
+            name=name,
+            description="Sample toolbox combining Microsoft Learn Docs MCP and Foundry web search.",
+            tools=tools,
+            headers=FOUNDRY_FEATURES_HEADERS,
+        )
+        print(f"Created toolbox {created.name}@{created.version} ({len(created.tools)} tool(s)).")
+
+
+class _BearerAuth(httpx.Auth):
+    """Inject a fresh Azure AD bearer token on every request.
+
+    ``httpx.Auth.auth_flow`` is a sync generator and works for both sync
+    and async clients. ``get_bearer_token_provider`` caches/refreshes the
+    token internally, so calling it per request is cheap.
+    """
+
+    def __init__(self, credential: TokenCredential) -> None:
+        self._get_token = get_bearer_token_provider(credential, TOOLBOX_AAD_SCOPE)
+
+    def auth_flow(self, request: httpx.Request) -> Iterator[httpx.Request]:
+        request.headers["Authorization"] = f"Bearer {self._get_token()}"
+        yield request
+
+
+class _ToolboxMcpToolHandler:
+    """:class:`MCPToolHandler` that adds ``tools/list`` support to the default handler.
+
+    The reserved tool name ``"tools/list"`` is intercepted client-side: it
+    is translated to an MCP ``session.list_tools()`` call and the result
+    is returned as a single JSON-encoded ``TextContent`` matching the
+    shape produced by the .NET ``DefaultMcpToolHandler``
+    (``{"tools": [{name, description, inputSchema, outputSchema}]}``).
+
+    All other tool invocations delegate to the wrapped
+    :class:`DefaultMCPToolHandler` so the LRU client cache, error
+    normalisation, and approval flow remain unchanged.
+
+    The ``tools/list`` path uses a transient :class:`MCPStreamableHTTPTool`
+    (``load_tools=False`` so MCP discovery only happens once via the
+    explicit ``session.list_tools()`` call). The same caller-supplied
+    ``httpx.AsyncClient`` is reused so the bearer token and any other
+    transport-level configuration stay consistent with the cached calls.
+    """
+
+    def __init__(self, inner: DefaultMCPToolHandler, http_client: httpx.AsyncClient) -> None:
+        self._inner = inner
+        self._http_client = http_client
+
+    async def invoke_tool(self, invocation: MCPToolInvocation) -> MCPToolResult:
+        if invocation.tool_name == LIST_TOOLS_TOOL_NAME:
+            return await self._list_tools(invocation)
+        return await self._inner.invoke_tool(invocation)
+
+    async def _list_tools(self, invocation: MCPToolInvocation) -> MCPToolResult:
+        if invocation.arguments:
+            return MCPToolResult(
+                outputs=[Content.from_text("Error: 'tools/list' does not accept arguments.")],
+                is_error=True,
+                error_message="'tools/list' does not accept arguments.",
+            )
+
+        # Snapshot headers so the closure does not see later mutations.
+        captured_headers = dict(invocation.headers)
+
+        def _header_provider(_kwargs: dict[str, Any]) -> dict[str, str]:
+            return dict(captured_headers)
+
+        tool = MCPStreamableHTTPTool(
+            name=invocation.server_label or "foundry_toolbox_list",
+            url=invocation.server_url,
+            http_client=self._http_client,
+            header_provider=_header_provider if captured_headers else None,
+            load_tools=False,
+            load_prompts=False,
+        )
+
+        try:
+            await tool.connect()
+            tool_list = await tool.session.list_tools()  # type: ignore[union-attr]
+            payload = {
+                "tools": [
+                    {
+                        "name": entry.name,
+                        "description": entry.description,
+                        "inputSchema": entry.inputSchema,
+                        "outputSchema": entry.outputSchema,
+                    }
+                    for entry in tool_list.tools
+                ]
+            }
+            return MCPToolResult(outputs=[Content.from_text(json.dumps(payload))])
+        except Exception as exc:  # noqa: BLE001 - surface as tool error per protocol contract
+            message = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+            return MCPToolResult(
+                outputs=[Content.from_text(f"Error: {message}")],
+                is_error=True,
+                error_message=message,
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await tool.close()
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+    async def __aenter__(self) -> "_ToolboxMcpToolHandler":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.aclose()
+
+
+async def main() -> None:
+    """Run the Foundry toolbox MCP workflow."""
+    # 1. Read configuration. ``FOUNDRY_PROJECT_ENDPOINT`` and
+    #    ``FOUNDRY_MODEL`` are required; everything else has defaults.
+    project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
+    model = os.environ["FOUNDRY_MODEL"]
+    toolbox_name = os.environ.get("FOUNDRY_TOOLBOX_NAME", DEFAULT_TOOLBOX_NAME)
+    toolbox_api_version = os.environ.get("FOUNDRY_TOOLBOX_API_VERSION", DEFAULT_TOOLBOX_API_VERSION)
+    docs_server_label = os.environ.get("FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL", DEFAULT_DOCS_SERVER_LABEL)
+    web_search_tool_name = os.environ.get(
+        "FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", DEFAULT_WEB_SEARCH_TOOL_NAME
+    )
+
+    print("=" * 60)
+    print("Invoke Foundry Toolbox MCP Workflow Demo")
+    print("=" * 60)
+
+    # 2. Provision the toolbox in Foundry. Idempotent: delete-then-create.
+    print(f"Provisioning toolbox '{toolbox_name}' in Foundry...")
+    create_sample_toolbox(
+        name=toolbox_name,
+        docs_server_label=docs_server_label,
+        project_endpoint=project_endpoint,
+    )
+
+    # 3. Resolve the toolbox MCP proxy URL and publish all dynamic values
+    #    the YAML expects via ``Env.*``. Setting them after toolbox
+    #    creation ensures the URL points at the freshly created version.
+    toolbox_endpoint = os.environ.get("FOUNDRY_TOOLBOX_ENDPOINT") or build_toolbox_mcp_server_url(
+        project_endpoint=project_endpoint,
+        name=toolbox_name,
+        api_version=toolbox_api_version,
+    )
+    os.environ["FOUNDRY_TOOLBOX_MCP_SERVER_URL"] = toolbox_endpoint
+    os.environ["FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL"] = docs_server_label
+    os.environ["FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME"] = web_search_tool_name
+    print(f"Toolbox endpoint: {toolbox_endpoint}")
+    print()
+
+    # 4. Build the Foundry chat client + the summarising agent. The agent
+    #    is registered with the factory by name, matching the sibling
+    #    ``invoke_mcp_tool/`` sample.
+    credential = AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS)
+    chat_client = FoundryChatClient(
+        project_endpoint=project_endpoint,
+        model=model,
+        credential=credential,
+    )
+    summary_agent = Agent(
+        client=chat_client,
+        name=AGENT_NAME,
+        instructions=AGENT_INSTRUCTIONS,
+    )
+
+    # 5. Build a bearer-authenticated httpx client. The same client is
+    #    reused for every MCP request: the LRU cache inside
+    #    ``DefaultMCPToolHandler`` will keep a single MCP session alive
+    #    for the toolbox URL, and the ``tools/list`` interceptor reuses
+    #    the same httpx client so headers / auth stay consistent.
+    #
+    # Key configuration choices:
+    #   * ``headers=FOUNDRY_FEATURES_HEADERS`` attaches the
+    #     ``Foundry-Features: Toolboxes=V1Preview`` flag to EVERY
+    #     outbound request — including the MCP ``initialize`` handshake
+    #     during ``connect()``. The YAML's per-action ``headers:`` block
+    #     also sets this value but only takes effect during
+    #     ``call_tool`` (the ``MCPStreamableHTTPTool`` header_provider
+    #     contextvar is empty during connect — see
+    #     ``python/packages/core/agent_framework/_mcp.py:1639-1645``).
+    #     Without the client-level default the toolbox MCP proxy rejects
+    #     the session handshake and surfaces "unhandled errors in a
+    #     TaskGroup".
+    #   * ``timeout=Timeout(30.0, read=300.0)`` matches the MCP
+    #     recommended defaults (``mcp.shared._httpx_utils``: 30s
+    #     connect/write/pool, 5min SSE read). The httpx defaults of 5s
+    #     EVERYWHERE break long-running MCP tool calls — the Foundry
+    #     built-in ``web_search``, for instance, can take longer than
+    #     5s to return through the toolbox SSE stream and would
+    #     otherwise leave the client waiting on a future that never
+    #     resolves (i.e. visibly hang on the host).
+    #   * ``follow_redirects=True`` also mirrors the MCP defaults so
+    #     proxy redirects don't surface as broken streams.
+    http_client = httpx.AsyncClient(
+        auth=_BearerAuth(credential),
+        headers=FOUNDRY_FEATURES_HEADERS,
+        timeout=httpx.Timeout(MCP_CONNECT_TIMEOUT_SECONDS, read=MCP_READ_TIMEOUT_SECONDS),
+        follow_redirects=True,
+    )
+
+    async def _client_provider(_inv: MCPToolInvocation) -> httpx.AsyncClient | None:
+        return http_client
+
+    async with (
+        http_client,
+        DefaultMCPToolHandler(client_provider=_client_provider) as inner_handler,
+        _ToolboxMcpToolHandler(inner_handler, http_client) as mcp_handler,
+    ):
+        factory = WorkflowFactory(
+            agents={AGENT_NAME: summary_agent},
+            mcp_tool_handler=mcp_handler,
+        )
+
+        workflow_path = Path(__file__).parent / "workflow.yaml"
+        workflow = factory.create_workflow_from_yaml_path(workflow_path)
+
+        print("Ask one question that benefits from both Microsoft Learn docs and a web search.")
+        print()
+        user_input = input("You: ").strip()  # noqa: ASYNC250
+        if not user_input:
+            user_input = "How do I configure logging in the Agent Framework?"
+
+        # 6. Drive the workflow with the user's question. The YAML fans
+        #    out three MCP calls and finishes with the InvokeAzureAgent
+        #    summarisation step. We render two kinds of host-visible
+        #    feedback:
+        #
+        #      * Per-action progress lines via ``executor_invoked``
+        #        events so a slow MCP call or agent invocation cannot
+        #        look like a hang.
+        #      * The final agent summary via ``output`` events. The
+        #        three MCP actions use ``autoSend: false`` in the YAML
+        #        so only the summarising agent's text reaches this
+        #        branch.
+        printed_prefix = False
+        produced_output = False
+        agent_executor_id = SUMMARIZE_ACTION_ID
+        async for event in workflow.run({"text": user_input}, stream=True):
+            if event.type == "executor_invoked":
+                label = _ACTION_PROGRESS_LABELS.get(event.executor_id or "")
+                if label is not None:
+                    print(f"[{label}]")
+                continue
+
+            if event.type == "output" and isinstance(event.data, str):
+                # Only the summarising agent action sends an output
+                # event (MCP calls use ``autoSend: false``). Guard the
+                # display so any future autoSend additions still print
+                # under the "Agent:" prefix only when they come from
+                # that action.
+                if event.executor_id and event.executor_id != agent_executor_id:
+                    continue
+                if not printed_prefix:
+                    print("\nAgent: ", end="", flush=True)
+                    printed_prefix = True
+                print(event.data, end="", flush=True)
+                produced_output = True
+
+        if produced_output:
+            print()
+        else:
+            print("\n(no response produced)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -2,18 +2,13 @@
 
 """Invoke a Foundry toolbox MCP endpoint from a declarative workflow.
 
-The workflow lists the toolbox's tools, queries Microsoft Learn Docs
-and ``web_search`` through the toolbox, and summarises the combined
-results with a Foundry agent. The reserved ``tools/list`` tool name is
-intercepted natively by ``DefaultMCPToolHandler``.
+The workflow calls ``microsoft_docs_search`` (the Microsoft Learn Docs
+MCP server, bundled into a sample toolbox by ``toolbox_provisioning``)
+through the toolbox proxy and asks a Foundry agent to summarise the
+result.
 
 Required env vars:
     FOUNDRY_PROJECT_ENDPOINT, FOUNDRY_MODEL.
-
-Optional env vars:
-    FOUNDRY_TOOLBOX_NAME, FOUNDRY_TOOLBOX_API_VERSION,
-    FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL,
-    FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME, FOUNDRY_TOOLBOX_ENDPOINT.
 
 Run with:
     python samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -34,25 +29,17 @@ from agent_framework.declarative import (
 from agent_framework.foundry import FoundryChatClient
 from azure.core.credentials import TokenCredential
 from azure.identity import AzureCliCredential, get_bearer_token_provider
-from toolbox_provisioning import (
-    FOUNDRY_FEATURES_HEADERS,
-    build_toolbox_mcp_server_url,
-    create_sample_toolbox,
-)
+from toolbox_provisioning import FOUNDRY_FEATURES_HEADERS, create_sample_toolbox
 
 AGENT_NAME = "FoundryToolboxMcpAgent"
+TOOLBOX_NAME = "declarative_foundry_toolbox_mcp"
+DOCS_SERVER_LABEL = "microsoft_docs"
 
 AGENT_INSTRUCTIONS = """\
-You combine results from two tool calls in the conversation:
-
-  - ``microsoft_docs_search`` from the Microsoft Learn Docs MCP server
-    (authoritative Microsoft documentation), and
-  - ``web_search`` (Foundry built-in) for general web context.
-
-Answer the user's question using ONLY the information present in the
-conversation. Prefer Microsoft Learn results for any product or API
-question and cite document titles or URLs when available. If neither
-result set contains an answer, say so plainly rather than guessing.
+Answer the user's question using ONLY the Microsoft Learn docs search
+result already present in the conversation. Cite document titles or
+URLs when available. If the result does not contain an answer, say so
+plainly rather than guessing.
 """
 
 
@@ -71,33 +58,18 @@ async def main() -> None:
     """Run the Foundry toolbox MCP workflow."""
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
     model = os.environ["FOUNDRY_MODEL"]
-    toolbox_name = os.environ.get("FOUNDRY_TOOLBOX_NAME", "declarative_foundry_toolbox_mcp")
-    toolbox_api_version = os.environ.get("FOUNDRY_TOOLBOX_API_VERSION", "v1")
-    docs_server_label = os.environ.get("FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL", "microsoft_docs")
-    web_search_tool_name = os.environ.get("FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", "web_search")
 
     print("=" * 60)
     print("Invoke Foundry Toolbox MCP Workflow Demo")
     print("=" * 60)
-    print(f"Provisioning toolbox '{toolbox_name}' in Foundry...")
+    print(f"Provisioning toolbox '{TOOLBOX_NAME}' in Foundry...")
     create_sample_toolbox(
-        name=toolbox_name,
-        docs_server_label=docs_server_label,
+        name=TOOLBOX_NAME,
+        docs_server_label=DOCS_SERVER_LABEL,
         project_endpoint=project_endpoint,
     )
 
-    toolbox_endpoint = os.environ.get("FOUNDRY_TOOLBOX_ENDPOINT") or build_toolbox_mcp_server_url(
-        project_endpoint=project_endpoint,
-        name=toolbox_name,
-        api_version=toolbox_api_version,
-    )
-    # Values exposed to ``=Env.*`` in workflow.yaml. Passing them via
-    # ``configuration`` keeps the symbol table scoped to this workflow.
-    workflow_configuration = {
-        "FOUNDRY_TOOLBOX_MCP_SERVER_URL": toolbox_endpoint,
-        "FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL": docs_server_label,
-        "FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME": web_search_tool_name,
-    }
+    toolbox_endpoint = f"{project_endpoint.rstrip('/')}/toolboxes/{TOOLBOX_NAME}/mcp?api-version=v1"
     print(f"Toolbox endpoint: {toolbox_endpoint}")
     print()
 
@@ -109,7 +81,7 @@ async def main() -> None:
     # request, including the MCP ``initialize`` handshake (the YAML's
     # per-action ``headers`` only takes effect during ``call_tool``).
     # ``timeout=`` matches the MCP-recommended values; httpx's 5s
-    # default breaks long-running tool calls like ``web_search``.
+    # default breaks long-running tool calls.
     http_client = httpx.AsyncClient(
         auth=_BearerAuth(credential),
         headers=FOUNDRY_FEATURES_HEADERS,
@@ -136,46 +108,31 @@ async def main() -> None:
         factory = WorkflowFactory(
             agents={AGENT_NAME: summary_agent},
             mcp_tool_handler=mcp_handler,
-            configuration=workflow_configuration,
+            configuration={
+                "FOUNDRY_TOOLBOX_MCP_SERVER_URL": toolbox_endpoint,
+                "FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL": DOCS_SERVER_LABEL,
+            },
         )
         workflow = factory.create_workflow_from_yaml_path(Path(__file__).parent / "workflow.yaml")
 
-        print("Ask one question that benefits from both Microsoft Learn docs and a web search.")
+        print("Ask a question that can be answered from the Microsoft Learn docs.")
         print()
         user_input = input("You: ").strip() or "How do I configure logging in the Agent Framework?"  # noqa: ASYNC250
 
-        # Progress markers per YAML action so slow MCP calls or agent
-        # invocations don't look like a hang. Action ids mirror
-        # workflow.yaml.
-        progress_labels = {
-            "list_toolbox_tools": "Listing toolbox tools...",
-            "search_docs_with_toolbox": "Searching Microsoft Learn docs...",
-            "search_web_with_toolbox": "Searching the web...",
-            "summarize_toolbox_result": "Summarizing results...",
-        }
         printed_prefix = False
-        produced_output = False
         async for event in workflow.run({"text": user_input}, stream=True):
             if event.type == "executor_invoked":
-                label = progress_labels.get(event.executor_id or "")
-                if label is not None:
-                    print(f"[{label}]")
-                continue
-            if event.type == "output" and isinstance(event.data, str):
-                # Only the summarising agent emits ``output``; the three
-                # MCP actions use ``autoSend: false`` in the YAML.
-                if event.executor_id and event.executor_id != "summarize_toolbox_result":
-                    continue
+                if event.executor_id == "search_docs_with_toolbox":
+                    print("[Searching Microsoft Learn docs...]")
+                elif event.executor_id == "summarize_toolbox_result":
+                    print("[Summarizing results...]")
+            elif event.type == "output" and isinstance(event.data, str):
                 if not printed_prefix:
                     print("\nAgent: ", end="", flush=True)
                     printed_prefix = True
                 print(event.data, end="", flush=True)
-                produced_output = True
 
-        if produced_output:
-            print()
-        else:
-            print("\n(no response produced)")
+        print()
 
 
 if __name__ == "__main__":

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -1,94 +1,27 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Invoke Foundry Toolbox MCP sample — combines an MCP server tool and a
-Foundry built-in tool through a single Foundry **toolbox** endpoint.
+"""Invoke a Foundry toolbox MCP endpoint from a declarative workflow.
 
-A Foundry toolbox bundles multiple tool definitions (MCP servers, built-in
-Foundry tools such as ``web_search``, etc.) behind a single MCP-compatible
-proxy URL. Calling MCP-server-backed tools through the toolbox returns
-results namespaced as ``<server_label>___<tool_name>``; calling built-in
-tools (e.g. ``web_search``) returns the tool under its plain name.
+The workflow lists the toolbox's tools, queries Microsoft Learn Docs
+and ``web_search`` through the toolbox, and summarises the combined
+results with a Foundry agent. The reserved ``tools/list`` tool name is
+intercepted natively by ``DefaultMCPToolHandler``.
 
-This sample mirrors the .NET sample
-``dotnet/samples/03-workflows/Declarative/InvokeFoundryToolboxMcp/`` and
-focuses on the **workflow execution path**:
+Required env vars:
+    FOUNDRY_PROJECT_ENDPOINT, FOUNDRY_MODEL.
 
-  1. Build a bearer-authenticated ``httpx.AsyncClient`` for the toolbox
-     MCP proxy and hand it to :class:`DefaultMCPToolHandler` so the YAML
-     can call MCP tools (and introspect the toolbox tool list via the
-     reserved ``"tools/list"`` tool name handled natively by the
-     framework, matching .NET
-     ``DefaultMcpToolHandler.ListToolsToolName``).
-  2. Configure a :class:`WorkflowFactory` with that handler plus a local
-     :class:`Agent` registered by name so the YAML's ``InvokeAzureAgent``
-     action can summarise the combined tool output.
-  3. Drive the workflow with a user question and render per-action
-     progress markers plus the final agent summary.
-
-One-off **toolbox administration** (delete + create_version) is delegated
-to :mod:`toolbox_provisioning` so this file stays focused on the workflow.
-
-Security note:
-    The default ``DefaultMCPToolHandler`` performs no URL allowlisting or
-    SSRF protection. This sample uses a project-scoped ``client_provider``
-    that pins outbound requests to ``Authorization: Bearer …`` via Azure
-    AD AND fails closed (raises) when the YAML resolves a different
-    ``serverUrl``, so a tampered ``=Env.*`` value cannot redirect the
-    bearer token to an attacker-controlled URL. MCP outputs flow back
-    into agent conversations and share the prompt-injection risk
-    surface of any other tool output.
+Optional env vars:
+    FOUNDRY_TOOLBOX_NAME, FOUNDRY_TOOLBOX_API_VERSION,
+    FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL,
+    FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME, FOUNDRY_TOOLBOX_ENDPOINT.
 
 Run with:
     python samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
-
-Required environment variables:
-    FOUNDRY_PROJECT_ENDPOINT
-        Azure AI Foundry project endpoint.
-    FOUNDRY_MODEL
-        Deployed Foundry model name used by ``FoundryChatClient``.
-
-Optional environment variables:
-    FOUNDRY_TOOLBOX_NAME
-        Name of the toolbox to (re)create. Defaults to
-        ``declarative_foundry_toolbox_mcp``.
-    FOUNDRY_TOOLBOX_API_VERSION
-        Toolbox MCP API version used when building the endpoint URL.
-        Defaults to ``v1``.
-    FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL
-        The ``server_label`` registered for the Microsoft Learn Docs MCP
-        server in the toolbox. Tool names from that server get the
-        ``<server_label>___`` prefix on the toolbox MCP proxy.
-        Defaults to ``microsoft_docs``.
-    FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME
-        Name of the Foundry built-in web-search tool surfaced by the
-        toolbox. Defaults to ``web_search``.
-    FOUNDRY_TOOLBOX_ENDPOINT
-        Explicit toolbox MCP endpoint URL. When set, overrides the URL
-        computed from ``FOUNDRY_PROJECT_ENDPOINT``,
-        ``FOUNDRY_TOOLBOX_NAME``, and ``FOUNDRY_TOOLBOX_API_VERSION``.
-
-Sample output:
-
-    ============================================================
-    Invoke Foundry Toolbox MCP Workflow Demo
-    ============================================================
-    Provisioning toolbox 'declarative_foundry_toolbox_mcp' in Foundry...
-    Toolbox endpoint: https://<account>.services.ai.azure.com/api/projects/<project>/toolboxes/declarative_foundry_toolbox_mcp/mcp?api-version=v1
-
-    Ask one question that benefits from both Microsoft Learn docs and a web search.
-
-    You: How do I configure logging in the Agent Framework?
-    [Listing toolbox tools...]
-    [Searching Microsoft Learn docs...]
-    [Searching the web...]
-    [Summarizing results...]
-
-    Agent: The Agent Framework declarative workflow runtime ...
 """
 
 import asyncio
 import os
-from collections.abc import Iterator
+from collections.abc import Generator
 from pathlib import Path
 
 import httpx
@@ -102,47 +35,12 @@ from agent_framework.foundry import FoundryChatClient
 from azure.core.credentials import TokenCredential
 from azure.identity import AzureCliCredential, get_bearer_token_provider
 from toolbox_provisioning import (
-    AZ_CLI_PROCESS_TIMEOUT_SECONDS,
     FOUNDRY_FEATURES_HEADERS,
     build_toolbox_mcp_server_url,
     create_sample_toolbox,
 )
 
-DEFAULT_TOOLBOX_NAME = "declarative_foundry_toolbox_mcp"
-DEFAULT_TOOLBOX_API_VERSION = "v1"
-DEFAULT_DOCS_SERVER_LABEL = "microsoft_docs"
-DEFAULT_WEB_SEARCH_TOOL_NAME = "web_search"
-
 AGENT_NAME = "FoundryToolboxMcpAgent"
-
-# YAML action ids — kept in sync with ``workflow.yaml`` so the host can
-# render progress markers as each step starts. Long-running MCP calls
-# and a slow Foundry agent invocation can otherwise look like a hang.
-LIST_TOOLS_ACTION_ID = "list_toolbox_tools"
-DOCS_SEARCH_ACTION_ID = "search_docs_with_toolbox"
-WEB_SEARCH_ACTION_ID = "search_web_with_toolbox"
-SUMMARIZE_ACTION_ID = "summarize_toolbox_result"
-
-_ACTION_PROGRESS_LABELS: dict[str, str] = {
-    LIST_TOOLS_ACTION_ID: "Listing toolbox tools...",
-    DOCS_SEARCH_ACTION_ID: "Searching Microsoft Learn docs...",
-    WEB_SEARCH_ACTION_ID: "Searching the web...",
-    SUMMARIZE_ACTION_ID: "Summarizing results...",
-}
-
-# AAD audience for the toolbox MCP proxy. Same scope used by the existing
-# Foundry hosted-toolbox samples.
-TOOLBOX_AAD_SCOPE = "https://ai.azure.com/.default"
-
-# Match the MCP-recommended httpx timeouts (``mcp.shared._httpx_utils``:
-# 30s connect/write/pool, 5min SSE read). httpx's default ``Timeout(5.0)``
-# is far too aggressive for MCP streaming responses — long-running
-# tool calls through the Foundry toolbox MCP proxy (e.g. the built-in
-# ``web_search``) can take longer than 5s, and a read-timeout fired
-# mid-stream leaves the upper-level ``call_tool`` awaiting a future that
-# never resolves, surfacing as an indefinite hang.
-MCP_CONNECT_TIMEOUT_SECONDS = 30.0
-MCP_READ_TIMEOUT_SECONDS = 300.0
 
 AGENT_INSTRUCTIONS = """\
 You combine results from two tool calls in the conversation:
@@ -159,37 +57,28 @@ result set contains an answer, say so plainly rather than guessing.
 
 
 class _BearerAuth(httpx.Auth):
-    """Inject a fresh Azure AD bearer token on every request.
-
-    ``httpx.Auth.auth_flow`` is a sync generator and works for both sync
-    and async clients. ``get_bearer_token_provider`` caches/refreshes the
-    token internally, so calling it per request is cheap.
-    """
+    """Inject a fresh Azure AD bearer token on every request."""
 
     def __init__(self, credential: TokenCredential) -> None:
-        self._get_token = get_bearer_token_provider(credential, TOOLBOX_AAD_SCOPE)
+        self._get_token = get_bearer_token_provider(credential, "https://ai.azure.com/.default")
 
-    def auth_flow(self, request: httpx.Request) -> Iterator[httpx.Request]:
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
         request.headers["Authorization"] = f"Bearer {self._get_token()}"
         yield request
 
 
 async def main() -> None:
     """Run the Foundry toolbox MCP workflow."""
-    # 1. Read configuration. ``FOUNDRY_PROJECT_ENDPOINT`` and
-    #    ``FOUNDRY_MODEL`` are required; everything else has defaults.
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"]
     model = os.environ["FOUNDRY_MODEL"]
-    toolbox_name = os.environ.get("FOUNDRY_TOOLBOX_NAME", DEFAULT_TOOLBOX_NAME)
-    toolbox_api_version = os.environ.get("FOUNDRY_TOOLBOX_API_VERSION", DEFAULT_TOOLBOX_API_VERSION)
-    docs_server_label = os.environ.get("FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL", DEFAULT_DOCS_SERVER_LABEL)
-    web_search_tool_name = os.environ.get("FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", DEFAULT_WEB_SEARCH_TOOL_NAME)
+    toolbox_name = os.environ.get("FOUNDRY_TOOLBOX_NAME", "declarative_foundry_toolbox_mcp")
+    toolbox_api_version = os.environ.get("FOUNDRY_TOOLBOX_API_VERSION", "v1")
+    docs_server_label = os.environ.get("FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL", "microsoft_docs")
+    web_search_tool_name = os.environ.get("FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", "web_search")
 
     print("=" * 60)
     print("Invoke Foundry Toolbox MCP Workflow Demo")
     print("=" * 60)
-
-    # 2. Provision the toolbox in Foundry. Idempotent: delete-then-create.
     print(f"Provisioning toolbox '{toolbox_name}' in Foundry...")
     create_sample_toolbox(
         name=toolbox_name,
@@ -197,16 +86,14 @@ async def main() -> None:
         project_endpoint=project_endpoint,
     )
 
-    # 3. Resolve the toolbox MCP proxy URL. The workflow YAML references
-    #    these values via ``=Env.FOUNDRY_TOOLBOX_*``; we publish them
-    #    through ``WorkflowFactory(configuration=...)`` so the values stay scoped to
-    #    this workflow.
     toolbox_endpoint = os.environ.get("FOUNDRY_TOOLBOX_ENDPOINT") or build_toolbox_mcp_server_url(
         project_endpoint=project_endpoint,
         name=toolbox_name,
         api_version=toolbox_api_version,
     )
-    workflow_configuration: dict[str, str] = {
+    # Values exposed to ``=Env.*`` in workflow.yaml. Passing them via
+    # ``configuration`` keeps the symbol table scoped to this workflow.
+    workflow_configuration = {
         "FOUNDRY_TOOLBOX_MCP_SERVER_URL": toolbox_endpoint,
         "FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL": docs_server_label,
         "FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME": web_search_tool_name,
@@ -214,64 +101,27 @@ async def main() -> None:
     print(f"Toolbox endpoint: {toolbox_endpoint}")
     print()
 
-    # 4. Build the Foundry chat client + the summarising agent. The agent
-    #    is registered with the factory by name, matching the sibling
-    #    ``invoke_mcp_tool/`` sample.
-    credential = AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS)
-    chat_client = FoundryChatClient(
-        project_endpoint=project_endpoint,
-        model=model,
-        credential=credential,
-    )
-    summary_agent = Agent(
-        client=chat_client,
-        name=AGENT_NAME,
-        instructions=AGENT_INSTRUCTIONS,
-    )
+    credential = AzureCliCredential()
+    chat_client = FoundryChatClient(project_endpoint=project_endpoint, model=model, credential=credential)
+    summary_agent = Agent(client=chat_client, name=AGENT_NAME, instructions=AGENT_INSTRUCTIONS)
 
-    # 5. Build a bearer-authenticated httpx client. The same client is
-    #    reused for every MCP request: the LRU cache inside
-    #    ``DefaultMCPToolHandler`` keeps a single MCP session alive
-    #    for the toolbox URL, and ``tools/list`` reuses that same
-    #    cached session for full transport-level consistency.
-    #
-    # Key configuration choices:
-    #   * ``headers=FOUNDRY_FEATURES_HEADERS`` attaches the
-    #     ``Foundry-Features: Toolboxes=V1Preview`` flag to EVERY
-    #     outbound request — including the MCP ``initialize`` handshake
-    #     during ``connect()``. The YAML's per-action ``headers:`` block
-    #     also sets this value but only takes effect during
-    #     ``call_tool`` (the ``MCPStreamableHTTPTool`` header_provider
-    #     contextvar is empty during connect — see
-    #     ``python/packages/core/agent_framework/_mcp.py:1639-1645``).
-    #     Without the client-level default the toolbox MCP proxy rejects
-    #     the session handshake and surfaces "unhandled errors in a
-    #     TaskGroup".
-    #   * ``timeout=Timeout(30.0, read=300.0)`` matches the MCP
-    #     recommended defaults (``mcp.shared._httpx_utils``: 30s
-    #     connect/write/pool, 5min SSE read). The httpx defaults of 5s
-    #     EVERYWHERE break long-running MCP tool calls — the Foundry
-    #     built-in ``web_search``, for instance, can take longer than
-    #     5s to return through the toolbox SSE stream and would
-    #     otherwise leave the client waiting on a future that never
-    #     resolves (i.e. visibly hang on the host).
-    #   * ``follow_redirects=True`` also mirrors the MCP defaults so
-    #     proxy redirects don't surface as broken streams.
+    # ``headers=`` attaches the Foundry-Features preview flag on every
+    # request, including the MCP ``initialize`` handshake (the YAML's
+    # per-action ``headers`` only takes effect during ``call_tool``).
+    # ``timeout=`` matches the MCP-recommended values; httpx's 5s
+    # default breaks long-running tool calls like ``web_search``.
     http_client = httpx.AsyncClient(
         auth=_BearerAuth(credential),
         headers=FOUNDRY_FEATURES_HEADERS,
-        timeout=httpx.Timeout(MCP_CONNECT_TIMEOUT_SECONDS, read=MCP_READ_TIMEOUT_SECONDS),
+        timeout=httpx.Timeout(30.0, read=300.0),
         follow_redirects=True,
     )
 
     async def _client_provider(invocation: MCPToolInvocation) -> httpx.AsyncClient | None:
-        # Pin the bearer-authenticated client to the resolved toolbox URL.
-        # The Foundry AAD bearer token is scoped to ``https://ai.azure.com``
-        # but we still refuse to attach it to any URL we did not provision —
-        # if the YAML resolves a different ``serverUrl`` (e.g. via a tampered
-        # ``Env.*`` value or a config injection), fail closed by raising so
-        # ``DefaultMCPToolHandler`` cannot fall back to an unauthenticated
-        # client that silently leaks the request shape.
+        # Fail closed when the YAML resolves a different ``serverUrl``
+        # so the bearer-bound client cannot be reused against an
+        # unexpected endpoint and ``DefaultMCPToolHandler`` cannot
+        # silently fall back to an unauthenticated client.
         if invocation.server_url.casefold() != toolbox_endpoint.casefold():
             raise ValueError(
                 f"Refusing to attach Foundry bearer token to unexpected MCP URL: "
@@ -286,55 +136,35 @@ async def main() -> None:
         factory = WorkflowFactory(
             agents={AGENT_NAME: summary_agent},
             mcp_tool_handler=mcp_handler,
-            # The workflow YAML references ``=Env.FOUNDRY_TOOLBOX_*`` to keep
-            # the toolbox URL / tool names configurable without editing the
-            # YAML. We supply those values through ``configuration`` so the
-            # PowerFx ``Env`` symbol is populated from a local dict instead
-            # of the process environment. ``restrict_env_to_configuration``
-            # defaults to ``True`` which suppresses any ``os.environ``
-            # fallback — the workflow only sees the keys explicitly listed
-            # in ``workflow_configuration`` below.
             configuration=workflow_configuration,
         )
-
-        workflow_path = Path(__file__).parent / "workflow.yaml"
-        workflow = factory.create_workflow_from_yaml_path(workflow_path)
+        workflow = factory.create_workflow_from_yaml_path(Path(__file__).parent / "workflow.yaml")
 
         print("Ask one question that benefits from both Microsoft Learn docs and a web search.")
         print()
-        user_input = input("You: ").strip()  # noqa: ASYNC250
-        if not user_input:
-            user_input = "How do I configure logging in the Agent Framework?"
+        user_input = input("You: ").strip() or "How do I configure logging in the Agent Framework?"  # noqa: ASYNC250
 
-        # 6. Drive the workflow with the user's question. The YAML fans
-        #    out three MCP calls and finishes with the InvokeAzureAgent
-        #    summarisation step. We render two kinds of host-visible
-        #    feedback:
-        #
-        #      * Per-action progress lines via ``executor_invoked``
-        #        events so a slow MCP call or agent invocation cannot
-        #        look like a hang.
-        #      * The final agent summary via ``output`` events. The
-        #        three MCP actions use ``autoSend: false`` in the YAML
-        #        so only the summarising agent's text reaches this
-        #        branch.
+        # Progress markers per YAML action so slow MCP calls or agent
+        # invocations don't look like a hang. Action ids mirror
+        # workflow.yaml.
+        progress_labels = {
+            "list_toolbox_tools": "Listing toolbox tools...",
+            "search_docs_with_toolbox": "Searching Microsoft Learn docs...",
+            "search_web_with_toolbox": "Searching the web...",
+            "summarize_toolbox_result": "Summarizing results...",
+        }
         printed_prefix = False
         produced_output = False
-        agent_executor_id = SUMMARIZE_ACTION_ID
         async for event in workflow.run({"text": user_input}, stream=True):
             if event.type == "executor_invoked":
-                label = _ACTION_PROGRESS_LABELS.get(event.executor_id or "")
+                label = progress_labels.get(event.executor_id or "")
                 if label is not None:
                     print(f"[{label}]")
                 continue
-
             if event.type == "output" and isinstance(event.data, str):
-                # Only the summarising agent action sends an output
-                # event (MCP calls use ``autoSend: false``). Guard the
-                # display so any future autoSend additions still print
-                # under the "Agent:" prefix only when they come from
-                # that action.
-                if event.executor_id and event.executor_id != agent_executor_id:
+                # Only the summarising agent emits ``output``; the three
+                # MCP actions use ``autoSend: false`` in the YAML.
+                if event.executor_id and event.executor_id != "summarize_toolbox_result":
                     continue
                 if not printed_prefix:
                     print("\nAgent: ", end="", flush=True)

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -11,35 +11,32 @@ tools (e.g. ``web_search``) returns the tool under its plain name.
 
 This sample mirrors the .NET sample
 ``dotnet/samples/03-workflows/Declarative/InvokeFoundryToolboxMcp/`` and
-shows how to:
+focuses on the **workflow execution path**:
 
-  1. Provision a toolbox in a Foundry project (delete-then-create_version,
-     so the sample can be re-run without manual cleanup).
-  2. Configure a ``WorkflowFactory`` with a custom :class:`MCPToolHandler`
-     that:
-       * routes every MCP request through a single
-         :class:`httpx.AsyncClient` carrying an Azure AD bearer token
-         (the toolbox endpoint requires AAD auth), and
-       * intercepts the reserved tool name ``"tools/list"`` so the YAML
-         can introspect the toolbox tool set without an extra Python
-         round-trip (matching the .NET ``DefaultMcpToolHandler``
-         behaviour).
-  3. Invoke ``microsoft_docs_search`` (from the Microsoft Learn Docs MCP
-     server surfaced by the toolbox) and ``web_search`` (Foundry built-in)
-     from a single declarative workflow.
-  4. Hand both result sets to a local :class:`Agent` registered with the
-     factory by name so the workflow's ``InvokeAzureAgent`` action can
-     summarise them.
+  1. Build a bearer-authenticated ``httpx.AsyncClient`` for the toolbox
+     MCP proxy and hand it to :class:`DefaultMCPToolHandler` so the YAML
+     can call MCP tools (and introspect the toolbox tool list via the
+     reserved ``"tools/list"`` tool name handled natively by the
+     framework, matching .NET
+     ``DefaultMcpToolHandler.ListToolsToolName``).
+  2. Configure a :class:`WorkflowFactory` with that handler plus a local
+     :class:`Agent` registered by name so the YAML's ``InvokeAzureAgent``
+     action can summarise the combined tool output.
+  3. Drive the workflow with a user question and render per-action
+     progress markers plus the final agent summary.
+
+One-off **toolbox administration** (delete + create_version) is delegated
+to :mod:`toolbox_provisioning` so this file stays focused on the workflow.
 
 Security note:
     The default ``DefaultMCPToolHandler`` performs no URL allowlisting or
-    SSRF protection. This sample wraps it with a project-scoped handler
+    SSRF protection. This sample uses a project-scoped ``client_provider``
     that pins outbound requests to ``Authorization: Bearer …`` via Azure
-    AD; for production deployments, additionally constrain the workflow
-    YAML to a known toolbox URL and reject any other server URL before
-    delegating to the inner handler. MCP outputs flow back into agent
-    conversations and share the prompt-injection risk surface of any
-    other tool output.
+    AD AND fails closed (raises) when the YAML resolves a different
+    ``serverUrl``, so a tampered ``=Env.*`` value cannot redirect the
+    bearer token to an attacker-controlled URL. MCP outputs flow back
+    into agent conversations and share the prompt-injection risk
+    surface of any other tool output.
 
 Run with:
     python samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -90,31 +87,31 @@ Sample output:
 """
 
 import asyncio
-import contextlib
-import json
 import os
-import sys
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import httpx
-from agent_framework import Agent, Content, MCPStreamableHTTPTool
+from agent_framework import Agent
 from agent_framework.declarative import (
     DefaultMCPToolHandler,
     MCPToolInvocation,
-    MCPToolResult,
     WorkflowFactory,
 )
 from agent_framework.foundry import FoundryChatClient
 from azure.core.credentials import TokenCredential
 from azure.identity import AzureCliCredential, get_bearer_token_provider
+from toolbox_provisioning import (
+    AZ_CLI_PROCESS_TIMEOUT_SECONDS,
+    FOUNDRY_FEATURES_HEADERS,
+    build_toolbox_mcp_server_url,
+    create_sample_toolbox,
+)
 
 DEFAULT_TOOLBOX_NAME = "declarative_foundry_toolbox_mcp"
 DEFAULT_TOOLBOX_API_VERSION = "v1"
 DEFAULT_DOCS_SERVER_LABEL = "microsoft_docs"
 DEFAULT_WEB_SEARCH_TOOL_NAME = "web_search"
-DEFAULT_DOCS_MCP_SERVER_URL = "https://learn.microsoft.com/api/mcp"
 
 AGENT_NAME = "FoundryToolboxMcpAgent"
 
@@ -133,37 +130,9 @@ _ACTION_PROGRESS_LABELS: dict[str, str] = {
     SUMMARIZE_ACTION_ID: "Summarizing results...",
 }
 
-# Reserved tool name that the YAML uses to ask the handler for the toolbox
-# tool list. Mirrors .NET ``DefaultMcpToolHandler.ListToolsToolName``.
-LIST_TOOLS_TOOL_NAME = "tools/list"
-
 # AAD audience for the toolbox MCP proxy. Same scope used by the existing
 # Foundry hosted-toolbox samples.
 TOOLBOX_AAD_SCOPE = "https://ai.azure.com/.default"
-
-# Toolbox administration is gated by an Azure AI Foundry preview feature
-# flag. The .NET sample injects this header via a pipeline policy on the
-# ``AgentAdministrationClient``; the Python ``AIProjectClient`` doesn't
-# add it automatically, so we pass it as a per-call header on every
-# toolbox admin operation (delete + create_version) to make sure the
-# toolbox is actually provisioned in the V1Preview routing path that the
-# MCP proxy serves. Without this header, the calls can succeed at the
-# HTTP layer but the toolbox is never wired up to the MCP endpoint —
-# which surfaces at runtime as "MCP server failed to initialize:
-# Session terminated" on the first ``InvokeMcpTool`` call.
-FOUNDRY_FEATURES_HEADER_NAME = "Foundry-Features"
-FOUNDRY_FEATURES_HEADER_VALUE = "Toolboxes=V1Preview"
-FOUNDRY_FEATURES_HEADERS: dict[str, str] = {
-    FOUNDRY_FEATURES_HEADER_NAME: FOUNDRY_FEATURES_HEADER_VALUE,
-}
-
-# Bump the ``az.cmd`` subprocess timeout from the default 10s. On Windows
-# the Azure CLI batch wrapper can take noticeably longer than 10s to
-# return a token (cold-start + ``az`` self-update checks + AAD round-trip),
-# which surfaces as ``CredentialUnavailableError: Failed to invoke the
-# Azure CLI`` after a ``subprocess.TimeoutExpired`` from the credential's
-# internal call.
-AZ_CLI_PROCESS_TIMEOUT_SECONDS = 60
 
 # Match the MCP-recommended httpx timeouts (``mcp.shared._httpx_utils``:
 # 30s connect/write/pool, 5min SSE read). httpx's default ``Timeout(5.0)``
@@ -189,70 +158,6 @@ result set contains an answer, say so plainly rather than guessing.
 """
 
 
-def build_toolbox_mcp_server_url(project_endpoint: str, name: str, api_version: str) -> str:
-    """Compose the Foundry toolbox MCP proxy URL.
-
-    Toolboxes provisioned via ``AIProjectClient.beta.toolboxes`` live under
-    the ``/toolboxes/{name}`` resource path (the Python SDK's
-    ``BetaToolboxesOperations`` routes POST/GET/DELETE there — see
-    ``azure/ai/projects/operations/_operations.py``). Their MCP proxy URL
-    is ``<project_endpoint>/toolboxes/{name}/mcp?api-version=<api_version>``,
-    matching the .NET sample.
-    """
-    base = project_endpoint.rstrip("/")
-    return f"{base}/toolboxes/{name}/mcp?api-version={api_version}"
-
-
-def create_sample_toolbox(
-    *,
-    name: str,
-    docs_server_label: str,
-    project_endpoint: str,
-    docs_server_url: str = DEFAULT_DOCS_MCP_SERVER_URL,
-) -> None:
-    """Provision a toolbox version in the Foundry project (idempotent).
-
-    Toolboxes are normally provisioned through the Foundry portal or a
-    deployment script; this helper exists so the sample can be re-run
-    end-to-end without manual cleanup. It deletes any toolbox under
-    ``name`` and then creates a new version that bundles:
-
-    - the Microsoft Learn Docs MCP server (``server_label=docs_server_label``),
-      and
-    - the Foundry built-in ``web_search`` tool.
-    """
-    from azure.ai.projects import AIProjectClient
-    from azure.ai.projects.models import MCPTool, Tool, WebSearchTool
-    from azure.core.exceptions import ResourceNotFoundError
-
-    with (
-        AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS) as credential,
-        AIProjectClient(credential=credential, endpoint=project_endpoint) as project_client,
-    ):
-        try:
-            project_client.beta.toolboxes.delete(name, headers=FOUNDRY_FEATURES_HEADERS)
-            print(f"Toolbox '{name}' deleted (replacing with a fresh version).")
-        except ResourceNotFoundError:
-            pass
-
-        tools: list[Tool] = [
-            MCPTool(
-                server_label=docs_server_label,
-                server_url=docs_server_url,
-                require_approval="never",
-            ),
-            WebSearchTool(),
-        ]
-
-        created = project_client.beta.toolboxes.create_version(
-            name=name,
-            description="Sample toolbox combining Microsoft Learn Docs MCP and Foundry web search.",
-            tools=tools,
-            headers=FOUNDRY_FEATURES_HEADERS,
-        )
-        print(f"Created toolbox {created.name}@{created.version} ({len(created.tools)} tool(s)).")
-
-
 class _BearerAuth(httpx.Auth):
     """Inject a fresh Azure AD bearer token on every request.
 
@@ -269,94 +174,6 @@ class _BearerAuth(httpx.Auth):
         yield request
 
 
-class _ToolboxMcpToolHandler:
-    """:class:`MCPToolHandler` that adds ``tools/list`` support to the default handler.
-
-    The reserved tool name ``"tools/list"`` is intercepted client-side: it
-    is translated to an MCP ``session.list_tools()`` call and the result
-    is returned as a single JSON-encoded ``TextContent`` matching the
-    shape produced by the .NET ``DefaultMcpToolHandler``
-    (``{"tools": [{name, description, inputSchema, outputSchema}]}``).
-
-    All other tool invocations delegate to the wrapped
-    :class:`DefaultMCPToolHandler` so the LRU client cache, error
-    normalisation, and approval flow remain unchanged.
-
-    The ``tools/list`` path uses a transient :class:`MCPStreamableHTTPTool`
-    (``load_tools=False`` so MCP discovery only happens once via the
-    explicit ``session.list_tools()`` call). The same caller-supplied
-    ``httpx.AsyncClient`` is reused so the bearer token and any other
-    transport-level configuration stay consistent with the cached calls.
-    """
-
-    def __init__(self, inner: DefaultMCPToolHandler, http_client: httpx.AsyncClient) -> None:
-        self._inner = inner
-        self._http_client = http_client
-
-    async def invoke_tool(self, invocation: MCPToolInvocation) -> MCPToolResult:
-        if invocation.tool_name == LIST_TOOLS_TOOL_NAME:
-            return await self._list_tools(invocation)
-        return await self._inner.invoke_tool(invocation)
-
-    async def _list_tools(self, invocation: MCPToolInvocation) -> MCPToolResult:
-        if invocation.arguments:
-            return MCPToolResult(
-                outputs=[Content.from_text("Error: 'tools/list' does not accept arguments.")],
-                is_error=True,
-                error_message="'tools/list' does not accept arguments.",
-            )
-
-        # Snapshot headers so the closure does not see later mutations.
-        captured_headers = dict(invocation.headers)
-
-        def _header_provider(_kwargs: dict[str, Any]) -> dict[str, str]:
-            return dict(captured_headers)
-
-        tool = MCPStreamableHTTPTool(
-            name=invocation.server_label or "foundry_toolbox_list",
-            url=invocation.server_url,
-            http_client=self._http_client,
-            header_provider=_header_provider if captured_headers else None,
-            load_tools=False,
-            load_prompts=False,
-        )
-
-        try:
-            await tool.connect()
-            tool_list = await tool.session.list_tools()  # type: ignore[union-attr]
-            payload = {
-                "tools": [
-                    {
-                        "name": entry.name,
-                        "description": entry.description,
-                        "inputSchema": entry.inputSchema,
-                        "outputSchema": entry.outputSchema,
-                    }
-                    for entry in tool_list.tools
-                ]
-            }
-            return MCPToolResult(outputs=[Content.from_text(json.dumps(payload))])
-        except Exception as exc:  # noqa: BLE001 - surface as tool error per protocol contract
-            message = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
-            return MCPToolResult(
-                outputs=[Content.from_text(f"Error: {message}")],
-                is_error=True,
-                error_message=message,
-            )
-        finally:
-            with contextlib.suppress(Exception):
-                await tool.close()
-
-    async def aclose(self) -> None:
-        await self._inner.aclose()
-
-    async def __aenter__(self) -> "_ToolboxMcpToolHandler":
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        await self.aclose()
-
-
 async def main() -> None:
     """Run the Foundry toolbox MCP workflow."""
     # 1. Read configuration. ``FOUNDRY_PROJECT_ENDPOINT`` and
@@ -366,9 +183,7 @@ async def main() -> None:
     toolbox_name = os.environ.get("FOUNDRY_TOOLBOX_NAME", DEFAULT_TOOLBOX_NAME)
     toolbox_api_version = os.environ.get("FOUNDRY_TOOLBOX_API_VERSION", DEFAULT_TOOLBOX_API_VERSION)
     docs_server_label = os.environ.get("FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL", DEFAULT_DOCS_SERVER_LABEL)
-    web_search_tool_name = os.environ.get(
-        "FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", DEFAULT_WEB_SEARCH_TOOL_NAME
-    )
+    web_search_tool_name = os.environ.get("FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME", DEFAULT_WEB_SEARCH_TOOL_NAME)
 
     print("=" * 60)
     print("Invoke Foundry Toolbox MCP Workflow Demo")
@@ -382,17 +197,20 @@ async def main() -> None:
         project_endpoint=project_endpoint,
     )
 
-    # 3. Resolve the toolbox MCP proxy URL and publish all dynamic values
-    #    the YAML expects via ``Env.*``. Setting them after toolbox
-    #    creation ensures the URL points at the freshly created version.
+    # 3. Resolve the toolbox MCP proxy URL. The workflow YAML references
+    #    these values via ``=Env.FOUNDRY_TOOLBOX_*``; we publish them
+    #    through ``WorkflowFactory(configuration=...)`` so the values stay scoped to
+    #    this workflow.
     toolbox_endpoint = os.environ.get("FOUNDRY_TOOLBOX_ENDPOINT") or build_toolbox_mcp_server_url(
         project_endpoint=project_endpoint,
         name=toolbox_name,
         api_version=toolbox_api_version,
     )
-    os.environ["FOUNDRY_TOOLBOX_MCP_SERVER_URL"] = toolbox_endpoint
-    os.environ["FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL"] = docs_server_label
-    os.environ["FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME"] = web_search_tool_name
+    workflow_configuration: dict[str, str] = {
+        "FOUNDRY_TOOLBOX_MCP_SERVER_URL": toolbox_endpoint,
+        "FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL": docs_server_label,
+        "FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME": web_search_tool_name,
+    }
     print(f"Toolbox endpoint: {toolbox_endpoint}")
     print()
 
@@ -413,9 +231,9 @@ async def main() -> None:
 
     # 5. Build a bearer-authenticated httpx client. The same client is
     #    reused for every MCP request: the LRU cache inside
-    #    ``DefaultMCPToolHandler`` will keep a single MCP session alive
-    #    for the toolbox URL, and the ``tools/list`` interceptor reuses
-    #    the same httpx client so headers / auth stay consistent.
+    #    ``DefaultMCPToolHandler`` keeps a single MCP session alive
+    #    for the toolbox URL, and ``tools/list`` reuses that same
+    #    cached session for full transport-level consistency.
     #
     # Key configuration choices:
     #   * ``headers=FOUNDRY_FEATURES_HEADERS`` attaches the
@@ -451,36 +269,32 @@ async def main() -> None:
         # The Foundry AAD bearer token is scoped to ``https://ai.azure.com``
         # but we still refuse to attach it to any URL we did not provision —
         # if the YAML resolves a different ``serverUrl`` (e.g. via a tampered
-        # ``Env.*`` value or a config injection), returning ``None`` causes
-        # ``DefaultMCPToolHandler`` to fall back to an unauthenticated client,
-        # which will fail to authenticate to the proxy instead of forwarding
-        # the token outbound. Mirrors the .NET sample's
-        # ``httpClientProvider`` URL guard.
+        # ``Env.*`` value or a config injection), fail closed by raising so
+        # ``DefaultMCPToolHandler`` cannot fall back to an unauthenticated
+        # client that silently leaks the request shape.
         if invocation.server_url.casefold() != toolbox_endpoint.casefold():
-            print(
-                f"[security] Refusing to attach Foundry bearer token to unexpected MCP URL: "
-                f"{invocation.server_url}",
-                file=sys.stderr,
+            raise ValueError(
+                f"Refusing to attach Foundry bearer token to unexpected MCP URL: "
+                f"{invocation.server_url!r}. Expected: {toolbox_endpoint!r}."
             )
-            return None
         return http_client
 
     async with (
         http_client,
-        DefaultMCPToolHandler(client_provider=_client_provider) as inner_handler,
-        _ToolboxMcpToolHandler(inner_handler, http_client) as mcp_handler,
+        DefaultMCPToolHandler(client_provider=_client_provider) as mcp_handler,
     ):
         factory = WorkflowFactory(
             agents={AGENT_NAME: summary_agent},
             mcp_tool_handler=mcp_handler,
             # The workflow YAML references ``=Env.FOUNDRY_TOOLBOX_*`` to keep
-            # the sample's toolbox URL / tool names configurable without
-            # editing the YAML. ``WorkflowFactory`` defaults to ``safe_mode=True``
-            # which would block those expressions; this sample opts in to the
-            # less-safe mode because we control both the YAML and the env
-            # vars. Do NOT copy this flag into a workflow that loads YAML
-            # from untrusted sources.
-            safe_mode=False,
+            # the toolbox URL / tool names configurable without editing the
+            # YAML. We supply those values through ``configuration`` so the
+            # PowerFx ``Env`` symbol is populated from a local dict instead
+            # of the process environment. ``restrict_env_to_configuration``
+            # defaults to ``True`` which suppresses any ``os.environ``
+            # fallback — the workflow only sees the keys explicitly listed
+            # in ``workflow_configuration`` below.
+            configuration=workflow_configuration,
         )
 
         workflow_path = Path(__file__).parent / "workflow.yaml"

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/main.py
@@ -93,6 +93,7 @@ import asyncio
 import contextlib
 import json
 import os
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -445,7 +446,23 @@ async def main() -> None:
         follow_redirects=True,
     )
 
-    async def _client_provider(_inv: MCPToolInvocation) -> httpx.AsyncClient | None:
+    async def _client_provider(invocation: MCPToolInvocation) -> httpx.AsyncClient | None:
+        # Pin the bearer-authenticated client to the resolved toolbox URL.
+        # The Foundry AAD bearer token is scoped to ``https://ai.azure.com``
+        # but we still refuse to attach it to any URL we did not provision —
+        # if the YAML resolves a different ``serverUrl`` (e.g. via a tampered
+        # ``Env.*`` value or a config injection), returning ``None`` causes
+        # ``DefaultMCPToolHandler`` to fall back to an unauthenticated client,
+        # which will fail to authenticate to the proxy instead of forwarding
+        # the token outbound. Mirrors the .NET sample's
+        # ``httpClientProvider`` URL guard.
+        if invocation.server_url.casefold() != toolbox_endpoint.casefold():
+            print(
+                f"[security] Refusing to attach Foundry bearer token to unexpected MCP URL: "
+                f"{invocation.server_url}",
+                file=sys.stderr,
+            )
+            return None
         return http_client
 
     async with (
@@ -456,6 +473,14 @@ async def main() -> None:
         factory = WorkflowFactory(
             agents={AGENT_NAME: summary_agent},
             mcp_tool_handler=mcp_handler,
+            # The workflow YAML references ``=Env.FOUNDRY_TOOLBOX_*`` to keep
+            # the sample's toolbox URL / tool names configurable without
+            # editing the YAML. ``WorkflowFactory`` defaults to ``safe_mode=True``
+            # which would block those expressions; this sample opts in to the
+            # less-safe mode because we control both the YAML and the env
+            # vars. Do NOT copy this flag into a workflow that loads YAML
+            # from untrusted sources.
+            safe_mode=False,
         )
 
         workflow_path = Path(__file__).parent / "workflow.yaml"

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
@@ -1,67 +1,31 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Foundry toolbox provisioning helper for the ``invoke_foundry_toolbox_mcp`` sample.
+"""Foundry toolbox provisioning helper for ``invoke_foundry_toolbox_mcp``.
 
-This module is intentionally narrow: it covers the one-off **administrative**
-setup needed to (re)create a Foundry toolbox so the sample can be run
-end-to-end without manual portal/CLI steps. Workflow execution, MCP
-handling, and agent orchestration live in :mod:`main`.
-
-Toolboxes are normally provisioned through the Foundry portal or a separate
-deployment script. Bundling the provisioning step here keeps the sample
-self-contained and re-runnable.
-
-The Foundry-Features preview header is exported here as well so the
-runtime MCP client in ``main.py`` can attach it on every outbound request
-(the MCP ``initialize`` handshake also requires the flag, not just the
-toolbox administration calls).
+Toolboxes are normally provisioned through the Foundry portal or a
+separate deployment script; bundling the setup here lets the sample run
+end-to-end without manual steps. ``main.py`` owns the workflow execution
+path.
 """
 
 from collections.abc import Mapping
 
 from azure.identity import AzureCliCredential
 
-DEFAULT_DOCS_MCP_SERVER_URL = "https://learn.microsoft.com/api/mcp"
-
-# Bump the ``az.cmd`` subprocess timeout from the default 10s. On Windows
-# the Azure CLI batch wrapper can take noticeably longer than 10s to
-# return a token (cold-start + ``az`` self-update checks + AAD round-trip),
-# which surfaces as ``CredentialUnavailableError: Failed to invoke the
-# Azure CLI`` after a ``subprocess.TimeoutExpired`` from the credential's
-# internal call.
-AZ_CLI_PROCESS_TIMEOUT_SECONDS = 60
-
-# Toolbox administration AND runtime MCP traffic are both gated by an
-# Azure AI Foundry preview feature flag. The .NET sample injects this
-# header via a pipeline policy on the ``AgentAdministrationClient``;
-# the Python ``AIProjectClient`` doesn't add it automatically, so we pass
-# it as a per-call header on every toolbox admin operation (delete +
-# create_version) here, and the runtime code in ``main.py`` attaches it
-# as a default header on the ``httpx.AsyncClient`` so it travels on the
-# MCP ``initialize`` handshake as well. Without this header on admin
-# calls, provisioning succeeds at the HTTP layer but the toolbox is
-# never wired up to the MCP endpoint — surfacing at runtime as "MCP
-# server failed to initialize: Session terminated" on the first
-# ``InvokeMcpTool`` call.
-FOUNDRY_FEATURES_HEADER_NAME = "Foundry-Features"
-FOUNDRY_FEATURES_HEADER_VALUE = "Toolboxes=V1Preview"
-FOUNDRY_FEATURES_HEADERS: Mapping[str, str] = {
-    FOUNDRY_FEATURES_HEADER_NAME: FOUNDRY_FEATURES_HEADER_VALUE,
-}
+# Toolbox admin and MCP runtime traffic are both gated by a preview
+# feature flag. The Python ``AIProjectClient`` does not add it
+# automatically, so we attach it to every admin call here AND to the
+# ``httpx.AsyncClient`` in ``main.py`` so the MCP ``initialize``
+# handshake carries it too. Without the flag on admin calls,
+# provisioning succeeds at the HTTP layer but the toolbox is never
+# wired to the MCP endpoint — surfacing later as "MCP server failed to
+# initialize: Session terminated" on the first ``InvokeMcpTool`` call.
+FOUNDRY_FEATURES_HEADERS: Mapping[str, str] = {"Foundry-Features": "Toolboxes=V1Preview"}
 
 
 def build_toolbox_mcp_server_url(project_endpoint: str, name: str, api_version: str) -> str:
-    """Compose the Foundry toolbox MCP proxy URL.
-
-    Toolboxes provisioned via ``AIProjectClient.beta.toolboxes`` live under
-    the ``/toolboxes/{name}`` resource path (the Python SDK's
-    ``BetaToolboxesOperations`` routes POST/GET/DELETE there — see
-    ``azure/ai/projects/operations/_operations.py``). Their MCP proxy URL
-    is ``<project_endpoint>/toolboxes/{name}/mcp?api-version=<api_version>``,
-    matching the .NET sample.
-    """
-    base = project_endpoint.rstrip("/")
-    return f"{base}/toolboxes/{name}/mcp?api-version={api_version}"
+    """Compose the Foundry toolbox MCP proxy URL."""
+    return f"{project_endpoint.rstrip('/')}/toolboxes/{name}/mcp?api-version={api_version}"
 
 
 def create_sample_toolbox(
@@ -69,27 +33,21 @@ def create_sample_toolbox(
     name: str,
     docs_server_label: str,
     project_endpoint: str,
-    docs_server_url: str = DEFAULT_DOCS_MCP_SERVER_URL,
+    docs_server_url: str = "https://learn.microsoft.com/api/mcp",
 ) -> None:
-    """Provision a toolbox version in the Foundry project (idempotent).
+    """Provision a toolbox version (delete-then-create; idempotent).
 
-    Deletes any existing toolbox under ``name`` and then creates a new
-    version that bundles:
-
-    - the Microsoft Learn Docs MCP server
-      (``server_label=docs_server_label``), and
-    - the Foundry built-in ``web_search`` tool.
-
-    Uses ``AzureCliCredential`` because the sample is meant to be run by
-    a developer with ``az login`` already configured; switch to a managed
-    identity / service principal credential for production deployments.
+    Bundles the Microsoft Learn Docs MCP server and the Foundry built-in
+    ``web_search`` tool. Uses ``AzureCliCredential`` because the sample
+    expects ``az login``; switch to a managed identity or service
+    principal for production deployments.
     """
     from azure.ai.projects import AIProjectClient
     from azure.ai.projects.models import MCPTool, Tool, WebSearchTool
     from azure.core.exceptions import ResourceNotFoundError
 
     with (
-        AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS) as credential,
+        AzureCliCredential() as credential,
         AIProjectClient(credential=credential, endpoint=project_endpoint) as project_client,
     ):
         try:
@@ -99,11 +57,7 @@ def create_sample_toolbox(
             pass
 
         tools: list[Tool] = [
-            MCPTool(
-                server_label=docs_server_label,
-                server_url=docs_server_url,
-                require_approval="never",
-            ),
+            MCPTool(server_label=docs_server_label, server_url=docs_server_url, require_approval="never"),
             WebSearchTool(),
         ]
 

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
@@ -2,10 +2,10 @@
 
 """Foundry toolbox provisioning helper for ``invoke_foundry_toolbox_mcp``.
 
-Toolboxes are normally provisioned through the Foundry portal or a
-separate deployment script; bundling the setup here lets the sample run
-end-to-end without manual steps. ``main.py`` owns the workflow execution
-path.
+Toolboxes are normally created through the Foundry portal or a separate
+deployment script. Bundling the one-off setup here lets the sample run
+end-to-end without manual steps. ``main.py`` owns the workflow
+execution path.
 """
 
 from collections.abc import Mapping
@@ -23,27 +23,16 @@ from azure.identity import AzureCliCredential
 FOUNDRY_FEATURES_HEADERS: Mapping[str, str] = {"Foundry-Features": "Toolboxes=V1Preview"}
 
 
-def build_toolbox_mcp_server_url(project_endpoint: str, name: str, api_version: str) -> str:
-    """Compose the Foundry toolbox MCP proxy URL."""
-    return f"{project_endpoint.rstrip('/')}/toolboxes/{name}/mcp?api-version={api_version}"
-
-
-def create_sample_toolbox(
-    *,
-    name: str,
-    docs_server_label: str,
-    project_endpoint: str,
-    docs_server_url: str = "https://learn.microsoft.com/api/mcp",
-) -> None:
+def create_sample_toolbox(*, name: str, docs_server_label: str, project_endpoint: str) -> None:
     """Provision a toolbox version (delete-then-create; idempotent).
 
-    Bundles the Microsoft Learn Docs MCP server and the Foundry built-in
-    ``web_search`` tool. Uses ``AzureCliCredential`` because the sample
-    expects ``az login``; switch to a managed identity or service
-    principal for production deployments.
+    Bundles the Microsoft Learn Docs MCP server under ``docs_server_label``.
+    Uses ``AzureCliCredential`` because the sample expects ``az login``;
+    switch to a managed identity or service principal for production
+    deployments.
     """
     from azure.ai.projects import AIProjectClient
-    from azure.ai.projects.models import MCPTool, Tool, WebSearchTool
+    from azure.ai.projects.models import MCPTool, Tool
     from azure.core.exceptions import ResourceNotFoundError
 
     with (
@@ -57,13 +46,16 @@ def create_sample_toolbox(
             pass
 
         tools: list[Tool] = [
-            MCPTool(server_label=docs_server_label, server_url=docs_server_url, require_approval="never"),
-            WebSearchTool(),
+            MCPTool(
+                server_label=docs_server_label,
+                server_url="https://learn.microsoft.com/api/mcp",
+                require_approval="never",
+            ),
         ]
 
         created = project_client.beta.toolboxes.create_version(
             name=name,
-            description="Sample toolbox combining Microsoft Learn Docs MCP and Foundry web search.",
+            description="Sample toolbox exposing the Microsoft Learn Docs MCP server.",
             tools=tools,
             headers=FOUNDRY_FEATURES_HEADERS,
         )

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/toolbox_provisioning.py
@@ -1,0 +1,116 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Foundry toolbox provisioning helper for the ``invoke_foundry_toolbox_mcp`` sample.
+
+This module is intentionally narrow: it covers the one-off **administrative**
+setup needed to (re)create a Foundry toolbox so the sample can be run
+end-to-end without manual portal/CLI steps. Workflow execution, MCP
+handling, and agent orchestration live in :mod:`main`.
+
+Toolboxes are normally provisioned through the Foundry portal or a separate
+deployment script. Bundling the provisioning step here keeps the sample
+self-contained and re-runnable.
+
+The Foundry-Features preview header is exported here as well so the
+runtime MCP client in ``main.py`` can attach it on every outbound request
+(the MCP ``initialize`` handshake also requires the flag, not just the
+toolbox administration calls).
+"""
+
+from collections.abc import Mapping
+
+from azure.identity import AzureCliCredential
+
+DEFAULT_DOCS_MCP_SERVER_URL = "https://learn.microsoft.com/api/mcp"
+
+# Bump the ``az.cmd`` subprocess timeout from the default 10s. On Windows
+# the Azure CLI batch wrapper can take noticeably longer than 10s to
+# return a token (cold-start + ``az`` self-update checks + AAD round-trip),
+# which surfaces as ``CredentialUnavailableError: Failed to invoke the
+# Azure CLI`` after a ``subprocess.TimeoutExpired`` from the credential's
+# internal call.
+AZ_CLI_PROCESS_TIMEOUT_SECONDS = 60
+
+# Toolbox administration AND runtime MCP traffic are both gated by an
+# Azure AI Foundry preview feature flag. The .NET sample injects this
+# header via a pipeline policy on the ``AgentAdministrationClient``;
+# the Python ``AIProjectClient`` doesn't add it automatically, so we pass
+# it as a per-call header on every toolbox admin operation (delete +
+# create_version) here, and the runtime code in ``main.py`` attaches it
+# as a default header on the ``httpx.AsyncClient`` so it travels on the
+# MCP ``initialize`` handshake as well. Without this header on admin
+# calls, provisioning succeeds at the HTTP layer but the toolbox is
+# never wired up to the MCP endpoint — surfacing at runtime as "MCP
+# server failed to initialize: Session terminated" on the first
+# ``InvokeMcpTool`` call.
+FOUNDRY_FEATURES_HEADER_NAME = "Foundry-Features"
+FOUNDRY_FEATURES_HEADER_VALUE = "Toolboxes=V1Preview"
+FOUNDRY_FEATURES_HEADERS: Mapping[str, str] = {
+    FOUNDRY_FEATURES_HEADER_NAME: FOUNDRY_FEATURES_HEADER_VALUE,
+}
+
+
+def build_toolbox_mcp_server_url(project_endpoint: str, name: str, api_version: str) -> str:
+    """Compose the Foundry toolbox MCP proxy URL.
+
+    Toolboxes provisioned via ``AIProjectClient.beta.toolboxes`` live under
+    the ``/toolboxes/{name}`` resource path (the Python SDK's
+    ``BetaToolboxesOperations`` routes POST/GET/DELETE there — see
+    ``azure/ai/projects/operations/_operations.py``). Their MCP proxy URL
+    is ``<project_endpoint>/toolboxes/{name}/mcp?api-version=<api_version>``,
+    matching the .NET sample.
+    """
+    base = project_endpoint.rstrip("/")
+    return f"{base}/toolboxes/{name}/mcp?api-version={api_version}"
+
+
+def create_sample_toolbox(
+    *,
+    name: str,
+    docs_server_label: str,
+    project_endpoint: str,
+    docs_server_url: str = DEFAULT_DOCS_MCP_SERVER_URL,
+) -> None:
+    """Provision a toolbox version in the Foundry project (idempotent).
+
+    Deletes any existing toolbox under ``name`` and then creates a new
+    version that bundles:
+
+    - the Microsoft Learn Docs MCP server
+      (``server_label=docs_server_label``), and
+    - the Foundry built-in ``web_search`` tool.
+
+    Uses ``AzureCliCredential`` because the sample is meant to be run by
+    a developer with ``az login`` already configured; switch to a managed
+    identity / service principal credential for production deployments.
+    """
+    from azure.ai.projects import AIProjectClient
+    from azure.ai.projects.models import MCPTool, Tool, WebSearchTool
+    from azure.core.exceptions import ResourceNotFoundError
+
+    with (
+        AzureCliCredential(process_timeout=AZ_CLI_PROCESS_TIMEOUT_SECONDS) as credential,
+        AIProjectClient(credential=credential, endpoint=project_endpoint) as project_client,
+    ):
+        try:
+            project_client.beta.toolboxes.delete(name, headers=FOUNDRY_FEATURES_HEADERS)
+            print(f"Toolbox '{name}' deleted (replacing with a fresh version).")
+        except ResourceNotFoundError:
+            pass
+
+        tools: list[Tool] = [
+            MCPTool(
+                server_label=docs_server_label,
+                server_url=docs_server_url,
+                require_approval="never",
+            ),
+            WebSearchTool(),
+        ]
+
+        created = project_client.beta.toolboxes.create_version(
+            name=name,
+            description="Sample toolbox combining Microsoft Learn Docs MCP and Foundry web search.",
+            tools=tools,
+            headers=FOUNDRY_FEATURES_HEADERS,
+        )
+        print(f"Created toolbox {created.name}@{created.version} ({len(created.tools)} tool(s)).")

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
@@ -1,0 +1,123 @@
+#
+# This workflow demonstrates the InvokeMcpTool action against a Foundry
+# toolbox MCP proxy that exposes BOTH a built-in Foundry tool
+# (``web_search``) and an external MCP server (Microsoft Learn Docs)
+# behind a single MCP-compatible endpoint.
+#
+# The workflow:
+#   1. Accepts a documentation / web search query as input.
+#   2. Lists the tools exposed by the toolbox using the reserved
+#      toolName: ``tools/list``. The Python ``DefaultMCPToolHandler``
+#      does not intercept this name on its own; the sample's host code
+#      wraps it with a small handler that translates ``tools/list`` to
+#      an MCP ``session.list_tools()`` call.
+#   3. Invokes the Microsoft Learn ``microsoft_docs_search`` MCP tool
+#      surfaced by the toolbox. Tool names from MCP-server-backed
+#      toolbox tools are namespaced as ``<server_label>___<tool_name>``.
+#   4. Invokes the built-in ``web_search`` tool through the same
+#      toolbox proxy. Note: ``web_search`` expects ``search_query``
+#      (not ``query``).
+#   5. Asks a Foundry agent to combine the two result sets in the
+#      conversation and answer the user's question.
+#
+# Workflow inputs (set by the host via ``workflow.run({...})``):
+#   text: The user's question (required).
+#
+# Example inputs:
+#   How do I configure logging in the Agent Framework?
+#   What is Azure AI Foundry?
+#
+kind: Workflow
+trigger:
+
+  kind: OnConversationStart
+  id: workflow_invoke_foundry_toolbox_mcp
+  actions:
+
+    # Set the search query from the workflow input so each MCP tool
+    # call can pass it as an argument.
+    - kind: SetVariable
+      id: set_search_query
+      variable: Local.SearchQuery
+      value: =Workflow.Inputs.text
+
+    # List the tools exposed by the toolbox MCP proxy. The sample's
+    # custom MCPToolHandler intercepts the reserved ``tools/list`` name
+    # and returns the toolbox tool list as JSON.
+    #
+    # We intentionally OMIT ``conversationId`` here: the tool list is
+    # metadata for the demo, not useful context for the downstream
+    # summarising agent. Forwarding it into the conversation only
+    # inflates token usage and per-call latency. We also keep
+    # ``autoSend: false`` because the Python host's streaming loop
+    # prints every string ``output`` event — emitting the raw tool
+    # list JSON would visually bury the agent's final answer. The
+    # .NET sibling sample uses ``autoSend: true`` because the .NET
+    # ``WorkflowRunner`` console helper only renders agent updates
+    # (not ``WorkflowOutputEvent``s), so the same YAML value behaves
+    # differently across hosts.
+    - kind: InvokeMcpTool
+      id: list_toolbox_tools
+      serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
+      serverLabel: foundry_toolbox
+      toolName: tools/list
+      headers:
+        Foundry-Features: Toolboxes=V1Preview
+      output:
+        autoSend: false
+        result: Local.ToolboxTools
+
+    # Invoke ``microsoft_docs_search`` from the Microsoft Learn MCP
+    # server. The toolbox prefixes MCP-server tools with the server
+    # label declared at toolbox-creation time.
+    #
+    # ``autoSend: false`` suppresses dumping the raw JSON result to the
+    # workflow output stream — the result is still parsed into
+    # ``Local.SearchResult`` AND appended to the conversation (via
+    # ``conversationId``) so the downstream agent can summarise it.
+    - kind: InvokeMcpTool
+      id: search_docs_with_toolbox
+      serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
+      serverLabel: foundry_toolbox
+      toolName: =Env.FOUNDRY_TOOLBOX_DOCS_SERVER_LABEL & "___microsoft_docs_search"
+      conversationId: =System.ConversationId
+      headers:
+        Foundry-Features: Toolboxes=V1Preview
+      arguments:
+        query: =Local.SearchQuery
+      output:
+        autoSend: false
+        result: Local.SearchResult
+
+    # Invoke the built-in ``web_search`` tool through the same toolbox
+    # proxy. ``web_search`` is a Foundry built-in (not an MCP server),
+    # so it is NOT namespaced and expects the argument
+    # ``search_query`` (not ``query``). See the docs_search action
+    # above for why ``autoSend: false`` is used here.
+    - kind: InvokeMcpTool
+      id: search_web_with_toolbox
+      serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
+      serverLabel: foundry_toolbox
+      toolName: =Env.FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME
+      conversationId: =System.ConversationId
+      headers:
+        Foundry-Features: Toolboxes=V1Preview
+      arguments:
+        search_query: =Local.SearchQuery
+      output:
+        autoSend: false
+        result: Local.WebSearchResult
+
+    # Ask the agent to summarise the two toolbox results. The agent
+    # reads the prior conversation (which now contains both result
+    # sets via ``conversationId``) and produces a single answer.
+    - kind: InvokeAzureAgent
+      id: summarize_toolbox_result
+      agent:
+        name: FoundryToolboxMcpAgent
+      conversationId: =System.ConversationId
+      input:
+        messages: =Concat("Combine the Microsoft Learn docs results and the Foundry web search results in the conversation to answer the query ", Local.SearchQuery)
+      output:
+        autoSend: true
+        messages: Local.Summary

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
@@ -40,19 +40,11 @@ trigger:
       variable: Local.SearchQuery
       value: =Workflow.Inputs.text
 
-    # List the tools exposed by the toolbox MCP proxy.
-    #
-    # We intentionally OMIT ``conversationId`` here: the tool list is
-    # metadata for the demo, not useful context for the downstream
-    # summarising agent. Forwarding it into the conversation only
-    # inflates token usage and per-call latency. We also keep
-    # ``autoSend: false`` because the Python host's streaming loop
-    # prints every string ``output`` event — emitting the raw tool
-    # list JSON would visually bury the agent's final answer. The
-    # .NET sibling sample uses ``autoSend: true`` because the .NET
-    # ``WorkflowRunner`` console helper only renders agent updates
-    # (not ``WorkflowOutputEvent``s), so the same YAML value behaves
-    # differently across hosts.
+    # List the tools exposed by the toolbox MCP proxy. We omit
+    # ``conversationId`` (the catalog is demo metadata, not useful
+    # context for the downstream agent) and keep ``autoSend: false``
+    # so the raw JSON catalog doesn't bury the agent's final answer in
+    # the host's output stream.
     - kind: InvokeMcpTool
       id: list_toolbox_tools
       serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
@@ -7,10 +7,9 @@
 # The workflow:
 #   1. Accepts a documentation / web search query as input.
 #   2. Lists the tools exposed by the toolbox using the reserved
-#      toolName: ``tools/list``. The Python ``DefaultMCPToolHandler``
-#      does not intercept this name on its own; the sample's host code
-#      wraps it with a small handler that translates ``tools/list`` to
-#      an MCP ``session.list_tools()`` call.
+#      toolName: ``tools/list``. ``DefaultMCPToolHandler`` intercepts
+#      this reserved name natively and translates it
+#      to an MCP ``session.list_tools()`` call, returning a JSON catalog.
 #   3. Invokes the Microsoft Learn ``microsoft_docs_search`` MCP tool
 #      surfaced by the toolbox. Tool names from MCP-server-backed
 #      toolbox tools are namespaced as ``<server_label>___<tool_name>``.
@@ -41,9 +40,7 @@ trigger:
       variable: Local.SearchQuery
       value: =Workflow.Inputs.text
 
-    # List the tools exposed by the toolbox MCP proxy. The sample's
-    # custom MCPToolHandler intercepts the reserved ``tools/list`` name
-    # and returns the toolbox tool list as JSON.
+    # List the tools exposed by the toolbox MCP proxy.
     #
     # We intentionally OMIT ``conversationId`` here: the tool list is
     # metadata for the demo, not useful context for the downstream

--- a/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
+++ b/python/samples/03-workflows/declarative/invoke_foundry_toolbox_mcp/workflow.yaml
@@ -1,30 +1,11 @@
 #
-# This workflow demonstrates the InvokeMcpTool action against a Foundry
-# toolbox MCP proxy that exposes BOTH a built-in Foundry tool
-# (``web_search``) and an external MCP server (Microsoft Learn Docs)
-# behind a single MCP-compatible endpoint.
+# Calls the Microsoft Learn Docs MCP server through a Foundry toolbox
+# proxy from a declarative workflow, then asks a Foundry agent to
+# summarise the result. The toolbox surfaces MCP-server-backed tools
+# as ``<server_label>___<tool_name>``.
 #
-# The workflow:
-#   1. Accepts a documentation / web search query as input.
-#   2. Lists the tools exposed by the toolbox using the reserved
-#      toolName: ``tools/list``. ``DefaultMCPToolHandler`` intercepts
-#      this reserved name natively and translates it
-#      to an MCP ``session.list_tools()`` call, returning a JSON catalog.
-#   3. Invokes the Microsoft Learn ``microsoft_docs_search`` MCP tool
-#      surfaced by the toolbox. Tool names from MCP-server-backed
-#      toolbox tools are namespaced as ``<server_label>___<tool_name>``.
-#   4. Invokes the built-in ``web_search`` tool through the same
-#      toolbox proxy. Note: ``web_search`` expects ``search_query``
-#      (not ``query``).
-#   5. Asks a Foundry agent to combine the two result sets in the
-#      conversation and answer the user's question.
-#
-# Workflow inputs (set by the host via ``workflow.run({...})``):
+# Workflow inputs:
 #   text: The user's question (required).
-#
-# Example inputs:
-#   How do I configure logging in the Agent Framework?
-#   What is Azure AI Foundry?
 #
 kind: Workflow
 trigger:
@@ -33,37 +14,14 @@ trigger:
   id: workflow_invoke_foundry_toolbox_mcp
   actions:
 
-    # Set the search query from the workflow input so each MCP tool
-    # call can pass it as an argument.
     - kind: SetVariable
       id: set_search_query
       variable: Local.SearchQuery
       value: =Workflow.Inputs.text
 
-    # List the tools exposed by the toolbox MCP proxy. We omit
-    # ``conversationId`` (the catalog is demo metadata, not useful
-    # context for the downstream agent) and keep ``autoSend: false``
-    # so the raw JSON catalog doesn't bury the agent's final answer in
-    # the host's output stream.
-    - kind: InvokeMcpTool
-      id: list_toolbox_tools
-      serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
-      serverLabel: foundry_toolbox
-      toolName: tools/list
-      headers:
-        Foundry-Features: Toolboxes=V1Preview
-      output:
-        autoSend: false
-        result: Local.ToolboxTools
-
-    # Invoke ``microsoft_docs_search`` from the Microsoft Learn MCP
-    # server. The toolbox prefixes MCP-server tools with the server
-    # label declared at toolbox-creation time.
-    #
-    # ``autoSend: false`` suppresses dumping the raw JSON result to the
-    # workflow output stream — the result is still parsed into
-    # ``Local.SearchResult`` AND appended to the conversation (via
-    # ``conversationId``) so the downstream agent can summarise it.
+    # ``autoSend: false`` so the raw JSON tool result is not echoed to
+    # the host's output stream; ``conversationId`` still appends it to
+    # the conversation so the summarising agent can read it.
     - kind: InvokeMcpTool
       id: search_docs_with_toolbox
       serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
@@ -78,35 +36,13 @@ trigger:
         autoSend: false
         result: Local.SearchResult
 
-    # Invoke the built-in ``web_search`` tool through the same toolbox
-    # proxy. ``web_search`` is a Foundry built-in (not an MCP server),
-    # so it is NOT namespaced and expects the argument
-    # ``search_query`` (not ``query``). See the docs_search action
-    # above for why ``autoSend: false`` is used here.
-    - kind: InvokeMcpTool
-      id: search_web_with_toolbox
-      serverUrl: =Env.FOUNDRY_TOOLBOX_MCP_SERVER_URL
-      serverLabel: foundry_toolbox
-      toolName: =Env.FOUNDRY_TOOLBOX_WEB_SEARCH_TOOL_NAME
-      conversationId: =System.ConversationId
-      headers:
-        Foundry-Features: Toolboxes=V1Preview
-      arguments:
-        search_query: =Local.SearchQuery
-      output:
-        autoSend: false
-        result: Local.WebSearchResult
-
-    # Ask the agent to summarise the two toolbox results. The agent
-    # reads the prior conversation (which now contains both result
-    # sets via ``conversationId``) and produces a single answer.
     - kind: InvokeAzureAgent
       id: summarize_toolbox_result
       agent:
         name: FoundryToolboxMcpAgent
       conversationId: =System.ConversationId
       input:
-        messages: =Concat("Combine the Microsoft Learn docs results and the Foundry web search results in the conversation to answer the query ", Local.SearchQuery)
+        messages: '=Concat("Answer the query using the Microsoft Learn docs result already in the conversation: ", Local.SearchQuery)'
       output:
         autoSend: true
         messages: Local.Summary


### PR DESCRIPTION
### Motivation and Context

Add Python parity sample for invoking Foundry Toolbox tools from declarative workflows.
Matches #5829 for dotnet.

Fixes #5932 

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.