### PR TITLE
Python: fix(core): preserve null arguments in tool function calls

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -635,9 +635,7 @@ class FunctionTool(SerializationMixin):
                 if isinstance(arguments, Mapping):
                     parsed_arguments = dict(arguments)
                     if self.input_model is not None and not self._schema_supplied:
-                        parsed_arguments = self.input_model.model_validate(parsed_arguments).model_dump(
-                            exclude_none=True
-                        )
+                        parsed_arguments = self.input_model.model_validate(parsed_arguments).model_dump()
                 elif isinstance(arguments, BaseModel):
                     if (
                         self.input_model is not None
@@ -645,7 +643,7 @@ class FunctionTool(SerializationMixin):
                         and not isinstance(arguments, self.input_model)
                     ):
                         raise TypeError(f"Expected {self.input_model.__name__}, got {type(arguments).__name__}")
-                    parsed_arguments = arguments.model_dump(exclude_none=True)
+                    parsed_arguments = arguments.model_dump()
                 else:
                     raise TypeError(
                         f"Expected mapping-like arguments for tool '{self.name}', got {type(arguments).__name__}"
@@ -1492,7 +1490,7 @@ async def _auto_invoke_function(
         runtime_kwargs["session"] = invocation_session
     try:
         if not cast(bool, getattr(tool, "_schema_supplied", False)) and tool.input_model is not None:
-            args = tool.input_model.model_validate(parsed_args).model_dump(exclude_none=True)
+            args = tool.input_model.model_validate(parsed_args).model_dump()
         else:
             args = dict(parsed_args)
         args = _validate_arguments_against_schema(


### PR DESCRIPTION
## Summary

Remove `exclude_none=True` from `model_dump()` calls in `FunctionTool.invoke()` and `_auto_invoke_function()` so that null arguments from the LLM are preserved and passed to the tool function.

Previously, calling a tool with a nullable required parameter (e.g. `unit: Literal["C", "F"] | None`) and passing `null` would strip the key via `model_dump(exclude_none=True)`, causing `_validate_arguments_against_schema` to raise `TypeError` for "Missing required argument".

## Issue

Fixes #5934

## Verification

- `FunctionTool.invoke(arguments={"location": "Seattle", "unit": None})` now works correctly
- Normal calls with non-null values continue to work
- Tests pass
