### PR TITLE
.NET: fix inline skill string arguments

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -92,18 +92,50 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
             return [];
         }
 
-        if (arguments.Value.ValueKind != JsonValueKind.Object)
+        var argumentElement = arguments.Value;
+        using var parsedStringArguments = ParseStringArguments(argumentElement);
+        if (parsedStringArguments is not null)
+        {
+            argumentElement = parsedStringArguments.RootElement;
+        }
+
+        if (argumentElement.ValueKind != JsonValueKind.Object)
         {
             throw new InvalidOperationException(
-                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{arguments.Value.ValueKind}'.");
+                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{argumentElement.ValueKind}'.");
         }
 
         var dict = new Dictionary<string, object?>();
-        foreach (var property in arguments.Value.EnumerateObject())
+        foreach (var property in argumentElement.EnumerateObject())
         {
-            dict[property.Name] = property.Value;
+            dict[property.Name] = parsedStringArguments is null ? property.Value : property.Value.Clone();
         }
 
         return new AIFunctionArguments(dict);
+    }
+
+    private static JsonDocument? ParseStringArguments(JsonElement arguments)
+    {
+        if (arguments.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var json = arguments.GetString();
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                "Inline skill scripts received arguments as a JSON string, but the string did not contain valid JSON.",
+                ex);
+        }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
@@ -44,6 +44,22 @@ public sealed class AgentInlineSkillScriptTests
     }
 
     [Fact]
+    public async Task RunAsync_WithStringEncodedObjectArguments_PassesArgumentsAsync()
+    {
+        // Arrange
+        var script = new AgentInlineSkillScript("add", (int a, int b) => a + b);
+        var skill = new AgentInlineSkill("calc-skill", "Calc.", "Instructions.");
+        using var argsDoc = JsonDocument.Parse("\"{\\\"a\\\":3,\\\"b\\\":7}\"");
+        var args = argsDoc.RootElement;
+
+        // Act
+        var result = await script.RunAsync(skill, args, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, int.Parse(result?.ToString()!));
+    }
+
+    [Fact]
     public void ParametersSchema_NoParameters_ReturnsSchema()
     {
         // Arrange


### PR DESCRIPTION
﻿## Summary
- accept inline skill arguments when a provider sends the function arguments as a JSON string containing an object
- keep the existing object-only contract for inline skill arguments
- clone values parsed from the temporary JsonDocument so function invocation does not depend on a disposed document
- add a regression test for string-encoded object arguments

Fixes #6020

## To verify
- dotnet build dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --no-restore --tl:off
- dotnet dotnet\tests\Microsoft.Agents.AI.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.UnitTests.dll --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillScriptTests --timeout 2m
- dotnet format dotnet\agent-framework-dotnet.slnx --verify-no-changes --include dotnet\src\Microsoft.Agents.AI\Skills\Programmatic\AgentInlineSkillScript.cs dotnet\tests\Microsoft.Agents.AI.UnitTests\AgentSkills\AgentInlineSkillScriptTests.cs --no-restore --verbosity minimal
- git diff --check

Note: plain dotnet test currently starts through the VSTest path on this Windows SDK install and fails with the Microsoft.Testing.Platform opt-in error before test execution, so I ran the built MTP test assembly directly.
