### PR TITLE
.NET: Reduce re-rendering in harness console

### DIFF
--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/ListSelection.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/ListSelection.cs
@@ -39,7 +39,7 @@ public class ListSelection : ConsoleReactiveComponent<ListSelectionProps, Consol
         {
             foreach (string line in props.Title.Split('\n'))
             {
-                Console.Write(AnsiEscapes.MoveCursor(this.Y + row, this.X));
+                Console.Write(AnsiEscapes.MoveCursor(props.Y + row, props.X));
                 Console.Write(AnsiEscapes.EraseEntireLine);
                 Console.Write(line);
                 row++;
@@ -51,7 +51,7 @@ public class ListSelection : ConsoleReactiveComponent<ListSelectionProps, Consol
 
         for (int i = 0; i < totalItems; i++)
         {
-            Console.Write(AnsiEscapes.MoveCursor(this.Y + row, this.X));
+            Console.Write(AnsiEscapes.MoveCursor(props.Y + row, props.X));
             Console.Write(AnsiEscapes.EraseEntireLine);
 
             bool isSelected = i == props.SelectedIndex;

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextInput.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextInput.cs
@@ -58,11 +58,11 @@ public class TextInput : ConsoleReactiveComponent<TextInputProps, ConsoleReactiv
     public override void RenderCore(TextInputProps props, ConsoleReactiveState state)
     {
         int promptLength = props.Prompt.Length;
-        int textWidth = this.Width - promptLength;
+        int textWidth = props.Width - promptLength;
         string indent = new(' ', promptLength);
 
         // First line: prompt + start of text
-        Console.Write(AnsiEscapes.MoveCursor(this.Y, this.X));
+        Console.Write(AnsiEscapes.MoveCursor(props.Y, props.X));
         Console.Write(AnsiEscapes.EraseEntireLine);
         Console.Write(props.Prompt);
 
@@ -90,7 +90,7 @@ public class TextInput : ConsoleReactiveComponent<TextInputProps, ConsoleReactiv
         while (offset < props.Text.Length)
         {
             int chunk = Math.Min(textWidth, props.Text.Length - offset);
-            Console.Write(AnsiEscapes.MoveCursor(this.Y + row, this.X));
+            Console.Write(AnsiEscapes.MoveCursor(props.Y + row, props.X));
             Console.Write(AnsiEscapes.EraseEntireLine);
             Console.Write(indent);
             Console.Write(props.Text[offset..(offset + chunk)]);

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
@@ -17,7 +17,7 @@ public record TextPanelProps : ConsoleReactiveProps
 /// <summary>
 /// A component that renders a list of pre-rendered string items vertically.
 /// Designed for rendering dynamic items in a non-scroll region that may be
-/// re-rendered on each update. If the component's <see cref="ConsoleReactiveComponent.Height"/>
+/// re-rendered on each update. If the component's <see cref="ConsoleReactiveProps.Height"/>
 /// exceeds the number of output lines, leftover lines are erased.
 /// </summary>
 public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiveState>
@@ -51,18 +51,18 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
 
             for (int j = 0; j < lineCount; j++)
             {
-                Console.Write(AnsiEscapes.MoveAndEraseLine(this.Y + currentRow));
+                Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + currentRow));
                 Console.Write(lines[j]);
                 currentRow++;
             }
         }
 
         // If the component height exceeds the output, erase leftover lines
-        if (this.Height > currentRow)
+        if (props.Height > currentRow)
         {
-            for (int i = currentRow; i < this.Height; i++)
+            for (int i = currentRow; i < props.Height; i++)
             {
-                Console.Write(AnsiEscapes.MoveAndEraseLine(this.Y + i));
+                Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + i));
             }
         }
     }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
@@ -52,7 +52,7 @@ public class TextScrollPanel : ConsoleReactiveComponent<TextScrollPanelProps, Te
         }
 
         // Move cursor to the bottom of the scroll area
-        Console.Write(AnsiEscapes.MoveCursor(this.Y + this.Height - 1, this.X));
+        Console.Write(AnsiEscapes.MoveCursor(props.Y + props.Height - 1, props.X));
 
         // Output only new items since last rendered
         for (int i = state.RenderedCount; i < props.Items.Count; i++)

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TopBottomRule.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TopBottomRule.cs
@@ -9,9 +9,6 @@ namespace Harness.ConsoleReactiveComponents;
 /// </summary>
 public record TopBottomRuleProps : ConsoleReactiveProps
 {
-    /// <summary>Gets the width of the horizontal rules in characters.</summary>
-    public int Width { get; init; }
-
     /// <summary>Gets the foreground color of the horizontal rules. If <c>null</c>, the default terminal color is used.</summary>
     public ConsoleColor? Color { get; init; }
 }
@@ -32,7 +29,7 @@ public class TopBottomRule : ConsoleReactiveComponent<TopBottomRuleProps, Consol
         int childrenHeight = 0;
         foreach (var child in props.Children)
         {
-            childrenHeight += child.Height;
+            childrenHeight += child.BaseProps?.Height ?? 0;
         }
 
         // Top rule + children + bottom rule
@@ -51,11 +48,11 @@ public class TopBottomRule : ConsoleReactiveComponent<TopBottomRuleProps, Consol
         }
 
         // Top rule
-        Console.Write(AnsiEscapes.MoveCursor(this.Y, this.X));
+        Console.Write(AnsiEscapes.MoveCursor(props.Y, props.X));
         Console.Write(rule);
 
         // Render children stacked below the top rule
-        int currentY = this.Y + 1;
+        int currentY = props.Y + 1;
 
         if (props.Color.HasValue)
         {
@@ -64,10 +61,9 @@ public class TopBottomRule : ConsoleReactiveComponent<TopBottomRuleProps, Consol
 
         foreach (var child in props.Children)
         {
-            child.X = this.X;
-            child.Y = currentY;
+            child.BaseProps = child.BaseProps! with { X = props.X, Y = currentY };
             child.Render();
-            currentY += child.Height;
+            currentY += child.BaseProps.Height;
         }
 
         if (props.Color.HasValue)
@@ -76,7 +72,7 @@ public class TopBottomRule : ConsoleReactiveComponent<TopBottomRuleProps, Consol
         }
 
         // Bottom rule
-        Console.Write(AnsiEscapes.MoveCursor(currentY, this.X));
+        Console.Write(AnsiEscapes.MoveCursor(currentY, props.X));
         Console.Write(rule);
 
         if (props.Color.HasValue)

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
@@ -3,8 +3,8 @@
 namespace Harness.ConsoleReactiveFramework;
 
 /// <summary>
-/// Abstract base class for all console UI components. Provides layout properties
-/// (position and size) and a <see cref="Render"/> method for drawing to the console.
+/// Abstract base class for all console UI components. Provides access to layout
+/// through <see cref="BaseProps"/> and a <see cref="Render"/> method for drawing to the console.
 /// Derive from <see cref="ConsoleReactiveComponent{TProps, TState}"/> instead of this class directly.
 /// </summary>
 public abstract class ConsoleReactiveComponent
@@ -13,17 +13,12 @@ public abstract class ConsoleReactiveComponent
     {
     }
 
-    /// <summary>Gets or sets the 1-based column position of the component.</summary>
-    public int X { get; set; }
-
-    /// <summary>Gets or sets the 1-based row position of the component.</summary>
-    public int Y { get; set; }
-
-    /// <summary>Gets or sets the width of the component in columns.</summary>
-    public int Width { get; set; }
-
-    /// <summary>Gets or sets the height of the component in rows.</summary>
-    public int Height { get; set; }
+    /// <summary>
+    /// Gets or sets the component's props as the base <see cref="ConsoleReactiveProps"/> type.
+    /// Used by parent components to set layout (X, Y, Width, Height) on children without
+    /// knowing the concrete props type.
+    /// </summary>
+    public abstract ConsoleReactiveProps? BaseProps { get; set; }
 
     /// <summary>Renders the component to the console at its current position.</summary>
     public abstract void Render();
@@ -45,6 +40,13 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
 
     /// <summary>Gets or sets the component's props (external configuration).</summary>
     public TProps? Props { get; set; }
+
+    /// <inheritdoc/>
+    public override ConsoleReactiveProps? BaseProps
+    {
+        get => this.Props;
+        set => this.Props = (TProps?)value;
+    }
 
     /// <summary>Gets or sets the component's internal state.</summary>
     protected TState? State { get; set; }
@@ -73,8 +75,8 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
                 return;
             }
 
-            if (ReferenceEquals(this.Props, this._lastRenderedProps)
-                && ReferenceEquals(this.State, this._lastRenderedState))
+            if (this.Props.Equals(this._lastRenderedProps)
+                && this.State?.Equals(this._lastRenderedState) is true)
             {
                 return;
             }
@@ -95,11 +97,23 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
 }
 
 /// <summary>
-/// Base record for component props. Provides an optional <see cref="Children"/> collection
-/// for composing child components.
+/// Base record for component props. Provides layout properties (position and size)
+/// and an optional <see cref="Children"/> collection for composing child components.
 /// </summary>
 public record ConsoleReactiveProps
 {
+    /// <summary>Gets the 1-based column position of the component.</summary>
+    public int X { get; init; }
+
+    /// <summary>Gets the 1-based row position of the component.</summary>
+    public int Y { get; init; }
+
+    /// <summary>Gets the width of the component in columns.</summary>
+    public int Width { get; init; }
+
+    /// <summary>Gets the height of the component in rows.</summary>
+    public int Height { get; init; }
+
     /// <summary>Gets the child components to render within this component.</summary>
     public IReadOnlyList<ConsoleReactiveComponent> Children { get; init; } = [];
 }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
@@ -22,6 +22,12 @@ public abstract class ConsoleReactiveComponent
 
     /// <summary>Renders the component to the console at its current position.</summary>
     public abstract void Render();
+
+    /// <summary>
+    /// Invalidates the component's cached render state, causing the next <see cref="Render"/> call
+    /// to proceed even if props and state have not changed. Use after a screen erase to force repaint.
+    /// </summary>
+    public abstract void Invalidate();
 }
 
 /// <summary>
@@ -75,8 +81,8 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
                 return;
             }
 
-            if (this.Props.Equals(this._lastRenderedProps)
-                && this.State?.Equals(this._lastRenderedState) is true)
+            if (EqualityComparer<TProps>.Default.Equals(this.Props, this._lastRenderedProps)
+                && EqualityComparer<TState>.Default.Equals(this.State, this._lastRenderedState))
             {
                 return;
             }
@@ -85,6 +91,16 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
 
             this._lastRenderedProps = this.Props;
             this._lastRenderedState = this.State;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Invalidate()
+    {
+        lock (this._renderLock)
+        {
+            this._lastRenderedProps = default;
+            this._lastRenderedState = default;
         }
     }
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentModeAndHelp.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentModeAndHelp.cs
@@ -37,33 +37,42 @@ public class AgentModeAndHelp : ConsoleReactiveComponent<AgentModeAndHelpProps, 
     /// <inheritdoc />
     public override void RenderCore(AgentModeAndHelpProps props, ConsoleReactiveState state)
     {
-        if (props.Mode is null && string.IsNullOrEmpty(props.HelpText))
-        {
-            return;
-        }
-
         System.Console.Write(AnsiEscapes.SaveCursor);
-        System.Console.Write(AnsiEscapes.MoveAndEraseLine(this.Y));
 
-        bool hasMode = props.Mode is not null;
+        int renderedLines = 0;
 
-        if (hasMode)
+        if (props.Mode is not null || !string.IsNullOrEmpty(props.HelpText))
         {
-            if (props.ModeColor.HasValue)
+            System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y));
+
+            bool hasMode = props.Mode is not null;
+
+            if (hasMode)
             {
-                System.Console.Write(AnsiEscapes.SetForegroundColor(props.ModeColor.Value));
+                if (props.ModeColor.HasValue)
+                {
+                    System.Console.Write(AnsiEscapes.SetForegroundColor(props.ModeColor.Value));
+                }
+
+                System.Console.Write($" [{props.Mode}]");
+                System.Console.Write(AnsiEscapes.ResetAttributes);
             }
 
-            System.Console.Write($" [{props.Mode}]");
-            System.Console.Write(AnsiEscapes.ResetAttributes);
+            if (!string.IsNullOrEmpty(props.HelpText))
+            {
+                string prefix = hasMode ? "  " : " ";
+                System.Console.Write(AnsiEscapes.SetForegroundColor(ConsoleColor.DarkGray));
+                System.Console.Write($"{prefix}{props.HelpText}");
+                System.Console.Write(AnsiEscapes.ResetAttributes);
+            }
+
+            renderedLines = 1;
         }
 
-        if (!string.IsNullOrEmpty(props.HelpText))
+        // Clear any remaining lines up to the component's height (handles bottom padding)
+        for (int i = renderedLines; i < props.Height; i++)
         {
-            string prefix = hasMode ? "  " : " ";
-            System.Console.Write(AnsiEscapes.SetForegroundColor(ConsoleColor.DarkGray));
-            System.Console.Write($"{prefix}{props.HelpText}");
-            System.Console.Write(AnsiEscapes.ResetAttributes);
+            System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + i));
         }
 
         System.Console.Write(AnsiEscapes.RestoreCursor);

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentModeAndHelp.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentModeAndHelp.cs
@@ -37,42 +37,33 @@ public class AgentModeAndHelp : ConsoleReactiveComponent<AgentModeAndHelpProps, 
     /// <inheritdoc />
     public override void RenderCore(AgentModeAndHelpProps props, ConsoleReactiveState state)
     {
-        System.Console.Write(AnsiEscapes.SaveCursor);
-
-        int renderedLines = 0;
-
-        if (props.Mode is not null || !string.IsNullOrEmpty(props.HelpText))
+        if (props.Mode is null && string.IsNullOrEmpty(props.HelpText))
         {
-            System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y));
-
-            bool hasMode = props.Mode is not null;
-
-            if (hasMode)
-            {
-                if (props.ModeColor.HasValue)
-                {
-                    System.Console.Write(AnsiEscapes.SetForegroundColor(props.ModeColor.Value));
-                }
-
-                System.Console.Write($" [{props.Mode}]");
-                System.Console.Write(AnsiEscapes.ResetAttributes);
-            }
-
-            if (!string.IsNullOrEmpty(props.HelpText))
-            {
-                string prefix = hasMode ? "  " : " ";
-                System.Console.Write(AnsiEscapes.SetForegroundColor(ConsoleColor.DarkGray));
-                System.Console.Write($"{prefix}{props.HelpText}");
-                System.Console.Write(AnsiEscapes.ResetAttributes);
-            }
-
-            renderedLines = 1;
+            return;
         }
 
-        // Clear any remaining lines up to the component's height (handles bottom padding)
-        for (int i = renderedLines; i < props.Height; i++)
+        System.Console.Write(AnsiEscapes.SaveCursor);
+        System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y));
+
+        bool hasMode = props.Mode is not null;
+
+        if (hasMode)
         {
-            System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + i));
+            if (props.ModeColor.HasValue)
+            {
+                System.Console.Write(AnsiEscapes.SetForegroundColor(props.ModeColor.Value));
+            }
+
+            System.Console.Write($" [{props.Mode}]");
+            System.Console.Write(AnsiEscapes.ResetAttributes);
+        }
+
+        if (!string.IsNullOrEmpty(props.HelpText))
+        {
+            string prefix = hasMode ? "  " : " ";
+            System.Console.Write(AnsiEscapes.SetForegroundColor(ConsoleColor.DarkGray));
+            System.Console.Write($"{prefix}{props.HelpText}");
+            System.Console.Write(AnsiEscapes.ResetAttributes);
         }
 
         System.Console.Write(AnsiEscapes.RestoreCursor);

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentStatus.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentStatus.cs
@@ -85,7 +85,7 @@ public class AgentStatus : ConsoleReactiveComponent<AgentStatusProps, AgentStatu
         }
 
         System.Console.Write(AnsiEscapes.SaveCursor);
-        System.Console.Write(AnsiEscapes.MoveAndEraseLine(this.Y));
+        System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y));
 
         if (props.ShowSpinner)
         {

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentStatus.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Components/AgentStatus.cs
@@ -86,16 +86,12 @@ public class AgentStatus : ConsoleReactiveComponent<AgentStatusProps, AgentStatu
         }
 
         System.Console.Write(AnsiEscapes.SaveCursor);
-<<<<<<< harness-console-reduce-rerender
-        System.Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y));
-=======
-        System.Console.Write(AnsiEscapes.MoveCursor(this.Y, this.X));
+        System.Console.Write(AnsiEscapes.MoveCursor(props.Y, props.X));
         if (props != this._previousProps)
         {
             System.Console.Write(AnsiEscapes.EraseToEndOfLine);
             this._previousProps = props;
         }
->>>>>>> main
 
         if (props.ShowSpinner)
         {

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
@@ -371,7 +371,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             };
 
             bottomChildHeight = ListSelection.CalculateHeight(listProps);
-            this._listSelection.Height = bottomChildHeight;
+            listProps = listProps with { Height = bottomChildHeight };
             this._listSelection.Props = listProps;
             bottomChild = this._listSelection;
         }
@@ -398,8 +398,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             }
 
             bottomChildHeight = TextInput.CalculateHeight(textInputProps, state.ConsoleWidth);
-            this._textInput.Width = state.ConsoleWidth;
-            this._textInput.Height = bottomChildHeight;
+            textInputProps = textInputProps with { Width = state.ConsoleWidth, Height = bottomChildHeight };
             this._textInput.Props = textInputProps;
             bottomChild = this._textInput;
         }
@@ -413,8 +412,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             };
 
             bottomChildHeight = TextInput.CalculateHeight(textInputProps, state.ConsoleWidth);
-            this._textInput.Width = state.ConsoleWidth;
-            this._textInput.Height = bottomChildHeight;
+            textInputProps = textInputProps with { Width = state.ConsoleWidth, Height = bottomChildHeight };
             this._textInput.Props = textInputProps;
             bottomChild = this._textInput;
         }
@@ -443,10 +441,10 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
         // as they clutter the UI and aren't relevant.
         bool showStatusAndHelp = state.Mode != BottomPanelMode.ListSelection;
         int agentStatusHeight = showStatusAndHelp ? AgentStatus.CalculateHeight(agentStatusProps) : 0;
-        int modeAndHelpHeight = showStatusAndHelp ? AgentModeAndHelp.CalculateHeight(modeAndHelpProps) : 0;
+        int modeAndHelpHeight = showStatusAndHelp ? AgentModeAndHelp.CalculateHeight(modeAndHelpProps) + 1 : 0; // +1 for bottom padding
 
         int ruleHeight = TopBottomRule.CalculateHeight(ruleProps);
-        int nonScrollHeight = ruleHeight + textPanelHeight + agentStatusHeight + queuedPanelHeight + modeAndHelpHeight + 1; // +1 for bottom padding
+        int nonScrollHeight = ruleHeight + textPanelHeight + agentStatusHeight + queuedPanelHeight + modeAndHelpHeight;
         int scrollBottom = Math.Max(1, state.ConsoleHeight - nonScrollHeight);
 
         // If scroll region changed or a clear is needed, reset everything
@@ -470,35 +468,35 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             ? state.ScrollAreaContentItems.Take(state.ScrollAreaContentItems.Count - 1).ToList()
             : [];
 
-        this._textScrollPanel.X = 1;
-        this._textScrollPanel.Y = 1;
-        this._textScrollPanel.Width = state.ConsoleWidth;
-        this._textScrollPanel.Height = scrollBottom;
         this._textScrollPanel.Props = new TextScrollPanelProps
         {
+            X = 1,
+            Y = 1,
+            Width = state.ConsoleWidth,
+            Height = scrollBottom,
             Items = scrollItems,
         };
         this._textScrollPanel.Render();
 
         // Render the text panel for the last (dynamic) item just below the scroll region
-        this._textPanel.X = 1;
-        this._textPanel.Y = scrollBottom + 1;
-        this._textPanel.Width = state.ConsoleWidth;
-        this._textPanel.Height = textPanelHeight;
         this._textPanel.Props = new TextPanelProps
         {
+            X = 1,
+            Y = scrollBottom + 1,
+            Width = state.ConsoleWidth,
+            Height = textPanelHeight,
             Items = lastItems,
         };
         this._textPanel.Render();
 
         // Render queued input items between text panel and agent status
         int queuedPanelY = scrollBottom + textPanelHeight + 1;
-        this._queuedPanel.X = 1;
-        this._queuedPanel.Y = queuedPanelY;
-        this._queuedPanel.Width = state.ConsoleWidth;
-        this._queuedPanel.Height = queuedPanelHeight;
         this._queuedPanel.Props = new TextPanelProps
         {
+            X = 1,
+            Y = queuedPanelY,
+            Width = state.ConsoleWidth,
+            Height = queuedPanelHeight,
             Items = state.QueuedItems,
         };
         this._queuedPanel.Render();
@@ -507,29 +505,35 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
         int agentStatusY = queuedPanelY + queuedPanelHeight;
         if (showStatusAndHelp)
         {
-            this._agentStatus.X = 1;
-            this._agentStatus.Y = agentStatusY;
-            this._agentStatus.Width = state.ConsoleWidth;
-            this._agentStatus.Height = agentStatusHeight;
-            this._agentStatus.Props = agentStatusProps;
+            this._agentStatus.Props = agentStatusProps with
+            {
+                X = 1,
+                Y = agentStatusY,
+                Width = state.ConsoleWidth,
+                Height = agentStatusHeight,
+            };
             this._agentStatus.Render();
         }
 
         // Render the bottom rule + child below the agent status
-        this._rule.X = 1;
-        this._rule.Y = agentStatusY + agentStatusHeight;
-        this._rule.Props = ruleProps;
+        this._rule.Props = ruleProps with
+        {
+            X = 1,
+            Y = agentStatusY + agentStatusHeight,
+        };
         this._rule.Render();
 
         // Render the mode-and-help line below the bottom rule
         if (showStatusAndHelp)
         {
-            int modeAndHelpY = this._rule.Y + ruleHeight;
-            this._modeAndHelp.X = 1;
-            this._modeAndHelp.Y = modeAndHelpY;
-            this._modeAndHelp.Width = state.ConsoleWidth;
-            this._modeAndHelp.Height = modeAndHelpHeight;
-            this._modeAndHelp.Props = modeAndHelpProps;
+            int modeAndHelpY = agentStatusY + agentStatusHeight + ruleHeight;
+            this._modeAndHelp.Props = modeAndHelpProps with
+            {
+                X = 1,
+                Y = modeAndHelpY,
+                Width = state.ConsoleWidth,
+                Height = modeAndHelpHeight,
+            };
             this._modeAndHelp.Render();
         }
 
@@ -546,7 +550,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             int textWidth = state.ConsoleWidth - promptLength;
             int textLength = state.InputText.Length;
 
-            int textInputY = this._rule.Y + 1;
+            int textInputY = (this._rule.Props?.Y ?? 0) + 1;
 
             if (textWidth <= 0 || textLength == 0)
             {
@@ -564,7 +568,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             && state.ListSelectionIndex == state.ListSelectionOptions.Count)
         {
             int titleLines = state.ListSelectionTitle?.Split('\n').Length ?? 0;
-            int customOptionY = this._rule.Y + 1 + titleLines + state.ListSelectionOptions.Count;
+            int customOptionY = (this._rule.Props?.Y ?? 0) + 1 + titleLines + state.ListSelectionOptions.Count;
             int cursorCol = 2 + state.ListSelectionCustomInputText.Length + 1;
             System.Console.Write(AnsiEscapes.MoveCursor(customOptionY, cursorCol));
         }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
@@ -441,10 +441,10 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
         // as they clutter the UI and aren't relevant.
         bool showStatusAndHelp = state.Mode != BottomPanelMode.ListSelection;
         int agentStatusHeight = showStatusAndHelp ? AgentStatus.CalculateHeight(agentStatusProps) : 0;
-        int modeAndHelpHeight = showStatusAndHelp ? AgentModeAndHelp.CalculateHeight(modeAndHelpProps) + 1 : 0; // +1 for bottom padding
+        int modeAndHelpHeight = showStatusAndHelp ? AgentModeAndHelp.CalculateHeight(modeAndHelpProps) : 0;
 
         int ruleHeight = TopBottomRule.CalculateHeight(ruleProps);
-        int nonScrollHeight = ruleHeight + textPanelHeight + agentStatusHeight + queuedPanelHeight + modeAndHelpHeight;
+        int nonScrollHeight = ruleHeight + textPanelHeight + agentStatusHeight + queuedPanelHeight + modeAndHelpHeight + 1; // +1 for bottom padding
         int scrollBottom = Math.Max(1, state.ConsoleHeight - nonScrollHeight);
 
         // If scroll region changed or a clear is needed, reset everything
@@ -457,6 +457,16 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             System.Console.Write(AnsiEscapes.EraseScrollbackBuffer);
             this._textScrollPanel.Reset();
             this._resizedSinceLastRender = false;
+
+            // Invalidate all children so they re-render even if props haven't changed
+            this._rule.Invalidate();
+            this._textScrollPanel.Invalidate();
+            this._textPanel.Invalidate();
+            this._queuedPanel.Invalidate();
+            this._agentStatus.Invalidate();
+            this._modeAndHelp.Invalidate();
+            this._textInput.Invalidate();
+            this._listSelection.Invalidate();
         }
 
         this._scrollRegionBottom = scrollBottom;
@@ -536,6 +546,9 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             };
             this._modeAndHelp.Render();
         }
+
+        // Clear the bottom padding line
+        System.Console.Write(AnsiEscapes.MoveAndEraseLine(state.ConsoleHeight));
 
         // Position cursor for natural typing appearance
         this.PositionCursor(state);


### PR DESCRIPTION
### Motivation and Context

We are using object comparison to decide whether to re-render, but this means unnecessary re-renders, so switching to value based comparison.

### Description

- Added positional properties to properties base class
- Only re-render if props or status values actually changed, rather than object comparison

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.