### PR TITLE
Python: Fix auto function calling stripping explicit null arguments (fixes #5934)

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -636,7 +636,7 @@ class FunctionTool(SerializationMixin):
                     parsed_arguments = dict(arguments)
                     if self.input_model is not None and not self._schema_supplied:
                         parsed_arguments = self.input_model.model_validate(parsed_arguments).model_dump(
-                            exclude_none=True
+                            exclude_none=False
                         )
                 elif isinstance(arguments, BaseModel):
                     if (
@@ -645,7 +645,7 @@ class FunctionTool(SerializationMixin):
                         and not isinstance(arguments, self.input_model)
                     ):
                         raise TypeError(f"Expected {self.input_model.__name__}, got {type(arguments).__name__}")
-                    parsed_arguments = arguments.model_dump(exclude_none=True)
+                    parsed_arguments = arguments.model_dump(exclude_none=False)
                 else:
                     raise TypeError(
                         f"Expected mapping-like arguments for tool '{self.name}', got {type(arguments).__name__}"
@@ -1492,7 +1492,7 @@ async def _auto_invoke_function(
         runtime_kwargs["session"] = invocation_session
     try:
         if not cast(bool, getattr(tool, "_schema_supplied", False)) and tool.input_model is not None:
-            args = tool.input_model.model_validate(parsed_args).model_dump(exclude_none=True)
+            args = tool.input_model.model_validate(parsed_args).model_dump(exclude_none=False)
         else:
             args = dict(parsed_args)
         args = _validate_arguments_against_schema(

--- a/python/packages/core/tests/core/test_tools.py
+++ b/python/packages/core/tests/core/test_tools.py
@@ -1,4 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
+import asyncio
 from typing import Annotated, Any, Literal, get_args, get_origin
 from unittest.mock import Mock
 
@@ -1460,6 +1461,22 @@ def test_skip_parsing_is_singleton() -> None:
 
     assert _SkipParsingSentinel() is SKIP_PARSING
     assert repr(SKIP_PARSING) == "SKIP_PARSING"
+
+
+def test_invoke_preserves_explicit_none_arguments() -> None:
+    """Optional parameters explicitly set to None must not be stripped before invocation."""
+
+    @tool
+    def greet(name: str, greeting: str | None = None) -> str:
+        return f"{greeting or 'Hello'}, {name}!"
+
+    result = asyncio.run(greet.invoke(arguments={"name": "World", "greeting": None}))
+    assert isinstance(result, list)
+    assert result[0].text == "Hello, World!"
+
+    result = asyncio.run(greet.invoke(arguments={"name": "World"}))
+    assert isinstance(result, list)
+    assert result[0].text == "Hello, World!"
 
 
 # endregion


### PR DESCRIPTION
## Summary

Changes exclude_none=True to exclude_none=False in FunctionTool.invoke() and _auto_invoke_function() to preserve explicitly-provided 
ull values. When a model passes {"param": null} for a required-but-nullable parameter, exclude_none=True strips the key, causing the schema validation to report it as "missing required argument".

## Root Cause

model_dump(exclude_none=True) cannot distinguish between "field was never provided" (default None) and "field was explicitly set to None". This splits the model's intent when it provides 
ull for optional parameters.

## Changes

- python/packages/core/agent_framework/_tools.py: Changed exclude_none=True to exclude_none=False in 3 locations (lines 639, 648, 1495)
- python/packages/core/tests/core/test_tools.py: Added 	est_invoke_preserves_explicit_none_arguments test

## Issue

Fixes #5934

## Verification

- New test 	est_invoke_preserves_explicit_none_arguments passes
- All existing tests in test_tools.py continue to pass
