### PR TITLE
Python: fix: propagate created_at from response.completed into streaming update (#5347)

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1975,6 +1975,7 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         local_shell_tool_name = self._get_local_shell_tool_name(options.get("tools"))
         conversation_id: str | None = None
         response_id: str | None = None
+        created_at: str | None = None
         continuation_token: OpenAIContinuationToken | None = None
         model = self.model
         match event.type:
@@ -2156,6 +2157,10 @@ class RawOpenAIChatClient(  # type: ignore[misc]
                 response_id = event.response.id
                 conversation_id = self._get_conversation_id(event.response, options.get("store"))
                 model = event.response.model
+                if event.response.created_at is not None:
+                    created_at = datetime.fromtimestamp(event.response.created_at, tz=timezone.utc).strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    )
                 if event.response.usage:
                     usage = self._parse_usage_from_openai(event.response.usage)
                     if usage:
@@ -2521,6 +2526,7 @@ class RawOpenAIChatClient(  # type: ignore[misc]
             contents=contents,
             conversation_id=conversation_id,
             response_id=response_id,
+            created_at=created_at,
             role="assistant",
             model=model,
             continuation_token=continuation_token,

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -2013,6 +2013,53 @@ def test_streaming_chunk_with_usage_only() -> None:
     assert update.contents[0].usage_details["total_token_count"] == 75
 
 
+def test_streaming_response_completed_propagates_created_at() -> None:
+    """response.completed must propagate created_at into ChatResponseUpdate.
+
+    Without the fix, created_at was never set on the streaming update, so the
+    final ChatResponse assembled from updates would have created_at=None —
+    causing the durabletask persistence warning.
+
+    Fixes #5347.
+    """
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+    chat_options = ChatOptions()
+    function_call_ids: dict[int, tuple[str, str]] = {}
+
+    mock_event = MagicMock()
+    mock_event.type = "response.completed"
+    mock_event.response = MagicMock()
+    mock_event.response.id = "resp_ts"
+    mock_event.response.model = "test-model"
+    mock_event.response.conversation = None
+    mock_event.response.usage = None
+    mock_event.response.created_at = 1000000000  # 2001-09-09T01:46:40.000000Z
+
+    update = client._parse_chunk_from_openai(mock_event, chat_options, function_call_ids)
+
+    assert update.created_at == "2001-09-09T01:46:40.000000Z"
+
+
+def test_streaming_response_completed_with_null_created_at_does_not_raise() -> None:
+    """When created_at is None on the event, created_at on the update should stay None."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+    chat_options = ChatOptions()
+    function_call_ids: dict[int, tuple[str, str]] = {}
+
+    mock_event = MagicMock()
+    mock_event.type = "response.completed"
+    mock_event.response = MagicMock()
+    mock_event.response.id = "resp_no_ts"
+    mock_event.response.model = "test-model"
+    mock_event.response.conversation = None
+    mock_event.response.usage = None
+    mock_event.response.created_at = None
+
+    update = client._parse_chunk_from_openai(mock_event, chat_options, function_call_ids)
+
+    assert update.created_at is None
+
+
 def test_prepare_tools_for_openai_with_mcp() -> None:
     """Test that MCP tool dict is converted to the correct response tool dict."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")


### PR DESCRIPTION
### Motivation and Context

Fixes #5347

`await agent.run(..., stream=True)` followed by `stream.get_final_response()` returned an `AgentResponse` with `created_at=None`, while the non-streaming path returned the correct timestamp. This caused the durabletask persistence warning:

```
Invalid or missing created_at value in durable agent state; defaulting to current UTC time, None
```

### Description

`_parse_chunk_from_openai` never populated `created_at` on the `ChatResponseUpdate` it returned. When the final `ChatResponse` is assembled from the list of streaming updates, `created_at` is only set when an update carries it — so it stayed `None`.

The `response.completed` event already has `event.response.created_at` (a Unix timestamp). This patch:
1. Adds a `created_at: str | None = None` local variable to `_parse_chunk_from_openai`
2. In the `response.completed` case, converts the timestamp to the same ISO-8601 format used by the non-streaming path
3. Passes it to the returned `ChatResponseUpdate`

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No.