### PR TITLE
.NET: Fix: preserve multi-field records in ForeachExecutor (fixes #6183)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
@@ -49,7 +49,7 @@ internal sealed class ForeachExecutor : DeclarativeActionExecutor<Foreach>
         EvaluationResult<DataValue> expressionResult = this.Evaluator.GetValue(this.Model.Items);
         if (expressionResult.Value is TableDataValue tableValue)
         {
-            this._values = [.. tableValue.Values.Select(value => value.Properties.Values.First().ToFormula())];
+            this._values = [.. tableValue.Values.Select(value => value.ToFormula())];
         }
         else
         {


### PR DESCRIPTION
## Summary

Fixes `ForeachExecutor.ExecuteAsync` to preserve multi-field records as the loop `value` variable instead of collapsing them to only the first field.

## Issue

Closes #6183

## Root Cause

`ForeachExecutor.ExecuteAsync` line 52 used `value.Properties.Values.First().ToFormula()` which picks only the first property of each record. For multi-field records like `{ name: "Alice", role: "Engineer" }`, this assigned only `"Alice"` to the loop value variable, making `Local.currentItem.role` inaccessible.

## Fix

Changed to `value.ToFormula()` which routes through `DataValueExtensions.ToFormula`'s existing `RecordDataValue -> ToRecordValue()` branch, preserving all fields.

```diff
- this._values = [.. tableValue.Values.Select(value => value.Properties.Values.First().ToFormula())];
+ this._values = [.. tableValue.Values.Select(value => value.ToFormula())];
```

## Verification

Change is trivially correct by inspection. The `ToFormula` extension method already handles `RecordDataValue` correctly at `<see href="https://github.com/microsoft/agent-framework/blob/main/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Extensions/DataValueExtensions.cs#L53-L57">DataValueExtensions.cs</see>`.
