### PR TITLE
Python: add ChatMessageStore backward-compat alias for HistoryProvider (fixes #5700)

### DIFF
--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -153,6 +153,7 @@ from ._sessions import (
     SessionContext,
     register_state_type,
 )
+ChatMessageStore = HistoryProvider
 from ._settings import SecretString, load_settings
 from ._skills import (
     AggregatingSkillsSource,
@@ -371,6 +372,7 @@ __all__ = [
     "ChatMiddleware",
     "ChatMiddlewareLayer",
     "ChatMiddlewareTypes",
+    "ChatMessageStore",
     "ChatOptions",
     "ChatResponse",
     "ChatResponseUpdate",


### PR DESCRIPTION
## Summary

Add a backward-compatible `ChatMessageStore` alias for `HistoryProvider` in the public API exports.

## Issue

Fixes #5700

## Background

`ChatMessageStore` was removed in #3850 (Feb 2026) when the thread/memory layer was reworked into the context-provider pipeline. The replacement is `HistoryProvider`. However, users attempting to import `ChatMessageStore` (as documented in some upgrade guides) receive an ImportError.

## Changes

- Added `ChatMessageStore = HistoryProvider` alias in `agent_framework/__init__.py`
- Added `ChatMessageStore` to `__all__`

## Verification

```
from agent_framework import ChatMessageStore, HistoryProvider
assert ChatMessageStore is HistoryProvider
assert ChatMessageStore in __import__(agent_framework).__all__
```