### PR TITLE
Python: Update Declarative workflows actions documentation (fixes #6125)

### DIFF
--- a/python/samples/03-workflows/declarative/README.md
+++ b/python/samples/03-workflows/declarative/README.md
@@ -64,7 +64,6 @@ actions:
 
 ### Agent Invocation
 - `InvokeAzureAgent` - Call an Azure AI agent
-- `InvokePromptAgent` - Call a local prompt agent
 
 ### Tool Invocation
 - `InvokeFunctionTool` - Call a registered Python function


### PR DESCRIPTION
﻿## Summary
Remove InvokePromptAgent from the supported action types list in the declarative workflows README. This action kind was removed in PR #6126 as part of cleaning up Python-only declarative actions.

## Issue
Fixes #6125

## Verification
- grep -n "InvokePromptAgent" python/samples/03-workflows/declarative/README.md now returns no matches
- No other references to InvokePromptAgent remain in the codebase
