### PR TITLE
Python: [A2A] Set message_id on AgentResponseUpdate for message-bearing paths

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -487,6 +487,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                     contents=contents,
                     role="assistant" if msg.role == A2ARole.ROLE_AGENT else "user",
                     response_id=msg.message_id or str(uuid.uuid4()),
+                    message_id=msg.message_id,
                     additional_properties={"a2a_metadata": metadata} if metadata else None,
                     raw_representation=msg,
                 )
@@ -727,6 +728,7 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
                 contents=contents,
                 role="assistant" if message.role == A2ARole.ROLE_AGENT else "user",
                 response_id=update_event.task_id,
+                message_id=message.message_id,
                 additional_properties={"a2a_metadata": merged_metadata} if merged_metadata else None,
                 raw_representation=update_event,
             )

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -420,6 +420,7 @@ async def test_run_streaming_with_message_response(a2a_agent: A2AAgent, mock_a2a
     assert content.text == "Streaming response from agent!"
 
     assert updates[0].response_id == "msg-stream-123"
+    assert updates[0].message_id == "msg-stream-123"
     assert mock_a2a_client.call_count == 1
 
 
@@ -1335,7 +1336,7 @@ async def test_streaming_status_update_event_yields_content(
         status=TaskStatus(
             state=TaskState.TASK_STATE_COMPLETED,
             message=A2AMessage(
-                message_id=str(uuid4()),
+                message_id="msg-status-done",
                 role=A2ARole.ROLE_AGENT,
                 parts=[Part(text="Done")],
             ),
@@ -1350,6 +1351,7 @@ async def test_streaming_status_update_event_yields_content(
     assert len(updates) == 1
     assert updates[0].text == "Done"
     assert updates[0].role == "assistant"
+    assert updates[0].message_id == "msg-status-done"
     assert updates[0].raw_representation == update_event
 
 
@@ -1362,7 +1364,7 @@ async def test_streaming_input_required_emits_content(a2a_agent: A2AAgent, mock_
         status=TaskStatus(
             state=TaskState.TASK_STATE_INPUT_REQUIRED,
             message=A2AMessage(
-                message_id=str(uuid4()),
+                message_id="msg-input-req",
                 role=A2ARole.ROLE_AGENT,
                 parts=[Part(text="What is your name?")],
             ),
@@ -1376,6 +1378,7 @@ async def test_streaming_input_required_emits_content(a2a_agent: A2AAgent, mock_
 
     assert len(updates) == 1
     assert updates[0].text == "What is your name?"
+    assert updates[0].message_id == "msg-input-req"
 
 
 @mark.asyncio


### PR DESCRIPTION
## Summary

Maps A2A protocol `message_id` to `AgentResponseUpdate.message_id` in two paths where it was previously omitted, aligning Python behavior with .NET:

1. **Standalone A2AMessage**: set `message_id=msg.message_id` (matches .NET `ConvertToAgentResponseUpdate(Message)` which sets both `ResponseId` and `MessageId` to `message.MessageId`)

2. **TaskStatusUpdateEvent (terminal/input_required)**: set `message_id=message.message_id` (matches .NET which sets `MessageId=statusUpdateEvent.Status.Message?.MessageId`)

## Motivation

Issue #5949 reported that `task_id` is correctly mapped to `response_id`, but `message_id` from A2A protocol messages is discarded. The .NET side already correctly sets `MessageId` in both of these paths.

The semantic mapping is:
- `task_id` → `response_id` (identifies the conversation round)
- `message_id` / `artifact_id` → `message_id` (identifies the individual content piece)

## Changes

- `_agent.py`: Added `message_id=msg.message_id` to the standalone `A2AMessage` path
- `_agent.py`: Added `message_id=message.message_id` to the `TaskStatusUpdateEvent` path
- `test_a2a_agent.py`: Updated tests to assert `message_id` is correctly set

## Testing

All 103 tests in `test_a2a_agent.py` pass.

Fixes #5949