### PR TITLE
.NET: fix: coalesce AGUI completion text

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/Shared/ChatResponseUpdateAGUIExtensions.cs
@@ -448,6 +448,7 @@ internal static class ChatResponseUpdateAGUIExtensions
         };
 
         string? currentMessageId = null;
+        string? currentMessageRole = null;
         string? streamingMessageId = null;
         string? currentReasoningBaseId = null;
         string? currentReasoningId = null;
@@ -464,45 +465,51 @@ internal static class ChatResponseUpdateAGUIExtensions
             }
 
             if (chatResponse is { Contents.Count: > 0 } &&
-                chatResponse.Contents[0] is TextContent &&
-                !string.Equals(currentMessageId, chatResponse.MessageId, StringComparison.Ordinal))
+                chatResponse.Contents[0] is TextContent)
             {
-                // Close any open reasoning block before opening a text message, so AG-UI
-                // events are properly bracketed. MEAI providers share one MessageId across
-                // reasoning and text content, so the reasoning-block state alone wouldn't
-                // detect the transition.
-                if (currentReasoningMessageId is not null)
+                string chatResponseRole = chatResponse.Role!.Value.Value;
+                bool startTextMessage = currentMessageId is null ||
+                    !string.Equals(currentMessageRole, chatResponseRole, StringComparison.Ordinal);
+                if (startTextMessage)
                 {
-                    yield return new ReasoningMessageEndEvent
+                    // Close any open reasoning block before opening a text message, so AG-UI
+                    // events are properly bracketed. MEAI providers share one MessageId across
+                    // reasoning and text content, so the reasoning-block state alone wouldn't
+                    // detect the transition.
+                    if (currentReasoningMessageId is not null)
                     {
-                        MessageId = currentReasoningMessageId
-                    };
-                    yield return new ReasoningEndEvent
+                        yield return new ReasoningMessageEndEvent
+                        {
+                            MessageId = currentReasoningMessageId
+                        };
+                        yield return new ReasoningEndEvent
+                        {
+                            MessageId = currentReasoningId!
+                        };
+                        currentReasoningBaseId = null;
+                        currentReasoningId = null;
+                        currentReasoningMessageId = null;
+                    }
+
+                    // End the previous message if there was one
+                    if (currentMessageId is not null)
                     {
-                        MessageId = currentReasoningId!
+                        yield return new TextMessageEndEvent
+                        {
+                            MessageId = currentMessageId
+                        };
+                    }
+
+                    // Start the new message
+                    yield return new TextMessageStartEvent
+                    {
+                        MessageId = chatResponse.MessageId!,
+                        Role = chatResponseRole
                     };
-                    currentReasoningBaseId = null;
-                    currentReasoningId = null;
-                    currentReasoningMessageId = null;
+
+                    currentMessageId = chatResponse.MessageId;
+                    currentMessageRole = chatResponseRole;
                 }
-
-                // End the previous message if there was one
-                if (currentMessageId is not null)
-                {
-                    yield return new TextMessageEndEvent
-                    {
-                        MessageId = currentMessageId
-                    };
-                }
-
-                // Start the new message
-                yield return new TextMessageStartEvent
-                {
-                    MessageId = chatResponse.MessageId!,
-                    Role = chatResponse.Role!.Value.Value
-                };
-
-                currentMessageId = chatResponse.MessageId;
             }
 
             // Emit text content if present

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/ChatResponseUpdateAGUIExtensionsTests.cs
@@ -139,15 +139,17 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
     }
 
     [Fact]
-    public async Task AsAGUIEventStreamAsync_EmitsTextMessageEndEvent_WhenMessageIdChangesAsync()
+    public async Task AsAGUIEventStreamAsync_CoalescesAssistantTextAcrossCompletionMessageIdsAsync()
     {
         // Arrange
         const string ThreadId = "thread1";
         const string RunId = "run1";
+        FunctionCallContent functionCall = new("call_1", "Tool1", new Dictionary<string, object?>());
         List<ChatResponseUpdate> updates =
         [
             new ChatResponseUpdate(ChatRole.Assistant, "First") { MessageId = "msg1" },
-            new ChatResponseUpdate(ChatRole.Assistant, "Second") { MessageId = "msg2" }
+            new ChatResponseUpdate(ChatRole.Assistant, [functionCall]) { MessageId = "msg2" },
+            new ChatResponseUpdate(ChatRole.Assistant, "Second") { MessageId = "msg3" }
         ];
 
         // Act
@@ -158,9 +160,14 @@ public sealed class ChatResponseUpdateAGUIExtensionsTests
         }
 
         // Assert
+        List<TextMessageStartEvent> startEvents = events.OfType<TextMessageStartEvent>().ToList();
         List<TextMessageEndEvent> endEvents = events.OfType<TextMessageEndEvent>().ToList();
-        Assert.NotEmpty(endEvents);
-        Assert.Contains(endEvents, e => e.MessageId == "msg1");
+        List<TextMessageContentEvent> contentEvents = events.OfType<TextMessageContentEvent>().ToList();
+        Assert.Single(startEvents);
+        Assert.Single(endEvents);
+        Assert.Equal("msg1", startEvents[0].MessageId);
+        Assert.Equal("msg1", endEvents[0].MessageId);
+        Assert.Equal(["First", "Second"], contentEvents.Select(e => e.Delta));
     }
 
     [Fact]


### PR DESCRIPTION
﻿Fixes #6010.

## Summary
- keep assistant text in one AG-UI text message even when provider completion chunks carry different MEAI message ids
- still start a new AG-UI text message when the role changes
- add a regression with a tool call between two assistant completion text chunks

## To verify
- `dotnet run --project dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests.csproj --framework net10.0 -c Release --no-restore -- --filter-class Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests.ChatResponseUpdateAGUIExtensionsTests`
- `dotnet run --project dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests.csproj --framework net10.0 -c Release --no-build -- --filter-class Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests.AGUIEndpointRouteBuilderExtensionsTests`
- `git diff --check`
