### PR TITLE
.NET: fix GetSessionAsync doc comment incorrectly stating null is returned (fixes #6082)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting/AgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/AgentSessionStore.cs
@@ -69,7 +69,7 @@ public abstract class AgentSessionStore
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>
     /// A task that represents the asynchronous retrieval operation.
-    /// The task result contains the serialized session state, or <see langword="null"/> if not found.
+    /// The task result contains the serialized session state. If the session is not found, a new session is created and returned.
     /// </returns>
     public abstract ValueTask<AgentSession> GetSessionAsync(
         AIAgent agent,


### PR DESCRIPTION
﻿## Summary

The XML doc comment on AgentSessionStore.GetSessionAsync() states that the method returns 
ull when the session is not found. However, the return type is ValueTask<AgentSession> (non-nullable), and both existing implementations (noop session store, in memory session store) as well as the usage by AIHostAgent expect a new session to be returned instead of null.

This fix corrects the documentation to match the actual contract.

## Issue

Fixes #6082

## Verification

- Compared with the identical type in Microsoft.Agents.AI.Foundry.Hosting which already has the correct wording: "…or a new session if not found."
- The change is purely a documentation comment fix; no runtime behavior is affected.
