### PR TITLE
Python: fix: evaluate simple declarative refs without powerfx

### DIFF
--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -62,6 +62,7 @@ logger = logging.getLogger(__name__)
 
 
 _ENV_REFERENCE_RE = re.compile(r"\bEnv\.([A-Za-z_][A-Za-z0-9_]*)")
+_SIMPLE_STATE_REFERENCE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+")
 
 
 @dataclass(frozen=True)
@@ -508,6 +509,10 @@ class DeclarativeWorkflowState:
         formula = self._preprocess_custom_functions(formula)
 
         if Engine is None:
+            handled, value = self._eval_simple_state_reference(formula)
+            if handled:
+                return value
+
             raise RuntimeError(
                 f"PowerFx is not available (dotnet runtime not installed). "
                 f"Expression '={formula[:80]}' cannot be evaluated. "
@@ -551,6 +556,24 @@ class DeclarativeWorkflowState:
             raise
         finally:
             locale.setlocale(locale.LC_NUMERIC, original_numeric_locale)
+
+    def _eval_simple_state_reference(self, formula: str) -> tuple[bool, Any]:
+        formula = formula.strip()
+        if not _SIMPLE_STATE_REFERENCE_RE.fullmatch(formula):
+            return False, None
+
+        if formula.startswith("inputs."):
+            return True, self.get(f"Workflow.Inputs.{formula.removeprefix('inputs.')}")
+
+        if formula.startswith(("Workflow.", "Local.", "System.", "Agent.", "Conversation.")):
+            return True, self.get(formula)
+
+        not_found = object()
+        value = self.get(formula, default=not_found)
+        if value is not not_found:
+            return True, value
+
+        return False, None
 
     def _eval_custom_function(self, formula: str) -> Any | None:
         """Handle custom functions not supported by the Python PowerFx library.

--- a/python/packages/declarative/tests/test_graph_executors.py
+++ b/python/packages/declarative/tests/test_graph_executors.py
@@ -1314,6 +1314,46 @@ class TestPowerFxConditionalImport:
         finally:
             base_mod.Engine = original_engine
 
+    def test_eval_handles_simple_state_references_without_engine(self):
+        import agent_framework_declarative._workflows._declarative_base as base_mod
+
+        mock_state = MagicMock()
+        mock_state._data: dict[str, Any] = {}
+        mock_state.get = MagicMock(side_effect=lambda k, d=None: mock_state._data.get(k, d))
+        mock_state.set = MagicMock(side_effect=lambda k, v: mock_state._data.__setitem__(k, v))
+
+        state = DeclarativeWorkflowState(mock_state)
+        state.initialize({"age": 25})
+        state.set("Local.status", "ready")
+
+        original_engine = base_mod.Engine
+        try:
+            base_mod.Engine = None
+            assert state.eval("=inputs.age") == 25
+            assert state.eval("=Workflow.Inputs.age") == 25
+            assert state.eval("=Local.status") == "ready"
+        finally:
+            base_mod.Engine = original_engine
+
+    def test_eval_still_requires_engine_for_complex_expressions(self):
+        import agent_framework_declarative._workflows._declarative_base as base_mod
+
+        mock_state = MagicMock()
+        mock_state._data: dict[str, Any] = {}
+        mock_state.get = MagicMock(side_effect=lambda k, d=None: mock_state._data.get(k, d))
+        mock_state.set = MagicMock(side_effect=lambda k, v: mock_state._data.__setitem__(k, v))
+
+        state = DeclarativeWorkflowState(mock_state)
+        state.initialize({"age": 25})
+
+        original_engine = base_mod.Engine
+        try:
+            base_mod.Engine = None
+            with pytest.raises(RuntimeError, match="PowerFx is not available"):
+                state.eval("=inputs.age + 1")
+        finally:
+            base_mod.Engine = original_engine
+
     def test_eval_passes_through_plain_strings_without_engine(self):
         """Non-PowerFx strings (no leading '=') should work without Engine."""
         import agent_framework_declarative._workflows._declarative_base as base_mod


### PR DESCRIPTION
﻿## Summary
- allow declarative workflow state to resolve simple state references when PowerFx/.NET is unavailable
- support the common `inputs.*` alias plus `Workflow`, `Local`, `System`, `Agent`, and `Conversation` references
- keep complex expressions on the existing RuntimeError path so missing PowerFx is not hidden

Fixes #5388.

## To verify
- $env:PYTHONPATH='python\packages\core;python\packages\declarative'; python -m pytest python\packages\declarative\tests\test_graph_executors.py -q -k "PowerFxConditionalImport" --basetemp .tmp\pytest-5388
- $env:PYTHONPATH='python\packages\core;python\packages\declarative'; python -m py_compile python\packages\declarative\agent_framework_declarative\_workflows\_declarative_base.py python\packages\declarative\tests\test_graph_executors.py
- python -m ruff check python\packages\declarative\agent_framework_declarative\_workflows\_declarative_base.py python\packages\declarative\tests\test_graph_executors.py
- git diff --check
