### PR TITLE
.NET: fix: accept function approval response input

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIHostingJsonUtilities.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIHostingJsonUtilities.cs
@@ -120,6 +120,7 @@ internal static class OpenAIHostingJsonUtilities
 [JsonSerializable(typeof(ResponsesDeveloperMessageItemParam))]
 [JsonSerializable(typeof(FunctionToolCallItemParam))]
 [JsonSerializable(typeof(FunctionToolCallOutputItemParam))]
+[JsonSerializable(typeof(FunctionApprovalResponseItemParam))]
 [JsonSerializable(typeof(FileSearchToolCallItemParam))]
 [JsonSerializable(typeof(ComputerToolCallItemParam))]
 [JsonSerializable(typeof(ComputerToolCallOutputItemParam))]

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
@@ -60,10 +60,7 @@ internal sealed class AIAgentResponseExecutor : IResponseExecutor
             messages.AddRange(conversationHistory);
         }
 
-        foreach (var inputMessage in request.Input.GetInputMessages())
-        {
-            messages.Add(inputMessage.ToChatMessage());
-        }
+        messages.AddRange(request.Input.GetChatMessages());
 
         // Use the extension method to convert streaming updates to streaming response events
         await foreach (var streamingEvent in this._agent.RunStreamingAsync(messages, options: options, cancellationToken: cancellationToken)

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemParamConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemParamConverter.cs
@@ -30,6 +30,7 @@ internal sealed class ItemParamConverter : JsonConverter<ItemParam>
             "message" => doc.Deserialize(OpenAIHostingJsonContext.Default.ResponsesMessageItemParam),
             "function_call" => doc.Deserialize(OpenAIHostingJsonContext.Default.FunctionToolCallItemParam),
             "function_call_output" => doc.Deserialize(OpenAIHostingJsonContext.Default.FunctionToolCallOutputItemParam),
+            "function_approval_response" => doc.Deserialize(OpenAIHostingJsonContext.Default.FunctionApprovalResponseItemParam),
             "file_search_call" => doc.Deserialize(OpenAIHostingJsonContext.Default.FileSearchToolCallItemParam),
             "computer_call" => doc.Deserialize(OpenAIHostingJsonContext.Default.ComputerToolCallItemParam),
             "computer_call_output" => doc.Deserialize(OpenAIHostingJsonContext.Default.ComputerToolCallOutputItemParam),

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
@@ -111,10 +111,7 @@ internal sealed class HostedAgentResponseExecutor : IResponseExecutor
             messages.AddRange(conversationHistory);
         }
 
-        foreach (var inputMessage in request.Input.GetInputMessages())
-        {
-            messages.Add(inputMessage.ToChatMessage());
-        }
+        messages.AddRange(request.Input.GetChatMessages());
 
         await foreach (var streamingEvent in agent.RunStreamingAsync(messages, options: options, cancellationToken: cancellationToken)
             .ToStreamingResponseAsync(request, context, cancellationToken).ConfigureAwait(false))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemParam.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemParam.cs
@@ -182,6 +182,38 @@ internal sealed class FunctionToolCallOutputItemParam : ItemParam
 }
 
 /// <summary>
+/// A function approval response item parameter.
+/// </summary>
+internal sealed class FunctionApprovalResponseItemParam : ItemParam
+{
+    /// <summary>
+    /// The constant item type identifier for function approval response items.
+    /// </summary>
+    public const string ItemType = "function_approval_response";
+
+    /// <inheritdoc/>
+    public override string Type => ItemType;
+
+    /// <summary>
+    /// The ID of the approval request being answered.
+    /// </summary>
+    [JsonPropertyName("approval_request_id")]
+    public required string ApprovalRequestId { get; init; }
+
+    /// <summary>
+    /// Whether the request was approved.
+    /// </summary>
+    [JsonPropertyName("approve")]
+    public bool Approve { get; init; }
+
+    /// <summary>
+    /// Optional reason for the decision.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}
+
+/// <summary>
 /// A file search tool call item parameter.
 /// </summary>
 internal sealed class FileSearchToolCallItemParam : ItemParam

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ResponseInput.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ResponseInput.cs
@@ -5,12 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Converters;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
 
 /// <summary>
-/// Represents the input to a response request, which can be either a simple string or a list of messages.
+/// Represents the input to a response request, which can be a simple string, messages, or typed input items.
 /// </summary>
 [JsonConverter(typeof(ResponseInputJsonConverter))]
 internal sealed class ResponseInput : IEquatable<ResponseInput>
@@ -19,12 +20,21 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
     {
         this.Text = text ?? throw new ArgumentNullException(nameof(text));
         this.Messages = null;
+        this.Items = null;
     }
 
     private ResponseInput(List<InputMessage> messages)
     {
         this.Messages = messages ?? throw new ArgumentNullException(nameof(messages));
         this.Text = null;
+        this.Items = null;
+    }
+
+    private ResponseInput(List<ItemParam> items)
+    {
+        this.Items = items ?? throw new ArgumentNullException(nameof(items));
+        this.Text = null;
+        this.Messages = null;
     }
 
     /// <summary>
@@ -41,6 +51,11 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
     /// Creates a ResponseInput from a list of messages.
     /// </summary>
     public static ResponseInput FromMessages(params InputMessage[] messages) => new(messages.ToList());
+
+    /// <summary>
+    /// Creates a ResponseInput from a list of input items.
+    /// </summary>
+    public static ResponseInput FromItems(List<ItemParam> items) => new(items);
 
     /// <summary>
     /// Implicit conversion from string to ResponseInput.
@@ -68,6 +83,11 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
     public bool IsMessages => this.Messages is not null;
 
     /// <summary>
+    /// Gets whether this input is a list of typed input items.
+    /// </summary>
+    public bool IsItems => this.Items is not null;
+
+    /// <summary>
     /// Gets the text value, or null if this is not a text input.
     /// </summary>
     public string? Text { get; }
@@ -76,6 +96,11 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
     /// Gets the messages value, or null if this is not a messages input.
     /// </summary>
     public List<InputMessage>? Messages { get; }
+
+    /// <summary>
+    /// Gets the input item value, or null if this is not an item input.
+    /// </summary>
+    public List<ItemParam>? Items { get; }
 
     /// <summary>
     /// Gets the input as a list of InputMessage objects.
@@ -92,7 +117,154 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
             }];
         }
 
-        return this.Messages ?? [];
+        if (this.Messages is not null)
+        {
+            return this.Messages;
+        }
+
+        if (this.Items is not null)
+        {
+            var messages = new List<InputMessage>();
+            foreach (ItemParam item in this.Items)
+            {
+                if (ToInputMessage(item) is { } message)
+                {
+                    messages.Add(message);
+                }
+            }
+
+            return messages;
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Gets the input as a list of ChatMessage objects.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Method performs transformation logic")]
+    public List<ChatMessage> GetChatMessages()
+    {
+        if (this.Text is not null)
+        {
+            return [new ChatMessage(ChatRole.User, this.Text)];
+        }
+
+        if (this.Messages is not null)
+        {
+            return this.Messages.ConvertAll(static message => message.ToChatMessage());
+        }
+
+        if (this.Items is not null)
+        {
+            var messages = new List<ChatMessage>();
+            foreach (ItemParam item in this.Items)
+            {
+                if (ToChatMessage(item) is { } message)
+                {
+                    messages.Add(message);
+                }
+            }
+
+            return messages;
+        }
+
+        return [];
+    }
+
+    private static InputMessage? ToInputMessage(ItemParam item) => item switch
+    {
+        ResponsesUserMessageItemParam userMessage => new InputMessage { Role = ChatRole.User, Content = userMessage.Content },
+        ResponsesAssistantMessageItemParam assistantMessage => new InputMessage { Role = ChatRole.Assistant, Content = assistantMessage.Content },
+        ResponsesSystemMessageItemParam systemMessage => new InputMessage { Role = ChatRole.System, Content = systemMessage.Content },
+        ResponsesDeveloperMessageItemParam developerMessage => new InputMessage { Role = new ChatRole("developer"), Content = developerMessage.Content },
+        _ => null
+    };
+
+    private static ChatMessage? ToChatMessage(ItemParam item) => item switch
+    {
+        ResponsesUserMessageItemParam userMessage => new ChatMessage(ChatRole.User, ToAIContents(userMessage.Content)),
+        ResponsesAssistantMessageItemParam assistantMessage => new ChatMessage(ChatRole.Assistant, ToAIContents(assistantMessage.Content)),
+        ResponsesSystemMessageItemParam systemMessage => new ChatMessage(ChatRole.System, ToAIContents(systemMessage.Content)),
+        ResponsesDeveloperMessageItemParam developerMessage => new ChatMessage(new ChatRole("developer"), ToAIContents(developerMessage.Content)),
+        FunctionToolCallItemParam functionCall => new ChatMessage(
+            ChatRole.Assistant,
+            [new FunctionCallContent(functionCall.CallId, functionCall.Name, ParseFunctionArgumentsObject(functionCall.Arguments))]),
+        FunctionToolCallOutputItemParam functionOutput => new ChatMessage(
+            ChatRole.Tool,
+            [new FunctionResultContent(functionOutput.CallId, functionOutput.Output)]),
+        FunctionApprovalResponseItemParam approvalResponse => ToChatMessage(approvalResponse),
+        _ => null
+    };
+
+    private static ChatMessage ToChatMessage(FunctionApprovalResponseItemParam approvalResponse)
+    {
+        FunctionCallContent placeholderCall = new(
+            approvalResponse.ApprovalRequestId,
+            string.Empty,
+            arguments: null);
+        ToolApprovalResponseContent content = new(approvalResponse.ApprovalRequestId, approvalResponse.Approve, placeholderCall)
+        {
+            Reason = approvalResponse.Reason
+        };
+
+        return new ChatMessage(ChatRole.User, [content]);
+    }
+
+    private static List<AIContent> ToAIContents(InputMessageContent content)
+    {
+        if (content.IsText)
+        {
+            return [new TextContent(content.Text)];
+        }
+
+        if (content.IsContents)
+        {
+            var result = new List<AIContent>();
+            foreach (ItemContent itemContent in content.Contents!)
+            {
+                if (ItemContentConverter.ToAIContent(itemContent) is { } aiContent)
+                {
+                    result.Add(aiContent);
+                }
+            }
+
+            return result;
+        }
+
+        return [];
+    }
+
+    private static Dictionary<string, object?>? ParseFunctionArgumentsObject(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(arguments);
+            var result = new Dictionary<string, object?>();
+            foreach (JsonProperty property in doc.RootElement.EnumerateObject())
+            {
+                result[property.Name] = property.Value.ValueKind switch
+                {
+                    JsonValueKind.String => property.Value.GetString(),
+                    JsonValueKind.Number => property.Value.GetDouble(),
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Null => null,
+                    _ => property.Value.GetRawText()
+                };
+            }
+
+            return result;
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, object?> { ["_raw"] = arguments };
+        }
     }
 
     /// <inheritdoc/>
@@ -120,7 +292,12 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
             return this.Messages.SequenceEqual(other.Messages);
         }
 
-        // One is text, one is messages - not equal
+        if (this.Items is not null && other.Items is not null)
+        {
+            return this.Items.SequenceEqual(other.Items);
+        }
+
+        // Different input shapes are not equal.
         return false;
     }
 
@@ -138,6 +315,11 @@ internal sealed class ResponseInput : IEquatable<ResponseInput>
         if (this.Messages is not null)
         {
             return this.Messages.Count > 0 ? this.Messages[0].GetHashCode() : 0;
+        }
+
+        if (this.Items is not null)
+        {
+            return this.Items.Count > 0 ? this.Items[0].GetHashCode() : 0;
         }
 
         return 0;
@@ -178,12 +360,42 @@ internal sealed class ResponseInputJsonConverter : JsonConverter<ResponseInput>
         // Check if it's an array
         if (reader.TokenType == JsonTokenType.StartArray)
         {
-            var messages = JsonSerializer.Deserialize(ref reader, OpenAIHostingJsonContext.Default.ListInputMessage);
-            return messages is not null ? ResponseInput.FromMessages(messages) : null;
+            using var doc = JsonDocument.ParseValue(ref reader);
+            bool hasTypedItems = doc.RootElement.EnumerateArray().Any(static element =>
+                element.ValueKind == JsonValueKind.Object && element.TryGetProperty("type", out _));
+
+            if (!hasTypedItems)
+            {
+                var messages = doc.RootElement.Deserialize(OpenAIHostingJsonContext.Default.ListInputMessage);
+                return messages is not null ? ResponseInput.FromMessages(messages) : null;
+            }
+
+            var items = new List<ItemParam>();
+            foreach (JsonElement element in doc.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("type", out _))
+                {
+                    ItemParam? item = element.Deserialize(OpenAIHostingJsonContext.Default.ItemParam);
+                    if (item is not null)
+                    {
+                        items.Add(item);
+                    }
+                }
+                else
+                {
+                    InputMessage? message = element.Deserialize(OpenAIHostingJsonContext.Default.InputMessage);
+                    if (message is not null)
+                    {
+                        items.Add(ToItemParam(message));
+                    }
+                }
+            }
+
+            return ResponseInput.FromItems(items);
         }
 
         throw new JsonException(
-            "ResponseInput must be either a string or an array of messages. " +
+            "ResponseInput must be either a string or an array of messages/input items. " +
             $"Objects are not supported. Received token type: {reader.TokenType}");
     }
 
@@ -198,9 +410,33 @@ internal sealed class ResponseInputJsonConverter : JsonConverter<ResponseInput>
         {
             JsonSerializer.Serialize(writer, value.Messages!, OpenAIHostingJsonContext.Default.ListInputMessage);
         }
+        else if (value.IsItems)
+        {
+            JsonSerializer.Serialize(writer, value.Items!, OpenAIHostingJsonContext.Default.ListItemParam);
+        }
         else
         {
             throw new JsonException("ResponseInput has no value");
         }
+    }
+
+    private static ItemParam ToItemParam(InputMessage message)
+    {
+        if (message.Role == ChatRole.User)
+        {
+            return new ResponsesUserMessageItemParam { Content = message.Content };
+        }
+
+        if (message.Role == ChatRole.Assistant)
+        {
+            return new ResponsesAssistantMessageItemParam { Content = message.Content };
+        }
+
+        if (message.Role == ChatRole.System)
+        {
+            return new ResponsesSystemMessageItemParam { Content = message.Content };
+        }
+
+        return new ResponsesDeveloperMessageItemParam { Content = message.Content };
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/FunctionApprovalTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/FunctionApprovalTests.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
 using Microsoft.Agents.AI.Hosting.OpenAI.Tests;
 using Microsoft.Extensions.AI;
 
@@ -174,6 +176,48 @@ public sealed class FunctionApprovalTests : ConformanceTestBase
     #endregion
 
     #region ToolApprovalResponseContent Tests
+
+    [Fact]
+    public async Task FunctionApprovalResponseInput_IsAcceptedAndForwardedAsync()
+    {
+        // Arrange
+        const string AgentName = "approval-response-input-agent";
+        const string RequestId = "req-devui-123";
+        HttpClient client = await this.CreateTestServerAsync(AgentName, "You are a test agent.", string.Empty, (msg) =>
+            [new TextContent("approval response accepted")]);
+
+        string requestJson = $$"""
+            {
+              "model": "gpt-4o-mini",
+              "input": [
+                {
+                  "type": "function_approval_response",
+                  "approval_request_id": "{{RequestId}}",
+                  "approve": true,
+                  "reason": "approved in DevUI"
+                }
+              ],
+              "stream": true
+            }
+            """;
+
+        CreateResponse? parsedRequest = JsonSerializer.Deserialize(requestJson, OpenAIHostingJsonContext.Default.CreateResponse);
+        ToolApprovalResponseContent parsedApproval = parsedRequest!.Input.GetChatMessages()
+            .Single()
+            .Contents
+            .OfType<ToolApprovalResponseContent>()
+            .Single();
+
+        // Act
+        HttpResponseMessage httpResponse = await this.SendResponsesRequestAsync(client, AgentName, requestJson);
+        _ = await httpResponse.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        Assert.Equal(RequestId, parsedApproval.RequestId);
+        Assert.True(parsedApproval.Approved);
+        Assert.Equal("approved in DevUI", parsedApproval.Reason);
+    }
 
     [Fact]
     public async Task FunctionApprovalResponse_Approved_GeneratesCorrectEvent_SuccessAsync()


### PR DESCRIPTION
﻿## Summary
- accept `function_approval_response` items in Responses `input` arrays
- convert typed Responses input items into chat messages before agent execution
- add an HTTP coverage case for the DevUI approval response payload

Fixes #6006

## To verify
- `dotnet run --project dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.csproj --framework net10.0 -c Release --no-restore -- --filter-class Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.FunctionApprovalTests`
- `dotnet run --project dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.csproj --framework net10.0 -c Release --no-build -- --filter-class Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.OpenAIResponsesSerializationTests`
- `git diff --check`
