### PR TITLE
ci(python-setup): drop -U upgrade flag from uv sync

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -40,4 +40,4 @@ runs:
       - name: Install the project
         shell: bash
         run: |
-          cd python && uv sync --all-packages --all-extras --dev -U --prerelease=if-necessary-or-explicit
+          cd python && uv sync --all-packages --all-extras --dev --prerelease=if-necessary-or-explicit


### PR DESCRIPTION
### Motivation and Context

Every Python CI job currently fails in the shared `python-setup` composite action with:

```
× No solution found when resolving dependencies for split
  (markers: python_full_version >= '3.11' and sys_platform == 'darwin')
  Because there are no versions of durabletask and
  agent-framework-durabletask depends on durabletask>=1.3.0,<2,
  we can conclude that agent-framework-durabletask's requirements
  are unsatisfiable.
```

The failing step is `uv sync --all-packages --all-extras --dev -U --prerelease=if-necessary-or-explicit`. The `-U` flag upgrades every dependency to the latest compatible version on every run, ignoring the workspace `uv.lock`. With the current PyPI state for `durabletask`, that upgrade fails resolution and blocks every PR.

### Description

Drops the `-U` flag from `.github/actions/python-setup/action.yml`. The composite action now runs:

```
uv sync --all-packages --all-extras --dev --prerelease=if-necessary-or-explicit
```

This uses the pinned versions from `uv.lock`, which is what local development uses and what releases are built against. Upgrades should be opt-in (via a scheduled job or a dedicated workflow) rather than implicit on every CI run.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
