### PR TITLE
.NET: fix: populate MessageId from TaskStatusUpdateEvent in A2AAgent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
@@ -456,6 +456,7 @@ public sealed class A2AAgent : AIAgent
             ResponseId = statusUpdateEvent.TaskId,
             RawRepresentation = statusUpdateEvent,
             Role = ChatRole.Assistant,
+            MessageId = statusUpdateEvent.Status.Message?.MessageId,
             FinishReason = MapTaskStateToFinishReason(statusUpdateEvent.Status.State),
             AdditionalProperties = statusUpdateEvent.Metadata?.ToAdditionalProperties() ?? [],
             Contents = statusUpdateEvent.Status.GetUserInputRequests(),

--- a/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
@@ -1058,12 +1058,57 @@ public sealed class A2AAgentTests : IDisposable
         Assert.Equal(TaskId, update0.ResponseId);
         Assert.Equal(this._agent.Id, update0.AgentId);
         Assert.Null(update0.FinishReason);
+        Assert.Null(update0.MessageId);
         Assert.IsType<TaskStatusUpdateEvent>(update0.RawRepresentation);
 
         // Assert - session should be updated with context and task IDs
         var a2aSession = (A2AAgentSession)session;
         Assert.Equal(ContextId, a2aSession.ContextId);
         Assert.Equal(TaskId, a2aSession.TaskId);
+    }
+
+    [Fact]
+    public async Task RunStreamingAsync_WithTaskStatusUpdateEventAndMessageId_YieldsMessageIdAsync()
+    {
+        // Arrange
+        const string TaskId = "task-status-msg-123";
+        const string ContextId = "ctx-status-msg-456";
+        const string ExpectedMessageId = "msg-status-789";
+
+        this._handler.StreamingResponseToReturn = new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                TaskId = TaskId,
+                ContextId = ContextId,
+                Status = new()
+                {
+                    State = TaskState.Working,
+                    Message = new Message
+                    {
+                        MessageId = ExpectedMessageId,
+                        Parts = [Part.FromText("Processing your request...")]
+                    }
+                }
+            }
+        };
+
+        var session = await this._agent.CreateSessionAsync();
+
+        // Act
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in this._agent.RunStreamingAsync("Check task status", session))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        Assert.Single(updates);
+
+        var update0 = updates[0];
+        Assert.Equal(ExpectedMessageId, update0.MessageId);
+        Assert.Equal(TaskId, update0.ResponseId);
+        Assert.IsType<TaskStatusUpdateEvent>(update0.RawRepresentation);
     }
 
     [Fact]
@@ -1084,6 +1129,7 @@ public sealed class A2AAgentTests : IDisposable
                     State = TaskState.InputRequired,
                     Message = new Message
                     {
+                        MessageId = "input-msg-789",
                         Parts = [Part.FromText("Where would you like to fly?")]
                     }
                 }
@@ -1104,6 +1150,7 @@ public sealed class A2AAgentTests : IDisposable
 
         var update0 = updates[0];
         Assert.Equal(TaskId, update0.ResponseId);
+        Assert.Equal("input-msg-789", update0.MessageId);
         Assert.Null(update0.FinishReason);
 
         var textContent = Assert.Single(update0.Contents.OfType<TextContent>());


### PR DESCRIPTION
### Motivation and Context

Fixes microsoft/agent-framework#4987

`A2AAgent.ConvertToAgentResponseUpdate(TaskStatusUpdateEvent)` does not set `MessageId` from `Status.Message.MessageId`, dropping message correlation metadata during streaming.

### Description

Added `MessageId = statusUpdateEvent.Status.Message?.MessageId` to `ConvertToAgentResponseUpdate(TaskStatusUpdateEvent)` and updated/added unit tests to cover both present and absent `MessageId` scenarios.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No
