### PR TITLE
Python: fix A2A status message ids

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -566,6 +566,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                         contents=contents,
                         role="assistant" if status.message.role == A2ARole.ROLE_AGENT else "user",
                         response_id=task.id,
+                        message_id=status.message.message_id,
                         additional_properties={"a2a_metadata": task_metadata} if task_metadata else None,
                         raw_representation=task,
                     )
@@ -614,6 +615,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                 contents=contents,
                 role="assistant" if message.role == A2ARole.ROLE_AGENT else "user",
                 response_id=update_event.task_id,
+                message_id=message.message_id,
                 additional_properties={"a2a_metadata": merged_metadata} if merged_metadata else None,
                 raw_representation=update_event,
             )

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -1222,9 +1222,14 @@ async def test_streaming_working_update_without_message_is_skipped(
 
 async def test_streaming_working_update_user_role_mapping(a2a_agent: A2AAgent, mock_a2a_client: MockA2AClient) -> None:
     """Test that A2ARole.ROLE_USER in status message maps to role='user'."""
-    mock_a2a_client.add_in_progress_task_response(
-        "task-u", context_id="ctx-u", text="User echo", role=A2ARole.ROLE_USER
+    message = A2AMessage(
+        message_id="msg-user-echo",
+        role=A2ARole.ROLE_USER,
+        parts=[Part(text="User echo")],
     )
+    status = TaskStatus(state=TaskState.TASK_STATE_WORKING, message=message)
+    task = Task(id="task-u", context_id="ctx-u", status=status)
+    mock_a2a_client.responses.append(StreamResponse(task=task))
     mock_a2a_client.add_task_response("task-u", [{"id": "art-u", "content": "Done"}])
 
     updates: list[AgentResponseUpdate] = []
@@ -1234,6 +1239,7 @@ async def test_streaming_working_update_user_role_mapping(a2a_agent: A2AAgent, m
     assert len(updates) == 2
     assert updates[0].contents[0].text == "User echo"
     assert updates[0].role == "user"
+    assert updates[0].message_id == "msg-user-echo"
 
 
 async def test_background_with_status_message_yields_continuation_token(
@@ -1339,7 +1345,7 @@ async def test_streaming_status_update_event_yields_content(
         status=TaskStatus(
             state=TaskState.TASK_STATE_WORKING,
             message=A2AMessage(
-                message_id=str(uuid4()),
+                message_id="msg-status",
                 role=A2ARole.ROLE_AGENT,
                 parts=[Part(text="Still working")],
             ),
@@ -1354,6 +1360,7 @@ async def test_streaming_status_update_event_yields_content(
     assert len(updates) == 1
     assert updates[0].text == "Still working"
     assert updates[0].role == "assistant"
+    assert updates[0].message_id == "msg-status"
     assert updates[0].raw_representation == update_event
 
 


### PR DESCRIPTION
﻿## Summary
- preserve the A2A status message ID when a streaming `TaskStatusUpdateEvent` is converted to `AgentResponseUpdate`
- preserve the same ID for in-progress task status messages surfaced from `Task` payloads
- add regression coverage for both status-event and in-progress-task streaming paths

Fixes #5949.

## Validation
- `uv run pytest tests\test_a2a_agent.py -q -k "streaming_working_update_user_role_mapping or streaming_status_update_event_yields_content"`
- `uv run ruff check agent_framework_a2a\_agent.py tests\test_a2a_agent.py`
- `uv run ruff format --check agent_framework_a2a\_agent.py tests\test_a2a_agent.py`
- `python -m py_compile python\packages\a2a\agent_framework_a2a\_agent.py python\packages\a2a\tests\test_a2a_agent.py`
- `git diff --check upstream/main..HEAD`
