### PR TITLE
.NET: accept JSON string inline skill args

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -92,18 +92,42 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
             return [];
         }
 
-        if (arguments.Value.ValueKind != JsonValueKind.Object)
+        JsonDocument? parsedStringArguments = null;
+        var argumentElement = arguments.Value;
+
+        if (argumentElement.ValueKind == JsonValueKind.String)
+        {
+            string? rawArguments = argumentElement.GetString();
+            try
+            {
+                parsedStringArguments = JsonDocument.Parse(rawArguments ?? string.Empty);
+                argumentElement = parsedStringArguments.RootElement;
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException("Inline skill scripts received arguments as a JSON string, but the string did not contain valid JSON.", ex);
+            }
+        }
+
+        if (argumentElement.ValueKind != JsonValueKind.Object)
         {
             throw new InvalidOperationException(
-                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{arguments.Value.ValueKind}'.");
+                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{argumentElement.ValueKind}'.");
         }
 
-        var dict = new Dictionary<string, object?>();
-        foreach (var property in arguments.Value.EnumerateObject())
+        try
         {
-            dict[property.Name] = property.Value;
-        }
+            var dict = new Dictionary<string, object?>();
+            foreach (var property in argumentElement.EnumerateObject())
+            {
+                dict[property.Name] = parsedStringArguments is null ? property.Value : property.Value.Clone();
+            }
 
-        return new AIFunctionArguments(dict);
+            return new AIFunctionArguments(dict);
+        }
+        finally
+        {
+            parsedStringArguments?.Dispose();
+        }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillScriptTests.cs
@@ -44,6 +44,37 @@ public sealed class AgentInlineSkillScriptTests
     }
 
     [Fact]
+    public async Task RunAsync_WithJsonStringObjectArguments_PassesArgumentsAsync()
+    {
+        // Arrange
+        var script = new AgentInlineSkillScript("add", (int a, int b) => a + b);
+        var skill = new AgentInlineSkill("calc-skill", "Calc.", "Instructions.");
+        using var argsDoc = JsonDocument.Parse("\"{\\\"a\\\":3,\\\"b\\\":7}\"");
+        var args = argsDoc.RootElement;
+
+        // Act
+        var result = await script.RunAsync(skill, args, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(10, int.Parse(result?.ToString()!));
+    }
+
+    [Fact]
+    public async Task RunAsync_WithInvalidJsonStringArguments_ThrowsInvalidOperationExceptionAsync()
+    {
+        // Arrange
+        var script = new AgentInlineSkillScript("noop", () => "ok");
+        var skill = new AgentInlineSkill("test-skill", "Test.", "Instructions.");
+        using var argsDoc = JsonDocument.Parse("\"not json\"");
+        var args = argsDoc.RootElement;
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => script.RunAsync(skill, args, null, CancellationToken.None));
+        Assert.Contains("did not contain valid JSON", ex.Message);
+    }
+
+    [Fact]
     public void ParametersSchema_NoParameters_ReturnsSchema()
     {
         // Arrange


### PR DESCRIPTION
﻿Fixes #6020.

## Summary
- parse inline skill arguments when an OpenAI-compatible backend sends the function-call arguments as a JSON string containing an object
- keep the existing fast-fail behavior for non-object arguments and invalid JSON strings
- add regression coverage for the JSON-string object path and the invalid JSON string path

## To verify
- `dotnet restore tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj`
- `dotnet test --project tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj -- --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillScriptTests`
- `dotnet build src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj --no-restore`
- `dotnet format agent-framework-dotnet.slnx --include src\Microsoft.Agents.AI\Skills\Programmatic\AgentInlineSkillScript.cs tests\Microsoft.Agents.AI.UnitTests\AgentSkills\AgentInlineSkillScriptTests.cs --verify-no-changes`
- `git diff --check`
