### PR TITLE
.NET: coalesce AG-UI text chunks by response

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -448,6 +448,8 @@ internal static class ChatResponseUpdateAGUIExtensions
         };
 
         string? currentMessageId = null;
+        string? currentMessageResponseId = null;
+        ChatRole? currentMessageRole = null;
         string? streamingMessageId = null;
         string? currentReasoningBaseId = null;
         string? currentReasoningId = null;
@@ -461,6 +463,13 @@ internal static class ChatResponseUpdateAGUIExtensions
                 chatResponse.MessageId = ContainsToolResult(chatResponse)
                     ? Guid.NewGuid().ToString("N")
                     : (streamingMessageId ??= Guid.NewGuid().ToString("N"));
+            }
+
+            if (IsTextUpdate(chatResponse) &&
+                currentMessageId is not null &&
+                ShouldContinueCurrentTextMessage(chatResponse, currentMessageResponseId, currentMessageRole))
+            {
+                chatResponse.MessageId = currentMessageId;
             }
 
             if (chatResponse is { Contents.Count: > 0 } &&
@@ -503,6 +512,8 @@ internal static class ChatResponseUpdateAGUIExtensions
                 };
 
                 currentMessageId = chatResponse.MessageId;
+                currentMessageResponseId = chatResponse.ResponseId;
+                currentMessageRole = chatResponse.Role;
             }
 
             // Emit text content if present
@@ -739,4 +750,17 @@ internal static class ChatResponseUpdateAGUIExtensions
 
         return false;
     }
+
+    private static bool IsTextUpdate(ChatResponseUpdate chatResponse) =>
+        chatResponse.Contents.Count > 0 &&
+        chatResponse.Contents[0] is TextContent;
+
+    private static bool ShouldContinueCurrentTextMessage(
+        ChatResponseUpdate chatResponse,
+        string? currentMessageResponseId,
+        ChatRole? currentMessageRole) =>
+        !string.IsNullOrWhiteSpace(chatResponse.ResponseId) &&
+        string.Equals(currentMessageResponseId, chatResponse.ResponseId, StringComparison.Ordinal) &&
+        chatResponse.Role == currentMessageRole &&
+        chatResponse.FinishReason is null;
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
@@ -101,6 +101,34 @@ public sealed class BasicStreamingTests : IAsyncDisposable
     }
 
     [Fact]
+    public async Task ClientCoalescesTextChunksWithSameResponseIdAsync()
+    {
+        // Arrange
+        await this.SetupTestServerAsync(useProviderChunkIdsAgent: true);
+        var chatClient = new AGUIChatClient(this._client!, "", null);
+        AIAgent agent = chatClient.AsAIAgent(instructions: null, name: "assistant", description: "Sample assistant", tools: []);
+        ChatClientAgentSession? session = (ChatClientAgentSession)await agent.CreateSessionAsync();
+        ChatMessage userMessage = new(ChatRole.User, "hello");
+
+        List<AgentResponseUpdate> updates = [];
+
+        // Act
+        await foreach (AgentResponseUpdate update in agent.RunStreamingAsync([userMessage], session, new AgentRunOptions(), CancellationToken.None))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        List<AgentResponseUpdate> textUpdates = updates.Where(u => !string.IsNullOrEmpty(u.Text)).ToList();
+        textUpdates.Should().NotBeEmpty();
+        textUpdates.Select(u => u.MessageId).Distinct().Should().HaveCount(1);
+
+        AgentResponse response = updates.ToAgentResponse();
+        response.Messages.Should().HaveCount(1);
+        response.Messages[0].Text.Should().Be("Hello from provider chunks!");
+    }
+
+    [Fact]
     public async Task RunAsyncAggregatesStreamingUpdatesAsync()
     {
         // Arrange
@@ -231,14 +259,18 @@ public sealed class BasicStreamingTests : IAsyncDisposable
         response.Messages[0].Text.Should().Be("Hello from fake agent!");
     }
 
-    private async Task SetupTestServerAsync(bool useMultiMessageAgent = false)
+    private async Task SetupTestServerAsync(bool useMultiMessageAgent = false, bool useProviderChunkIdsAgent = false)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
 
         builder.Services.AddAGUI();
 
-        if (useMultiMessageAgent)
+        if (useProviderChunkIdsAgent)
+        {
+            builder.Services.AddSingleton(new FakeChatClientAgent(useProviderChunkIds: true));
+        }
+        else if (useMultiMessageAgent)
         {
             builder.Services.AddSingleton<FakeMultiMessageAgent>();
         }
@@ -277,6 +309,13 @@ public sealed class BasicStreamingTests : IAsyncDisposable
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated via dependency injection")]
 internal sealed class FakeChatClientAgent : AIAgent
 {
+    private readonly bool _useProviderChunkIds;
+
+    public FakeChatClientAgent(bool useProviderChunkIds = false)
+    {
+        this._useProviderChunkIds = useProviderChunkIds;
+    }
+
     protected override string? IdCore => "fake-agent";
 
     public override string? Description => "A fake agent for testing";
@@ -312,13 +351,19 @@ internal sealed class FakeChatClientAgent : AIAgent
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         string messageId = Guid.NewGuid().ToString("N");
+        const string ResponseId = "response-with-provider-chunk-ids";
+        var chunkIndex = 0;
+        string[] chunks = this._useProviderChunkIds
+            ? ["Hello ", "from ", "provider ", "chunks!"]
+            : ["Hello", " ", "from", " ", "fake", " ", "agent", "!"];
 
         // Simulate streaming a deterministic response
-        foreach (string chunk in new[] { "Hello", " ", "from", " ", "fake", " ", "agent", "!" })
+        foreach (string chunk in chunks)
         {
             yield return new AgentResponseUpdate
             {
-                MessageId = messageId,
+                ResponseId = this._useProviderChunkIds ? ResponseId : null,
+                MessageId = this._useProviderChunkIds ? $"chunk-{++chunkIndex}" : messageId,
                 Role = ChatRole.Assistant,
                 Contents = [new TextContent(chunk)]
             };


### PR DESCRIPTION
## Summary

Fixes #6010.

The AG-UI event converter currently treats every changed `ChatResponseUpdate.MessageId` as a new text message. Some OpenAI/Azure OpenAI streaming paths can produce provider chunk IDs while keeping the same response ID, which makes the AG-UI stream emit repeated `TEXT_MESSAGE_START` / `TEXT_MESSAGE_CONTENT` / `TEXT_MESSAGE_END` groups for one assistant answer.

This keeps consecutive text chunks with the same non-empty `ResponseId` and role in the current AG-UI text message instead of starting a new one for each provider chunk ID. Existing multi-message behavior is preserved when there is no shared response ID.

## Validation

```text
dotnet test --project dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests.csproj -f net10.0 --no-restore -- --filter-method '*ClientCoalescesTextChunksWithSameResponseIdAsync'
dotnet test --project dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests.csproj -f net10.0 --no-restore
dotnet build dotnet/src/Microsoft.Agents.AI.AGUI/Microsoft.Agents.AI.AGUI.csproj -f net10.0 --no-restore
dotnet build dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests.csproj -f net10.0 --no-restore
git diff --check
```

I also tried the default multi-target test command first, but this local Windows machine only has the .NET 10 ASP.NET runtime installed, so net8/net9 execution could not start locally.