### PR TITLE
Python: stream start_executor events in real time via concurrent polling

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import hashlib
 import json
@@ -558,7 +559,35 @@ class Workflow(DictConvertible):
 
                 # Execute initial setup if provided
                 if initial_executor_fn:
-                    await initial_executor_fn()
+                    # concurrently with event polling so events emitted by
+                    # yield_output stream in real time. Vanilla behavior awaits
+                    # initial_executor_fn to completion, then
+                    # run_until_convergence drains the pre-loop queue as a
+                    # burst — manifests as N seconds of silence followed by
+                    # all events arriving at once. Mirrors the
+                    # iteration_task pattern already used inside
+                    # run_until_convergence.
+                    async def _run_initial() -> None:
+                        await initial_executor_fn()
+
+                    initial_task = asyncio.create_task(_run_initial())
+                    try:
+                        while not initial_task.done():
+                            try:
+                                event = await asyncio.wait_for(self._runner_context.next_event(), timeout=0.05)
+                                yield event
+                            except asyncio.TimeoutError:
+                                continue
+                        if await self._runner_context.has_events():
+                            for event in await self._runner_context.drain_events():
+                                yield event
+                        await initial_task  # propagate exception if any
+                    except asyncio.CancelledError:
+                        if not initial_task.done():
+                            initial_task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await initial_task
+                        raise
 
                 # All executor executions happen within workflow span
                 async for event in self._runner.run_until_convergence():

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -559,25 +559,32 @@ class Workflow(DictConvertible):
 
                 # Execute initial setup if provided
                 if initial_executor_fn:
-                    # concurrently with event polling so events emitted by
-                    # yield_output stream in real time. Vanilla behavior awaits
-                    # initial_executor_fn to completion, then
-                    # run_until_convergence drains the pre-loop queue as a
-                    # burst — manifests as N seconds of silence followed by
-                    # all events arriving at once. Mirrors the
-                    # iteration_task pattern already used inside
-                    # run_until_convergence.
+                    # Run the initial executor concurrently with event streaming so
+                    # events emitted by yield_output during its run reach the
+                    # consumer in real time. Vanilla behavior awaited
+                    # initial_executor_fn() to completion, so run_until_convergence
+                    # then drained the pre-loop queue as a burst — N seconds of
+                    # silence followed by all events arriving at once.
                     async def _run_initial() -> None:
                         await initial_executor_fn()
 
                     initial_task = asyncio.create_task(_run_initial())
+                    event_task: asyncio.Task[WorkflowEvent[Any]] | None = None
                     try:
-                        while not initial_task.done():
-                            try:
-                                event = await asyncio.wait_for(self._runner_context.next_event(), timeout=0.05)
-                                yield event
-                            except asyncio.TimeoutError:
-                                continue
+                        while True:
+                            if event_task is None:
+                                event_task = asyncio.create_task(self._runner_context.next_event())
+                            done, _pending = await asyncio.wait(
+                                {initial_task, event_task},
+                                return_when=asyncio.FIRST_COMPLETED,
+                            )
+                            if event_task in done:
+                                yield event_task.result()
+                                event_task = None
+                            if initial_task in done:
+                                break
+                        # Drain any events that landed between initial_task
+                        # finishing and the next_event task being cancelled.
                         if await self._runner_context.has_events():
                             for event in await self._runner_context.drain_events():
                                 yield event
@@ -588,6 +595,11 @@ class Workflow(DictConvertible):
                             with contextlib.suppress(asyncio.CancelledError):
                                 await initial_task
                         raise
+                    finally:
+                        if event_task is not None and not event_task.done():
+                            event_task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await event_task
 
                 # All executor executions happen within workflow span
                 async for event in self._runner.run_until_convergence():

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -65,6 +65,25 @@ class AggregatorExecutor(Executor):
         await ctx.yield_output(sum(msg.data for msg in messages))
 
 
+class SlowProgressExecutor(Executor):
+    """A mock executor that emits ``step_count`` outputs via ``yield_output``,
+    sleeping ``step_sleep`` seconds between each. Simulates an executor that
+    emits progress events during a multi-step handler (e.g. an agent doing
+    planning, retrieval, and answer generation in sequence).
+    """
+
+    def __init__(self, id: str, *, step_count: int = 4, step_sleep: float = 0.1) -> None:
+        super().__init__(id=id)
+        self.step_count = step_count
+        self.step_sleep = step_sleep
+
+    @handler
+    async def mock_handler(self, _message: str, ctx: WorkflowContext[str, str]) -> None:
+        for i in range(self.step_count):
+            await ctx.yield_output(f"step {i}")
+            await asyncio.sleep(self.step_sleep)
+
+
 @dataclass
 class MockRequest:
     """A mock request message for testing purposes."""
@@ -141,6 +160,50 @@ async def test_workflow_run_stream_not_completed():
     with pytest.raises(WorkflowConvergenceException):
         async for _ in workflow.run(NumberMessage(data=0), stream=True):
             pass
+
+
+async def test_workflow_run_stream_does_not_buffer_initial_executor_outputs() -> None:
+    """Outputs emitted by the start executor via ``ctx.yield_output(...)``
+    must reach the ``run(..., stream=True)`` consumer as they happen, not
+    be buffered until ``execute()`` returns.
+
+    Regression target: previously the initial executor was awaited to
+    completion before ``run_until_convergence`` began iterating, so every
+    ``yield_output`` only enqueued onto the runner context's event queue
+    and the entire backlog was drained as a burst via
+    ``run_until_convergence``'s pre-loop drain. Manifested as N seconds
+    of silence followed by all events arriving in the same millisecond,
+    even though ``stream=True`` was set and each ``yield_output`` returned
+    promptly.
+    """
+    import time
+
+    step_count = 4
+    step_sleep = 0.1
+
+    executor = SlowProgressExecutor(id="slow", step_count=step_count, step_sleep=step_sleep)
+    workflow = WorkflowBuilder(start_executor=executor).build()
+
+    arrivals: list[float] = []
+    t0 = time.monotonic()
+    async for event in workflow.run("go", stream=True):
+        if event.type == "output":
+            arrivals.append(time.monotonic() - t0)
+
+    assert len(arrivals) == step_count, f"expected {step_count} outputs, got {len(arrivals)}"
+
+    # Buggy behavior packs all arrivals within milliseconds of each other
+    # at the end of execute(). Fixed behavior spreads them across the run.
+    # Require the spread between first and last arrival to be at least
+    # half the expected total sleep time — CI-tolerant but still catches
+    # the burst pattern (which would yield a spread of ~ms).
+    expected_total = (step_count - 1) * step_sleep
+    spread = arrivals[-1] - arrivals[0]
+    assert spread >= expected_total * 0.5, (
+        f"outputs arrived as a burst rather than streamed: "
+        f"spread={spread * 1000:.1f}ms (expected >= {expected_total * 500:.1f}ms); "
+        f"arrivals: {[f'+{t * 1000:.1f}ms' for t in arrivals]}"
+    )
 
 
 async def test_workflow_run():

--- a/python/packages/core/tests/workflow/test_workflow.py
+++ b/python/packages/core/tests/workflow/test_workflow.py
@@ -176,19 +176,20 @@ async def test_workflow_run_stream_does_not_buffer_initial_executor_outputs() ->
     even though ``stream=True`` was set and each ``yield_output`` returned
     promptly.
     """
-    import time
-
     step_count = 4
-    step_sleep = 0.1
+    step_sleep = 0.15  # slightly above pytest-asyncio's default scheduling jitter on loaded CI
 
     executor = SlowProgressExecutor(id="slow", step_count=step_count, step_sleep=step_sleep)
     workflow = WorkflowBuilder(start_executor=executor).build()
 
+    # Event-loop clock — same monotonic source as asyncio.sleep(), avoids
+    # drift between wall-clock time.monotonic() and loop scheduling.
+    loop = asyncio.get_running_loop()
     arrivals: list[float] = []
-    t0 = time.monotonic()
+    t0 = loop.time()
     async for event in workflow.run("go", stream=True):
         if event.type == "output":
-            arrivals.append(time.monotonic() - t0)
+            arrivals.append(loop.time() - t0)
 
     assert len(arrivals) == step_count, f"expected {step_count} outputs, got {len(arrivals)}"
 


### PR DESCRIPTION
Fixes #6079

  Run `initial_executor_fn()` as a background task while polling
  `runner_context.next_event()` so events emitted via `yield_output`
  reach the `run(stream=True)` consumer in real time, instead of being
  drained as a burst after `execute()` returns.

  Mirrors the `iteration_task` pattern already used inside
  `run_until_convergence`. Adds a regression test that fails on the
  current behavior (all outputs arrive at the same timestamp) and passes
  with the fix.