### PR TITLE
Python: read response headers defensively to support stream wrappers without `.headers` (#6028)

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -636,7 +636,11 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                             continuation_token["response_id"],
                             stream=True,
                         )
-                        served_model = self._extract_served_model(raw_stream_response.headers)
+                        # Read headers defensively: telemetry instrumentors (e.g. azure-ai-projects
+                        # experimental tracing) wrap the streaming response in objects that do not
+                        # proxy ``.headers``. Degrade gracefully so the served-model surfacing is
+                        # best-effort instead of crashing the whole call.
+                        served_model = self._extract_served_model(getattr(raw_stream_response, "headers", None))
                         async with raw_stream_response.parse() as stream_response:
                             async for chunk in stream_response:
                                 update = self._parse_chunk_from_openai(
@@ -677,7 +681,8 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                             raw_create_response = await client.responses.with_raw_response.create(
                                 stream=True, **run_options
                             )
-                            served_model = self._extract_served_model(raw_create_response.headers)
+                            # See note above on ``raw_stream_response.headers``.
+                            served_model = self._extract_served_model(getattr(raw_create_response, "headers", None))
                             async with raw_create_response.parse() as stream_response:
                                 async for chunk in stream_response:
                                     update = self._parse_chunk_from_openai(
@@ -706,7 +711,8 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                 except Exception as ex:
                     self._handle_request_error(ex)
                 chat_response = self._parse_response_from_openai(response, options=validated_options)
-                served_model = self._extract_served_model(raw_response.headers)
+                # See note above on ``raw_stream_response.headers``.
+                served_model = self._extract_served_model(getattr(raw_response, "headers", None))
                 if served_model is not None:
                     chat_response.model = served_model
                 # Once the background response completes, drop the continuation_token from
@@ -728,7 +734,8 @@ class RawOpenAIChatClient(  # type: ignore[misc]
             except Exception as ex:
                 self._handle_request_error(ex)
             chat_response = self._parse_response_from_openai(response, options=validated_options)
-            served_model = self._extract_served_model(raw_response.headers)
+            # See note above on ``raw_stream_response.headers``.
+            served_model = self._extract_served_model(getattr(raw_response, "headers", None))
             if served_model is not None:
                 chat_response.model = served_model
             return chat_response

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -841,6 +841,88 @@ async def test_served_model_header_not_captured_for_streaming_text_format() -> N
         assert update.model == "test-model"
 
 
+async def test_streaming_response_without_headers_attribute_does_not_crash() -> None:
+    """Regression for #6028.
+
+    Some telemetry instrumentors (e.g. ``azure-ai-projects`` experimental GenAI tracing,
+    activated by ``AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING=true``) monkey-patch
+    ``openai.resources.responses.AsyncResponses.create`` at the class level and return
+    an ``AsyncStreamWrapper`` whose class genuinely has no ``headers`` attribute. The
+    ``with_raw_response.create`` wrapper does not re-wrap the return value
+    (``async_to_raw_response_wrapper`` only injects an extra header into the request),
+    so ``raw_create_response`` in ``_inner_get_response`` ends up being the wrapper
+    itself. Reading ``raw_create_response.headers`` used to raise ``AttributeError``
+    and bubble up as ``ChatClientException``, breaking every streaming call. The
+    defensive ``getattr(..., "headers", None)`` should now degrade gracefully:
+    no served-model surfacing, but the stream still completes.
+    """
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    events = [
+        ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            content_index=0,
+            item_id="text_item",
+            output_index=0,
+            sequence_number=1,
+            logprobs=[],
+            delta="Hello",
+        ),
+    ]
+
+    class _StreamWrapperWithoutHeaders:
+        """Mimics ``azure.ai.projects.telemetry._responses_instrumentor.AsyncStreamWrapper``:
+        an async iterator that proxies the stream contents but does not expose ``.headers``.
+        ``hasattr(wrapper, "headers")`` returns ``False`` so ``getattr(..., "headers", None)``
+        falls through to the default — matching the real instrumentor's class layout.
+        """
+
+        def __init__(self, events: list[object]) -> None:
+            self._events = events
+            self._iterator = iter(())
+
+        def __aiter__(self) -> "_StreamWrapperWithoutHeaders":
+            self._iterator = iter(self._events)
+            return self
+
+        async def __anext__(self) -> object:
+            try:
+                return next(self._iterator)
+            except StopIteration as exc:
+                raise StopAsyncIteration from exc
+
+        def parse(self) -> "_StreamWrapperWithoutHeaders":
+            return self
+
+        async def __aenter__(self) -> "_StreamWrapperWithoutHeaders":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: object | None,
+        ) -> None:
+            return None
+
+    headerless_stream = _StreamWrapperWithoutHeaders(events)
+    # Sanity-check the simulation: the real instrumentor's wrapper genuinely lacks ``.headers``.
+    assert not hasattr(headerless_stream, "headers")
+
+    with (
+        patch.object(client, "_prepare_request", new=AsyncMock(return_value=(client.client, {}, {}))),
+        patch.object(client.client.responses, "create", new=AsyncMock(return_value=headerless_stream)),
+        patch.object(client, "_get_metadata_from_response", return_value={}),
+    ):
+        stream = client._inner_get_response(messages=[Message(role="user", contents=["Hi"])], options={}, stream=True)
+        updates = [update async for update in stream]
+
+    assert updates, "Expected the stream to complete even when the wrapper lacks .headers"
+    for update in updates:
+        # No header => no override => model stays the deployment alias.
+        assert update.model == "test-model"
+
+
 async def test_streaming_text_format_preserves_final_structured_output() -> None:
     """Streaming structured output should still parse into the final ChatResponse value."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")


### PR DESCRIPTION
## Summary

Fixes #6028.

Since #5910, `OpenAIChatClient._inner_get_response()` reads `.headers` on the raw response returned by `client.responses.with_raw_response.create/retrieve(...)` to surface the `x-ms-served-model` Azure header. When `azure-ai-projects` experimental GenAI tracing is enabled (`AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING=true`), the instrumentor wraps the raw streaming response in an `AsyncStreamWrapper` (defined inline at `azure/ai/projects/telemetry/_responses_instrumentor.py:2929`) that exposes `.response` / `.stream_async_iter` but **not** `.headers`. Reading `raw_create_response.headers` then raises:

```
AttributeError: 'AsyncStreamWrapper' object has no attribute 'headers'
```

`FoundryChatClient` rethrows this as a `ChatClientException` and **every streaming call breaks** (workflows + free chat) as soon as you upgrade to `agent-framework-openai>=1.6.0` with experimental Azure tracing on.

## Fix

Read headers defensively at all four call sites in `agent_framework_openai/_chat_client.py`:

```python
served_model = self._extract_served_model(getattr(raw_response, "headers", None))
```

`_extract_served_model()` (line 739) already short-circuits on `None`, so the served-model surfacing **degrades gracefully** — `update.model` falls back to the deployment alias instead of crashing the call. No behavior change when `.headers` is present.

The four call sites covered:
- `_chat_client.py:639` — `raw_stream_response` (retrieve-streaming, continuation token)
- `_chat_client.py:680` — `raw_create_response` (streaming create)
- `_chat_client.py:709` — `raw_response` (non-streaming retrieve)
- `_chat_client.py:731` — `raw_response` (non-streaming create)

## Test plan

- [x] New regression test `test_streaming_response_without_headers_attribute_does_not_crash` simulates a stream wrapper that raises `AttributeError` on `.headers`, mirroring the `azure-ai-projects` instrumentor behavior. Asserts the stream completes and `update.model` falls back to the deployment alias.
- [x] Manual repro in M365 Agents Playground against `gpt-5.1-dzs` and `gpt-5.5-dzs` Azure deployments confirms the crash disappears with this patch (validated independently of any local workarounds).
- [x] Existing tests `test_served_model_header_*` already cover the happy path (headers present) and are not touched by this change.

## Notes for reviewers

- The defensive `getattr` is preferred over a `try/except AttributeError` block to avoid swallowing unrelated attribute errors that might surface from response model changes.
- An alternative would be to make the instrumentor wrapper expose `.headers`, but that lives in `azure-ai-projects` (separate repo) and only this side can land quickly to unblock users on the 1.6.0 train.
- Documented as experimental by Microsoft: ["GenAI tracing instrumentation is an experimental preview feature"](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-projects/README.md#tracing) — so silently dropping the served-model surfacing in this niche is consistent with the broader contract.