### PR TITLE
Python: fix: BedrockChatClient omits toolConfig when no tools are configured (#5165)

### DIFF
--- a/python/packages/bedrock/agent_framework_bedrock/_chat_client.py
+++ b/python/packages/bedrock/agent_framework_bedrock/_chat_client.py
@@ -411,14 +411,16 @@ class BedrockChatClient(
                     # Omit toolConfig entirely so the model won't attempt tool calls.
                     tool_config = None
                 case "auto":
-                    tool_config = tool_config or {}
-                    tool_config["toolChoice"] = {"auto": {}}
+                    # Bedrock requires toolConfig.tools to be present alongside toolChoice.
+                    # When there are no tools, omit toolChoice rather than send an invalid request.
+                    if tool_config is not None:
+                        tool_config["toolChoice"] = {"auto": {}}
                 case "required":
-                    tool_config = tool_config or {}
-                    if required_name := tool_mode.get("required_function_name"):
-                        tool_config["toolChoice"] = {"tool": {"name": required_name}}
-                    else:
-                        tool_config["toolChoice"] = {"any": {}}
+                    if tool_config is not None:
+                        if required_name := tool_mode.get("required_function_name"):
+                            tool_config["toolChoice"] = {"tool": {"name": required_name}}
+                        else:
+                            tool_config["toolChoice"] = {"any": {}}
                 case _:
                     raise ValueError(f"Unsupported tool mode for Bedrock: {tool_mode.get('mode')}")
         if tool_config:

--- a/python/packages/bedrock/tests/test_bedrock_client.py
+++ b/python/packages/bedrock/tests/test_bedrock_client.py
@@ -137,3 +137,24 @@ def test_prepare_options_tool_choice_required_includes_any() -> None:
 
     assert "toolConfig" in request
     assert request["toolConfig"]["toolChoice"] == {"any": {}}
+
+
+def test_prepare_options_no_tools_omits_tool_config() -> None:
+    """When no tools are provided, toolConfig must be omitted even if tool_choice is set.
+
+    Bedrock requires toolConfig.tools to be present whenever toolConfig.toolChoice
+    is specified. The Agent always defaults tool_choice='auto', so without this fix
+    a toolless agent would send {"toolChoice": {"auto": {}}} and get a
+    ParamValidationError: Missing required parameter in toolConfig: "tools".
+
+    Fixes #5165.
+    """
+    client = _make_client()
+    messages = [Message(role="user", contents=[Content.from_text(text="hello")])]
+
+    for tool_choice in ("auto", "required"):
+        request = client._prepare_options(messages, {"tool_choice": tool_choice})
+        assert "toolConfig" not in request, (
+            f"toolConfig should be omitted when tool_choice='{tool_choice}' and no tools are configured, "
+            f"got: {request.get('toolConfig')}"
+        )


### PR DESCRIPTION
### Motivation and Context

Fixes #5165

`Agent` always defaults `tool_choice='auto'`. In `BedrockChatClient._prepare_options`, the `'auto'` and `'required'` branches did `tool_config = tool_config or {}` even when `_prepare_tools` returned `None` (no tools configured). This produced a `toolConfig` dict containing only `toolChoice` (no `tools`), which AWS Bedrock rejects:

```
botocore.exceptions.ParamValidationError: Missing required parameter in toolConfig: "tools"
```

### Description

Only write `toolChoice` into `toolConfig` when `tool_config` is not `None` (i.e., there are actually tools to choose from). When there are no tools, skip `toolChoice` entirely — `toolConfig` remains `None` and is excluded from the request.

The `'none'` branch (omit `toolConfig` entirely) already handled the no-tools case correctly; this PR extends the same pattern to `'auto'` and `'required'`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No.