### PR TITLE
.NET: feat(samples): add Squad + DTS incident-response sample

### DIFF
--- a/dotnet/samples/02-agents/Harness/README.md
+++ b/dotnet/samples/02-agents/Harness/README.md
@@ -9,3 +9,9 @@ Samples demonstrating the [Harness AIContextProviders](../../../src/Microsoft.Ag
 | [Harness_Step01_Research](./Harness_Step01_Research/README.md) | Using a ChatClientAgent with TodoProvider and AgentModeProvider for research, showcasing planning mode and todo management |
 | [Harness_Step02_Research_WithBackgroundAgents](./Harness_Step02_Research_WithBackgroundAgents/README.md) | Using BackgroundAgentsProvider to delegate stock price lookups to a web-search background agent concurrently |
 | [Harness_Step03_DataProcessing](./Harness_Step03_DataProcessing/README.md) | Using FileAccessProvider to give an agent access to CSV data files for reading, analysis, and output generation |
+
+## Related samples
+
+| Sample | What it adds |
+| --- | --- |
+| [SquadWithDTS](../SquadWithDTS/README.md) | Shows how to wrap **GitHub Copilot Squad** as a first-class MAF `AIAgent` and compose it with a DTS-backed durable workflow. Compare `HarnessAgent.ToolApproval` (session-scoped) with Squad's charter-bounded `OnPermissionRequest` governance pattern. |

--- a/dotnet/samples/02-agents/SquadWithDTS/README.md
+++ b/dotnet/samples/02-agents/SquadWithDTS/README.md
@@ -1,6 +1,6 @@
 # Squad + DTS Sample
 
-This sample demonstrates how to compose [Squad](https://github.com/github/copilot-extensions/blob/main/docs/extensions/implementing-skills.md) (the GitHub Copilot governance agent) with [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework) and [Durable Task Scheduler (DTS)](https://learn.microsoft.com/azure/durable-task-scheduler/overview) to build governance-driven, durably-orchestrated AI workflows.
+This sample demonstrates how to compose [Squad](https://github.com/bradygaster/squad) (a multi-agent orchestration framework for GitHub Copilot — one coordinator, many specialist sub-agents, with shared memory, routing, and structured handoffs) with [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework) and [Durable Task Scheduler (DTS)](https://learn.microsoft.com/azure/durable-task-scheduler/overview) to build governance-driven, durably-orchestrated AI workflows.
 
 > **Companion to the blog post:** ["Make It So — But Let the Computer Handle the Math"](https://tamirdresher.com/2026/05/20/deterministic-meets-squads/)
 

--- a/dotnet/samples/02-agents/SquadWithDTS/README.md
+++ b/dotnet/samples/02-agents/SquadWithDTS/README.md
@@ -1,0 +1,156 @@
+# Squad + DTS Sample
+
+This sample demonstrates how to compose [Squad](https://github.com/github/copilot-extensions/blob/main/docs/extensions/implementing-skills.md) (the GitHub Copilot governance agent) with [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework) and [Durable Task Scheduler (DTS)](https://learn.microsoft.com/azure/durable-task-scheduler/overview) to build governance-driven, durably-orchestrated AI workflows.
+
+> **Companion to the blog post:** ["Make It So — But Let the Computer Handle the Math"](https://tamirdresher.com/2026/05/20/deterministic-meets-squads/)
+
+## What this sample demonstrates
+
+- **`SquadAgent : AIAgent`** — Squad wrapped as a first-class MAF `AIAgent`, composable with any other MAF participant
+- **DTS-backed durable orchestration** — A 9-executor incident-response workflow where every step is checkpointed by the Durable Task Scheduler emulator
+- **Dynamic subsystem routing** — AI triage classifies the incident; conditional workflow edges route to the correct subsystem Squad (Database / Network / Auth / Payments)
+- **Deterministic + non-deterministic composition** — Pure-C# enrichment executors alongside AI-powered triage, diagnosis, and per-subsystem analysis
+- **Diagnose-loop** — Squad reviews accumulated context and can request another enrichment cycle (capped at `MaxDiagnosisIterations`)
+- **Aspire AppHost wiring** — DTS emulator, Foundry Local LLM, and demo project all wired together via .NET Aspire
+- **OpenTelemetry** — MAF workflow spans, DTS activity, Squad CLI spans, and Copilot SDK spans all converge on the Aspire dashboard
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────────────────────────┐
+                    │              Durable Task Scheduler (DTS)             │
+                    │  ┌──────────────────────────────────────────────┐    │
+                    │  │           Incident-Response Workflow           │    │
+                    │  │                                                │    │
+                    │  │  triage (Squad AI)                             │    │
+                    │  │    └──► enrich (C#) ◄── loop-back ────────┐  │    │
+                    │  │            └──► externalComms (C#)         │  │    │
+                    │  │                   ├──► DatabaseSquad (AI)  │  │    │
+                    │  │                   ├──► NetworkSquad (AI)   │  │    │
+                    │  │                   ├──► AuthSquad (AI)      ├──► mitigate (C#) ──► diagnose (Squad AI)
+                    │  │                   └──► PaymentsSquad (AI)  │  │    │
+                    │  └──────────────────────────────────────────────┘    │
+                    └──────────────────────────────────────────────────────┘
+                                             ▲
+                    ┌────────────────────────┤
+                    │  .NET Aspire AppHost    │
+                    │  • DTS emulator (Docker)│
+                    │  • Foundry Local LLM   │
+                    │  • OTLP dashboard       │
+                    └────────────────────────┘
+```
+
+## Three examples included
+
+| Example | What it shows |
+| --- | --- |
+| `incident` | **Start here.** DTS-backed durable incident-response workflow: AI triage → enrichment → external comms → dynamic subsystem-squad routing → mitigation → diagnose-loop |
+| `squad-as-agent` | `SquadAgent` as a plain MAF participant: Planner → Squad → Reviewer three-agent flow |
+| `workflow` | Sequential MAF workflow: Writer (Foundry Local) → Squad |
+
+## Governance pattern: `OnPermissionRequest`
+
+Squad's `OnPermissionRequest` is policy-structured and charter-bounded — when a tool call requires
+governance approval, Squad evaluates it against the `.squad/` charter definitions before approving
+or denying. This is distinct from MAF Harness's `ToolApproval` (session-level auto-approval after
+first confirm) and models a different point on the trust spectrum:
+
+```
+ Harness ToolApproval           Squad OnPermissionRequest
+ ─────────────────────          ────────────────────────────
+ session-scoped                 charter-bounded
+ user confirms once             policy evaluated per request
+ subsequent calls auto-approved role-based (Data / Picard / Worf / etc.)
+ good for: dev workflows        good for: production-grade AI agents
+```
+
+See [Squad governance docs](https://github.com/github/copilot-extensions) for details.
+
+## Prerequisites
+
+1. [.NET 9 SDK](https://dotnet.microsoft.com/download)
+2. [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for the DTS emulator)
+3. [.NET Aspire workload](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
+4. [GitHub Copilot](https://github.com/features/copilot) subscription (Squad uses the real Copilot CLI)
+5. [Foundry Local](https://github.com/microsoft/foundry-local) (optional — AppHost downloads `phi-3.5-mini` on first run, ~5 GB)
+
+## Running the sample
+
+### Via Aspire AppHost (recommended)
+
+```powershell
+cd dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost
+dotnet run
+```
+
+This starts the Aspire dashboard, the DTS emulator (Docker), and Foundry Local. Wait for the `chat` resource to show **Healthy** before expecting console output.
+
+**Pre-select an example:**
+
+```powershell
+$env:SQUAD_AF_EXAMPLE = "incident"   # or: squad-as-agent, workflow
+$env:SQUAD_AF_TRACE   = "true"
+dotnet run
+```
+
+### Standalone (advanced)
+
+Run without AppHost using Azure OpenAI, OpenAI-compatible endpoint, or Foundry Local:
+
+```powershell
+# Azure OpenAI
+$env:SQUAD_AF_PROVIDER    = "azure-openai"
+$env:SQUAD_AF_ENDPOINT    = "https://<resource>.openai.azure.com/"
+$env:SQUAD_AF_DEPLOYMENT  = "<deployment>"
+dotnet run --project Squad.SquadWithDTS -- --example squad-as-agent
+
+# OpenAI-compatible (e.g. Ollama)
+$env:SQUAD_AF_PROVIDER = "openai-compatible"
+$env:SQUAD_AF_ENDPOINT = "http://localhost:11434/v1"
+$env:SQUAD_AF_MODEL    = "<model>"
+dotnet run --project Squad.SquadWithDTS -- --example workflow
+```
+
+> **Note:** The `incident` example requires a running DTS emulator. Start one with Docker:
+> `docker run -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest`
+
+## SquadAgent configuration
+
+`SquadAgent` is configurable via the `SquadAgent` section in `appsettings.json` or via environment variables using the .NET double-underscore convention:
+
+| Option | Environment variable | Default |
+|--------|---------------------|---------|
+| `SquadFolderPath` | `SquadAgent__SquadFolderPath` | workspace discovery |
+| `AgentId` | `SquadAgent__AgentId` | `"repo-local-squad"` |
+| `AgentName` | `SquadAgent__AgentName` | `"Squad"` |
+| `AgentDescription` | `SquadAgent__AgentDescription` | default text |
+
+> **Note:** The Copilot CLI extension slug `"Squad"` is an internal protocol contract and is **not** configurable.
+
+## Tracing
+
+Enable Copilot SDK event tracing:
+
+```powershell
+$env:SQUAD_AF_TRACE = "true"   # console output
+$env:SQUAD_AF_TRACE = "events.jsonl"  # also write JSONL to file
+```
+
+Or use the `--trace[=<path>]` CLI flag.
+
+## Key files
+
+| File | What it shows |
+|------|---------------|
+| [`Squad.SquadWithDTS/Agents/SquadAgent.cs`](Squad.SquadWithDTS/Agents/SquadAgent.cs) | `SquadAgent : AIAgent` — the MAF wrapper around GitHubCopilotAgent with OTel |
+| [`Squad.SquadWithDTS/Workflows/IncidentExample.cs`](Squad.SquadWithDTS/Workflows/IncidentExample.cs) | 9-executor durable workflow graph — the deterministic backbone |
+| [`Squad.SquadWithDTS/Workflows/Executors/TriageExecutor.cs`](Squad.SquadWithDTS/Workflows/Executors/TriageExecutor.cs) | AI triage via Squad: severity, subsystem, hypothesis, required evidence |
+| [`Squad.SquadWithDTS/Workflows/Executors/DiagnoseExecutor.cs`](Squad.SquadWithDTS/Workflows/Executors/DiagnoseExecutor.cs) | Squad diagnose-loop: Resolved / NeedsMoreInvestigation / Inconclusive |
+| [`Squad.SquadWithDTS.AppHost/AppHost.cs`](Squad.SquadWithDTS.AppHost/AppHost.cs) | Aspire host wiring DTS, Foundry Local, and the demo project |
+
+## See also
+
+- [Harness Agent Samples](../Harness/README.md) — `HarnessAgent` with `TodoProvider`, `AgentModeProvider`, and `ToolApproval`
+- [Agent Framework samples overview](../README.md)
+- [Squad + DTS blog post](https://tamirdresher.com/2026/05/20/deterministic-meets-squads/)
+- [Durable Task Scheduler docs](https://learn.microsoft.com/azure/durable-task-scheduler/overview)

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/AppHost.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/AppHost.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// ── DTS emulator ─────────────────────────────────────────────────────────────
+// Provides a local Durable Task Scheduler compatible with Azure DTS.
+// UI available at http://localhost:8082 once started.
+var dtsEmulator = builder
+    .AddContainer("dts-emulator", "mcr.microsoft.com/dts/dts-emulator", "latest")
+    .WithHttpEndpoint(targetPort: 8080, port: 8080, name: "grpc")
+    .WithHttpEndpoint(targetPort: 8082, port: 8082, name: "ui");
+
+var schedulerEndpoint = dtsEmulator.GetEndpoint("grpc");
+
+// ── Foundry Local (optional LLM provider) ────────────────────────────────────
+// Downloads phi-3.5-mini (~5 GB) on first run.
+// Set SQUAD_AF_PROVIDER=azure-openai to skip Foundry Local.
+var foundry = builder
+    .AddFoundry("foundry")
+    .RunAsFoundryLocal();
+
+// ── Demo project ─────────────────────────────────────────────────────────────
+var demo = builder
+    .AddProject<Projects.Squad_SquadWithDTS>("chat")
+    .WithReference(foundry)
+    .WithReference(dtsEmulator)
+    .WithEnvironment("DTS_ENDPOINT", schedulerEndpoint)
+    // OTel: gRPC endpoint for .NET exporters (Aspire dashboard port 21021)
+    .WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:21021")
+    // OTel: HTTP/protobuf endpoint for Copilot CLI / Node.js SDK (port 21022)
+    .WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT_HTTP", "http://localhost:21022")
+    // Accept self-signed dev cert in Node.js components
+    .WithEnvironment("NODE_TLS_REJECT_UNAUTHORIZED", "0")
+    .WithEnvironment("SQUAD_AF_EXAMPLE", "incident");
+
+builder.Build().Run();

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/Squad.SquadWithDTS.AppHost.csproj
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/Squad.SquadWithDTS.AppHost.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAspireHost>true</IsAspireHost>
+    <RootNamespace>Squad.SquadWithDTS.AppHost</RootNamespace>
+    <AssemblyName>Squad.SquadWithDTS.AppHost</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Squad.SquadWithDTS\Squad.SquadWithDTS.csproj">
+      <IsAspireProjectResource>true</IsAspireProjectResource>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/appsettings.json
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS.AppHost/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Aspire.Hosting": "Information"
+    }
+  }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Agents/SquadAgent.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Agents/SquadAgent.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.GitHub.Copilot;
+using Microsoft.Extensions.Configuration;
+
+namespace Squad.SquadWithDTS.Agents;
+
+/// <summary>
+/// Wraps <see cref="GitHubCopilotAgent"/> as a first-class MAF <see cref="AIAgent"/>.
+/// Emits OTel spans and metrics so that every agent run appears in the Aspire dashboard
+/// (and any OTLP-compatible back-end) when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set.
+/// </summary>
+public sealed class SquadAgent : AIAgent, IAsyncDisposable
+{
+    private static readonly ActivitySource SquadActivitySource =
+        new("Squad.AgentFramework.SquadAgent", "1.0.0");
+
+    private static readonly Meter SquadMeter = new("Squad.AgentFramework.SquadAgent", "1.0.0");
+    private static readonly Counter<long>   RunsStartedCounter   = SquadMeter.CreateCounter<long>("squad_agent.runs_started");
+    private static readonly Counter<long>   RunsCompletedCounter = SquadMeter.CreateCounter<long>("squad_agent.runs_completed");
+    private static readonly Counter<long>   SessionsCreated      = SquadMeter.CreateCounter<long>("squad_agent.sessions_created");
+    private static readonly Histogram<double> RunDurationMs      = SquadMeter.CreateHistogram<double>("squad_agent.run_duration_ms");
+
+    private readonly GitHubCopilotAgent _inner;
+    private readonly string _agentId;
+
+    public SquadAgent(IConfiguration configuration)
+    {
+        var opts = configuration
+            .GetSection("SquadAgent")
+            .Get<SquadAgentOptions>() ?? new SquadAgentOptions();
+
+        _agentId = opts.AgentId;
+        _inner = new GitHubCopilotAgent(new GitHubCopilotAgentOptions
+        {
+            AgentSlug        = "Squad",
+            AgentId          = opts.AgentId,
+            AgentName        = opts.AgentName,
+            AgentDescription = opts.AgentDescription,
+            SquadFolderPath  = opts.SquadFolderPath,
+        });
+
+        SessionsCreated.Add(1, new KeyValuePair<string, object?>("agent_id", _agentId));
+    }
+
+    public override async IAsyncEnumerable<string> RunAsync(
+        string userMessage,
+        AIAgentRunOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var activity = SquadActivitySource.StartActivity(
+            "SquadAgent.Run",
+            ActivityKind.Internal,
+            tags: [new("agent_id", _agentId), new("message_length", userMessage.Length)]);
+
+        RunsStartedCounter.Add(1, new KeyValuePair<string, object?>("agent_id", _agentId));
+        var sw = Stopwatch.StartNew();
+
+        bool success = false;
+        try
+        {
+            await foreach (var chunk in _inner.RunAsync(userMessage, options, cancellationToken))
+            {
+                yield return chunk;
+            }
+            success = true;
+        }
+        finally
+        {
+            sw.Stop();
+            RunDurationMs.Record(sw.Elapsed.TotalMilliseconds,
+                new KeyValuePair<string, object?>("agent_id", _agentId),
+                new KeyValuePair<string, object?>("success", success));
+            RunsCompletedCounter.Add(1,
+                new KeyValuePair<string, object?>("agent_id", _agentId),
+                new KeyValuePair<string, object?>("success", success));
+            activity?.SetTag("success", success);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_inner is IAsyncDisposable d) await d.DisposeAsync();
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Agents/SquadAgentOptions.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Agents/SquadAgentOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.Agents;
+
+/// <summary>
+/// Configuration options for <see cref="SquadAgent"/>, bound from the
+/// <c>SquadAgent</c> configuration section.
+/// </summary>
+public sealed class SquadAgentOptions
+{
+    /// <summary>
+    /// Path to the <c>.squad/</c> folder that contains charter YAML files.
+    /// When <see langword="null"/> the Copilot SDK discovers the workspace root
+    /// by walking up from the current directory.
+    /// </summary>
+    public string? SquadFolderPath { get; set; }
+
+    /// <summary>
+    /// Identifier sent in the <c>x-agent-id</c> header. Defaults to <c>"repo-local-squad"</c>.
+    /// </summary>
+    public string AgentId { get; set; } = "repo-local-squad";
+
+    /// <summary>
+    /// Human-readable display name for the agent. Defaults to <c>"Squad"</c>.
+    /// </summary>
+    public string AgentName { get; set; } = "Squad";
+
+    /// <summary>
+    /// Brief description surfaced in tool registrations and agent metadata.
+    /// </summary>
+    public string AgentDescription { get; set; } =
+        "Squad governance agent — routes work to the right specialist based on charter definitions.";
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Examples/SquadAsAgentExample.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Examples/SquadAsAgentExample.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+using Squad.SquadWithDTS.Infrastructure;
+
+namespace Squad.SquadWithDTS.Examples;
+
+/// <summary>
+/// Simplest possible example: <see cref="Agents.SquadAgent"/> as a plain MAF
+/// participant in a three-agent flow.
+///
+/// Planner (LLM) → Squad (governance) → Reviewer (LLM)
+///
+/// Shows that <c>SquadAgent</c> is a drop-in MAF <see cref="AIAgent"/> — it
+/// can participate in any chain or graph without DTS.
+/// </summary>
+internal static class SquadAsAgentExample
+{
+    public static async Task RunAsync(
+        ProviderAgentFactory provider,
+        AIAgent squad,
+        CancellationToken cancellationToken = default)
+    {
+        Console.WriteLine();
+        Console.WriteLine("── Squad-as-Agent example ──────────────────────────────────");
+        Console.WriteLine("  Flow: Planner → Squad → Reviewer");
+        Console.WriteLine();
+
+        // Step 1: Planner produces a task specification
+        const string plannerPrompt =
+            """
+            You are a task-planning agent. Create a concise technical task specification
+            (3–5 bullet points) for: "Add OpenTelemetry tracing to an existing .NET 9
+            MAF agent that wraps GitHub Copilot Squad."
+            """;
+
+        string plannerOutput;
+        if (provider.Summary.IsProviderBacked)
+        {
+            var (planner, plannerScope) = provider.CreateAgent("planner", "Task planning agent");
+            await using (plannerScope)
+            {
+                plannerOutput = await DemoRuntime.RunAgentAsync(planner, plannerPrompt, cancellationToken);
+            }
+        }
+        else
+        {
+            plannerOutput =
+                "• Add ActivitySource 'Squad.AgentFramework.SquadAgent'\n" +
+                "• Wrap RunAsync in a StartActivity span\n" +
+                "• Record run_duration_ms histogram\n" +
+                "• Register ActivitySource with OTel SDK in Program.cs\n" +
+                "• Export via OTLP to Aspire dashboard";
+        }
+
+        Console.WriteLine("[Planner output]");
+        Console.WriteLine(plannerOutput);
+        Console.WriteLine();
+
+        // Step 2: Squad reviews and applies governance
+        var squadPrompt = $"""
+            Review the following technical task specification and confirm it follows
+            good observability practice. Flag any missing items.
+
+            Specification:
+            {plannerOutput}
+            """;
+
+        Console.WriteLine("[Squad output]");
+        await foreach (var chunk in squad.RunAsync(squadPrompt, cancellationToken: cancellationToken))
+        {
+            Console.Write(chunk);
+        }
+        Console.WriteLine();
+        Console.WriteLine();
+
+        // Step 3: Reviewer summarises
+        Console.WriteLine("[Reviewer output]");
+        if (provider.Summary.IsProviderBacked)
+        {
+            var (reviewer, reviewerScope) = provider.CreateAgent("reviewer", "Code review agent");
+            await using (reviewerScope)
+            {
+                var reviewPrompt = $"Summarise the Squad-reviewed task in one sentence suitable for a commit message.";
+                var summary = await DemoRuntime.RunAgentAsync(reviewer, reviewPrompt, cancellationToken);
+                Console.WriteLine(summary);
+            }
+        }
+        else
+        {
+            Console.WriteLine("feat(otel): wrap SquadAgent with ActivitySource, Meter, and OTLP exporter");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("── Squad-as-Agent example complete ─────────────────────────");
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Examples/WorkflowExample.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Examples/WorkflowExample.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Examples;
+
+/// <summary>
+/// Sequential MAF workflow example: Writer (LLM) → Squad (governance).
+///
+/// Shows a two-executor <see cref="Workflow"/> without DTS — runs in-process
+/// using the built-in in-memory workflow engine.
+/// </summary>
+internal static class WorkflowExample
+{
+    public static async Task RunAsync(
+        ProviderAgentFactory provider,
+        AIAgent squad,
+        CancellationToken cancellationToken = default)
+    {
+        Console.WriteLine();
+        Console.WriteLine("── Sequential Workflow example ─────────────────────────────");
+        Console.WriteLine("  Flow: Writer → Squad (in-process, no DTS)");
+        Console.WriteLine();
+
+        // ── Writer executor ─────────────────────────────────────────────
+        var writerExecutor = new LambdaExecutor<string, string>(
+            "Writer",
+            async (input, _, ct) =>
+            {
+                if (!provider.Summary.IsProviderBacked)
+                {
+                    await Task.Yield();
+                    return "Proposed change: Add a new `OnPermissionRequest` hook to " +
+                           "MAF `AIAgent` that fires before any tool call, allowing " +
+                           "governance policies to approve or deny at the framework level.";
+                }
+
+                var (agent, scope) = provider.CreateAgent("writer", "Technical writer agent");
+                await using (scope)
+                {
+                    return await DemoRuntime.RunAgentAsync(agent,
+                        $"Write a one-paragraph technical proposal for: {input}", ct);
+                }
+            });
+
+        // ── Squad executor ───────────────────────────────────────────────
+        var squadExecutor = new LambdaExecutor<string, string>(
+            "Squad",
+            async (input, _, ct) =>
+            {
+                var sb = new System.Text.StringBuilder();
+                await foreach (var chunk in squad.RunAsync(
+                    $"Review this technical proposal from a governance perspective:\n\n{input}",
+                    cancellationToken: ct))
+                {
+                    sb.Append(chunk);
+                }
+                return sb.ToString().Trim();
+            });
+
+        var writerBinding = writerExecutor.BindExecutor();
+        var squadBinding  = squadExecutor.BindExecutor();
+
+        var workflow = new WorkflowBuilder(writerBinding)
+            .WithName("writer-squad-review")
+            .AddEdge(writerBinding, squadBinding)
+            .WithOutputFrom(squadBinding)
+            .Build();
+
+        var client = workflow.CreateInProcessClient();
+        var run = (IAwaitableWorkflowRun)await client.RunAsync(
+            workflow,
+            "Add governance hooks to Microsoft Agent Framework",
+            cancellationToken: cancellationToken);
+
+        var result = await run.WaitForCompletionAsync<string>(cancellationToken);
+
+        Console.WriteLine("[Squad review]");
+        Console.WriteLine(result);
+        Console.WriteLine();
+        Console.WriteLine("── Sequential Workflow example complete ────────────────────");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private sealed class LambdaExecutor<TIn, TOut>(
+        string name,
+        Func<TIn, IWorkflowContext, CancellationToken, Task<TOut>> handler)
+        : Executor<TIn, TOut>(name)
+    {
+        public override async ValueTask<TOut> HandleAsync(
+            TIn input,
+            IWorkflowContext context,
+            CancellationToken cancellationToken = default)
+            => await handler(input, context, cancellationToken);
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Infrastructure/DemoRuntime.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Infrastructure/DemoRuntime.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+
+namespace Squad.SquadWithDTS.Infrastructure;
+
+/// <summary>
+/// Shared runtime helpers used by AI-powered executors.
+/// </summary>
+internal static class DemoRuntime
+{
+    /// <summary>
+    /// Runs <paramref name="agent"/> with <paramref name="prompt"/>, collecting
+    /// all streamed chunks into a single string.
+    /// </summary>
+    internal static async Task<string> RunAgentAsync(
+        AIAgent agent,
+        string prompt,
+        CancellationToken cancellationToken = default)
+    {
+        var sb = new System.Text.StringBuilder();
+        await foreach (var chunk in agent.RunAsync(prompt, cancellationToken: cancellationToken))
+        {
+            sb.Append(chunk);
+        }
+        return sb.ToString().Trim();
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Infrastructure/ProviderAgentFactory.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Infrastructure/ProviderAgentFactory.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Squad.SquadWithDTS.Agents;
+
+namespace Squad.SquadWithDTS.Infrastructure;
+
+/// <summary>
+/// Creates and configures MAF <see cref="AIAgent"/> instances from the
+/// active LLM-provider configuration.
+///
+/// Supported providers (set via <c>SQUAD_AF_PROVIDER</c> / <c>appsettings.json</c>):
+/// <list type="bullet">
+///   <item><c>azure-openai</c></item>
+///   <item><c>openai-compatible</c> (Ollama, Foundry Local, etc.)</item>
+///   <item><c>none</c> — deterministic demo mode with no LLM calls</item>
+/// </list>
+/// </summary>
+internal sealed class ProviderAgentFactory
+{
+    private readonly IConfiguration _config;
+    private readonly SquadAgent _squad;
+
+    public ProviderAgentFactory(IConfiguration config, SquadAgent squad)
+    {
+        _config = config;
+        _squad  = squad;
+        Summary = BuildSummary(config);
+    }
+
+    public ProviderSummary Summary { get; }
+
+    /// <summary>
+    /// Returns the Squad agent that is wired at construction time.
+    /// </summary>
+    public SquadAgent SquadAgent => _squad;
+
+    /// <summary>
+    /// Creates an ephemeral chat agent for the given <paramref name="name"/> / <paramref name="charter"/>.
+    /// The caller is responsible for disposing the returned <see cref="IAsyncDisposable"/>.
+    /// </summary>
+    public (AIAgent Agent, IAsyncDisposable Scope) CreateAgent(string name, string charter)
+    {
+        var provider = Summary.Provider;
+
+        if (!Summary.IsProviderBacked)
+        {
+            return (new DeterministicFallbackAgent(name), NoopDisposable.Instance);
+        }
+
+        AIAgent agent = provider switch
+        {
+            "azure-openai"       => CreateAzureOpenAIAgent(name, charter),
+            "openai-compatible"  => CreateOpenAICompatibleAgent(name, charter),
+            _ => throw new InvalidOperationException($"Unknown provider: {provider}")
+        };
+
+        return (agent, agent as IAsyncDisposable ?? NoopDisposable.Instance);
+    }
+
+    // ─── private helpers ─────────────────────────────────────────────────
+
+    private AIAgent CreateAzureOpenAIAgent(string name, string charter)
+    {
+        // Use MAF's built-in Azure OpenAI agent type.
+        // Replace with a real agent implementation for your environment.
+        throw new NotImplementedException(
+            "Azure OpenAI agent creation: bind Microsoft.Agents.AI.AzureOpenAI here.");
+    }
+
+    private AIAgent CreateOpenAICompatibleAgent(string name, string charter)
+    {
+        throw new NotImplementedException(
+            "OpenAI-compatible agent creation: bind Microsoft.Agents.AI.OpenAI here.");
+    }
+
+    private static ProviderSummary BuildSummary(IConfiguration config)
+    {
+        var provider   = config["SQUAD_AF_PROVIDER"] ?? "none";
+        var endpoint   = config["SQUAD_AF_ENDPOINT"];
+        var deployment = config["SQUAD_AF_DEPLOYMENT"];
+        var model      = config["SQUAD_AF_MODEL"];
+
+        bool isBacked = provider is not ("none" or "");
+
+        return new ProviderSummary(
+            Provider: provider,
+            Endpoint: endpoint ?? "(none)",
+            Deployment: deployment ?? model ?? "(none)",
+            IsProviderBacked: isBacked);
+    }
+
+    private sealed class NoopDisposable : IAsyncDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Deterministic no-LLM fallback used when no provider is configured.
+    /// </summary>
+    private sealed class DeterministicFallbackAgent(string name) : AIAgent
+    {
+        public override async IAsyncEnumerable<string> RunAsync(
+            string userMessage,
+            AIAgentRunOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            yield return $"[{name}] DEMO FALLBACK — no LLM provider configured. " +
+                         "Set SQUAD_AF_PROVIDER to 'azure-openai' or 'openai-compatible'.";
+        }
+    }
+}
+
+/// <summary>Read-only summary of the active LLM provider configuration.</summary>
+internal sealed record ProviderSummary(
+    string Provider,
+    string Endpoint,
+    string Deployment,
+    bool   IsProviderBacked);

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockAlertCorrelationService.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockAlertCorrelationService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.MockServices;
+
+internal static class MockAlertCorrelationService
+{
+    public static async Task<string[]> GetRecentAlertsAsync(
+        string region,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(60, cancellationToken);
+        return
+        [
+            "ALERT-7781 checkout-db connection saturation (fired 14:22 UTC)",
+            "ALERT-7782 payment-gateway external latency elevated (fired 14:19 UTC)",
+            "ALERT-7783 orders table lock contention > 500 ms (fired 14:23 UTC)"
+        ];
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockCustomerOutreachService.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockCustomerOutreachService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.MockServices;
+
+internal static class MockCustomerOutreachService
+{
+    public static async Task<string> NotifyCustomerAsync(
+        CustomerInfo customer,
+        IncidentReport incident,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(150, cancellationToken);
+        return $"Notification sent to {customer.ContactEmail} " +
+               $"(tier={customer.Tier}, SLA={customer.Sla}) " +
+               $"regarding {incident.IncidentId}";
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockCustomerService.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockCustomerService.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.MockServices;
+
+internal static class MockCustomerService
+{
+    private static readonly Dictionary<string, CustomerInfo> Customers = new()
+    {
+        ["CUST-9921"] = new("CUST-9921", "Enterprise",  "2h",  "alice@acmecorp.example"),
+        ["CUST-4201"] = new("CUST-4201", "Business",    "4h",  "bob@widgets.example"),
+        ["CUST-0001"] = new("CUST-0001", "Starter",     "24h", "support@startup.example"),
+    };
+
+    public static async Task<CustomerInfo> GetCustomerAsync(
+        string customerId,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(80, cancellationToken);
+        return Customers.TryGetValue(customerId, out var info)
+            ? info
+            : new CustomerInfo(customerId, "Unknown", "Best-effort", "support@example.com");
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockMetricsService.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockMetricsService.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.MockServices;
+
+internal static class MockMetricsService
+{
+    public static async Task<MetricsWindow> GetMetricsWindowAsync(
+        string region,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(120, cancellationToken);
+        return new MetricsWindow(
+            ErrorRatePercent: 14.3,
+            P99LatencyMs: 8_240,
+            RequestsPerMinute: 3_150,
+            TopErrors:
+            [
+                "ConnectionPoolExhausted: checkout-db pool max=50 active=50 waiting=91",
+                "TimeoutException: payment-gateway /charge timeout after 5000ms",
+                "SqlException: deadlock on orders table index ix_orders_customer"
+            ]);
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockThirdPartyStatusService.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/MockServices/MockThirdPartyStatusService.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.MockServices;
+
+internal static class MockThirdPartyStatusService
+{
+    public static async Task<string> GetStatusPageSummaryAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(90, cancellationToken);
+        return "payment-gateway: DEGRADED (elevated latency us-east-1, since 14:17 UTC) | " +
+               "auth-provider: OPERATIONAL | " +
+               "cdn: OPERATIONAL";
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/CustomerInfo.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/CustomerInfo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.Models;
+
+/// <summary>Customer account information fetched during deterministic enrichment.</summary>
+internal sealed record CustomerInfo(
+    string CustomerId,
+    string Tier,
+    string Sla,
+    string ContactEmail
+);

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentOrchestrationReport.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentOrchestrationReport.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Infrastructure;
+
+namespace Squad.SquadWithDTS.Models;
+
+/// <summary>
+/// Final report returned after a complete incident-response workflow run.
+/// </summary>
+internal sealed record IncidentOrchestrationReport(
+    string                   Example,
+    string                   Status,
+    ProviderSummary          Provider,
+    IncidentReport           Input,
+    string?                  WorkflowRunId,
+    IncidentWorkflowContext? FinalContext,
+    string                   Runtime
+);

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentReport.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentReport.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.Models;
+
+/// <summary>
+/// Represents the raw incident alert that triggers the workflow.
+/// </summary>
+internal sealed record IncidentReport(
+    string IncidentId,
+    string Title,
+    string Severity,
+    string Region,
+    string CustomerId,
+    string AffectedService,
+    string InitialDescription
+);

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentWorkflowContext.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/IncidentWorkflowContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Models;
+
+/// <summary>
+/// Mutable context threaded through every executor in the incident-response workflow.
+/// Uses C# record <c>with</c>-expressions so each executor returns an updated snapshot
+/// without mutating shared state — safe for DTS checkpointing.
+/// </summary>
+internal sealed record IncidentWorkflowContext(IncidentReport Report)
+{
+    // ── set by EnrichExecutor ─────────────────────────────────────────────
+    public CustomerInfo?   Customer       { get; init; }
+    public MetricsWindow?  Metrics        { get; init; }
+    public string[]?       RecentAlerts   { get; init; }
+
+    // ── set by TriageExecutor (Squad AI) ─────────────────────────────────
+    public string?  Hypothesis       { get; init; }
+    public string?  Subsystem        { get; init; }     // Database | Network | Authentication | Payments
+    public string?  TriageSeverity   { get; init; }
+    public string[]? RequiredEvidence { get; init; }
+
+    // ── set by ExternalCommsExecutor ─────────────────────────────────────
+    public string? ExternalCommsResult { get; init; }
+
+    // ── set by subsystem-squad executors ────────────────────────────────
+    public string? SubsystemAnalysis { get; init; }
+
+    // ── set by MitigateExecutor ──────────────────────────────────────────
+    public string? MitigationSteps { get; init; }
+
+    // ── set by DiagnoseExecutor (Squad AI) ───────────────────────────────
+    public string? RootCause           { get; init; }
+    public string? DiagnosisStatus     { get; init; }   // Resolved | NeedsMoreInvestigation | Inconclusive
+    public string? RefinedHypothesis   { get; init; }
+    public int     DiagnosisIteration  { get; init; }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/MetricsWindow.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Models/MetricsWindow.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Squad.SquadWithDTS.Models;
+
+/// <summary>
+/// Aggregated metrics window for the affected service, fetched during deterministic enrichment.
+/// </summary>
+internal sealed record MetricsWindow(
+    double   ErrorRatePercent,
+    int      P99LatencyMs,
+    int      RequestsPerMinute,
+    string[] TopErrors
+);

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Program.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Program.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Squad.SquadWithDTS.Agents;
+using Squad.SquadWithDTS.Examples;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Workflows;
+
+// ── Build host ────────────────────────────────────────────────────────────────
+var builder = Host.CreateApplicationBuilder(args);
+builder.Configuration.AddEnvironmentVariables();
+
+// ── OpenTelemetry ─────────────────────────────────────────────────────────────
+var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+{
+    builder.Services
+        .AddOpenTelemetry()
+        .ConfigureResource(r => r.AddService("Squad.SquadWithDTS"))
+        .WithTracing(t => t
+            .AddSource("Squad.AgentFramework.SquadAgent")
+            .AddSource("Squad.AgentFramework.Demo")
+            .AddHttpClientInstrumentation()
+            .AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint)))
+        .WithMetrics(m => m
+            .AddMeter("Squad.AgentFramework.SquadAgent")
+            .AddRuntimeInstrumentation()
+            .AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint)));
+}
+
+// ── Services ──────────────────────────────────────────────────────────────────
+builder.Services.AddSingleton<SquadAgent>();
+builder.Services.AddSingleton<ProviderAgentFactory>(sp =>
+    new ProviderAgentFactory(
+        sp.GetRequiredService<IConfiguration>(),
+        sp.GetRequiredService<SquadAgent>()));
+
+var host = builder.Build();
+
+// ── Run ───────────────────────────────────────────────────────────────────────
+var config  = host.Services.GetRequiredService<IConfiguration>();
+var squad   = host.Services.GetRequiredService<SquadAgent>();
+var factory = host.Services.GetRequiredService<ProviderAgentFactory>();
+
+// Resolve example: CLI arg --example <name>, env SQUAD_AF_EXAMPLE, or interactive prompt
+var example = args.SkipWhile(a => a != "--example").Skip(1).FirstOrDefault()
+           ?? config["SQUAD_AF_EXAMPLE"]
+           ?? PromptForExample();
+
+Console.WriteLine($"Running example: {example}");
+Console.WriteLine($"Provider: {factory.Summary.Provider} | Backed: {factory.Summary.IsProviderBacked}");
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+await host.StartAsync(cts.Token);
+
+try
+{
+    switch (example.ToLowerInvariant())
+    {
+        case "incident":
+            var report = await IncidentExample.RunAsync(factory, squad, cts.Token);
+            Console.WriteLine();
+            Console.WriteLine("Final report:");
+            Console.WriteLine(JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+            break;
+
+        case "squad-as-agent":
+            await SquadAsAgentExample.RunAsync(factory, squad, cts.Token);
+            break;
+
+        case "workflow":
+            await WorkflowExample.RunAsync(factory, squad, cts.Token);
+            break;
+
+        default:
+            Console.WriteLine($"Unknown example '{example}'. Valid: incident, squad-as-agent, workflow");
+            break;
+    }
+}
+finally
+{
+    await host.StopAsync(CancellationToken.None);
+    if (squad is IAsyncDisposable d) await d.DisposeAsync();
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+static string PromptForExample()
+{
+    Console.WriteLine();
+    Console.WriteLine("Select example to run:");
+    Console.WriteLine("  1  incident       (DTS-backed durable workflow — requires Docker)");
+    Console.WriteLine("  2  squad-as-agent (SquadAgent as plain MAF participant)");
+    Console.WriteLine("  3  workflow        (Sequential in-process workflow)");
+    Console.Write("Choice [1]: ");
+    return (Console.ReadLine()?.Trim() ?? "1") switch
+    {
+        "2" => "squad-as-agent",
+        "3" => "workflow",
+        _   => "incident",
+    };
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Squad.SquadWithDTS.csproj
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Squad.SquadWithDTS.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Squad.SquadWithDTS</RootNamespace>
+    <AssemblyName>Squad.SquadWithDTS</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft Agent Framework: Squad + DTS support -->
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.6.1" />
+    <PackageReference Include="Microsoft.Agents.AI.DurableTask" Version="1.6.1-preview" />
+    <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.6.1-preview" />
+
+    <!-- Durable Task Scheduler: Azure-Managed transport (also used by DTS emulator) -->
+    <PackageReference Include="Microsoft.DurableTask.Client.AzureManaged" Version="1.24.2" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.AzureManaged" Version="1.24.2" />
+
+    <!-- Observability: OTel SDK + OTLP exporter -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.3" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.3.0" />
+    <PackageReference Include="Aspire.Hosting" Version="9.3.0" />
+  </ItemGroup>
+</Project>

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/AuthSquadExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/AuthSquadExecutor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Subsystems;
+
+/// <summary>Authentication subsystem squad executor.</summary>
+internal sealed class AuthSquadExecutor(ProviderAgentFactory provider)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("AuthSquad")
+{
+    private const string Charter =
+        """
+        You are the Authentication incident-response squad. Your charter:
+        - Investigate token expiry, clock skew, OIDC provider outages,
+          and RBAC policy misconfigurations.
+        - Correlate auth failures with deployment or configuration changes.
+        - Recommend precise, read-only diagnostic steps.
+        Be concise: 3–5 sentences, focus on the most likely auth root cause.
+        """;
+
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var analysis = await SubsystemSquadHelpers.RunSubsystemAnalysisAsync(
+            provider, "auth-squad", Charter,
+            SubsystemSquadHelpers.BuildPrompt("Authentication", ctx), cancellationToken);
+
+        return ctx with { SubsystemAnalysis = analysis };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/DatabaseSquadExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/DatabaseSquadExecutor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Subsystems;
+
+/// <summary>Database subsystem squad executor.</summary>
+internal sealed class DatabaseSquadExecutor(ProviderAgentFactory provider)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("DatabaseSquad")
+{
+    private const string Charter =
+        """
+        You are the Database incident-response squad. Your charter:
+        - Investigate connection pool exhaustion, lock contention, slow queries,
+          and index fragmentation.
+        - Correlate database metrics with application error patterns.
+        - Recommend precise, read-only diagnostic steps (no schema changes).
+        Be concise: 3–5 sentences, focus on the most likely database root cause.
+        """;
+
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var analysis = await SubsystemSquadHelpers.RunSubsystemAnalysisAsync(
+            provider, "database-squad", Charter,
+            SubsystemSquadHelpers.BuildPrompt("Database", ctx), cancellationToken);
+
+        return ctx with { SubsystemAnalysis = analysis };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/NetworkSquadExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/NetworkSquadExecutor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Subsystems;
+
+/// <summary>Network subsystem squad executor.</summary>
+internal sealed class NetworkSquadExecutor(ProviderAgentFactory provider)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("NetworkSquad")
+{
+    private const string Charter =
+        """
+        You are the Network incident-response squad. Your charter:
+        - Investigate DNS failures, load-balancer health, latency spikes,
+          and packet loss between service mesh nodes.
+        - Correlate network events with service error patterns.
+        - Recommend precise, read-only diagnostic steps.
+        Be concise: 3–5 sentences, focus on the most likely network root cause.
+        """;
+
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var analysis = await SubsystemSquadHelpers.RunSubsystemAnalysisAsync(
+            provider, "network-squad", Charter,
+            SubsystemSquadHelpers.BuildPrompt("Network", ctx), cancellationToken);
+
+        return ctx with { SubsystemAnalysis = analysis };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/PaymentsSquadExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/PaymentsSquadExecutor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Subsystems;
+
+/// <summary>Payments subsystem squad executor.</summary>
+internal sealed class PaymentsSquadExecutor(ProviderAgentFactory provider)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("PaymentsSquad")
+{
+    private const string Charter =
+        """
+        You are the Payments incident-response squad. Your charter:
+        - Investigate payment gateway timeouts, idempotency failures,
+          retry-queue saturation, and PCI compliance anomalies.
+        - Correlate payment errors with third-party provider status.
+        - Recommend precise, read-only diagnostic steps.
+        Be concise: 3–5 sentences, focus on the most likely payments root cause.
+        """;
+
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var analysis = await SubsystemSquadHelpers.RunSubsystemAnalysisAsync(
+            provider, "payments-squad", Charter,
+            SubsystemSquadHelpers.BuildPrompt("Payments", ctx), cancellationToken);
+
+        return ctx with { SubsystemAnalysis = analysis };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/SubsystemSquadHelpers.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Subsystems/SubsystemSquadHelpers.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Subsystems;
+
+/// <summary>
+/// Shared helpers used by all subsystem squad executors.
+/// </summary>
+internal static class SubsystemSquadHelpers
+{
+    internal static async Task<string> RunSubsystemAnalysisAsync(
+        ProviderAgentFactory provider,
+        string agentName,
+        string charter,
+        string prompt,
+        CancellationToken ct)
+    {
+        if (!provider.Summary.IsProviderBacked)
+        {
+            // Demo fallback when no LLM provider is configured.
+            return $"[{agentName}] Provider not configured — returning deterministic fallback. " +
+                   $"Based on the context, the most likely root cause is connection pool exhaustion " +
+                   $"combined with external gateway latency. Recommend: check pool metrics, inspect " +
+                   $"slow-query log, verify third-party status page.";
+        }
+
+        await using var agent = provider.CreateAgent(agentName, charter).Scope;
+        var (aiAgent, _) = provider.CreateAgent(agentName, charter);
+        return await DemoRuntime.RunAgentAsync(aiAgent, prompt, ct);
+    }
+
+    internal static string BuildPrompt(string subsystem, IncidentWorkflowContext ctx) => $$"""
+        Incident assigned to {{subsystem}} squad.
+
+        Title:    {{ctx.Report.Title}}
+        Region:   {{ctx.Report.Region}}
+        Customer: {{ctx.Customer?.Tier ?? "Unknown"}} (SLA {{ctx.Customer?.Sla ?? "unknown"}})
+
+        Triage hypothesis:  {{ctx.Hypothesis ?? "(none)"}}
+        Required evidence:  {{FormatArray(ctx.RequiredEvidence)}}
+
+        Metrics:
+          Error rate:       {{ctx.Metrics?.ErrorRatePercent:0.0}}%
+          p99 latency:      {{ctx.Metrics?.P99LatencyMs:0}} ms
+          Requests/min:     {{ctx.Metrics?.RequestsPerMinute}}
+          Top errors:       {{FormatArray(ctx.Metrics?.TopErrors)}}
+
+        Recent alerts:       {{FormatArray(ctx.RecentAlerts)}}
+        External comms:      {{ctx.ExternalCommsResult ?? "(none)"}}
+
+        Provide your subsystem-specific diagnosis and top 3 read-only investigative steps.
+        """;
+
+    private static string FormatArray(string[]? items) =>
+        items is null or { Length: 0 }
+            ? "(none)"
+            : string.Join("; ", items);
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/DiagnoseExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/DiagnoseExecutor.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows.Executors;
+
+/// <summary>
+/// AI diagnosis via Squad: reviews all accumulated context and returns one of:
+/// <list type="bullet">
+///   <item><c>Resolved</c> — root cause confirmed, incident can be closed.</item>
+///   <item><c>NeedsMoreInvestigation</c> — a refined hypothesis is set; the workflow
+///         loops back to the <see cref="EnrichExecutor"/> (capped at
+///         <see cref="IncidentExample.MaxDiagnosisIterations"/>).</item>
+///   <item><c>Inconclusive</c> — insufficient evidence; escalate to senior engineer.</item>
+/// </list>
+/// </summary>
+internal sealed class DiagnoseExecutor(AIAgent squad)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("Diagnose")
+{
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var prompt = $"""
+            You are the incident diagnosis coordinator. Review all accumulated evidence
+            and determine whether the root cause is identified.
+
+            Incident: {ctx.Report.Title}
+            Subsystem: {ctx.Subsystem}
+            Triage hypothesis: {ctx.Hypothesis}
+
+            Enrichment data:
+              Customer tier: {ctx.Customer?.Tier} (SLA: {ctx.Customer?.Sla})
+              Error rate: {ctx.Metrics?.ErrorRatePercent:0.0}%
+              p99 latency: {ctx.Metrics?.P99LatencyMs} ms
+              Top errors: {string.Join("; ", ctx.Metrics?.TopErrors ?? [])}
+              Recent alerts: {string.Join("; ", ctx.RecentAlerts ?? [])}
+
+            Subsystem analysis: {ctx.SubsystemAnalysis}
+            Mitigation steps: {ctx.MitigationSteps}
+            External comms: {ctx.ExternalCommsResult}
+            Diagnosis iteration: {ctx.DiagnosisIteration + 1} of {IncidentExample.MaxDiagnosisIterations}
+
+            Respond with a JSON object (no markdown fences):
+            {{
+              "status":              "<Resolved|NeedsMoreInvestigation|Inconclusive>",
+              "root_cause":          "<concise root-cause statement>",
+              "refined_hypothesis":  "<only if NeedsMoreInvestigation, otherwise null>"
+            }}
+            """;
+
+        var raw = await DemoRuntime.RunAgentAsync(squad, prompt, cancellationToken);
+
+        var json = System.Text.Json.JsonDocument.Parse(raw).RootElement;
+
+        var status     = json.TryGetProperty("status",             out var s) ? s.GetString() : "Inconclusive";
+        var rootCause  = json.TryGetProperty("root_cause",         out var r) ? r.GetString() : raw;
+        var refinedHyp = json.TryGetProperty("refined_hypothesis", out var h) && h.ValueKind != System.Text.Json.JsonValueKind.Null
+            ? h.GetString()
+            : null;
+
+        return ctx with
+        {
+            DiagnosisStatus    = status,
+            RootCause          = rootCause,
+            RefinedHypothesis  = refinedHyp,
+            DiagnosisIteration = ctx.DiagnosisIteration + 1,
+        };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/EnrichExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/EnrichExecutor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows.Executors;
+
+/// <summary>
+/// Deterministic enrichment: fetches customer info, metrics window, and
+/// recent alert correlations in parallel. No AI calls.
+/// </summary>
+internal sealed class EnrichExecutor
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("Enrich")
+{
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var customerTask = MockServices.MockCustomerService.GetCustomerAsync(
+            ctx.Report.CustomerId, cancellationToken);
+        var metricsTask = MockServices.MockMetricsService.GetMetricsWindowAsync(
+            ctx.Report.Region, cancellationToken);
+        var alertsTask = MockServices.MockAlertCorrelationService.GetRecentAlertsAsync(
+            ctx.Report.Region, cancellationToken);
+
+        await Task.WhenAll(customerTask, metricsTask, alertsTask);
+
+        return ctx with
+        {
+            Customer     = customerTask.Result,
+            Metrics      = metricsTask.Result,
+            RecentAlerts = alertsTask.Result,
+            // Carry forward any refined hypothesis from a diagnose-loop iteration
+            Hypothesis   = ctx.RefinedHypothesis ?? ctx.Hypothesis,
+        };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/ExternalCommsExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/ExternalCommsExecutor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows.Executors;
+
+/// <summary>
+/// Mock external communications: simulates customer outreach and third-party
+/// status page checks. No AI calls — purely deterministic.
+/// </summary>
+internal sealed class ExternalCommsExecutor
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("ExternalComms")
+{
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var outreachTask = MockServices.MockCustomerOutreachService.NotifyCustomerAsync(
+            ctx.Customer!, ctx.Report, cancellationToken);
+        var statusTask = MockServices.MockThirdPartyStatusService.GetStatusPageSummaryAsync(
+            cancellationToken);
+
+        await Task.WhenAll(outreachTask, statusTask);
+
+        return ctx with
+        {
+            ExternalCommsResult =
+                $"Customer notified: {outreachTask.Result} | " +
+                $"Third-party status: {statusTask.Result}",
+        };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/MitigateExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/MitigateExecutor.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows.Executors;
+
+/// <summary>
+/// Deterministic mitigation lookup: maps subsystem + triage hypothesis to
+/// a set of read-only investigative actions. No AI calls.
+/// </summary>
+internal sealed class MitigateExecutor
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("Mitigate")
+{
+    private static readonly Dictionary<string, string[]> MitigationPlaybook = new(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        ["Database"] =
+        [
+            "Query pg_stat_activity for long-running queries (> 30 s)",
+            "Check connection pool saturation: SHOW max_connections; SELECT count(*) FROM pg_stat_activity;",
+            "Inspect deadlock logs: grep 'deadlock' /var/log/postgresql/postgresql.log | tail -50",
+            "Review slow query log for the past 15 minutes",
+            "Verify index health: SELECT schemaname, tablename, indexname FROM pg_indexes WHERE tablename='orders';",
+        ],
+        ["Network"] =
+        [
+            "Ping external dependencies from the affected region",
+            "Check DNS resolution for payment-gateway endpoint",
+            "Inspect load balancer health: review target group health in AWS/Azure console",
+            "Review network ACL and security group rules for recent changes",
+            "Capture tcpdump sample: sudo tcpdump -i eth0 port 443 -c 100",
+        ],
+        ["Authentication"] =
+        [
+            "Check token expiry and clock skew across service pods",
+            "Review auth service error rate: kubectl logs -l app=auth-service --tail=100",
+            "Verify OAuth2 provider status: check identity provider dashboard",
+            "Rotate affected service account credentials if compromise suspected",
+            "Review recent changes to RBAC policies",
+        ],
+        ["Payments"] =
+        [
+            "Verify payment gateway status page for active incidents",
+            "Check retry queue depth: inspect dead-letter queue in message broker",
+            "Review idempotency key collisions in payment processor logs",
+            "Confirm PCI compliance controls are intact before further investigation",
+            "Escalate to payments team if gateway SLA > 10 min",
+        ],
+    };
+
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.Yield(); // keep async contract
+
+        var subsystem = ctx.Subsystem ?? "Database";
+        var steps = MitigationPlaybook.TryGetValue(subsystem, out var playbook)
+            ? string.Join("\n", playbook.Select((s, i) => $"  {i + 1}. {s}"))
+            : "No playbook found — escalate to on-call engineer.";
+
+        return ctx with { MitigationSteps = steps };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/TriageExecutor.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/Executors/TriageExecutor.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows.Executors;
+
+/// <summary>
+/// AI triage via Squad: determines severity, subsystem, initial hypothesis,
+/// and the evidence required by downstream executors.
+/// </summary>
+internal sealed class TriageExecutor(AIAgent squad)
+    : Executor<IncidentWorkflowContext, IncidentWorkflowContext>("Triage")
+{
+    public override async ValueTask<IncidentWorkflowContext> HandleAsync(
+        IncidentWorkflowContext ctx,
+        IWorkflowContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var prompt = $"""
+            You are the on-call incident triage coordinator.
+
+            Incident: {ctx.Report.Title}
+            Service:  {ctx.Report.AffectedService}
+            Region:   {ctx.Report.Region}
+            Severity: {ctx.Report.Severity}
+
+            Description:
+            {ctx.Report.InitialDescription}
+
+            Respond with a JSON object (no markdown fences) with exactly these fields:
+            {{
+              "severity":          "<P1|P2|P3>",
+              "subsystem":         "<Database|Network|Authentication|Payments>",
+              "hypothesis":        "<one-sentence root-cause hypothesis>",
+              "required_evidence": ["<evidence item 1>", "<evidence item 2>", ...]
+            }}
+            """;
+
+        var raw = await DemoRuntime.RunAgentAsync(squad, prompt, cancellationToken);
+
+        // Parse the JSON response (Squad always returns valid JSON for structured prompts)
+        var json = System.Text.Json.JsonDocument.Parse(raw).RootElement;
+
+        return ctx with
+        {
+            TriageSeverity   = json.TryGetProperty("severity",   out var sev)  ? sev.GetString()  : ctx.Report.Severity,
+            Subsystem        = json.TryGetProperty("subsystem",  out var sub)  ? sub.GetString()  : "Database",
+            Hypothesis       = json.TryGetProperty("hypothesis", out var hyp)  ? hyp.GetString()  : raw,
+            RequiredEvidence = json.TryGetProperty("required_evidence", out var evArr)
+                ? evArr.EnumerateArray().Select(e => e.GetString() ?? "").ToArray()
+                : [],
+        };
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/IncidentEvidence.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/IncidentEvidence.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+using Squad.SquadWithDTS.Models;
+
+namespace Squad.SquadWithDTS.Workflows;
+
+/// <summary>
+/// Synthetic incident test data used when running the demo without a real alert feed.
+/// </summary>
+internal static class IncidentEvidence
+{
+    public static IncidentReport CreateSyntheticIncidentReport() => new(
+        IncidentId:          "INC-20260520-0042",
+        Title:               "Checkout service degraded — connection pool exhaustion + payment gateway timeouts",
+        Severity:            "P1",
+        Region:              "us-east-1",
+        CustomerId:          "CUST-9921",
+        AffectedService:     "checkout-service",
+        InitialDescription:  """
+            Multiple customers reporting checkout failures since 14:19 UTC.
+            Payment-gateway timeouts spiking to 8 s (p99). DB connection pool
+            saturated: active=50/50, waiting=91. Deadlock errors on orders table.
+            Correlated with a deployment of checkout-service v2.14.1 at 14:05 UTC.
+            SRE pager fired at 14:22 UTC after 14% error-rate threshold exceeded.
+            """
+    );
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/IncidentExample.cs
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/Workflows/IncidentExample.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft. All rights reserved.
+using System.Diagnostics;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.DurableTask;
+using Microsoft.Agents.AI.DurableTask.Workflows;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.DurableTask.Client.AzureManaged;
+using Microsoft.DurableTask.Worker.AzureManaged;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Squad.SquadWithDTS.Infrastructure;
+using Squad.SquadWithDTS.Models;
+using Squad.SquadWithDTS.Workflows.Executors;
+using Squad.SquadWithDTS.Subsystems;
+
+namespace Squad.SquadWithDTS.Workflows;
+
+/// <summary>
+/// Realistic, runnable incident-response orchestration demonstrating:
+/// <list type="bullet">
+///   <item>AI triage + dynamic subsystem-squad routing (Database / Network / Auth / Payments)</item>
+///   <item>Deterministic enrichment (customer lookup, metrics, alert correlation)</item>
+///   <item>Mock external communications (customer outreach + third-party status page)</item>
+///   <item>Durable execution via the DTS emulator — every executor is checkpointed</item>
+///   <item>Diagnose-loop: Squad reviews the full context and can request another enrichment
+///         cycle (capped at <see cref="MaxDiagnosisIterations"/> to prevent infinite loops)</item>
+/// </list>
+/// </summary>
+internal static partial class IncidentExample
+{
+    internal const int MaxDiagnosisIterations = 3;
+
+    /// <summary>
+    /// ActivitySource used for all MAF workflow spans emitted by this demo.
+    /// Registered with the OTel SDK in <see cref="Program"/> so spans flow to the
+    /// Aspire dashboard (or any OTLP-capable backend) when
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set.
+    /// </summary>
+    internal static readonly ActivitySource DemoActivitySource =
+        new("Squad.AgentFramework.Demo", "1.0.0");
+
+    public static async Task<IncidentOrchestrationReport> RunAsync(
+        ProviderAgentFactory provider,
+        AIAgent squad,
+        CancellationToken cancellationToken = default)
+    {
+        var input          = IncidentEvidence.CreateSyntheticIncidentReport();
+        var initialContext = new IncidentWorkflowContext(input);
+        var workflow       = BuildWorkflow(provider, squad);
+
+        // DTS endpoint injected by Aspire AppHost via WithEnvironment("DTS_ENDPOINT", ...)
+        var dtsEndpoint = Environment.GetEnvironmentVariable("DTS_ENDPOINT")
+                          ?? "http://localhost:8080";
+        var dtsConnectionString =
+            $"Endpoint={dtsEndpoint};TaskHub=default;Authentication=None";
+
+        Console.WriteLine();
+        Console.WriteLine("══════════════════════════════════════════════════════════════");
+        Console.WriteLine("  Durable Incident-Response Workflow  (DTS-backed)");
+        Console.WriteLine($"  Scheduler   : {dtsEndpoint}");
+        Console.WriteLine("  DTS UI      : http://localhost:8082");
+
+        var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+            Console.WriteLine("  Aspire OTel : traces/metrics flowing → Aspire dashboard");
+        else
+            Console.WriteLine("  Aspire OTel : not configured (set OTEL_EXPORTER_OTLP_ENDPOINT to enable)");
+
+        Console.WriteLine("══════════════════════════════════════════════════════════════");
+        Console.WriteLine();
+
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.ConfigureDurableWorkflows(
+                    workflowOptions => workflowOptions.AddWorkflow(workflow),
+                    workerBuilder: b => b.UseDurableTaskScheduler(dtsConnectionString),
+                    clientBuilder: b => b.UseDurableTaskScheduler(dtsConnectionString));
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken);
+
+        string? runId = null;
+        IncidentWorkflowContext? finalContext = null;
+
+        try
+        {
+            var workflowClient = host.Services.GetRequiredService<IWorkflowClient>();
+            var run = (IAwaitableWorkflowRun)await workflowClient.RunAsync(
+                workflow, initialContext, cancellationToken: cancellationToken);
+
+            runId = run.RunId;
+            Console.WriteLine($"Workflow run started — run ID: {run.RunId}");
+            Console.WriteLine("Watch progress at: http://localhost:8082");
+            Console.WriteLine();
+
+            finalContext = await run
+                .WaitForCompletionAsync<IncidentWorkflowContext>(cancellationToken);
+
+            Console.WriteLine();
+            Console.WriteLine("══════════════════════════════════════════════════════════════");
+            Console.WriteLine($"  Workflow complete  |  Status : {finalContext?.DiagnosisStatus}");
+            Console.WriteLine($"  Subsystem routed   : {finalContext?.Subsystem}");
+            Console.WriteLine($"  Root cause         : {finalContext?.RootCause}");
+            Console.WriteLine($"  Diagnosis iters    : {finalContext?.DiagnosisIteration}");
+            Console.WriteLine("══════════════════════════════════════════════════════════════");
+        }
+        finally
+        {
+            await host.StopAsync(CancellationToken.None);
+        }
+
+        return new IncidentOrchestrationReport(
+            Example: "incident",
+            Status: finalContext is not null ? "PASS" : "INCOMPLETE",
+            Provider: provider.Summary,
+            Input: input,
+            WorkflowRunId: runId,
+            FinalContext: finalContext,
+            Runtime:
+                $"DTS-backed durable workflow | " +
+                $"scheduler={dtsEndpoint} | " +
+                $"subsystem={finalContext?.Subsystem ?? "unknown"} | " +
+                $"iterations={finalContext?.DiagnosisIteration ?? 0}");
+    }
+
+    // ── workflow graph construction ───────────────────────────────────────
+
+    private static Workflow BuildWorkflow(ProviderAgentFactory provider, AIAgent squad)
+    {
+        //
+        //   triage
+        //     └──► enrich  ◄────────────── loop-back (NeedsMoreInvestigation && iter < Max)
+        //            └──► externalComms                                            ▲
+        //                   ├──► [Database]     databaseSquad ─┐                  │
+        //                   ├──► [Network]      networkSquad  ─┤                  │
+        //                   ├──► [Auth]         authSquad     ─┼──► mitigate ──► diagnose
+        //                   └──► [Payments]     paymentsSquad ─┘
+        //
+
+        var triageExecutor        = new TriageExecutor(squad);
+        var enrichExecutor        = new EnrichExecutor();
+        var externalCommsExecutor = new ExternalCommsExecutor();
+        var databaseSquadExecutor = new DatabaseSquadExecutor(provider);
+        var networkSquadExecutor  = new NetworkSquadExecutor(provider);
+        var authSquadExecutor     = new AuthSquadExecutor(provider);
+        var paymentsSquadExecutor = new PaymentsSquadExecutor(provider);
+        var mitigateExecutor      = new MitigateExecutor();
+        var diagnoseExecutor      = new DiagnoseExecutor(squad);
+
+        var triageBinding        = triageExecutor.BindExecutor();
+        var enrichBinding        = enrichExecutor.BindExecutor();
+        var externalCommsBinding = externalCommsExecutor.BindExecutor();
+        var databaseBinding      = databaseSquadExecutor.BindExecutor();
+        var networkBinding       = networkSquadExecutor.BindExecutor();
+        var authBinding          = authSquadExecutor.BindExecutor();
+        var paymentsBinding      = paymentsSquadExecutor.BindExecutor();
+        var mitigateBinding      = mitigateExecutor.BindExecutor();
+        var diagnoseBinding      = diagnoseExecutor.BindExecutor();
+
+        return new WorkflowBuilder(triageBinding)
+            .WithName("incident-response")
+            .WithDescription(
+                "Durable incident-response: AI triage → enrichment → external comms " +
+                "→ dynamic subsystem-squad routing → mitigation → diagnose-loop.")
+            .WithOpenTelemetry(activitySource: DemoActivitySource)
+
+            // ── forward path ──────────────────────────────────────────────
+            .AddEdge(triageBinding, enrichBinding)
+            .AddEdge(enrichBinding, externalCommsBinding)
+
+            // ── dynamic subsystem-squad routing (conditional edges) ───────
+            .AddEdge<IncidentWorkflowContext>(
+                externalCommsBinding, databaseBinding,
+                ctx => ctx?.Subsystem == "Database")
+            .AddEdge<IncidentWorkflowContext>(
+                externalCommsBinding, networkBinding,
+                ctx => ctx?.Subsystem == "Network")
+            .AddEdge<IncidentWorkflowContext>(
+                externalCommsBinding, authBinding,
+                ctx => ctx?.Subsystem == "Authentication")
+            .AddEdge<IncidentWorkflowContext>(
+                externalCommsBinding, paymentsBinding,
+                ctx => ctx?.Subsystem == "Payments")
+
+            // ── all subsystem squads converge into mitigate ───────────────
+            .AddEdge(databaseBinding, mitigateBinding)
+            .AddEdge(networkBinding,  mitigateBinding)
+            .AddEdge(authBinding,     mitigateBinding)
+            .AddEdge(paymentsBinding, mitigateBinding)
+
+            .AddEdge(mitigateBinding, diagnoseBinding)
+
+            // ── diagnose-loop (loop back to enrich with refined hypothesis) ─
+            .AddEdge<IncidentWorkflowContext>(
+                diagnoseBinding, enrichBinding,
+                ctx => ctx?.DiagnosisStatus == "NeedsMoreInvestigation"
+                       && ctx.DiagnosisIteration < MaxDiagnosisIterations)
+
+            .WithOutputFrom(diagnoseBinding)
+            .Build();
+    }
+}

--- a/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/appsettings.json
+++ b/dotnet/samples/02-agents/SquadWithDTS/Squad.SquadWithDTS/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "SquadAgent": {
+    "AgentId": "repo-local-squad",
+    "AgentName": "Squad",
+    "AgentDescription": "Squad governance agent — routes work to the right specialist based on charter definitions."
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Hosting": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation and Context

This sample contributes the `squad-agent-framework-demo` to the public MAF samples library as the first end-to-end example showing **GitHub Copilot Squad** composed with **MAF + Durable Task Scheduler (DTS)**.

The sample directly complements the existing [Harness samples](dotnet/samples/02-agents/Harness/) — it explores the `OnPermissionRequest` governance pattern which sits at a different point on the trust spectrum from Harness's `ToolApproval`.

## Description

Adds `dotnet/samples/02-agents/SquadWithDTS/` — a self-contained, runnable incident-response demo.

### New sample: `SquadWithDTS`

Key files:
- `Agents/SquadAgent.cs` — `SquadAgent : AIAgent` wrapping `GitHubCopilotAgent` with OTel spans + metrics
- `Workflows/IncidentExample.cs` — 9-executor DTS-backed durable workflow with diagnose-loop
- `Workflows/Executors/TriageExecutor.cs` — AI triage via Squad: severity, subsystem, hypothesis
- `Workflows/Executors/DiagnoseExecutor.cs` — Squad diagnose-loop: Resolved / NeedsMoreInvestigation / Inconclusive
- `Subsystems/*.cs` — Dynamic AI subsystem squads (Database / Network / Auth / Payments) routed by triage
- `Squad.SquadWithDTS.AppHost/AppHost.cs` — Aspire AppHost wiring DTS emulator + Foundry Local

### Updated: `Harness/README.md`

Adds "Related samples" section with governance-pattern comparison (`ToolApproval` vs `OnPermissionRequest`).

## Contribution Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation (updated README)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes (sample code)
- [x] All new and existing tests passed