### PR TITLE
Python A2A: Expose `supported_protocol_bindings` as configurable parameter

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -98,7 +98,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         http_client: httpx.AsyncClient | None = None,
         auth_interceptor: AuthInterceptor | None = None,
         timeout: float | httpx.Timeout | None = None,
-        supported_protocol_bindings: list[str] | None = None,
+        supported_protocol_bindings: list[Literal["JSONRPC", "GRPC", "HTTP+JSON"] | str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the A2AAgent.

--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -98,6 +98,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         http_client: httpx.AsyncClient | None = None,
         auth_interceptor: AuthInterceptor | None = None,
         timeout: float | httpx.Timeout | None = None,
+        supported_protocol_bindings: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the A2AAgent.
@@ -115,6 +116,9 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
             timeout: Request timeout configuration. Can be a float (applied to all timeout components),
                 httpx.Timeout object (for full control), or None (uses 10.0s connect, 60.0s read,
                 10.0s write, 5.0s pool - optimized for A2A operations).
+            supported_protocol_bindings: List of protocol bindings to use for transport negotiation.
+                Defaults to ["JSONRPC"]. Specify alternative transports (e.g., ["GRPC", "JSONRPC"])
+                when supported by the target agent.
             kwargs: any additional properties, passed to BaseAgent.
         """
         # Default name/description from agent_card when not explicitly provided
@@ -127,6 +131,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         super().__init__(id=id, name=name, description=description, **kwargs)
         self._http_client: httpx.AsyncClient | None = http_client
         self._timeout_config = self._create_timeout_config(timeout)
+        bindings = supported_protocol_bindings or ["JSONRPC"]
         if client is not None:
             self.client = client
             self._non_streaming_client: Client | None = None
@@ -136,7 +141,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
             if url is None:
                 raise ValueError("Either agent_card or url must be provided")
             # Create minimal agent card from URL
-            agent_card = minimal_agent_card(url, ["JSONRPC"])
+            agent_card = minimal_agent_card(url, bindings)
 
         # Create or use provided httpx client
         if http_client is None:
@@ -151,13 +156,13 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         streaming_config = ClientConfig(
             httpx_client=http_client,
             streaming=True,
-            supported_protocol_bindings=["JSONRPC"],
+            supported_protocol_bindings=bindings,
         )
         # Create non-streaming client (single request/response for stream=False)
         non_streaming_config = ClientConfig(
             httpx_client=http_client,
             streaming=False,
-            supported_protocol_bindings=["JSONRPC"],
+            supported_protocol_bindings=bindings,
         )
         streaming_factory = ClientFactory(streaming_config)
         non_streaming_factory = ClientFactory(non_streaming_config)
@@ -178,7 +183,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                     "Provide a 'url' argument or ensure 'agent_card.supported_interfaces' "
                     "contains at least one interface with a URL."
                 ) from transport_error
-            fallback_card = minimal_agent_card(fallback_url, ["JSONRPC"])
+            fallback_card = minimal_agent_card(fallback_url, bindings)
             try:
                 self.client = streaming_factory.create(fallback_card, interceptors=interceptors)  # type: ignore
                 self._non_streaming_client = non_streaming_factory.create(

--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -117,8 +117,8 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                 httpx.Timeout object (for full control), or None (uses 10.0s connect, 60.0s read,
                 10.0s write, 5.0s pool - optimized for A2A operations).
             supported_protocol_bindings: List of protocol bindings to use for transport negotiation.
-                Defaults to ["JSONRPC"]. Specify alternative transports (e.g., ["GRPC", "JSONRPC"])
-                when supported by the target agent.
+                Known values: "JSONRPC", "GRPC", "HTTP+JSON". Defaults to ["JSONRPC"].
+                The A2A spec treats this as an open-form string, so custom bindings are also accepted.
             kwargs: any additional properties, passed to BaseAgent.
         """
         # Default name/description from agent_card when not explicitly provided

--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -131,7 +131,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
         super().__init__(id=id, name=name, description=description, **kwargs)
         self._http_client: httpx.AsyncClient | None = http_client
         self._timeout_config = self._create_timeout_config(timeout)
-        bindings = supported_protocol_bindings or ["JSONRPC"]
+        bindings = supported_protocol_bindings if supported_protocol_bindings is not None else ["JSONRPC"]
         if client is not None:
             self.client = client
             self._non_streaming_client: Client | None = None

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -743,6 +743,54 @@ def test_a2a_agent_initialization_defaults_to_jsonrpc() -> None:
             assert call.kwargs["supported_protocol_bindings"] == ["JSONRPC"]
 
 
+def test_a2a_agent_initialization_empty_list_preserved() -> None:
+    """Test that an explicit empty list is preserved and not replaced with defaults."""
+    with (
+        patch("agent_framework_a2a._agent.httpx.AsyncClient") as mock_async_client,
+        patch("agent_framework_a2a._agent.ClientConfig") as mock_config,
+        patch("agent_framework_a2a._agent.ClientFactory") as mock_factory,
+    ):
+        mock_async_client.return_value = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_factory.return_value.create.return_value = mock_client_instance
+
+        A2AAgent(
+            name="Test Agent",
+            url="https://test-agent.example.com",
+            supported_protocol_bindings=[],
+        )
+
+        # Verify ClientConfig was called with the explicit empty list, not the default
+        assert mock_config.call_count == 2
+        for call in mock_config.call_args_list:
+            assert call.kwargs["supported_protocol_bindings"] == []
+
+
+def test_a2a_agent_fallback_uses_custom_bindings() -> None:
+    """Test that transport fallback path uses custom bindings."""
+    mock_agent_card = MagicMock()
+    mock_agent_card.supported_interfaces = [MagicMock(url="https://fallback.example.com")]
+
+    mock_factory = MagicMock()
+    # First create() call fails (primary streaming), then fallback calls succeed
+    primary_error = Exception("no compatible transports found")
+    mock_factory.create.side_effect = [primary_error, MagicMock(), MagicMock()]
+
+    with (
+        patch("agent_framework_a2a._agent.ClientFactory", return_value=mock_factory),
+        patch("agent_framework_a2a._agent.minimal_agent_card") as mock_minimal_card,
+        patch("agent_framework_a2a._agent.httpx.AsyncClient"),
+    ):
+        A2AAgent(
+            name="test-agent",
+            agent_card=mock_agent_card,
+            supported_protocol_bindings=["GRPC", "HTTP+JSON"],
+        )
+
+        # Verify minimal_agent_card was called with the custom bindings
+        mock_minimal_card.assert_called_once_with("https://fallback.example.com", ["GRPC", "HTTP+JSON"])
+
+
 async def test_working_task_emits_continuation_token(a2a_agent: A2AAgent, mock_a2a_client: MockA2AClient) -> None:
     """Test that a working (non-terminal) task yields an update with a continuation token when background=True."""
     mock_a2a_client.add_in_progress_task_response("task-wip", context_id="ctx-1", state=TaskState.TASK_STATE_WORKING)

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -701,7 +701,46 @@ def test_a2a_agent_initialization_with_timeout_parameter() -> None:
         assert isinstance(timeout_arg, httpx.Timeout)
 
 
-# region Continuation Token Tests
+def test_a2a_agent_initialization_with_supported_protocol_bindings() -> None:
+    """Test A2AAgent initialization with custom supported_protocol_bindings."""
+    with (
+        patch("agent_framework_a2a._agent.httpx.AsyncClient") as mock_async_client,
+        patch("agent_framework_a2a._agent.ClientConfig") as mock_config,
+        patch("agent_framework_a2a._agent.ClientFactory") as mock_factory,
+    ):
+        mock_async_client.return_value = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_factory.return_value.create.return_value = mock_client_instance
+
+        A2AAgent(
+            name="Test Agent",
+            url="https://test-agent.example.com",
+            supported_protocol_bindings=["GRPC", "JSONRPC"],
+        )
+
+        # Verify ClientConfig was called with our custom bindings for both streaming and non-streaming
+        assert mock_config.call_count == 2
+        for call in mock_config.call_args_list:
+            assert call.kwargs["supported_protocol_bindings"] == ["GRPC", "JSONRPC"]
+
+
+def test_a2a_agent_initialization_defaults_to_jsonrpc() -> None:
+    """Test A2AAgent defaults to JSONRPC when supported_protocol_bindings is not provided."""
+    with (
+        patch("agent_framework_a2a._agent.httpx.AsyncClient") as mock_async_client,
+        patch("agent_framework_a2a._agent.ClientConfig") as mock_config,
+        patch("agent_framework_a2a._agent.ClientFactory") as mock_factory,
+    ):
+        mock_async_client.return_value = MagicMock()
+        mock_client_instance = MagicMock()
+        mock_factory.return_value.create.return_value = mock_client_instance
+
+        A2AAgent(name="Test Agent", url="https://test-agent.example.com")
+
+        # Verify ClientConfig was called with default JSONRPC bindings
+        assert mock_config.call_count == 2
+        for call in mock_config.call_args_list:
+            assert call.kwargs["supported_protocol_bindings"] == ["JSONRPC"]
 
 
 async def test_working_task_emits_continuation_token(a2a_agent: A2AAgent, mock_a2a_client: MockA2AClient) -> None:


### PR DESCRIPTION
## Description

Expose `supported_protocol_bindings` as a configurable parameter on `A2AAgent.__init__()`, allowing users to specify which A2A protocol bindings the client prefers when connecting to remote agents.

### Motivation

Per the A2A v1.0 specification (Section 5), agents can declare multiple protocol interfaces (JSONRPC, GRPC, HTTP+JSON) in their AgentCard. Clients need a way to express their binding preference for transport negotiation.

This was previously hardcoded to JSONRPC. This PR makes it user-configurable while preserving the default behavior.

### Changes

- Added `supported_protocol_bindings: list[Literal["JSONRPC", "GRPC", "HTTP+JSON"] | str] | None = None` parameter to `A2AAgent.__init__()`
- Resolves to `["JSONRPC"]` by default (backward-compatible)
- Passes through to `ClientConfig` for transport negotiation with the A2A SDK
- Replaced 4 hardcoded JSONRPC references with the configurable value
- Added 2 unit tests (custom bindings, default behavior)

### .NET Parity

Aligns with .NET's `A2AClientOptions.PreferredBindings` from the A2A SDK NuGet package.

### Type of Change

- [x] Feature

### Process

- [x] Associated with an issue
- [x] Unit tests added
- [x] pyright clean
- [x] All existing tests pass

