### PR TITLE
.NET: increase default search depth for script and resource discovery (fixes #5968)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Agents.AI;
 internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
 {
     private const string SkillFileName = "SKILL.md";
-    private const int DefaultSearchDepth = 2;
+    private const int DefaultSearchDepth = 10;
     private const int MaxSkillDirectorySearchDepth = 2;
 
     private static readonly string[] s_defaultScriptExtensions = [".py", ".js", ".sh", ".ps1", ".cs", ".csx"];


### PR DESCRIPTION
## Summary
Increase the default `SearchDepth` for script and resource file discovery from 2 to 10, allowing the discovery of nested scripts/resources in deeper subdirectory structures.

### Background
`AgentFileSkillsSource` already supports recursive directory traversal via `ScanDirectoryForScripts` and `ScanDirectoryForResources`, but the default `_searchDepth` of 2 limits discovery to the root directory plus one level of subdirectories. Files nested deeper (e.g., `scripts/subdir/tool/my_script.py`) are silently skipped.

### Fix
Changed `DefaultSearchDepth` from 2 to 10. This allows discovery up to 10 levels of nesting while maintaining the existing security checks (symlink detection, path traversal prevention) and the `SearchDepth` configuration option for users who need different limits.

## Issue
Fixes #5968

## Verification
- Existing tests in `AgentFileSkillsSourceScriptTests.cs` cover the default depth behavior
- The `SearchDepth` option remains configurable via `AgentFileSkillsSourceOptions.SearchDepth`
- Security checks (symlink, path traversal) are unaffected
