### PR TITLE
.NET: add FunctionApprovalResponseItemParam to fix unrecognized type discriminator (fixes #6006)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIHostingJsonUtilities.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIHostingJsonUtilities.cs
@@ -133,6 +133,7 @@ internal static class OpenAIHostingJsonUtilities
 [JsonSerializable(typeof(MCPListToolsItemParam))]
 [JsonSerializable(typeof(MCPApprovalRequestItemParam))]
 [JsonSerializable(typeof(MCPApprovalResponseItemParam))]
+[JsonSerializable(typeof(FunctionApprovalResponseItemParam))]
 [JsonSerializable(typeof(MCPCallItemParam))]
 [JsonSerializable(typeof(List<ItemParam>))]
 // ItemContent types

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemParamConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemParamConverter.cs
@@ -43,6 +43,7 @@ internal sealed class ItemParamConverter : JsonConverter<ItemParam>
             "mcp_list_tools" => doc.Deserialize(OpenAIHostingJsonContext.Default.MCPListToolsItemParam),
             "mcp_approval_request" => doc.Deserialize(OpenAIHostingJsonContext.Default.MCPApprovalRequestItemParam),
             "mcp_approval_response" => doc.Deserialize(OpenAIHostingJsonContext.Default.MCPApprovalResponseItemParam),
+            "function_approval_response" => doc.Deserialize(OpenAIHostingJsonContext.Default.FunctionApprovalResponseItemParam),
             "mcp_call" => doc.Deserialize(OpenAIHostingJsonContext.Default.MCPCallItemParam),
             _ => null // Ignore unknown types.
         };

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemParam.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemParam.cs
@@ -533,6 +533,33 @@ internal sealed class MCPApprovalResponseItemParam : ItemParam
 }
 
 /// <summary>
+/// A function approval response item parameter.
+/// This is a non-standard DevUI extension for human-in-the-loop scenarios.
+/// </summary>
+internal sealed class FunctionApprovalResponseItemParam : ItemParam
+{
+    /// <summary>
+    /// The constant item type identifier for function approval response items.
+    /// </summary>
+    public const string ItemType = "function_approval_response";
+
+    /// <inheritdoc/>
+    public override string Type => ItemType;
+
+    /// <summary>
+    /// The unique identifier of the approval request being responded to.
+    /// </summary>
+    [JsonPropertyName("request_id")]
+    public required string RequestId { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the function call was approved.
+    /// </summary>
+    [JsonPropertyName("approved")]
+    public bool Approved { get; init; }
+}
+
+/// <summary>
 /// An MCP call item parameter.
 /// </summary>
 internal sealed class MCPCallItemParam : ItemParam


### PR DESCRIPTION
﻿## Summary

When DevUI sends a human-in-the-loop approval response via the Responses API, the payload includes an item with type "function_approval_response". The ItemParamConverter did not have a case for this type, causing a 400 error.

This fix adds:

1. **FunctionApprovalResponseItemParam** class in ItemParam.cs — a new ItemParam subclass with request_id and approved properties
2. **Case in ItemParamConverter.cs** — maps "function_approval_response" to the new type
3. **[JsonSerializable] attribute** in OpenAIHostingJsonUtilities.cs — registers the type for source-generated JSON serialization

## Issue

Fixes #6006

## Verification

- All three changes follow existing patterns used by similar item param types (e.g., MCPApprovalResponseItemParam)
- The FunctionApprovalResponseItemParam mirrors the StreamingFunctionApprovalResponded event shape
