### PR TITLE
Python: fix(core): coalesce streamed code_interpreter_tool_call chunks per call_id

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1973,11 +1973,95 @@ def _coalesce_text_content(contents: list[Content], type_str: Literal["text", "t
     contents.extend(coalesced_contents)
 
 
+def _coalesce_code_interpreter_tool_calls(contents: list[Content]) -> None:
+    """Deduplicate code_interpreter_tool_call items that share a call_id.
+
+    During streaming, the OpenAI Responses API emits one
+    ``response.code_interpreter_call_code.delta`` event per chunk of generated
+    code, followed by a single ``response.code_interpreter_call_code.done``
+    event whose ``code`` field holds the complete aggregated script. The
+    provider client surfaces each event as its own
+    ``code_interpreter_tool_call`` content item (see
+    ``agent_framework_openai/_chat_client.py``). Without this pass, those
+    items flow through ``_process_update`` into ``message.contents`` and end
+    up persisted one-per-chunk by downstream history providers
+    (microsoft/agent-framework#5793).
+
+    Each chunk's ``additional_properties.sequence_number`` is monotonically
+    increasing; the ``done`` event has the highest sequence number and its
+    first text input contains the full script. This function keeps only the
+    highest-sequence_number content per ``call_id``. When sequence numbers are
+    not available (other providers, or future changes), it falls back to the
+    item whose first input text is the longest, which preserves the same
+    "most complete wins" semantics.
+
+    Providers that emit a single content per call (Anthropic, Foundry, the
+    non-streaming OpenAI path) are unaffected: only the single item exists
+    per ``call_id`` and the loop is a no-op.
+    """
+    if not contents:
+        return
+
+    # Group code_interpreter_tool_call items by call_id and find the best
+    # candidate (highest sequence number, or longest input text as fallback).
+    def _sequence_number(content: Content) -> int | None:
+        props = content.additional_properties or {}
+        value = props.get("sequence_number")
+        return value if isinstance(value, int) else None
+
+    def _first_input_text_len(content: Content) -> int:
+        inputs = getattr(content, "inputs", None)
+        if not inputs:
+            return 0
+        first = inputs[0]
+        text = getattr(first, "text", None)
+        return len(text) if isinstance(text, str) else 0
+
+    best_per_call: dict[str | None, Content] = {}
+    for content in contents:
+        if content.type != "code_interpreter_tool_call":
+            continue
+        call_id = getattr(content, "call_id", None)
+        existing = best_per_call.get(call_id)
+        if existing is None:
+            best_per_call[call_id] = content
+            continue
+        existing_seq = _sequence_number(existing)
+        new_seq = _sequence_number(content)
+        if existing_seq is not None and new_seq is not None:
+            if new_seq > existing_seq:
+                best_per_call[call_id] = content
+        elif _first_input_text_len(content) > _first_input_text_len(existing):
+            best_per_call[call_id] = content
+
+    if not best_per_call:
+        return
+
+    # Rebuild contents, replacing each call_id's first occurrence with the
+    # winning item and dropping the rest. Order is preserved relative to the
+    # other content types.
+    rebuilt: list[Content] = []
+    emitted: set[str | None] = set()
+    for content in contents:
+        if content.type != "code_interpreter_tool_call":
+            rebuilt.append(content)
+            continue
+        call_id = getattr(content, "call_id", None)
+        if call_id in emitted:
+            continue
+        rebuilt.append(best_per_call[call_id])
+        emitted.add(call_id)
+
+    contents.clear()
+    contents.extend(rebuilt)
+
+
 def _finalize_response(response: ChatResponse | AgentResponse) -> None:
     """Finalizes the response by performing any necessary post-processing."""
     for msg in response.messages:
         _coalesce_text_content(msg.contents, "text")
         _coalesce_text_content(msg.contents, "text_reasoning")
+        _coalesce_code_interpreter_tool_calls(msg.contents)
 
 
 # region ContinuationToken

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -1716,6 +1716,123 @@ def test_text_reasoning_content_add_neither_has_id():
     assert result.id is None
 
 
+def test_coalesce_code_interpreter_tool_calls_keeps_done_event():
+    """OpenAI Responses streaming emits one code_interpreter_tool_call per code
+    delta plus a final 'done' event with the full aggregated script. The
+    finalization pass should drop the deltas and keep only the done event.
+
+    Regression test for microsoft/agent-framework#5793 — without this,
+    CosmosHistoryProvider and other history providers persist hundreds of
+    per-chunk content items.
+    """
+    from agent_framework._types import _coalesce_code_interpreter_tool_calls
+
+    call_id = "ci_abc123"
+
+    def _chunk(text: str, seq: int) -> Content:
+        return Content.from_code_interpreter_tool_call(
+            call_id=call_id,
+            inputs=[Content.from_text(text=text)],
+            additional_properties={
+                "output_index": 1,
+                "sequence_number": seq,
+                "item_id": call_id,
+            },
+        )
+
+    contents: list[Content] = [
+        Content.from_text_reasoning(id="rs_x", text="planning"),
+        _chunk("import", seq=6),
+        _chunk(" pandas", seq=7),
+        _chunk(" as pd", seq=8),
+        # Final 'done' event carries the complete aggregated script.
+        _chunk("import pandas as pd\nprint('hi')", seq=261),
+    ]
+
+    _coalesce_code_interpreter_tool_calls(contents)
+
+    assert len(contents) == 2
+    assert contents[0].type == "text_reasoning"
+    assert contents[1].type == "code_interpreter_tool_call"
+    assert contents[1].call_id == call_id  # type: ignore[attr-defined]
+    assert contents[1].inputs[0].text == "import pandas as pd\nprint('hi')"  # type: ignore[attr-defined,index]
+
+
+def test_coalesce_code_interpreter_tool_calls_groups_by_call_id():
+    """Multiple distinct call_ids must each keep their own winning chunk."""
+    from agent_framework._types import _coalesce_code_interpreter_tool_calls
+
+    def _chunk(call_id: str, text: str, seq: int) -> Content:
+        return Content.from_code_interpreter_tool_call(
+            call_id=call_id,
+            inputs=[Content.from_text(text=text)],
+            additional_properties={"sequence_number": seq, "item_id": call_id},
+        )
+
+    contents: list[Content] = [
+        _chunk("call_one", "imp", seq=1),
+        _chunk("call_one", "import os", seq=20),  # winner for call_one
+        _chunk("call_two", "x =", seq=3),
+        _chunk("call_two", "x = 1 + 1", seq=15),  # winner for call_two
+    ]
+
+    _coalesce_code_interpreter_tool_calls(contents)
+
+    assert len(contents) == 2
+    assert contents[0].call_id == "call_one"  # type: ignore[attr-defined]
+    assert contents[0].inputs[0].text == "import os"  # type: ignore[attr-defined,index]
+    assert contents[1].call_id == "call_two"  # type: ignore[attr-defined]
+    assert contents[1].inputs[0].text == "x = 1 + 1"  # type: ignore[attr-defined,index]
+
+
+def test_coalesce_code_interpreter_tool_calls_no_sequence_number_falls_back_to_longest_text():
+    """Providers that emit code_interpreter chunks without sequence_number
+    metadata (e.g. future providers, or partial events) should still get the
+    longest text as the winner.
+    """
+    from agent_framework._types import _coalesce_code_interpreter_tool_calls
+
+    def _chunk(text: str) -> Content:
+        return Content.from_code_interpreter_tool_call(
+            call_id="ci_x",
+            inputs=[Content.from_text(text=text)],
+        )
+
+    contents: list[Content] = [
+        _chunk("short"),
+        _chunk("a much longer aggregated body"),
+        _chunk("medium length"),
+    ]
+
+    _coalesce_code_interpreter_tool_calls(contents)
+
+    assert len(contents) == 1
+    assert contents[0].inputs[0].text == "a much longer aggregated body"  # type: ignore[attr-defined,index]
+
+
+def test_coalesce_code_interpreter_tool_calls_single_call_is_noop():
+    """Providers that emit a single content per call (Anthropic, Foundry, the
+    non-streaming OpenAI path) must not be affected.
+    """
+    from agent_framework._types import _coalesce_code_interpreter_tool_calls
+
+    contents: list[Content] = [
+        Content.from_text(text="hello"),
+        Content.from_code_interpreter_tool_call(
+            call_id="ci_only",
+            inputs=[Content.from_text(text="print('hi')")],
+        ),
+        Content.from_text(text="world"),
+    ]
+    original_count = len(contents)
+
+    _coalesce_code_interpreter_tool_calls(contents)
+
+    assert len(contents) == original_count
+    assert contents[1].call_id == "ci_only"  # type: ignore[attr-defined]
+    assert contents[1].inputs[0].text == "print('hi')"  # type: ignore[attr-defined,index]
+
+
 def test_coalesce_text_reasoning_with_different_ids():
     """Test that _coalesce_text_content keeps separate text_reasoning items when IDs differ.
 


### PR DESCRIPTION
Fixes #5793.

## What the bug is

When the OpenAI Responses API streams a code-interpreter call, it emits:

- one `response.code_interpreter_call_code.delta` event per chunk of generated code
- a single `response.code_interpreter_call_code.done` event whose `code` field holds the complete aggregated script

`agent_framework_openai/_chat_client.py` surfaces each event as its own `code_interpreter_tool_call` content item, with `additional_properties.sequence_number` carrying the monotonically increasing event sequence.

In `_types.py`:

- `_process_update` appends every chunk to `message.contents` (`case _: message.contents.append(content)`).
- `_finalize_response` only coalesces `text` and `text_reasoning`.

The result: by the time a finalized `ChatResponse` reaches a `HistoryProvider.save_messages()`, one logical code interpreter call is represented by hundreds of near-duplicate content items. #5793 shows a `CosmosHistoryProvider` document that grew to 5000+ JSON lines for a single session because every chunk gets its own Cosmos record.

## The fix

Add `_coalesce_code_interpreter_tool_calls(contents)` and invoke it from `_finalize_response`:

```python
def _finalize_response(response):
    for msg in response.messages:
        _coalesce_text_content(msg.contents, \"text\")
        _coalesce_text_content(msg.contents, \"text_reasoning\")
        _coalesce_code_interpreter_tool_calls(msg.contents)
```

The pass groups `code_interpreter_tool_call` items by `call_id` and keeps the one with the highest `additional_properties.sequence_number`. The `done` event always has the highest sequence number and carries the complete script, so this exactly recovers the intended *one content item per call with the complete aggregated text*.

When sequence metadata is absent (other providers, or partial events), it falls back to the item whose first input text is longest — same \"most complete wins\" semantics.

## What this does NOT change

- **Providers that emit one content per call** (Anthropic via `_add_function_call_content` adjacent code at line 1051-ish, Foundry's `_responses.py`, and the non-streaming OpenAI path on line 2118 of `_chat_client.py`) are unaffected — only one item per `call_id` exists, the loop is a no-op.
- **Other content types** (text, text_reasoning, function_call, usage, hosted_file, etc.) — untouched.
- **Ordering** — the winning item keeps the position of the *first* occurrence of its `call_id`, so relative order with non-CI content is preserved.

## Tests

Four new regression tests in `packages/core/tests/core/test_types.py`:

| Test | Verifies |
|---|---|
| `test_coalesce_code_interpreter_tool_calls_keeps_done_event` | Streaming deltas + done collapse to the done event (the #5793 scenario) |
| `test_coalesce_code_interpreter_tool_calls_groups_by_call_id` | Multiple distinct `call_id`s each keep their own winning chunk |
| `test_coalesce_code_interpreter_tool_calls_no_sequence_number_falls_back_to_longest_text` | Fallback path for providers without `sequence_number` metadata |
| `test_coalesce_code_interpreter_tool_calls_single_call_is_noop` | Anthropic / Foundry / non-streaming OpenAI behavior is unchanged |

## Verification

```bash
uv run --package agent-framework-core pytest packages/core/tests/core/test_types.py
# 268 passed

uv run ruff check packages/core/agent_framework/_types.py packages/core/tests/core/test_types.py
# All checks passed!

uv run ruff format --check packages/core/agent_framework/_types.py packages/core/tests/core/test_types.py
# 2 files already formatted

uv run --package agent-framework-core mypy packages/core/agent_framework/_types.py
# Success: no issues found
```

The pre-existing failure in `test_telemetry.py::test_detect_hosted_fallback_import_error` is unrelated to this change and reproduces on a clean `main` checkout.