### PR TITLE
.NET: fix: keep injected messages in function loop history

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
@@ -263,8 +263,7 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
     }
 
     /// <summary>
-    /// Drains all pending injected messages from the queue and returns a new list combining
-    /// the original messages with the drained messages. The original list is never modified.
+    /// Drains all pending injected messages from the queue and returns the combined messages.
     /// </summary>
     private static IList<ChatMessage> DrainInjectedMessages(List<ChatMessage> queue, IList<ChatMessage> newMessages)
     {
@@ -273,6 +272,14 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
             if (queue.Count == 0)
             {
                 return newMessages;
+            }
+
+            if (newMessages is List<ChatMessage> mutableMessages)
+            {
+                // Keep the outer function loop's history list in sync with what was sent to the model.
+                mutableMessages.AddRange(queue);
+                queue.Clear();
+                return mutableMessages;
             }
 
             var combined = new List<ChatMessage>(newMessages);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/MessageInjectingChatClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/MessageInjectingChatClientTests.cs
@@ -407,6 +407,67 @@ public class MessageInjectingChatClientTests
         Assert.Equal("conv-123", capturedConversationIds[1]); // Second call: propagated from first response
     }
 
+    [Fact]
+    public async Task RunAsync_KeepsInjectedMessagesInFunctionLoopHistoryAsync()
+    {
+        // Arrange
+        int serviceCallCount = 0;
+        int toolCallCount = 0;
+        List<List<string>> capturedMessageTexts = [];
+        MessageInjectingChatClient? injectorRef = null;
+        ChatClientAgentSession? sessionRef = null;
+
+        Mock<IChatClient> mockService = new();
+        mockService.Setup(
+            s => s.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Returns((IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken _) =>
+            {
+                serviceCallCount++;
+                capturedMessageTexts.Add(msgs.Select(m => m.Text).ToList());
+
+                return Task.FromResult(serviceCallCount switch
+                {
+                    1 => new ChatResponse([new(ChatRole.Assistant,
+                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>())])]),
+                    2 => new ChatResponse([new(ChatRole.Assistant,
+                        [new FunctionCallContent("call2", "myTool", new Dictionary<string, object?>())])]),
+                    _ => new ChatResponse([new(ChatRole.Assistant, "final")]),
+                });
+            });
+
+        var tool = AIFunctionFactory.Create(() =>
+        {
+            toolCallCount++;
+            if (toolCallCount == 1)
+            {
+                injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected correction")]);
+            }
+
+            return "tool result";
+        }, "myTool", "A test tool");
+
+        ChatClientAgent agent = new(mockService.Object, options: new()
+        {
+            ChatOptions = new() { Tools = [tool] },
+            EnableMessageInjection = true,
+        }, services: new ServiceCollection().BuildServiceProvider());
+
+        injectorRef = agent.ChatClient.GetService<MessageInjectingChatClient>()!;
+
+        // Act
+        var session = await agent.CreateSessionAsync() as ChatClientAgentSession;
+        sessionRef = session;
+        await agent.RunAsync([new(ChatRole.User, "original")], session);
+
+        // Assert
+        Assert.Equal(3, serviceCallCount);
+        Assert.Contains(capturedMessageTexts[1], text => text == "injected correction");
+        Assert.Contains(capturedMessageTexts[2], text => text == "injected correction");
+    }
+
     /// <summary>
     /// Verifies that a session with pending injected messages can be serialized and deserialized,
     /// and that the deserialized session correctly delivers the injected messages on the next run.


### PR DESCRIPTION
﻿## Summary

- keep drained `MessageInjectingChatClient` messages in the mutable history list used by the outer function invocation loop
- add a regression test covering a second tool call after an injected user correction

Fixes #6056.

## Tests

- `dotnet run --project dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --framework net10.0 --no-restore -- --filter-method "Microsoft.Agents.AI.UnitTests.MessageInjectingChatClientTests.RunAsync_KeepsInjectedMessagesInFunctionLoopHistoryAsync" --no-progress`
- `dotnet run --project dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --framework net10.0 --no-restore -- --filter-class "Microsoft.Agents.AI.UnitTests.MessageInjectingChatClientTests" --no-progress`
- `dotnet build dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --no-restore`
- `dotnet format dotnet\agent-framework-dotnet.slnx --verify-no-changes --include dotnet\src\Microsoft.Agents.AI\ChatClient\MessageInjectingChatClient.cs dotnet\tests\Microsoft.Agents.AI.UnitTests\ChatClient\MessageInjectingChatClientTests.cs --no-restore`
