### PR TITLE
.NET: accept stringified inline skill arguments

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -92,6 +92,23 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
             return [];
         }
 
+        if (arguments.Value.ValueKind == JsonValueKind.String)
+        {
+            var text = arguments.Value.GetString();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                try
+                {
+                    using var document = JsonDocument.Parse(text);
+                    arguments = document.RootElement.Clone();
+                }
+                catch (JsonException)
+                {
+                    arguments = arguments.Value;
+                }
+            }
+        }
+
         if (arguments.Value.ValueKind != JsonValueKind.Object)
         {
             throw new InvalidOperationException(

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
@@ -44,6 +44,22 @@ public sealed class AgentInlineSkillScriptTests
     }
 
     [Fact]
+    public async Task RunAsync_WithJsonObjectStringArguments_PassesArgumentsAsync()
+    {
+        // Arrange
+        var script = new AgentInlineSkillScript("add", (int a, int b) => a + b);
+        var skill = new AgentInlineSkill("calc-skill", "Calc.", "Instructions.");
+        using var argsDoc = JsonDocument.Parse("\"{\\\"a\\\":3,\\\"b\\\":7}\"");
+        var args = argsDoc.RootElement;
+
+        // Act
+        var result = await script.RunAsync(skill, args, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, int.Parse(result?.ToString()!));
+    }
+
+    [Fact]
     public void ParametersSchema_NoParameters_ReturnsSchema()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Allow inline skill scripts to accept a JSON object that arrives as a stringified function-call arguments payload.
- Keep the existing failure path for non-object arguments, including plain strings and arrays.
- Add regression coverage for stringified object arguments.

Fixes #6020.

## To verify
- dotnet run --project dotnet/tests/Microsoft.Agents.AI.UnitTests/Microsoft.Agents.AI.UnitTests.csproj --framework net10.0 -c Release --no-restore -- --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillScriptTests
- dotnet/tests/Microsoft.Agents.AI.UnitTests/bin/Release/net472/Microsoft.Agents.AI.UnitTests.exe --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillScriptTests
- git diff --check

Note: dotnet test still hits the existing Microsoft.Testing.Platform/VSTest runner error on .NET 10 SDK, so I used the project runner directly.