### PR TITLE
Python: preserve A2A status message ids

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -537,6 +537,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                         contents=contents,
                         role="assistant" if status.message.role == A2ARole.ROLE_AGENT else "user",
                         response_id=task.id,
+                        message_id=status.message.message_id,
                         additional_properties={"a2a_metadata": task_metadata} if task_metadata else None,
                         raw_representation=task,
                     )
@@ -585,6 +586,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                 contents=contents,
                 role="assistant" if message.role == A2ARole.ROLE_AGENT else "user",
                 response_id=update_event.task_id,
+                message_id=message.message_id,
                 additional_properties={"a2a_metadata": merged_metadata} if merged_metadata else None,
                 raw_representation=update_event,
             )

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -1177,7 +1177,13 @@ async def test_terminal_no_artifacts_after_working_with_content(
     a2a_agent: A2AAgent, mock_a2a_client: MockA2AClient
 ) -> None:
     """Test that a terminal task with no artifacts after working-state messages does not re-emit the working content."""
-    mock_a2a_client.add_in_progress_task_response("task-t", context_id="ctx-t", text="Working on it...")
+    working_message = A2AMessage(
+        message_id="msg-working-task",
+        role=A2ARole.ROLE_AGENT,
+        parts=[Part(text="Working on it...")],
+    )
+    working_status = TaskStatus(state=TaskState.TASK_STATE_WORKING, message=working_message)
+    mock_a2a_client.responses.append(StreamResponse(task=Task(id="task-t", context_id="ctx-t", status=working_status)))
     # Terminal task with no artifacts and no history
     status = TaskStatus(state=TaskState.TASK_STATE_COMPLETED, message=None)
     task = Task(id="task-t", context_id="ctx-t", status=status)
@@ -1189,6 +1195,7 @@ async def test_terminal_no_artifacts_after_working_with_content(
 
     assert len(updates) == 2
     assert updates[0].contents[0].text == "Working on it..."
+    assert updates[0].message_id == "msg-working-task"
     # Terminal task with no artifacts yields an empty-contents update
     assert updates[1].contents == []
 
@@ -1247,7 +1254,7 @@ async def test_streaming_status_update_event_yields_content(
         status=TaskStatus(
             state=TaskState.TASK_STATE_WORKING,
             message=A2AMessage(
-                message_id=str(uuid4()),
+                message_id="msg-status-update",
                 role=A2ARole.ROLE_AGENT,
                 parts=[Part(text="Still working")],
             ),
@@ -1262,6 +1269,7 @@ async def test_streaming_status_update_event_yields_content(
     assert len(updates) == 1
     assert updates[0].text == "Still working"
     assert updates[0].role == "assistant"
+    assert updates[0].message_id == "msg-status-update"
     assert updates[0].raw_representation == update_event
 
 


### PR DESCRIPTION
## Summary

- Preserve A2A status message IDs when converting status messages into `AgentResponseUpdate`.
- Cover both in-progress task snapshots and `TaskStatusUpdateEvent` streaming updates.

Fixes #5949.

## Validation

- `python -m pytest packages\a2a\tests\test_a2a_agent.py::test_terminal_no_artifacts_after_working_with_content packages\a2a\tests\test_a2a_agent.py::test_streaming_status_update_event_yields_content -q -p no:cacheprovider`
- `python -m pytest packages\a2a\tests\test_a2a_agent.py -q -p no:cacheprovider`
- `python -m ruff check python\packages\a2a\agent_framework_a2a\_agent.py python\packages\a2a\tests\test_a2a_agent.py`
- `python -m py_compile python\packages\a2a\agent_framework_a2a\_agent.py python\packages\a2a\tests\test_a2a_agent.py`
- `python -m mypy --config-file pyproject.toml agent_framework_a2a`
- `python -m pyright --pythonpath .\.venv\Scripts\python.exe packages\a2a\agent_framework_a2a`
