### PR TITLE
Python: fix sequential workflow sample output handling

### DIFF
--- a/python/samples/03-workflows/orchestrations/sequential_agents.py
+++ b/python/samples/03-workflows/orchestrations/sequential_agents.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from typing import cast
 
-from agent_framework import Agent, Message
+from agent_framework import Agent, AgentResponse, Message
 from agent_framework.foundry import FoundryChatClient
 from agent_framework.orchestrations import SequentialBuilder
 from azure.identity import AzureCliCredential
@@ -17,9 +17,9 @@ load_dotenv()
 Sample: Sequential workflow (agent-focused API) with shared conversation context
 
 Build a high-level sequential workflow using SequentialBuilder and two domain agents.
-The shared conversation (list[Message]) flows through each participant. Each agent
-appends its assistant message to the context. The workflow outputs the final conversation
-list when complete.
+The shared conversation flows through each participant. Each agent appends its
+assistant message to the context. The sample prints the original user message plus
+the visible outputs from both agents.
 
 Note on internal adapters:
 - Sequential orchestration includes small adapter nodes for input normalization
@@ -56,17 +56,19 @@ async def main() -> None:
     )
 
     # 2) Build sequential workflow: writer -> reviewer
-    workflow = SequentialBuilder(participants=[writer, reviewer]).build()
+    workflow = SequentialBuilder(participants=[writer, reviewer], output_from="all").build()
 
     # 3) Run and collect outputs
-    outputs: list[list[Message]] = []
-    async for event in workflow.run("Write a tagline for a budget-friendly eBike.", stream=True):
-        if event.type == "output":
-            outputs.append(cast(list[Message], event.data))
+    prompt = "Write a tagline for a budget-friendly eBike."
+    result = await workflow.run(prompt)
+    conversation = [Message(role="user", contents=[prompt])]
+    for output in result.get_outputs():
+        response = cast(AgentResponse, output)
+        conversation.extend(response.messages)
 
-    if outputs:
+    if conversation:
         print("===== Final Conversation =====")
-        for i, msg in enumerate(outputs[-1], start=1):
+        for i, msg in enumerate(conversation, start=1):
             name = msg.author_name or ("assistant" if msg.role == "assistant" else "user")
             print(f"{'-' * 60}\n{i:02d} [{name}]\n{msg.text}")
 


### PR DESCRIPTION
## Summary
- update the sequential workflow sample to avoid treating streaming output chunks as a final conversation list
- use output_from=all so both participant responses are visible
- print the initial user prompt plus each agent response message from the non-streaming run result

Fixes #5975

## To verify
- uv run python -m py_compile samples/03-workflows/orchestrations/sequential_agents.py
- uv run ruff check samples/03-workflows/orchestrations/sequential_agents.py
- uv run pyright samples/03-workflows/orchestrations/sequential_agents.py
- uv run pytest packages/orchestrations/tests/test_sequential.py packages/orchestrations/tests/test_orchestration_intermediate_vs_terminal.py -q -p no:cacheprovider