### PR TITLE
Python: fix: keep reasoning with hosted MCP calls

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1484,10 +1484,22 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         # (replays_local_storage) still need stripping when the request also carries a continuation
         # marker, since the server-stored items would otherwise duplicate the inline ones. Without
         # storage, standalone reasoning items are invalid per the API ("reasoning was provided
-        # without its required following item"), so the reasoning branch always drops.
+        # without its required following item"), so only keep reasoning inline when it is paired
+        # with a hosted MCP call in the same assistant message.
+        has_hosted_mcp_call = any(
+            item.type == "mcp_server_tool_call" and getattr(item, "call_id", None) for item in message.contents
+        )
         for content in message.contents:
             match content.type:
                 case "text_reasoning":
+                    if not request_uses_service_side_storage and has_hosted_mcp_call:
+                        prepared_reasoning = self._prepare_content_for_openai(
+                            message.role,
+                            content,
+                            replays_local_storage=replays_local_storage,
+                        )
+                        if prepared_reasoning:
+                            all_messages.append(prepared_reasoning)
                     continue
                 case "function_result":
                     if request_uses_service_side_storage:

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -5518,6 +5518,63 @@ def test_prepare_messages_for_openai_serializes_mcp_server_tool_call_as_mcp_call
     assert "output" not in item or item["output"] is None
 
 
+def test_prepare_messages_for_openai_keeps_reasoning_with_hosted_mcp_call_storage_off() -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_text_reasoning(
+                    id="rs_abc123",
+                    text="Checking the hosted MCP tool",
+                    additional_properties={"status": "completed"},
+                ),
+                Content.from_mcp_server_tool_call(
+                    call_id="mcp_def456",
+                    tool_name="search",
+                    server_name="api_specs",
+                    arguments='{"q": "cats"}',
+                ),
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages, request_uses_service_side_storage=False)
+
+    types = [item.get("type") for item in result if isinstance(item, dict)]
+    assert types == ["reasoning", "mcp_call"]
+    assert result[0]["id"] == "rs_abc123"
+    assert result[1]["id"] == "mcp_def456"
+
+
+def test_prepare_messages_for_openai_drops_reasoning_and_hosted_mcp_call_with_storage() -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_text_reasoning(
+                    id="rs_abc123",
+                    text="Checking the hosted MCP tool",
+                    additional_properties={"status": "completed"},
+                ),
+                Content.from_mcp_server_tool_call(
+                    call_id="mcp_def456",
+                    tool_name="search",
+                    server_name="api_specs",
+                    arguments='{"q": "cats"}',
+                ),
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages, request_uses_service_side_storage=True)
+
+    assert result == []
+
+
 def test_prepare_messages_for_openai_coalesces_mcp_call_and_result_into_single_item() -> None:
     """An mcp_server_tool_call followed by an mcp_server_tool_result with the
     same call_id (in same or separate Messages) must produce ONE mcp_call
@@ -5561,6 +5618,45 @@ def test_prepare_messages_for_openai_coalesces_mcp_call_and_result_into_single_i
     # And no orphaned function_call_output should appear anywhere in the input.
     fco_items = [item for item in result if isinstance(item, dict) and item.get("type") == "function_call_output"]
     assert fco_items == [], f"unexpected orphan function_call_output items: {fco_items}"
+
+
+def test_prepare_messages_for_openai_keeps_reasoning_with_coalesced_hosted_mcp_result() -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_text_reasoning(
+                    id="rs_abc123",
+                    text="Need the MCP result",
+                    additional_properties={"status": "completed"},
+                ),
+                Content.from_mcp_server_tool_call(
+                    call_id="mcp_def456",
+                    tool_name="search",
+                    server_name="api_specs",
+                    arguments='{"q": "cats"}',
+                ),
+            ],
+        ),
+        Message(
+            role="tool",
+            contents=[
+                Content.from_mcp_server_tool_result(
+                    call_id="mcp_def456",
+                    output=[Content.from_text(text="found 10 cats")],
+                )
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_openai(messages, request_uses_service_side_storage=False)
+
+    assert [item.get("type") for item in result if isinstance(item, dict)] == ["reasoning", "mcp_call"]
+    assert result[0]["id"] == "rs_abc123"
+    assert result[1]["id"] == "mcp_def456"
+    assert result[1]["output"] == "found 10 cats"
 
 
 def test_prepare_messages_for_openai_drops_orphan_mcp_server_tool_result() -> None:


### PR DESCRIPTION
﻿Fixes #6074

## Summary
- keep `text_reasoning` items when replaying a hosted MCP call without service-side storage
- keep storage-backed replay stripping unchanged so stored hosted MCP items are not duplicated
- add regression coverage for hosted MCP call and coalesced result serialization

## Tests
- `python -m pytest python\packages\openai\tests\openai\test_openai_chat_client.py -q -p no:cacheprovider -k "hosted_mcp_call_storage_off or hosted_mcp_call_with_storage or coalesced_hosted_mcp_result or mcp_server_tool_call or coalesces_mcp_call"`
- `python -m pytest python\packages\openai\tests\openai\test_openai_chat_client.py -q -p no:cacheprovider -k "reasoning or mcp_server_tool"`
- `python -m ruff check python\packages\openai\agent_framework_openai\_chat_client.py python\packages\openai\tests\openai\test_openai_chat_client.py`
- `python -m ruff format --check python\packages\openai\agent_framework_openai\_chat_client.py python\packages\openai\tests\openai\test_openai_chat_client.py`
- `python -m py_compile python\packages\openai\agent_framework_openai\_chat_client.py python\packages\openai\tests\openai\test_openai_chat_client.py`
- `git diff --check`
