### PR TITLE
.NET: fix: accept stringified inline skill arguments

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -85,25 +85,58 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
     /// </exception>
     private static AIFunctionArguments ConvertToFunctionArguments(JsonElement? arguments)
     {
-        if (arguments is null ||
-            arguments.Value.ValueKind == JsonValueKind.Null ||
-            arguments.Value.ValueKind == JsonValueKind.Undefined)
+        if (arguments is null)
         {
             return [];
         }
 
-        if (arguments.Value.ValueKind != JsonValueKind.Object)
+        var argumentElement = arguments.Value;
+        if (argumentElement.ValueKind == JsonValueKind.Null ||
+            argumentElement.ValueKind == JsonValueKind.Undefined)
+        {
+            return [];
+        }
+
+        using JsonDocument? parsedArguments = argumentElement.ValueKind == JsonValueKind.String
+            ? ParseStringArguments(argumentElement)
+            : null;
+
+        if (parsedArguments is not null)
+        {
+            argumentElement = parsedArguments.RootElement;
+        }
+
+        if (argumentElement.ValueKind != JsonValueKind.Object)
         {
             throw new InvalidOperationException(
-                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{arguments.Value.ValueKind}'.");
+                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{argumentElement.ValueKind}'.");
         }
 
         var dict = new Dictionary<string, object?>();
-        foreach (var property in arguments.Value.EnumerateObject())
+        foreach (var property in argumentElement.EnumerateObject())
         {
-            dict[property.Name] = property.Value;
+            dict[property.Name] = property.Value.Clone();
         }
 
         return new AIFunctionArguments(dict);
+    }
+
+    private static JsonDocument? ParseStringArguments(JsonElement argumentElement)
+    {
+        var argumentText = argumentElement.GetString();
+        if (string.IsNullOrWhiteSpace(argumentText))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonDocument.Parse(argumentText);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                "Inline skill scripts expect string arguments to contain a JSON object.", ex);
+        }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
@@ -44,6 +44,22 @@ public sealed class AgentInlineSkillScriptTests
     }
 
     [Fact]
+    public async Task RunAsync_WithStringifiedObjectArguments_PassesArgumentsAsync()
+    {
+        // Arrange
+        var script = new AgentInlineSkillScript("add", (int a, int b) => a + b);
+        var skill = new AgentInlineSkill("calc-skill", "Calc.", "Instructions.");
+        using var argsDoc = JsonDocument.Parse("\"{\\\"a\\\":3,\\\"b\\\":7}\"");
+        var args = argsDoc.RootElement;
+
+        // Act
+        var result = await script.RunAsync(skill, args, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, int.Parse(result?.ToString()!));
+    }
+
+    [Fact]
     public void ParametersSchema_NoParameters_ReturnsSchema()
     {
         // Arrange


### PR DESCRIPTION
﻿Fixes #6020.

## Summary
- accept inline skill arguments that arrive as a JSON string containing an object
- keep non-object arguments rejected, so arrays/plain strings still fail fast
- clone argument `JsonElement` values before invoking the delegate so parsed string-backed arguments survive beyond the temporary `JsonDocument`
- add a regression test for stringified object arguments

## To verify
- `dotnet run --project dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --framework net10.0 -- --filter-class "Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillScriptTests"`
- `dotnet build dotnet\src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj --no-restore`
- `dotnet build dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --no-restore`
- `git diff --check`

One initial test attempt ran concurrently with a build and hit a transient Windows/Defender lock on an `obj` DLL; the same test command passed when rerun serially.
