### PR TITLE
.NET: Update Aspire to 13.3.5 and add ATS exports to DevUI integration

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Aspire -->
-    <AspireAppHostSdkVersion>13.1.0</AspireAppHostSdkVersion>
+    <AspireAppHostSdkVersion>13.3.5</AspireAppHostSdkVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire.* -->
@@ -41,18 +41,18 @@
     <!-- Newtonsoft.Json -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- System.* -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageVersion Include="System.ClientModel" Version="1.11.0" />
     <PackageVersion Include="System.CodeDom" Version="10.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.6" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.7" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.5" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.0" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.5" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="System.Threading.Channels" Version="10.0.6" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Net.Security" Version="4.3.2" />
@@ -78,22 +78,22 @@
     <PackageVersion Include="Microsoft.Extensions.AI.Evaluation.Quality" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Evaluation.Safety" Version="10.3.0-preview.1.26109.11" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Compliance.Abstractions" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
     <PackageVersion Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.7.0" />
     <!-- Vector Stores -->
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.67.0-preview" />

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/AgentEntityInfo.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/AgentEntityInfo.cs
@@ -18,6 +18,7 @@ namespace Aspire.Hosting.AgentFramework;
 /// </remarks>
 /// <param name="Id">The unique identifier for the agent, typically matching the name passed to <c>AddAIAgent</c>.</param>
 /// <param name="Description">A short description of the agent's capabilities.</param>
+[AspireDto]
 public record AgentEntityInfo(string Id, string? Description = null)
 {
     /// <summary>

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/AgentFrameworkBuilderExtensions.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/AgentFrameworkBuilderExtensions.cs
@@ -46,9 +46,11 @@ public static class AgentFrameworkBuilderExtensions
     ///     .WithAgentService(pythonAgent);
     /// </code>
     /// </example>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
     public static IResourceBuilder<DevUIResource> AddDevUI(
         this IDistributedApplicationBuilder builder,
-        string name,
+        [ResourceName] string name,
         int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -164,6 +166,8 @@ public static class AgentFrameworkBuilderExtensions
     ///     .WaitFor(editorAgent);
     /// </code>
     /// </example>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport]
     public static IResourceBuilder<DevUIResource> WithAgentService<TSource>(
         this IResourceBuilder<DevUIResource> builder,
         IResourceBuilder<TSource> agentService,

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/Aspire.Hosting.AgentFramework.DevUI.csproj
@@ -5,7 +5,7 @@
     <VersionSuffix>preview</VersionSuffix>
     <!-- Suppress analyzer warnings for Aspire integration code -->
     <!-- IL2026/IL3050: Suppress trimming/AOT warnings - DevUI is a dev-only tool not intended for AOT -->
-    <NoWarn>$(NoWarn);CA1873;RCS1061;VSTHRD002;IL2026;IL3050</NoWarn>
+    <NoWarn>$(NoWarn);CA1873;RCS1061;VSTHRD002;IL2026;IL3050;ASPIREATS001</NoWarn>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIResource.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIResource.cs
@@ -14,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// external container image.
 /// </remarks>
 /// <param name="name">The name of the DevUI resource.</param>
+[AspireExport(ExposeProperties = true)]
 public class DevUIResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithWaitSupport
 {
     internal const string PrimaryEndpointName = "http";

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/README.md
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/README.md
@@ -34,6 +34,10 @@ var devui = builder.AddDevUI("devui")
     .WaitFor(editorAgent);
 ```
 
+## Polyglot AppHost support
+
+`AddDevUI` and `WithAgentService` are exported through Aspire ATS, so this integration can also be used from polyglot Aspire AppHosts (for example TypeScript-based AppHosts).
+
 Each agent service only needs to map the standard OpenAI API endpoints — no custom discovery endpoints are required:
 
 ```csharp

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/AgentEntityInfoTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/AgentEntityInfoTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Reflection;
+
 namespace Aspire.Hosting.AgentFramework.DevUI.UnitTests;
 
 /// <summary>
@@ -128,6 +130,23 @@ public class AgentEntityInfoTests
 
         // Assert
         Assert.Equal("custom_framework", info.Framework);
+    }
+
+    #endregion
+
+    #region ATS Export Tests
+
+    /// <summary>
+    /// Verifies that AgentEntityInfo is marked as an ATS DTO.
+    /// </summary>
+    [Fact]
+    public void AgentEntityInfo_HasAspireDtoAttribute()
+    {
+        // Arrange & Act
+        var dtoAttribute = typeof(AgentEntityInfo).GetCustomAttribute<AspireDtoAttribute>();
+
+        // Assert
+        Assert.NotNull(dtoAttribute);
     }
 
     #endregion

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/AgentFrameworkBuilderExtensionsTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/AgentFrameworkBuilderExtensionsTests.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
+using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Moq;
 
@@ -537,6 +539,67 @@ public class AgentFrameworkBuilderExtensionsTests
         var annotation2 = devui2.Resource.Annotations.OfType<AgentServiceAnnotation>().Single();
         Assert.Equal("prefix1", annotation1.EntityIdPrefix);
         Assert.Equal("prefix2", annotation2.EntityIdPrefix);
+    }
+
+    #endregion
+
+    #region ATS Export Tests
+
+    /// <summary>
+    /// Verifies that AddDevUI is exported for Aspire Type System (ATS) usage.
+    /// </summary>
+    [Fact]
+    public void AddDevUI_HasAspireExportAttribute()
+    {
+        // Arrange
+        var method = typeof(AgentFrameworkBuilderExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(AgentFrameworkBuilderExtensions.AddDevUI));
+
+        // Act
+        var exportAttribute = method.GetCustomAttribute<AspireExportAttribute>();
+
+        // Assert
+        Assert.NotNull(exportAttribute);
+    }
+
+    /// <summary>
+    /// Verifies that AddDevUI marks the name parameter as a resource name for ATS tooling.
+    /// </summary>
+    [Fact]
+    public void AddDevUI_NameParameter_HasResourceNameAttribute()
+    {
+        // Arrange
+        var method = typeof(AgentFrameworkBuilderExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(AgentFrameworkBuilderExtensions.AddDevUI));
+        var nameParameter = method.GetParameters().Single(p => p.Name == "name");
+
+        // Act
+        var resourceNameAttribute = nameParameter.GetCustomAttribute<ResourceNameAttribute>();
+
+        // Assert
+        Assert.NotNull(resourceNameAttribute);
+    }
+
+    /// <summary>
+    /// Verifies that WithAgentService is exported for Aspire Type System (ATS) usage.
+    /// </summary>
+    [Fact]
+    public void WithAgentService_HasAspireExportAttribute()
+    {
+        // Arrange
+        var method = typeof(AgentFrameworkBuilderExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(AgentFrameworkBuilderExtensions.WithAgentService)
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 1);
+
+        // Act
+        var exportAttribute = method.GetCustomAttribute<AspireExportAttribute>();
+
+        // Assert
+        Assert.NotNull(exportAttribute);
     }
 
     #endregion

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/Aspire.Hosting.AgentFramework.DevUI.UnitTests.csproj
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/Aspire.Hosting.AgentFramework.DevUI.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
+    <NoWarn>$(NoWarn);ASPIREATS001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIResourceTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIResourceTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using System.Net.Sockets;
+using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.AgentFramework.DevUI.UnitTests;
@@ -187,6 +188,24 @@ public class DevUIResourceTests
 
         // Assert
         Assert.Same(endpoint1, endpoint2);
+    }
+
+    #endregion
+
+    #region ATS Export Tests
+
+    /// <summary>
+    /// Verifies that DevUIResource is exported for Aspire Type System (ATS) usage.
+    /// </summary>
+    [Fact]
+    public void DevUIResource_HasAspireExportAttributeWithExposedProperties()
+    {
+        // Arrange & Act
+        var exportAttribute = typeof(DevUIResource).GetCustomAttribute<AspireExportAttribute>();
+
+        // Assert
+        Assert.NotNull(exportAttribute);
+        Assert.True(exportAttribute.ExposeProperties);
     }
 
     #endregion


### PR DESCRIPTION
## Overview
Upgrades the DevUI hosting integration to Aspire 13.3.5 and adds Aspire Type System (ATS) exports for polyglot AppHost code generation support.

## Changes

### Aspire Upgrade
- Updated \AspireAppHostSdkVersion\ from 13.1.0 to 13.3.5
- Removed temporary ATS attribute shims (now provided by Aspire 13.3.5)
- Resolved transitive package version conflicts

### ATS Annotations
- Added \[AspireExport]\ to extension methods
- Added \[AspireExport(ExposeProperties = true)]\ to \DevUIResource\ class  
- Added \[AspireDto]\ to \AgentEntityInfo\ record
- Added \[ResourceName]\ to resource name parameters
- Added \<ats-returns>\ XML documentation tags

### Testing & Verification
- ✅ 76/76 unit tests pass across net8.0, net9.0, and net10.0
- ✅ Sample AppHosts build successfully
- ✅ Implementation matches patterns from \microsoft/aspire\
- ✅ Added ATS reflection tests to verify annotations

### Documentation
- Updated README with polyglot AppHost support note
- Added \ASPIREATS001\ diagnostic suppression - can be removed once Aspire 13.4 ships