### PR TITLE
.NET: Add additional openai specific error observers and move them to openai project

### DIFF
--- a/dotnet/agent-framework-dotnet.slnx
+++ b/dotnet/agent-framework-dotnet.slnx
@@ -121,6 +121,7 @@
   <Folder Name="/Samples/02-agents/Harness/">
     <File Path="samples/02-agents/Harness/README.md" />
     <Project Path="samples/02-agents/Harness/Harness_Shared_Console/Harness_Shared_Console.csproj" />
+    <Project Path="samples/02-agents/Harness/Harness_Shared_Console_OpenAI/Harness_Shared_Console_OpenAI.csproj" />
     <Project Path="samples/02-agents/Harness/Harness_Step01_Research/Harness_Step01_Research.csproj" />
     <Project Path="samples/02-agents/Harness/Harness_Step02_Research_WithBackgroundAgents/Harness_Step02_Research_WithBackgroundAgents.csproj" />
     <Project Path="samples/02-agents/Harness/Harness_Step03_DataProcessing/Harness_Step03_DataProcessing.csproj" />

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
@@ -192,6 +192,11 @@ public sealed class HarnessAgentRunner : IDisposable
                         }
                     }
 
+                    foreach (var observer in this._observers)
+                    {
+                        await observer.OnResponseUpdateAsync(this._ux, update, this._agent, this._session).ConfigureAwait(false);
+                    }
+
                     if (!string.IsNullOrEmpty(update.Text))
                     {
                         foreach (var observer in this._observers)

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
@@ -25,6 +25,17 @@ public abstract class ConsoleObserver
     }
 
     /// <summary>
+    /// Called for each <see cref="AgentResponseUpdate"/> in the response stream, regardless of
+    /// whether it contains content. Override to inspect update-level metadata such as
+    /// <see cref="AgentResponseUpdate.RawRepresentation"/> for provider-specific events.
+    /// </summary>
+    /// <param name="ux">The UX state driver, used for rendering output.</param>
+    /// <param name="update">The streaming response update.</param>
+    /// <param name="agent">The agent being interacted with.</param>
+    /// <param name="session">The current agent session.</param>
+    public virtual Task OnResponseUpdateAsync(IUXStateDriver ux, AgentResponseUpdate update, AIAgent agent, AgentSession session) => Task.CompletedTask;
+
+    /// <summary>
     /// Called for each <see cref="AIContent"/> item in the response stream.
     /// </summary>
     /// <param name="ux">The UX state driver, used for rendering output.</param>

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/Harness_Shared_Console_OpenAI.csproj
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/Harness_Shared_Console_OpenAI.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Harness_Shared_Console\Harness_Shared_Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable OPENAI001 // Suppress experimental API warnings for Responses API usage.
+
+using Harness.Shared.Console.Observers;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using OpenAI.Responses;
+
+namespace Harness.Shared.Console.OpenAI;
+
+/// <summary>
+/// Detects and displays error/incomplete status from OpenAI Responses API streaming updates.
+/// Handles <see cref="StreamingResponseFailedUpdate"/> and <see cref="StreamingResponseIncompleteUpdate"/>
+/// which are not surfaced as <see cref="ErrorContent"/> by the chat client.
+/// </summary>
+/// <remarks>
+/// Note: <see cref="StreamingResponseErrorUpdate"/> is already handled by the SDK — it produces
+/// an <see cref="ErrorContent"/> which is displayed by <see cref="ErrorDisplayObserver"/>.
+/// This observer covers the cases where the SDK does not produce <see cref="ErrorContent"/>.
+/// </remarks>
+public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
+{
+    /// <inheritdoc/>
+    public override async Task OnResponseUpdateAsync(IUXStateDriver ux, AgentResponseUpdate update, AIAgent agent, AgentSession session)
+    {
+        // AgentResponseUpdate.RawRepresentation is the ChatResponseUpdate,
+        // whose RawRepresentation is the underlying StreamingResponseUpdate.
+        object? rawUpdate = (update.RawRepresentation as ChatResponseUpdate)?.RawRepresentation
+            ?? update.RawRepresentation;
+
+        switch (rawUpdate)
+        {
+            case StreamingResponseFailedUpdate failedUpdate:
+                // Only display if the response has error details populated.
+                // When error is null, a follow-up StreamingResponseErrorUpdate typically
+                // carries the real error and is handled below.
+                if (failedUpdate.Response?.Error is { } error)
+                {
+                    string errorMessage = error.Message ?? "Unknown error";
+                    string? errorCode = error.Code.ToString();
+                    string errorText = $"❌ Response failed: {errorMessage}";
+                    if (!string.IsNullOrEmpty(errorCode))
+                    {
+                        errorText += $" (code: {errorCode})";
+                    }
+
+                    await ux.WriteInfoLineAsync(errorText, ConsoleColor.Red);
+                }
+
+                break;
+
+            case StreamingResponseIncompleteUpdate incompleteUpdate:
+                string? reason = incompleteUpdate.Response?.IncompleteStatusDetails?.Reason?.ToString();
+                string incompleteText = $"⚠️ Response incomplete: {reason ?? "unknown reason"}";
+                await ux.WriteInfoLineAsync(incompleteText, ConsoleColor.Yellow);
+                break;
+        }
+    }
+}

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
@@ -34,7 +34,8 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
             case StreamingResponseFailedUpdate failedUpdate:
                 // Only display if the response has error details populated.
                 // When error is null, a follow-up StreamingResponseErrorUpdate typically
-                // carries the real error and is handled below.
+                // carries the real error — the SDK surfaces that as ErrorContent,
+                // which is displayed by ErrorDisplayObserver.
                 if (failedUpdate.Response?.Error is { } error)
                 {
                     string errorMessage = error.Message ?? "Unknown error";

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesWebSearchDisplayObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesWebSearchDisplayObserver.cs
@@ -3,19 +3,18 @@
 #pragma warning disable OPENAI001 // Suppress experimental API warnings for Responses API usage.
 
 using System.Text;
-using Harness.Shared.Console;
 using Harness.Shared.Console.Observers;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using OpenAI.Responses;
 
-namespace SampleApp;
+namespace Harness.Shared.Console.OpenAI;
 
 /// <summary>
 /// Displays web search activity in the scroll area. Shows search queries,
 /// page opens, and find-in-page actions as they stream in from the API.
 /// </summary>
-internal sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
+public sealed class OpenAIResponsesWebSearchDisplayObserver : ConsoleObserver
 {
     private const int MaxQueryDisplayLength = 120;
 

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Harness_Step01_Research.csproj
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Harness_Step01_Research.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.Harness\Microsoft.Agents.AI.Harness.csproj" />
     <ProjectReference Include="..\Harness_Shared_Console\Harness_Shared_Console.csproj" />
+    <ProjectReference Include="..\Harness_Shared_Console_OpenAI\Harness_Shared_Console_OpenAI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -22,6 +22,7 @@ using Harness.Shared.Console;
 using Harness.Shared.Console.ToolFormatters;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using Harness.Shared.Console.OpenAI;
 using SampleApp;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("AZURE_AI_PROJECT_ENDPOINT is not set.");
@@ -107,6 +108,7 @@ await HarnessConsole.RunAgentAsync(
     {
         Observers = [
             new OpenAIResponsesWebSearchDisplayObserver(),
+            new OpenAIResponsesErrorObserver(),
             .. HarnessConsoleOptions.BuildObserversWithPlanning(
                 agent,
                 planModeName: "plan",

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -19,10 +19,10 @@ using System.ClientModel.Primitives;
 using Azure.AI.Projects;
 using Azure.Identity;
 using Harness.Shared.Console;
+using Harness.Shared.Console.OpenAI;
 using Harness.Shared.Console.ToolFormatters;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
-using Harness.Shared.Console.OpenAI;
 using SampleApp;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("AZURE_AI_PROJECT_ENDPOINT is not set.");

--- a/dotnet/samples/02-agents/Harness/Harness_Step02_Research_WithBackgroundAgents/Harness_Step02_Research_WithBackgroundAgents.csproj
+++ b/dotnet/samples/02-agents/Harness/Harness_Step02_Research_WithBackgroundAgents/Harness_Step02_Research_WithBackgroundAgents.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
     <ProjectReference Include="..\..\..\..\src\Microsoft.Agents.AI.Harness\Microsoft.Agents.AI.Harness.csproj" />
     <ProjectReference Include="..\Harness_Shared_Console\Harness_Shared_Console.csproj" />
+    <ProjectReference Include="..\Harness_Shared_Console_OpenAI\Harness_Shared_Console_OpenAI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/02-agents/Harness/Harness_Step02_Research_WithBackgroundAgents/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step02_Research_WithBackgroundAgents/Program.cs
@@ -16,6 +16,7 @@ using System.ClientModel.Primitives;
 using Azure.AI.Projects;
 using Azure.Identity;
 using Harness.Shared.Console;
+using Harness.Shared.Console.OpenAI;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
@@ -113,4 +114,8 @@ AIAgent parentAgent =
 // Run the interactive console session.
 await HarnessConsole.RunAgentAsync(
     parentAgent,
-    userPrompt: "Enter a list of stock tickers (e.g., BAC, MSFT, BA):");
+    userPrompt: "Enter a list of stock tickers (e.g., BAC, MSFT, BA):",
+    options: new HarnessConsoleOptions
+    {
+        Observers = [new OpenAIResponsesErrorObserver(), .. HarnessConsoleOptions.BuildDefaultObservers()],
+    });


### PR DESCRIPTION
### Motivation and Context

We were missing some errors in the console output, e.g. when content blocking happens.

### Description

- Adding more openai responses specific observers.
- Move them into their own openai specific project

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.