### PR TITLE
.NET: Fix render dupe and text input clear bugs, and improve guardrail error messaging

### DIFF
--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/AnsiEscapes.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/AnsiEscapes.cs
@@ -72,6 +72,40 @@ public static class AnsiEscapes
     /// </summary>
     public static string ResetAttributes => "\x1b[0m";
 
+    /// <summary>
+    /// Returns the visible (printed) length of a string after stripping ANSI escape sequences.
+    /// Escape sequences are zero-width on screen but occupy characters in the raw string.
+    /// </summary>
+    public static int VisibleLength(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        int length = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\x1b' && i + 1 < text.Length && text[i + 1] == '[')
+            {
+                // Skip the ESC[ and all characters up to and including the final byte (0x40–0x7E).
+                i += 2;
+                while (i < text.Length && text[i] < 0x40)
+                {
+                    i++;
+                }
+
+                // i now points to the final byte of the escape sequence; the for-loop will advance past it.
+            }
+            else if (text[i] != '\n' && text[i] != '\r')
+            {
+                length++;
+            }
+        }
+
+        return length;
+    }
+
     private static int ConsoleColorToAnsi(ConsoleColor color) => color switch
     {
         ConsoleColor.Black => 30,

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/AnsiEscapes.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/AnsiEscapes.cs
@@ -76,6 +76,12 @@ public static class AnsiEscapes
     /// Returns the visible (printed) length of a string after stripping ANSI escape sequences.
     /// Escape sequences are zero-width on screen but occupy characters in the raw string.
     /// </summary>
+    /// <remarks>
+    /// This counts UTF-16 code units (chars) rather than terminal display cells. Emoji,
+    /// combining characters, variation selectors, and East Asian wide characters may be
+    /// measured incorrectly. For the console harness this is acceptable since content is
+    /// predominantly ASCII, and emoji are padded with surrounding spaces.
+    /// </remarks>
     public static int VisibleLength(string text)
     {
         if (string.IsNullOrEmpty(text))
@@ -104,6 +110,55 @@ public static class AnsiEscapes
         }
 
         return length;
+    }
+
+    /// <summary>
+    /// Counts the number of physical terminal rows a text item will occupy,
+    /// accounting for both explicit newlines and terminal line wrapping.
+    /// </summary>
+    /// <param name="text">The text to measure.</param>
+    /// <param name="terminalWidth">The terminal width in columns. If &lt;= 0, wrapping is ignored (1 row per logical line).</param>
+    /// <returns>The number of physical rows the text occupies.</returns>
+    public static int CountPhysicalLines(string text, int terminalWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        int physicalLines = 0;
+        int lineStart = 0;
+
+        for (int i = 0; i <= text.Length; i++)
+        {
+            if (i == text.Length || text[i] == '\n')
+            {
+                if (terminalWidth <= 0)
+                {
+                    // No wrapping — each logical line is one physical row
+                    physicalLines += 1;
+                }
+                else
+                {
+                    string logicalLine = text[lineStart..i];
+                    int visibleWidth = VisibleLength(logicalLine);
+
+                    physicalLines += visibleWidth == 0
+                        ? 1
+                        : (visibleWidth - 1) / terminalWidth + 1;
+                }
+
+                lineStart = i + 1;
+            }
+        }
+
+        // If text ends with a newline, don't count the trailing empty line
+        if (text[text.Length - 1] == '\n')
+        {
+            physicalLines--;
+        }
+
+        return physicalLines;
     }
 
     private static int ConsoleColorToAnsi(ConsoleColor color) => color switch

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
@@ -23,16 +23,18 @@ public record TextPanelProps : ConsoleReactiveProps
 public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiveState>
 {
     /// <summary>
-    /// Calculates the height (in lines) needed to render all items.
+    /// Calculates the height (in lines) needed to render all items,
+    /// accounting for terminal line wrapping at the specified width.
     /// </summary>
     /// <param name="items">The items to measure.</param>
-    /// <returns>The total number of lines all items will occupy.</returns>
-    public static int CalculateHeight(IReadOnlyList<string> items)
+    /// <param name="terminalWidth">The terminal width in columns. When 0 or negative, wrapping is ignored.</param>
+    /// <returns>The total number of physical lines all items will occupy.</returns>
+    public static int CalculateHeight(IReadOnlyList<string> items, int terminalWidth = 0)
     {
         int total = 0;
         for (int i = 0; i < items.Count; i++)
         {
-            total += CountLines(items[i]);
+            total += CountPhysicalLines(items[i], terminalWidth);
         }
 
         return total;
@@ -47,9 +49,9 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         {
             string text = props.Items[i];
             string[] lines = text.Split('\n');
-            int lineCount = CountLines(text);
+            int lineCount = CountPhysicalLines(text, props.Width);
 
-            for (int j = 0; j < lineCount; j++)
+            for (int j = 0; j < lines.Length && currentRow < lineCount; j++)
             {
                 Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + currentRow));
                 Console.Write(lines[j]);
@@ -67,28 +69,51 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         }
     }
 
-    private static int CountLines(string text)
+    /// <summary>
+    /// Counts the number of physical terminal rows a text item will occupy,
+    /// accounting for both explicit newlines and terminal line wrapping.
+    /// </summary>
+    private static int CountPhysicalLines(string text, int terminalWidth)
     {
         if (string.IsNullOrEmpty(text))
         {
             return 0;
         }
 
-        int count = 1;
-        for (int i = 0; i < text.Length; i++)
+        if (terminalWidth <= 0)
         {
-            if (text[i] == '\n')
+            terminalWidth = int.MaxValue;
+        }
+
+        int physicalLines = 0;
+        int lineStart = 0;
+
+        for (int i = 0; i <= text.Length; i++)
+        {
+            if (i == text.Length || text[i] == '\n')
             {
-                count++;
+                string logicalLine = text[lineStart..i];
+                int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
+
+                if (visibleWidth == 0)
+                {
+                    physicalLines += 1;
+                }
+                else
+                {
+                    physicalLines += (visibleWidth + terminalWidth - 1) / terminalWidth;
+                }
+
+                lineStart = i + 1;
             }
         }
 
         // If text ends with a newline, don't count the trailing empty line
         if (text[text.Length - 1] == '\n')
         {
-            count--;
+            physicalLines--;
         }
 
-        return count;
+        return physicalLines;
     }
 }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
@@ -49,13 +49,20 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         {
             string text = props.Items[i];
             string[] lines = text.Split('\n');
-            int lineCount = CountPhysicalLines(text, props.Width);
+            int itemLineCount = CountPhysicalLines(text, props.Width);
+            int itemRow = 0;
 
-            for (int j = 0; j < lines.Length && currentRow < lineCount; j++)
+            for (int j = 0; j < lines.Length && itemRow < itemLineCount; j++)
             {
+                int linePhysicalRows = props.Width > 0
+                    ? Math.Max(1, (AnsiEscapes.VisibleLength(lines[j]) - 1) / props.Width + 1)
+                    : 1;
+
                 Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + currentRow));
                 Console.Write(lines[j]);
-                currentRow++;
+
+                currentRow += linePhysicalRows;
+                itemRow += linePhysicalRows;
             }
         }
 
@@ -80,11 +87,6 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
             return 0;
         }
 
-        if (terminalWidth <= 0)
-        {
-            terminalWidth = int.MaxValue;
-        }
-
         int physicalLines = 0;
         int lineStart = 0;
 
@@ -92,16 +94,19 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         {
             if (i == text.Length || text[i] == '\n')
             {
-                string logicalLine = text[lineStart..i];
-                int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
-
-                if (visibleWidth == 0)
+                if (terminalWidth <= 0)
                 {
+                    // No wrapping — each logical line is one physical row
                     physicalLines += 1;
                 }
                 else
                 {
-                    physicalLines += (visibleWidth + terminalWidth - 1) / terminalWidth;
+                    string logicalLine = text[lineStart..i];
+                    int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
+
+                    physicalLines += visibleWidth == 0
+                        ? 1
+                        : (visibleWidth - 1) / terminalWidth + 1;
                 }
 
                 lineStart = i + 1;

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextPanel.cs
@@ -34,7 +34,7 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         int total = 0;
         for (int i = 0; i < items.Count; i++)
         {
-            total += CountPhysicalLines(items[i], terminalWidth);
+            total += AnsiEscapes.CountPhysicalLines(items[i], terminalWidth);
         }
 
         return total;
@@ -49,7 +49,7 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
         {
             string text = props.Items[i];
             string[] lines = text.Split('\n');
-            int itemLineCount = CountPhysicalLines(text, props.Width);
+            int itemLineCount = AnsiEscapes.CountPhysicalLines(text, props.Width);
             int itemRow = 0;
 
             for (int j = 0; j < lines.Length && itemRow < itemLineCount; j++)
@@ -74,51 +74,5 @@ public class TextPanel : ConsoleReactiveComponent<TextPanelProps, ConsoleReactiv
                 Console.Write(AnsiEscapes.MoveAndEraseLine(props.Y + i));
             }
         }
-    }
-
-    /// <summary>
-    /// Counts the number of physical terminal rows a text item will occupy,
-    /// accounting for both explicit newlines and terminal line wrapping.
-    /// </summary>
-    private static int CountPhysicalLines(string text, int terminalWidth)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return 0;
-        }
-
-        int physicalLines = 0;
-        int lineStart = 0;
-
-        for (int i = 0; i <= text.Length; i++)
-        {
-            if (i == text.Length || text[i] == '\n')
-            {
-                if (terminalWidth <= 0)
-                {
-                    // No wrapping — each logical line is one physical row
-                    physicalLines += 1;
-                }
-                else
-                {
-                    string logicalLine = text[lineStart..i];
-                    int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
-
-                    physicalLines += visibleWidth == 0
-                        ? 1
-                        : (visibleWidth - 1) / terminalWidth + 1;
-                }
-
-                lineStart = i + 1;
-            }
-        }
-
-        // If text ends with a newline, don't count the trailing empty line
-        if (text[text.Length - 1] == '\n')
-        {
-            physicalLines--;
-        }
-
-        return physicalLines;
     }
 }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
@@ -97,11 +97,6 @@ public class TextScrollPanel : ConsoleReactiveComponent<TextScrollPanelProps, Te
             return 0;
         }
 
-        if (terminalWidth <= 0)
-        {
-            terminalWidth = int.MaxValue;
-        }
-
         int physicalLines = 0;
         int lineStart = 0;
 
@@ -109,17 +104,19 @@ public class TextScrollPanel : ConsoleReactiveComponent<TextScrollPanelProps, Te
         {
             if (i == text.Length || text[i] == '\n')
             {
-                // End of a logical line — measure its visible width to determine wrapped rows.
-                string logicalLine = text[lineStart..i];
-                int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
-
-                if (visibleWidth == 0)
+                if (terminalWidth <= 0)
                 {
+                    // No wrapping — each logical line is one physical row
                     physicalLines += 1;
                 }
                 else
                 {
-                    physicalLines += (visibleWidth + terminalWidth - 1) / terminalWidth;
+                    string logicalLine = text[lineStart..i];
+                    int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
+
+                    physicalLines += visibleWidth == 0
+                        ? 1
+                        : (visibleWidth - 1) / terminalWidth + 1;
                 }
 
                 lineStart = i + 1;

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
@@ -79,56 +79,10 @@ public class TextScrollPanel : ConsoleReactiveComponent<TextScrollPanelProps, Te
 
         // Calculate the offset from bottom for the start of the new last item,
         // accounting for terminal line wrapping at the available width.
-        int lastItemLines = CountPhysicalLines(props.Items[^1], props.Width);
+        int lastItemLines = AnsiEscapes.CountPhysicalLines(props.Items[^1], props.Width);
         this._lastItemOffsetFromBottom = lastItemLines > 0 ? lastItemLines - 1 : 0;
 
         // Update rendered count
         this._renderedCount = props.Items.Count;
-    }
-
-    /// <summary>
-    /// Counts the number of physical terminal rows a text item will occupy,
-    /// accounting for both explicit newlines and terminal line wrapping.
-    /// </summary>
-    private static int CountPhysicalLines(string text, int terminalWidth)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return 0;
-        }
-
-        int physicalLines = 0;
-        int lineStart = 0;
-
-        for (int i = 0; i <= text.Length; i++)
-        {
-            if (i == text.Length || text[i] == '\n')
-            {
-                if (terminalWidth <= 0)
-                {
-                    // No wrapping — each logical line is one physical row
-                    physicalLines += 1;
-                }
-                else
-                {
-                    string logicalLine = text[lineStart..i];
-                    int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
-
-                    physicalLines += visibleWidth == 0
-                        ? 1
-                        : (visibleWidth - 1) / terminalWidth + 1;
-                }
-
-                lineStart = i + 1;
-            }
-        }
-
-        // If text ends with a newline, don't count the trailing empty line
-        if (text[text.Length - 1] == '\n')
-        {
-            physicalLines--;
-        }
-
-        return physicalLines;
     }
 }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveComponents/TextScrollPanel.cs
@@ -77,36 +77,61 @@ public class TextScrollPanel : ConsoleReactiveComponent<TextScrollPanelProps, Te
             Console.Write(props.Items[i]);
         }
 
-        // Calculate the offset from bottom for the start of the new last item
-        int lastItemLines = CountLines(props.Items[^1]);
+        // Calculate the offset from bottom for the start of the new last item,
+        // accounting for terminal line wrapping at the available width.
+        int lastItemLines = CountPhysicalLines(props.Items[^1], props.Width);
         this._lastItemOffsetFromBottom = lastItemLines > 0 ? lastItemLines - 1 : 0;
 
         // Update rendered count
         this._renderedCount = props.Items.Count;
     }
 
-    private static int CountLines(string text)
+    /// <summary>
+    /// Counts the number of physical terminal rows a text item will occupy,
+    /// accounting for both explicit newlines and terminal line wrapping.
+    /// </summary>
+    private static int CountPhysicalLines(string text, int terminalWidth)
     {
         if (string.IsNullOrEmpty(text))
         {
             return 0;
         }
 
-        int count = 1;
-        for (int i = 0; i < text.Length; i++)
+        if (terminalWidth <= 0)
         {
-            if (text[i] == '\n')
+            terminalWidth = int.MaxValue;
+        }
+
+        int physicalLines = 0;
+        int lineStart = 0;
+
+        for (int i = 0; i <= text.Length; i++)
+        {
+            if (i == text.Length || text[i] == '\n')
             {
-                count++;
+                // End of a logical line — measure its visible width to determine wrapped rows.
+                string logicalLine = text[lineStart..i];
+                int visibleWidth = AnsiEscapes.VisibleLength(logicalLine);
+
+                if (visibleWidth == 0)
+                {
+                    physicalLines += 1;
+                }
+                else
+                {
+                    physicalLines += (visibleWidth + terminalWidth - 1) / terminalWidth;
+                }
+
+                lineStart = i + 1;
             }
         }
 
         // If text ends with a newline, don't count the trailing empty line
         if (text[text.Length - 1] == '\n')
         {
-            count--;
+            physicalLines--;
         }
 
-        return count;
+        return physicalLines;
     }
 }

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
@@ -14,6 +14,11 @@ public abstract class ConsoleReactiveComponent
     }
 
     /// <summary>
+    /// Gets the shared render lock across all component types to prevent ANSI escape sequence interleaving.
+    /// </summary>
+    protected static object RenderLock { get; } = new();
+
+    /// <summary>
     /// Gets or sets the component's props as the base <see cref="ConsoleReactiveProps"/> type.
     /// Used by parent components to set layout (X, Y, Width, Height) on children without
     /// knowing the concrete props type.
@@ -40,7 +45,6 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     where TProps : ConsoleReactiveProps
     where TState : ConsoleReactiveState
 {
-    private static readonly object s_renderLock = new();
     private TProps? _lastRenderedProps;
     private TState? _lastRenderedState;
 
@@ -74,7 +78,7 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     /// </summary>
     public override void Render()
     {
-        lock (s_renderLock)
+        lock (RenderLock)
         {
             if (this.Props is null)
             {
@@ -97,7 +101,7 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     /// <inheritdoc/>
     public override void Invalidate()
     {
-        lock (s_renderLock)
+        lock (RenderLock)
         {
             this._lastRenderedProps = default;
             this._lastRenderedState = default;

--- a/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
+++ b/dotnet/samples/02-agents/Harness/ConsoleReactiveFramework/ConsoleReactiveComponent.cs
@@ -40,7 +40,7 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     where TProps : ConsoleReactiveProps
     where TState : ConsoleReactiveState
 {
-    private readonly object _renderLock = new();
+    private static readonly object s_renderLock = new();
     private TProps? _lastRenderedProps;
     private TState? _lastRenderedState;
 
@@ -74,7 +74,7 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     /// </summary>
     public override void Render()
     {
-        lock (this._renderLock)
+        lock (s_renderLock)
         {
             if (this.Props is null)
             {
@@ -97,7 +97,7 @@ public abstract class ConsoleReactiveComponent<TProps, TState> : ConsoleReactive
     /// <inheritdoc/>
     public override void Invalidate()
     {
-        lock (this._renderLock)
+        lock (s_renderLock)
         {
             this._lastRenderedProps = default;
             this._lastRenderedState = default;

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAppComponent.cs
@@ -28,6 +28,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
     private int _scrollRegionBottom;
     private bool _resizedSinceLastRender = true;
     private bool _deactivated;
+    private BottomPanelMode _lastRenderedBottomPanelMode;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HarnessAppComponent"/> class.
@@ -341,7 +342,7 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
         }
 
         // Calculate queued items panel height
-        int queuedPanelHeight = TextPanel.CalculateHeight(state.QueuedItems);
+        int queuedPanelHeight = TextPanel.CalculateHeight(state.QueuedItems, state.ConsoleWidth);
 
         // Build the bottom panel child based on mode
         ConsoleReactiveComponent bottomChild;
@@ -404,6 +405,14 @@ public class HarnessAppComponent : ConsoleReactiveComponent<ConsoleReactiveProps
             textInputProps = textInputProps with { Width = state.ConsoleWidth, Height = bottomChildHeight };
             this._textInput.Props = textInputProps;
             bottomChild = this._textInput;
+        }
+
+        // When the bottom panel mode changes, the new child must repaint even if its
+        // props haven't changed — the screen area was overwritten by the previous child.
+        if (state.Mode != this._lastRenderedBottomPanelMode)
+        {
+            bottomChild.Invalidate();
+            this._lastRenderedBottomPanelMode = state.Mode;
         }
 
         var ruleProps = new TopBottomRuleProps

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -88,16 +88,17 @@ public sealed class PlanningOutputObserver : ConsoleObserver
         {
             planningResponse = JsonSerializer.Deserialize<PlanningResponse>(collectedText);
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            await ux.WriteInfoLineAsync($"❌ Failed to parse planning response: {ex.Message}", ConsoleColor.Red);
-            await ux.WriteInfoLineAsync($"(raw response) {collectedText}", ConsoleColor.DarkYellow);
+            // JSON parsing failed — fall back to rendering as regular text output.
+            await ux.WriteTextAsync(collectedText).ConfigureAwait(false);
             return null;
         }
 
         if (planningResponse is null)
         {
-            await ux.WriteInfoLineAsync("(no structured response from agent)", ConsoleColor.DarkYellow);
+            // Null result — fall back to rendering as regular text output.
+            await ux.WriteTextAsync(collectedText).ConfigureAwait(false);
             return null;
         }
 
@@ -118,7 +119,8 @@ public sealed class PlanningOutputObserver : ConsoleObserver
             return new List<FollowUpAction> { this.BuildApprovalAction(question, session) };
         }
 
-        await ux.WriteInfoLineAsync($"(unexpected response type: {planningResponse.Type})", ConsoleColor.DarkYellow);
+        // Unexpected type — fall back to rendering as regular text output.
+        await ux.WriteTextAsync(collectedText).ConfigureAwait(false);
         return null;
     }
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
@@ -2,6 +2,7 @@
 
 #pragma warning disable OPENAI001 // Suppress experimental API warnings for Responses API usage.
 
+using System.Text.Json;
 using Harness.Shared.Console.Observers;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -53,9 +54,88 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
 
             case StreamingResponseIncompleteUpdate incompleteUpdate:
                 string? reason = incompleteUpdate.Response?.IncompleteStatusDetails?.Reason?.ToString();
-                string incompleteText = $"⚠️ Response incomplete: {reason ?? "unknown reason"}";
-                await ux.WriteInfoLineAsync(incompleteText, ConsoleColor.Yellow);
+                if (string.Equals(reason, "content_filter", StringComparison.OrdinalIgnoreCase))
+                {
+                    await ux.WriteInfoLineAsync(
+                        "🛡️ The service's built-in content filter guardrails were triggered and the response was cut short.",
+                        ConsoleColor.Yellow);
+
+                    await WriteContentFilterDetailsAsync(ux, incompleteUpdate);
+                }
+                else
+                {
+                    string incompleteText = $"⚠️ Response incomplete: {reason ?? "unknown reason"}";
+                    await ux.WriteInfoLineAsync(incompleteText, ConsoleColor.Yellow);
+                }
+
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Extracts and displays content filter details from the serialized response JSON.
+    /// Parses the <c>content_filters[].content_filter_results</c> to show which specific
+    /// categories were triggered (e.g. hate, sexual, violence, self_harm, protected_material).
+    /// </summary>
+    private static async Task WriteContentFilterDetailsAsync(IUXStateDriver ux, StreamingResponseIncompleteUpdate incompleteUpdate)
+    {
+        try
+        {
+            var data = System.ClientModel.Primitives.ModelReaderWriter.Write(incompleteUpdate);
+            using var doc = JsonDocument.Parse(data.ToString());
+            var root = doc.RootElement;
+
+            // Navigate into the nested response object if present.
+            JsonElement responseElement = root.TryGetProperty("response", out var resp) ? resp : root;
+
+            if (!responseElement.TryGetProperty("content_filters", out var filtersArray)
+                || filtersArray.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+
+            foreach (var filter in filtersArray.EnumerateArray())
+            {
+                if (!filter.TryGetProperty("content_filter_results", out var results)
+                    || results.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                // Collect category data for aligned output.
+                var categories = new List<(string Name, bool Filtered, string? Severity)>();
+                foreach (var category in results.EnumerateObject())
+                {
+                    if (category.Value.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    bool filtered = category.Value.TryGetProperty("filtered", out var f) && f.GetBoolean();
+                    string? severity = category.Value.TryGetProperty("severity", out var s) ? s.GetString() : null;
+                    categories.Add((category.Name, filtered, severity));
+                }
+
+                // Calculate column widths for alignment.
+                int maxNameLen = categories.Count > 0 ? categories.Max(c => c.Name.Length) : 0;
+
+                foreach (var (name, filtered, severity) in categories)
+                {
+                    string paddedName = name.PadRight(maxNameLen);
+                    string icon = filtered ? "❌" : "✅";
+                    string statusText = filtered ? "Filtered    " : "Not Filtered";
+                    string severityText = severity is not null ? $"   Severity: {severity}" : "";
+                    ConsoleColor color = filtered ? ConsoleColor.Red : ConsoleColor.DarkGray;
+
+                    await ux.WriteInfoLineAsync(
+                        $"    {icon} {paddedName}  {statusText}{severityText}",
+                        color);
+                }
+            }
+        }
+        catch
+        {
+            // Parsing not critical — skip silently if it fails.
         }
     }
 }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console_OpenAI/OpenAIResponsesErrorObserver.cs
@@ -56,11 +56,11 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
                 string? reason = incompleteUpdate.Response?.IncompleteStatusDetails?.Reason?.ToString();
                 if (string.Equals(reason, "content_filter", StringComparison.OrdinalIgnoreCase))
                 {
+                    string detail = GetContentFilterDetails(incompleteUpdate);
+                    const string Message = "🛡️  The service's built-in content filter guardrails were triggered and the response was cut short.";
                     await ux.WriteInfoLineAsync(
-                        "🛡️ The service's built-in content filter guardrails were triggered and the response was cut short.",
+                        string.IsNullOrEmpty(detail) ? Message : $"{Message}\n{detail}",
                         ConsoleColor.Yellow);
-
-                    await WriteContentFilterDetailsAsync(ux, incompleteUpdate);
                 }
                 else
                 {
@@ -73,11 +73,11 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
     }
 
     /// <summary>
-    /// Extracts and displays content filter details from the serialized response JSON.
-    /// Parses the <c>content_filters[].content_filter_results</c> to show which specific
-    /// categories were triggered (e.g. hate, sexual, violence, self_harm, protected_material).
+    /// Extracts content filter details from the serialized response JSON and returns
+    /// a formatted string showing which specific categories were triggered.
+    /// Returns <see cref="string.Empty"/> if details cannot be extracted.
     /// </summary>
-    private static async Task WriteContentFilterDetailsAsync(IUXStateDriver ux, StreamingResponseIncompleteUpdate incompleteUpdate)
+    private static string GetContentFilterDetails(StreamingResponseIncompleteUpdate incompleteUpdate)
     {
         try
         {
@@ -91,7 +91,7 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
             if (!responseElement.TryGetProperty("content_filters", out var filtersArray)
                 || filtersArray.ValueKind != JsonValueKind.Array)
             {
-                return;
+                return string.Empty;
             }
 
             foreach (var filter in filtersArray.EnumerateArray())
@@ -116,8 +116,9 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
                     categories.Add((category.Name, filtered, severity));
                 }
 
-                // Calculate column widths for alignment.
+                // Build all category lines into a single string.
                 int maxNameLen = categories.Count > 0 ? categories.Max(c => c.Name.Length) : 0;
+                var lines = new List<string>();
 
                 foreach (var (name, filtered, severity) in categories)
                 {
@@ -125,17 +126,22 @@ public sealed class OpenAIResponsesErrorObserver : ConsoleObserver
                     string icon = filtered ? "❌" : "✅";
                     string statusText = filtered ? "Filtered    " : "Not Filtered";
                     string severityText = severity is not null ? $"   Severity: {severity}" : "";
-                    ConsoleColor color = filtered ? ConsoleColor.Red : ConsoleColor.DarkGray;
 
-                    await ux.WriteInfoLineAsync(
-                        $"    {icon} {paddedName}  {statusText}{severityText}",
-                        color);
+                    lines.Add($"    {icon} {paddedName}  {statusText}{severityText}");
+                }
+
+                if (lines.Count > 0)
+                {
+                    return string.Join("\n", lines);
                 }
             }
+
+            return string.Empty;
         }
         catch
         {
             // Parsing not critical — skip silently if it fails.
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
### Motivation and Context

- The input text box was not always rendered fully after switching from list selection back to input box views
- Re-rendering of the last item in the scroll view did not take into account line wrapping

### Description

- Fix bug where line wrapping caused duplicate text to render.
- Fix bug where approve and continue text or spinner/usage was shown in text input box.
- Improve guardrail error text since just printing the error code was not clear enough
- Gracefully fall back to text output when structured output fails

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.