### PR TITLE
docs: fix response typo

### DIFF
--- a/docs/decisions/0001-agent-run-response.md
+++ b/docs/decisions/0001-agent-run-response.md
@@ -139,7 +139,7 @@ Therefore something like `AgentResponse.Text` which also aggregates all `TextCon
 
 #### Option 1.2 Presence of Secondary Content is determined by a runtime parameter
 
-We can allow callers to choose whether to include secondary content in the list of reponse messages.
+We can allow callers to choose whether to include secondary content in the list of response messages.
 Open Question: Do we allow secondary content to use `TextContent` types?
 
 ```csharp


### PR DESCRIPTION
Fixes a small typo in the agent run response decision document.\n\nValidation: git diff --check