### PR TITLE
Python: fix: keep citation get_url metadata

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -2880,11 +2880,14 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     if ann_url:
                         ann_start = _get_ann_value("start_index")
                         ann_end = _get_ann_value("end_index")
+                        additional_properties: dict[str, Any] = {"annotation_index": event.annotation_index}
+                        if ann_get_url := _get_ann_value("get_url"):
+                            additional_properties["get_url"] = ann_get_url
                         annotation_obj = Annotation(
                             type="citation",
                             title=_get_ann_value("title") or "",
                             url=str(ann_url),
-                            additional_properties={"annotation_index": event.annotation_index},
+                            additional_properties=additional_properties,
                             raw_representation=annotation,
                         )
                         if ann_start is not None and ann_end is not None:

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -2880,14 +2880,15 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                     if ann_url:
                         ann_start = _get_ann_value("start_index")
                         ann_end = _get_ann_value("end_index")
-                        additional_properties: dict[str, Any] = {"annotation_index": event.annotation_index}
-                        if ann_get_url := _get_ann_value("get_url"):
-                            additional_properties["get_url"] = ann_get_url
+                        annotation_properties: dict[str, Any] = {"annotation_index": event.annotation_index}
+                        ann_get_url = _get_ann_value("get_url")
+                        if ann_get_url is not None:
+                            annotation_properties["get_url"] = ann_get_url
                         annotation_obj = Annotation(
                             type="citation",
                             title=_get_ann_value("title") or "",
                             url=str(ann_url),
-                            additional_properties=additional_properties,
+                            additional_properties=annotation_properties,
                             raw_representation=annotation,
                         )
                         if ann_start is not None and ann_end is not None:

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -3407,10 +3407,11 @@ def test_streaming_annotation_added_with_url_citation() -> None:
     mock_event = MagicMock()
     mock_event.type = "response.output_text.annotation.added"
     mock_event.annotation_index = 0
+    get_url = "https://example.search.windows.net/indexes/docs/documents/doc-123?api-version=2024-07-01"
     mock_event.annotation = {
         "type": "url_citation",
         "url": "https://example.sharepoint.com/sites/my-site/doc.pdf",
-        "get_url": "https://example.search.windows.net/indexes/docs/documents/doc-123?api-version=2024-07-01",
+        "get_url": get_url,
         "title": "doc.pdf",
         "start_index": 100,
         "end_index": 112,
@@ -3428,10 +3429,7 @@ def test_streaming_annotation_added_with_url_citation() -> None:
     assert annotation["title"] == "doc.pdf"
     assert annotation["url"] == "https://example.sharepoint.com/sites/my-site/doc.pdf"
     assert annotation["additional_properties"]["annotation_index"] == 0
-    assert (
-        annotation["additional_properties"]["get_url"]
-        == "https://example.search.windows.net/indexes/docs/documents/doc-123?api-version=2024-07-01"
-    )
+    assert annotation["additional_properties"]["get_url"] == get_url
     assert annotation["raw_representation"] == mock_event.annotation
     assert annotation["annotated_regions"] is not None
     assert len(annotation["annotated_regions"]) == 1

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -3410,6 +3410,7 @@ def test_streaming_annotation_added_with_url_citation() -> None:
     mock_event.annotation = {
         "type": "url_citation",
         "url": "https://example.sharepoint.com/sites/my-site/doc.pdf",
+        "get_url": "https://example.search.windows.net/indexes/docs/documents/doc-123?api-version=2024-07-01",
         "title": "doc.pdf",
         "start_index": 100,
         "end_index": 112,
@@ -3427,6 +3428,10 @@ def test_streaming_annotation_added_with_url_citation() -> None:
     assert annotation["title"] == "doc.pdf"
     assert annotation["url"] == "https://example.sharepoint.com/sites/my-site/doc.pdf"
     assert annotation["additional_properties"]["annotation_index"] == 0
+    assert (
+        annotation["additional_properties"]["get_url"]
+        == "https://example.search.windows.net/indexes/docs/documents/doc-123?api-version=2024-07-01"
+    )
     assert annotation["raw_representation"] == mock_event.annotation
     assert annotation["annotated_regions"] is not None
     assert len(annotation["annotated_regions"]) == 1


### PR DESCRIPTION
﻿## Summary
- preserve `get_url` from streaming `url_citation` annotations
- keep the field under `Annotation.additional_properties`
- extend the existing streaming url citation test

Fixes #5995

## To verify
- `python/.venv/Scripts/python.exe -m pytest python/packages/openai/tests/openai/test_openai_chat_client.py::test_streaming_annotation_added_with_url_citation -q`
- `python/.venv/Scripts/python.exe -m pytest python/packages/openai/tests/openai/test_openai_chat_client.py -q -k "streaming_annotation_added"`
- `python/.venv/Scripts/python.exe -m ruff check python/packages/openai/agent_framework_openai/_chat_client.py python/packages/openai/tests/openai/test_openai_chat_client.py`
- `git diff --check`
