### PR TITLE
Python: fix: AgentFrameworkException drops inner_exception when not None (#5155)

### DIFF
--- a/python/packages/core/agent_framework/exceptions.py
+++ b/python/packages/core/agent_framework/exceptions.py
@@ -34,7 +34,8 @@ class AgentFrameworkException(Exception):
             logger.log(log_level, message, exc_info=inner_exception)
         if inner_exception:
             super().__init__(message, inner_exception, *args)  # type: ignore
-        super().__init__(message, *args)  # type: ignore
+        else:
+            super().__init__(message, *args)  # type: ignore
 
 
 # region Agent Exceptions

--- a/python/packages/core/tests/core/test_exceptions.py
+++ b/python/packages/core/tests/core/test_exceptions.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Tests for the AgentFrameworkException hierarchy."""
+
+import pytest
+
+from agent_framework.exceptions import AgentFrameworkException
+
+
+def test_exception_without_inner_exception() -> None:
+    exc = AgentFrameworkException("something went wrong", log_level=None)
+    assert exc.args == ("something went wrong",)
+
+
+def test_exception_with_inner_exception_preserves_it() -> None:
+    inner = ValueError("root cause")
+    exc = AgentFrameworkException("outer message", inner_exception=inner, log_level=None)
+    assert exc.args == ("outer message", inner)
+    assert exc.args[1] is inner
+
+
+def test_exception_without_inner_exception_does_not_include_none() -> None:
+    exc = AgentFrameworkException("msg", inner_exception=None, log_level=None)
+    assert None not in exc.args


### PR DESCRIPTION
### Motivation and Context

Fixes #5155

`AgentFrameworkException.__init__` always called `super().__init__(message, *args)` unconditionally, even when `inner_exception` was provided. This meant the first `super().__init__(message, inner_exception, *args)` call was immediately overwritten and the inner exception was silently lost from `exc.args`.

### Description

Added `else:` to make the two `super().__init__` branches mutually exclusive:

```python
if inner_exception:
    super().__init__(message, inner_exception, *args)
else:
    super().__init__(message, *args)
```

Also added `tests/core/test_exceptions.py` to verify the fix:
- Exception without `inner_exception` has correct args
- Exception with `inner_exception` preserves it in `exc.args`
- Exception without `inner_exception` does not include `None` in args

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No.

🤖 Generated with [Claude Code](https://claude.ai/code)