### PR TITLE
Python: AG-UI: add optional auth guardrails for FastAPI endpoint

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import warnings
 from collections.abc import AsyncGenerator, Sequence
 from typing import Any
 
@@ -33,6 +34,8 @@ def add_agent_framework_fastapi_endpoint(
     default_state: dict[str, Any] | None = None,
     tags: list[str] | None = None,
     dependencies: Sequence[Depends] | None = None,
+    auth_required: bool = False,
+    warn_on_missing_auth: bool = False,
 ) -> None:
     """Add an AG-UI endpoint to a FastAPI app.
 
@@ -50,7 +53,27 @@ def add_agent_framework_fastapi_endpoint(
             These dependencies run before the endpoint handler. Use this to add
             authentication checks, rate limiting, or other middleware-like behavior.
             Example: `dependencies=[Depends(verify_api_key)]`
+        auth_required: When True, raise ValueError if dependencies is empty.
+            Use this for approval-capable or resume-capable workflows exposed
+            outside a trusted local development boundary.
+        warn_on_missing_auth: Emit a RuntimeWarning when no dependencies are
+            configured. Useful as an opt-in guardrail to surface accidental
+            unauthenticated deployments.
     """
+    if auth_required and not dependencies:
+        raise ValueError(
+            "add_agent_framework_fastapi_endpoint(auth_required=True) requires "
+            "authentication/authorization dependencies."
+        )
+    if warn_on_missing_auth and not dependencies:
+        warnings.warn(
+            "AG-UI endpoints do not enforce authentication unless FastAPI "
+            "dependencies are provided. Exposing approval-capable or resume-capable "
+            "workflows without dependencies can allow unauthorized resume payloads.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     protocol_runner: AgentFrameworkAgent | AgentFrameworkWorkflow
     if isinstance(agent, AgentFrameworkWorkflow):
         protocol_runner = agent

--- a/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
@@ -552,6 +552,64 @@ async def test_endpoint_without_dependencies_is_accessible(build_chat_client):
     assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
 
+async def test_endpoint_warn_on_missing_auth_emits_warning(build_chat_client):
+    """Opt-in guardrail: emit a warning when no auth dependencies are configured."""
+    app = FastAPI()
+    agent = Agent(name="test", instructions="Test agent", client=build_chat_client())
+
+    with pytest.warns(RuntimeWarning, match="do not enforce authentication"):
+        add_agent_framework_fastapi_endpoint(
+            app,
+            agent,
+            path="/warn",
+            warn_on_missing_auth=True,
+        )
+
+    client = TestClient(app)
+    response = client.post("/warn", json={"messages": [{"role": "user", "content": "Hello"}]})
+    assert response.status_code == 200
+
+
+async def test_endpoint_auth_required_rejects_missing_dependencies(build_chat_client):
+    """Opt-in guardrail: fail fast when auth_required=True but no deps are set."""
+    app = FastAPI()
+    agent = Agent(name="test", instructions="Test agent", client=build_chat_client())
+
+    with pytest.raises(ValueError, match="requires authentication/authorization"):
+        add_agent_framework_fastapi_endpoint(
+            app,
+            agent,
+            path="/auth-required",
+            auth_required=True,
+        )
+
+
+async def test_endpoint_auth_required_allows_with_dependencies(build_chat_client):
+    """auth_required=True is allowed when dependencies are configured."""
+    app = FastAPI()
+    agent = Agent(name="test", instructions="Test agent", client=build_chat_client())
+
+    async def require_api_key(x_api_key: str | None = Header(None)):
+        if x_api_key != "secret-key":
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    add_agent_framework_fastapi_endpoint(
+        app,
+        agent,
+        path="/auth-required",
+        dependencies=[Depends(require_api_key)],
+        auth_required=True,
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/auth-required",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+        headers={"x-api-key": "secret-key"},
+    )
+    assert response.status_code == 200
+
+
 async def test_endpoint_invalid_agent_type_raises_typeerror():
     """Passing an invalid agent type raises TypeError."""
     app = FastAPI()


### PR DESCRIPTION
This adds small opt-in guardrails to help avoid accidentally exposing resume-capable AG-UI endpoints without authentication.

Changes:
- `add_agent_framework_fastapi_endpoint(..., auth_required=..., warn_on_missing_auth=...)`
  - `auth_required=True` raises `ValueError` when `dependencies` is empty.
  - `warn_on_missing_auth=True` emits a `RuntimeWarning` when `dependencies` is empty.
  - Defaults preserve existing behavior (endpoint remains accessible when `dependencies` is omitted).
- Adds regression tests covering both guardrail options.

Local verification (package `python/packages/ag-ui`):
- `pytest tests/ag_ui/test_endpoint.py`

Notes:
- These options are intended for apps that deploy outside a trusted local boundary and want a fail-fast / warning signal when auth dependencies are missing.