### PR TITLE
Python: fix(openai): convert Pydantic models to schema dicts for Responses API (fixes #6023)

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -64,6 +64,7 @@ from agent_framework.exceptions import (
 )
 from agent_framework.observability import ChatTelemetryLayer
 from openai import AsyncAzureOpenAI, AsyncOpenAI, BadRequestError
+from openai.lib._parsing._completions import type_to_response_format_param
 from openai.types.responses import FunctionShellTool
 from openai.types.responses.file_search_tool_param import FileSearchToolParam
 from openai.types.responses.function_tool_param import FunctionToolParam
@@ -771,7 +772,18 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         if isinstance(response_format, type) and issubclass(response_format, BaseModel):
             if text_config and "format" in text_config:
                 raise ChatClientInvalidRequestException("response_format cannot be combined with explicit text.format.")
-            return response_format, text_config
+
+            # Convert Pydantic model to JSON schema and then to Responses format.
+            # Using the SDK's internal converter is safer as it handles complex types and strict mode.
+            res = type_to_response_format_param(response_format)
+            format_config = {
+                "type": "json_schema",
+                "name": res["json_schema"]["name"],
+                "schema": res["json_schema"]["schema"],
+                "strict": res["json_schema"].get("strict", True),
+            }
+
+            return format_config, text_config
 
         if isinstance(response_format, Mapping):
             format_config = self._convert_response_format(cast("Mapping[str, Any]", response_format))

--- a/python/packages/openai/tests/openai/test_issue_6023_regression.py
+++ b/python/packages/openai/tests/openai/test_issue_6023_regression.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from pydantic import BaseModel
+from agent_framework_openai import OpenAIChatClient
+from agent_framework._types import Message
+
+class OutputStruct(BaseModel):
+    city: str
+
+@pytest.mark.asyncio
+async def test_response_format_pydantic_model_converted_to_dict():
+    """Test that Pydantic model response_format is converted to a dict for the Responses API."""
+    mock_async_client = MagicMock()
+    mock_async_client.responses = MagicMock()
+    mock_stream_ctx = AsyncMock()
+    mock_async_client.responses.stream.return_value = mock_stream_ctx
+    
+    client = OpenAIChatClient(
+        model="gpt-4o",
+        api_key="fake-key",
+        async_client=mock_async_client
+    )
+    
+    messages = [Message(role="user", contents=["Test"])]
+    
+    # Trigger streaming path
+    stream = client._inner_get_response(
+        messages=messages,
+        options={"response_format": OutputStruct},
+        stream=True
+    )
+    
+    async for _ in stream:
+        break
+        
+    # Verify text_format was passed as a dict
+    _, kwargs = mock_async_client.responses.stream.call_args
+    text_format = kwargs.get("text_format")
+    
+    assert isinstance(text_format, dict)
+    assert text_format["type"] == "json_schema"
+    assert text_format["name"] == "OutputStruct"
+    assert "schema" in text_format
+    assert text_format["strict"] is True


### PR DESCRIPTION
Closes #6023

## Summary
Fixed a P1 bug where OpenAIChatClient (Responses API) crashed with BadRequestError when using structured outputs.

## Changes
- Converted Pydantic model response_format into a flat schema dict using type_to_response_format_param from the openai SDK.