### PR TITLE
.NET: Harness Console: Add a factory option for creating custom sessions

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
@@ -33,7 +33,9 @@ public static class HarnessConsole
         var modeProvider = agent.GetService<AgentModeProvider>();
         var messageInjector = agent.GetService<MessageInjectingChatClient>();
 
-        AgentSession session = await agent.CreateSessionAsync();
+        AgentSession session = options.SessionFactory is not null
+            ? await options.SessionFactory(agent)
+            : await agent.CreateSessionAsync();
 
         using var component = new HarnessAppComponent(
             placeholder: userPrompt,

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsoleOptions.cs
@@ -46,6 +46,12 @@ public class HarnessConsoleOptions
     public Dictionary<string, ConsoleColor> ModeColors { get; set; } = new(DefaultModeColors, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets or sets an optional factory for creating the <see cref="AgentSession"/>.
+    /// When <see langword="null"/> (the default), <see cref="AIAgent.CreateSessionAsync"/> is used.
+    /// </summary>
+    public Func<AIAgent, Task<AgentSession>>? SessionFactory { get; set; }
+
+    /// <summary>
     /// Creates the default set of observers without planning support.
     /// Includes tool call display, tool approval, error display, reasoning display,
     /// usage display, and text output.


### PR DESCRIPTION
### Motivation and Context

Some times a session needs to be created with a custom session creation method or specific conversation id.

### Description

- Add a factory option for creating custom sessions

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.