### PR TITLE
.NET: fix: preserve Foreach record values

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
@@ -49,7 +49,7 @@ internal sealed class ForeachExecutor : DeclarativeActionExecutor<Foreach>
         EvaluationResult<DataValue> expressionResult = this.Evaluator.GetValue(this.Model.Items);
         if (expressionResult.Value is TableDataValue tableValue)
         {
-            this._values = [.. tableValue.Values.Select(value => value.Properties.Values.First().ToFormula())];
+            this._values = [.. tableValue.Values.Select(value => value.ToFormula())];
         }
         else
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
@@ -143,6 +143,34 @@ public sealed class ForeachExecutorTest(ITestOutputHelper output) : WorkflowActi
     }
 
     [Fact]
+    public async Task ForeachTakeNextWithMultiFieldRecordAsync()
+    {
+        // Arrange
+        const string CurrentValueName = "CurrentValue";
+        this.SetVariableState(CurrentValueName);
+
+        TableDataValue tableValue = DataValue.TableFromRecords(
+            DataValue.RecordFromFields(
+                new KeyValuePair<string, DataValue>("name", new StringDataValue("Alice")),
+                new KeyValuePair<string, DataValue>("role", new StringDataValue("Engineer"))));
+
+        Foreach model = this.CreateModel(
+            displayName: nameof(ForeachTakeNextWithMultiFieldRecordAsync),
+            items: ValueExpression.Literal(tableValue),
+            valueName: CurrentValueName,
+            indexName: null);
+        ForeachExecutor action = new(model, this.State);
+
+        // Act
+        await this.ExecuteAsync(action, ForeachExecutor.Steps.Next(action.Id), action.TakeNextAsync);
+
+        // Assert
+        RecordValue currentValue = Assert.IsType<RecordValue>(this.State.Get(CurrentValueName), exactMatch: false);
+        Assert.Equal("Alice", currentValue.GetField("name").ToObject());
+        Assert.Equal("Engineer", currentValue.GetField("role").ToObject());
+    }
+
+    [Fact]
     public async Task ForeachTakeLastAsync()
     {
         // Arrange


### PR DESCRIPTION
﻿Fixes #6183.

## Summary
- preserve each `RecordDataValue` as a full record when `Foreach` materializes table rows
- add a regression test for a multi-field row so the loop value exposes both fields

## To verify
- `dotnet test --project tests\Microsoft.Agents.AI.Workflows.Declarative.UnitTests\Microsoft.Agents.AI.Workflows.Declarative.UnitTests.csproj -f net10.0 -v Normal --filter-class Microsoft.Agents.AI.Workflows.Declarative.UnitTests.ObjectModel.ForeachExecutorTest`
- `dotnet test --project tests\Microsoft.Agents.AI.Workflows.Declarative.UnitTests\Microsoft.Agents.AI.Workflows.Declarative.UnitTests.csproj -f net472 -v Normal --filter-class Microsoft.Agents.AI.Workflows.Declarative.UnitTests.ObjectModel.ForeachExecutorTest`
- `dotnet format agent-framework-dotnet.slnx --verify-no-changes --no-restore --include src\Microsoft.Agents.AI.Workflows.Declarative\ObjectModel\ForeachExecutor.cs tests\Microsoft.Agents.AI.Workflows.Declarative.UnitTests\ObjectModel\ForeachExecutorTest.cs`
- `git diff --check`
