### PR TITLE
.NET: Remove responses experimental flag from FoundryAgent et.al.

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry/AIProjectClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/AIProjectClientExtensions.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -13,7 +12,6 @@ using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Responses;
 
@@ -22,7 +20,6 @@ namespace Azure.AI.Projects;
 /// <summary>
 /// Provides extension methods for <see cref="AIProjectClient"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public static partial class AIProjectClientExtensions
 {
     /// <summary>
@@ -374,6 +371,7 @@ public static partial class AIProjectClientExtensions
         if (agentDefinition is DeclarativeAgentDefinition { Tools: { Count: > 0 } definitionTools })
         {
             // Check if no tools were provided while the agent definition requires in-proc tools.
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             if (requireInvocableTools && chatOptions?.Tools is not { Count: > 0 } && definitionTools.Any(t => t is FunctionTool))
             {
                 throw new ArgumentException("The agent definition in-process tools must be provided in the extension method tools parameter.");
@@ -406,6 +404,7 @@ public static partial class AIProjectClientExtensions
 
                 (agentTools ??= []).Add(responseTool.AsAITool());
             }
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             if (requireInvocableTools && missingTools is { Count: > 0 })
             {

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/ChatClientAgentFoundryExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/ChatClientAgentFoundryExtensions.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Foundry;
@@ -17,7 +15,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <c>to_prompt_agent(agent)</c> function for agents whose underlying chat client is a
 /// <see cref="FoundryChatClient"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public static class ChatClientAgentFoundryExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using OpenAI.Responses;
 
 #pragma warning disable OPENAI001
@@ -27,7 +26,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <c>FoundryAITool.CreateOpenApiTool(definition)</c>
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public static class FoundryAITool
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgent.cs
@@ -4,14 +4,12 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Foundry;
@@ -36,7 +34,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <c>AsAIAgent</c> extension methods on <see cref="AIProjectClient"/>.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public sealed class FoundryAgent : DelegatingAIAgent
 {
     /// <summary>
@@ -261,6 +258,7 @@ public sealed class FoundryAgent : DelegatingAIAgent
             return innerAgent;
         }
 
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         if (innerAgent.ChatClient.GetService<OpenAIRequestPolicies>() is { } policies)
         {
             OpenAIRequestPoliciesReflection.AddPolicyIfMissing(
@@ -268,6 +266,7 @@ public sealed class FoundryAgent : DelegatingAIAgent
                 ClientHeadersPolicy.Instance,
                 PipelinePosition.PerCall);
         }
+#pragma warning restore MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         return new ClientHeadersAgent(innerAgent);
     }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAgentExtensions.cs
@@ -2,13 +2,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Files;
 using OpenAI.VectorStores;
@@ -23,7 +21,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <see cref="FoundryChatClient"/> at the agent level so callers do not need to drop down to
 /// <c>agent.GetService&lt;FoundryChatClient&gt;().X()</c> for common workflows.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public static class FoundryAgentExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryChatClient.cs
@@ -4,7 +4,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -13,7 +12,6 @@ using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Files;
 using OpenAI.Responses;
@@ -53,7 +51,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// behind an Agent Endpoint. It is not synonymous with the Agent Endpoint mode itself.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public sealed class FoundryChatClient : DelegatingChatClient
 {
     private readonly ChatClientMetadata _metadata;
@@ -652,6 +649,7 @@ public sealed class FoundryChatClient : DelegatingChatClient
     /// <summary>Best-effort registration of <see cref="AgentFrameworkUserAgentPolicy"/> via the MEAI <see cref="OpenAIRequestPolicies"/> hook with at-most-once dedup per pipeline.</summary>
     private static void TryRegisterAgentFrameworkUserAgentPolicy(IChatClient? innerClient)
     {
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         if (innerClient?.GetService<OpenAIRequestPolicies>() is { } policies)
         {
             // OpenAIRequestPoliciesReflection.AddPolicyIfMissing performs a check-then-add against
@@ -663,6 +661,7 @@ public sealed class FoundryChatClient : DelegatingChatClient
                 AgentFrameworkUserAgentPolicy.Instance,
                 PipelinePosition.PerCall);
         }
+#pragma warning restore MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -675,6 +674,7 @@ public sealed class FoundryChatClient : DelegatingChatClient
     /// </summary>
     private static void TryRegisterServedModelPolicy(IChatClient? innerClient)
     {
+#pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         if (innerClient?.GetService<OpenAIRequestPolicies>() is { } policies)
         {
             OpenAIRequestPoliciesReflection.AddPolicyIfMissing(
@@ -682,6 +682,7 @@ public sealed class FoundryChatClient : DelegatingChatClient
                 ServedModelPolicy.Instance,
                 PipelinePosition.PerCall);
         }
+#pragma warning restore MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>Default OAuth scope for the Azure AI resource. Matches the scope used by <c>Azure.AI.Extensions.OpenAI</c>'s internal authentication helper so the bearer token is accepted by the Foundry control plane.</summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryPromptAgentConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryPromptAgentConverter.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.Extensions.OpenAI;
 using Azure.AI.Projects;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 using OpenAI.Responses;
 
@@ -34,7 +32,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <item><description><b>Agent Endpoint (Mode 3)</b>: throw — no local definition exists to convert.</description></item>
 /// </list>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 internal static class FoundryPromptAgentConverter
 {
     /// <summary>Performs the conversion for an agent whose chat client and chat options are supplied.</summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/HostedMcpToolboxAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/HostedMcpToolboxAITool.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI.Foundry;
 
@@ -22,7 +21,6 @@ namespace Microsoft.Agents.AI.Foundry;
 /// <c>FoundryAITool.CreateHostedMcpToolbox(...)</c> factory overloads.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public sealed class HostedMcpToolboxAITool : HostedMcpServerTool
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/Microsoft.Agents.AI.Foundry.csproj
@@ -6,7 +6,6 @@
          related per-agent endpoint surface). Flip back to IsReleased=true once Azure.AI.Projects
          ships a stable 2.1.0. -->
     <InjectSharedThrow>true</InjectSharedThrow>
-    <NoWarn>$(NoWarn);OPENAI001</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/ProjectResponsesClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/ProjectResponsesClientExtensions.cs
@@ -13,7 +13,6 @@ namespace Azure.AI.Extensions.OpenAI;
 /// Provides extension methods for <see cref="ProjectResponsesClient"/>
 /// to simplify the creation of AI agents that work with Azure AI services.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
 public static class ProjectResponsesClientExtensions
 {
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

Most of responses is now not experimental anymore, allowing us to remove the upstream flags.

### Description

- Remove responses experimental flag from FoundryAgent et.al.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.