### PR TITLE
.NET: fix: skip local history after service conversation ids

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -476,7 +476,7 @@ public sealed partial class ChatClientAgent : AIAgent
         ChatOptions? chatOptions,
         CancellationToken cancellationToken)
     {
-        ChatHistoryProvider? chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions);
+        ChatHistoryProvider? chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions, session);
 
         if (chatHistoryProvider is not null)
         {
@@ -508,7 +508,7 @@ public sealed partial class ChatClientAgent : AIAgent
         ChatOptions? chatOptions,
         CancellationToken cancellationToken)
     {
-        ChatHistoryProvider? chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions);
+        ChatHistoryProvider? chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions, session);
 
         if (chatHistoryProvider is not null)
         {
@@ -974,14 +974,15 @@ public sealed partial class ChatClientAgent : AIAgent
         }
     }
 
-    private ChatHistoryProvider? ResolveChatHistoryProvider(ChatOptions? chatOptions)
+    private ChatHistoryProvider? ResolveChatHistoryProvider(ChatOptions? chatOptions, ChatClientAgentSession? session = null)
     {
-        ChatHistoryProvider? provider = chatOptions?.ConversationId is null ? this.ChatHistoryProvider : null;
+        string? conversationId = !string.IsNullOrWhiteSpace(chatOptions?.ConversationId) ? chatOptions.ConversationId : session?.ConversationId;
+        ChatHistoryProvider? provider = IsServiceManagedConversationId(conversationId) ? null : this.ChatHistoryProvider;
 
         // If someone provided an override ChatHistoryProvider via AdditionalProperties, we should use that instead.
         if (chatOptions?.AdditionalProperties?.TryGetValue(out ChatHistoryProvider? overrideProvider) is true)
         {
-            if (this._agentOptions?.ThrowOnChatHistoryProviderConflict is true && string.IsNullOrWhiteSpace(chatOptions?.ConversationId) is false)
+            if (this._agentOptions?.ThrowOnChatHistoryProviderConflict is true && IsServiceManagedConversationId(conversationId))
             {
                 throw new InvalidOperationException(
                     $"Only {nameof(ChatClientAgentSession.ConversationId)} or {nameof(this.ChatHistoryProvider)} may be used, but not both. The current {nameof(ChatClientAgentSession)} has a {nameof(ChatClientAgentSession.ConversationId)} indicating server-side chat history management, but an override {nameof(this.ChatHistoryProvider)} was provided via {nameof(AgentRunOptions.AdditionalProperties)}.");
@@ -1006,6 +1007,12 @@ public sealed partial class ChatClientAgent : AIAgent
         return provider;
     }
 
+    private static bool IsServiceManagedConversationId(string? conversationId)
+    {
+        return !string.IsNullOrWhiteSpace(conversationId)
+            && conversationId != PerServiceCallChatHistoryPersistingChatClient.LocalHistoryConversationId;
+    }
+
     /// <summary>
     /// Loads chat history from the resolved <see cref="ChatHistoryProvider"/> and prepends it to the given messages.
     /// </summary>
@@ -1019,7 +1026,7 @@ public sealed partial class ChatClientAgent : AIAgent
         ChatOptions? chatOptions,
         CancellationToken cancellationToken)
     {
-        var chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions);
+        var chatHistoryProvider = this.ResolveChatHistoryProvider(chatOptions, session);
         if (chatHistoryProvider is null)
         {
             return messages;

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgent_ChatHistoryManagementTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgent_ChatHistoryManagementTests.cs
@@ -385,11 +385,11 @@ public class ChatClientAgent_ChatHistoryManagementTests
     }
 
     /// <summary>
-    /// Verify that RunAsync does not throw when no ChatHistoryProvider is configured on options,
-    /// even if the service returns a conversation id (default InMemoryChatHistoryProvider is used but not from options).
+    /// Verify that RunAsync does not persist the default InMemoryChatHistoryProvider when
+    /// the service returns a conversation id.
     /// </summary>
     [Fact]
-    public async Task RunAsync_DoesNotThrow_WhenNoChatHistoryProviderInOptionsAndConversationIdReturnedAsync()
+    public async Task RunAsync_DoesNotPersistDefaultChatHistoryProvider_WhenConversationIdReturnedByChatClientAsync()
     {
         // Arrange
         Mock<IChatClient> mockService = new();
@@ -407,8 +407,10 @@ public class ChatClientAgent_ChatHistoryManagementTests
         ChatClientAgentSession? session = await agent.CreateSessionAsync() as ChatClientAgentSession;
         await agent.RunAsync([new(ChatRole.User, "test")], session);
 
-        // Assert - no exception, session gets the conversation id
+        // Assert
         Assert.Equal("ConvId", session!.ConversationId);
+        var inMemoryProvider = Assert.IsType<InMemoryChatHistoryProvider>(agent.ChatHistoryProvider);
+        Assert.Empty(inMemoryProvider.GetMessages(session));
     }
 
     #endregion


### PR DESCRIPTION
﻿## Summary
- skip ChatHistoryProvider resolution once a real service-managed ConversationId is on the session
- keep the per-service-call local-history sentinel using the local provider path
- strengthen the default InMemory regression test for service-returned ConversationId

Fixes #6120

## To verify
- dotnet test --project tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj -f net10.0 -c Debug -v Normal --filter-class Microsoft.Agents.AI.UnitTests.ChatClientAgent_ChatHistoryManagementTests --report-xunit-trx --ignore-exit-code 8
- dotnet test --project tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj -f net472 -c Debug -v Normal --filter-class Microsoft.Agents.AI.UnitTests.ChatClientAgent_ChatHistoryManagementTests --report-xunit-trx --ignore-exit-code 8
- git diff --check
