### PR TITLE
Python: fix: serialize MCP loader reloads

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -255,6 +255,8 @@ class MCPTool:
         self._exit_stack = AsyncExitStack()
         self._lifecycle_lock = asyncio.Lock()
         self._lifecycle_request_lock = asyncio.Lock()
+        self._load_tools_lock = asyncio.Lock()
+        self._load_prompts_lock = asyncio.Lock()
         self._lifecycle_queue: asyncio.Queue[tuple[str, bool, bool, asyncio.Future[None]]] | None = None
         self._lifecycle_owner_task: asyncio.Task[None] | None = None
         self.session = session
@@ -1010,6 +1012,11 @@ class MCPTool:
         return self.approval_mode  # type: ignore[return-value]
 
     async def load_prompts(self) -> None:
+        """Load prompts from the MCP server."""
+        async with self._load_prompts_lock:
+            await self._load_prompts_locked()
+
+    async def _load_prompts_locked(self) -> None:
         """Load prompts from the MCP server.
 
         Retrieves available prompts from the connected MCP server and converts
@@ -1092,6 +1099,11 @@ class MCPTool:
             params = types.PaginatedRequestParams(cursor=prompt_list.nextCursor)
 
     async def load_tools(self) -> None:
+        """Load tools from the MCP server."""
+        async with self._load_tools_lock:
+            await self._load_tools_locked()
+
+    async def _load_tools_locked(self) -> None:
         """Load tools from the MCP server.
 
         Retrieves available tools from the connected MCP server and converts

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -3202,6 +3202,33 @@ async def test_load_tools_pagination_with_duplicates():
     assert [f.name for f in tool._functions] == ["tool_1", "tool_2", "tool_3"]
 
 
+async def test_load_tools_serializes_concurrent_loads():
+    tool = MCPTool(name="test_tool")
+    tool.session = AsyncMock()
+    tool.load_tools_flag = True
+
+    page = Mock()
+    page.tools = [
+        types.Tool(
+            name="tool_1",
+            description="First tool",
+            inputSchema={"type": "object", "properties": {"param": {"type": "string"}}},
+        ),
+    ]
+    page.nextCursor = None
+
+    async def list_tools(params=None):
+        await asyncio.sleep(0)
+        return page
+
+    tool.session.list_tools = AsyncMock(side_effect=list_tools)
+
+    await asyncio.gather(tool.load_tools(), tool.load_tools())
+
+    assert tool.session.list_tools.call_count == 2
+    assert [f.name for f in tool._functions] == ["tool_1"]
+
+
 async def test_load_prompts_pagination_with_duplicates():
     """Test that load_prompts prevents duplicates across paginated results."""
     from unittest.mock import AsyncMock, MagicMock
@@ -3258,6 +3285,33 @@ async def test_load_prompts_pagination_with_duplicates():
     assert mock_session.list_prompts.call_count == 2
     assert len(tool._functions) == 2
     assert [f.name for f in tool._functions] == ["prompt_1", "prompt_2"]
+
+
+async def test_load_prompts_serializes_concurrent_loads():
+    tool = MCPTool(name="test_tool")
+    tool.session = AsyncMock()
+    tool.load_prompts_flag = True
+
+    page = Mock()
+    page.prompts = [
+        types.Prompt(
+            name="prompt_1",
+            description="First prompt",
+            arguments=[types.PromptArgument(name="arg1", description="Arg 1", required=True)],
+        ),
+    ]
+    page.nextCursor = None
+
+    async def list_prompts(params=None):
+        await asyncio.sleep(0)
+        return page
+
+    tool.session.list_prompts = AsyncMock(side_effect=list_prompts)
+
+    await asyncio.gather(tool.load_prompts(), tool.load_prompts())
+
+    assert tool.session.list_prompts.call_count == 2
+    assert [f.name for f in tool._functions] == ["prompt_1"]
 
 
 async def test_load_tools_pagination_exception_handling():


### PR DESCRIPTION
﻿Fixes #5911.

## Summary

`MCPTool.load_tools()` and `load_prompts()` both snapshot existing function names before awaiting MCP list calls. If the initial load and a server-triggered reload interleave, both calls can see the same empty snapshot and append duplicate `FunctionTool` entries.

This serializes those two loader paths per MCP tool instance so initial loads and background reloads cannot mutate `_functions` concurrently.

## To verify

From `python/packages/core`:

```powershell
uv run --frozen pytest tests\core\test_mcp.py -q -k "serializes_concurrent_loads or pagination_with_duplicates" --basetemp .tmp\pytest-5911 -p no:cacheprovider
uv run --frozen pytest tests\core\test_mcp.py -q --basetemp .tmp\pytest-5911-full -p no:cacheprovider
uv run --frozen ruff check agent_framework\_mcp.py tests\core\test_mcp.py
```

From repo root:

```powershell
python -m py_compile python\packages\core\agent_framework\_mcp.py python\packages\core\tests\core\test_mcp.py
git diff --check
```

Local result: `test_mcp.py` passed on Windows, with 2 skipped integration tests and one existing coroutine cleanup warning from `test_mcp_tool_message_handler_cancel_and_replace`.
