### PR TITLE
.NET: docs: fix available typo

### DIFF
--- a/docs/decisions/0001-agent-run-response.md
+++ b/docs/decisions/0001-agent-run-response.md
@@ -200,7 +200,7 @@ var primaryContentOnly = response.Messages.FirstOrDefault();
 ```
 
 - **PROS**: Simple getting started experience, Reusing IChatClient response types.
-- **CONS**: Intermediate updates are only availble in streaming mode.
+- **CONS**: Intermediate updates are only available in streaming mode.
 
 ### Option 4: Remove Run API and retain RunStreaming API only, which returns a Stream of Primary + Secondary
 

--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
@@ -98,7 +98,7 @@ public class CopilotStudioAgent : AIAgent
             responseMessagesList.Add(message);
         }
 
-        // TODO: Review list of ChatResponse properties to ensure we set all availble values.
+        // TODO: Review list of ChatResponse properties to ensure we set all available values.
         // Setting ResponseId and MessageId end up being particularly important for streaming consumers
         // so that they can tell things like response boundaries.
         return new AgentResponse(responseMessagesList)
@@ -135,7 +135,7 @@ public class CopilotStudioAgent : AIAgent
         // Enumerate the response messages
         await foreach (ChatMessage message in responseMessages.ConfigureAwait(false))
         {
-            // TODO: Review list of ChatResponse properties to ensure we set all availble values.
+            // TODO: Review list of ChatResponse properties to ensure we set all available values.
             // Setting ResponseId and MessageId end up being particularly important for streaming consumers
             // so that they can tell things like response boundaries.
             yield return new AgentResponseUpdate(message.Role, message.Contents)


### PR DESCRIPTION
## Problem
A few documentation/comment lines spell "available" as "availble".

## Solution
Correct the typo in the agent run response decision note and Copilot Studio agent TODO comments.

## Validation
- `git diff --check`

## Confidence
85% — docs/comment typo fix (low-risk, directly verifiable).
