### PR TITLE
Python: fix: use AsyncOpenAI for /openai/v1 base_url in embedding client (#5068)

### DIFF
--- a/python/packages/openai/agent_framework_openai/_shared.py
+++ b/python/packages/openai/agent_framework_openai/_shared.py
@@ -282,6 +282,27 @@ def load_openai_service_settings(
             "Azure OpenAI client requires either an API key or an Azure AD token provider."
             " This can be provided either as a callable api_key or via the credential parameter."
         )
+    # When base_url points to an /openai/v1 endpoint and we are NOT in responses_mode,
+    # AsyncAzureOpenAI would incorrectly prepend /deployments/{model}/ to the path
+    # (e.g. /openai/v1/deployments/model/embeddings). Use AsyncOpenAI instead, which
+    # uses the plain /embeddings path that the OpenAI-compatible endpoint expects.
+    # responses_mode (chat client) already works correctly with AsyncAzureOpenAI.
+    resolved_base_url = client_args.get("base_url", "")
+    if (
+        not responses_mode
+        and isinstance(resolved_base_url, str)
+        and "/openai/v1" in resolved_base_url
+        and "azure_endpoint" not in client_args
+    ):
+        openai_v1_args: dict[str, Any] = {
+            "default_headers": client_args.get("default_headers"),
+            "base_url": resolved_base_url,
+        }
+        if token_provider := client_args.get("azure_ad_token_provider"):
+            openai_v1_args["api_key"] = token_provider
+        elif "api_key" in client_args:
+            openai_v1_args["api_key"] = client_args["api_key"]
+        return azure_settings, AsyncOpenAI(**openai_v1_args), False  # type: ignore[return-value]
     return azure_settings, AsyncAzureOpenAI(**client_args), True  # type: ignore[return-value]
 
 

--- a/python/packages/openai/tests/openai/test_openai_embedding_client.py
+++ b/python/packages/openai/tests/openai/test_openai_embedding_client.py
@@ -209,6 +209,60 @@ async def test_openai_empty_values_returns_empty(openai_unit_test_env: dict[str,
     client.client.embeddings.create.assert_not_called()
 
 
+def test_openai_v1_base_url_with_credential_uses_async_openai() -> None:
+    """OpenAIEmbeddingClient with base_url=/openai/v1 + credential must use AsyncOpenAI.
+
+    AsyncAzureOpenAI prepends /deployments/{model}/ to the path, producing
+    /openai/v1/deployments/model/embeddings which the /openai/v1 endpoint does not
+    recognise (404). The fix switches to AsyncOpenAI (plain /embeddings path) when
+    base_url contains '/openai/v1'.
+
+    Fixes #5068.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+    mock_token_provider = MagicMock(return_value="token")
+
+    with patch(
+        "agent_framework_openai._shared._resolve_azure_credential_to_token_provider",
+        return_value=mock_token_provider,
+    ):
+        client = OpenAIEmbeddingClient(
+            model="text-embedding-3-large",
+            base_url="https://myproject.openai.azure.com/openai/v1/",
+            credential=mock_token_provider,
+        )
+
+    assert isinstance(client.client, AsyncOpenAI), (
+        f"Expected AsyncOpenAI but got {type(client.client).__name__} — "
+        "AsyncAzureOpenAI would prepend /deployments/model/ to the path and 404."
+    )
+    assert not isinstance(client.client, AsyncAzureOpenAI)
+
+
+def test_non_openai_v1_base_url_with_credential_keeps_azure_client() -> None:
+    """When base_url does NOT contain /openai/v1, AsyncAzureOpenAI should still be used."""
+    from unittest.mock import MagicMock, patch
+
+    from openai import AsyncAzureOpenAI
+
+    mock_token_provider = MagicMock(return_value="token")
+
+    with patch(
+        "agent_framework_openai._shared._resolve_azure_credential_to_token_provider",
+        return_value=mock_token_provider,
+    ):
+        client = OpenAIEmbeddingClient(
+            model="text-embedding-ada-002",
+            azure_endpoint="https://myresource.openai.azure.com",
+            credential=mock_token_provider,
+        )
+
+    assert isinstance(client.client, AsyncAzureOpenAI)
+
+
 # --- Integration tests ---
 
 skip_if_openai_integration_tests_disabled = pytest.mark.skipif(


### PR DESCRIPTION
### Motivation and Context

Fixes #5068

`OpenAIEmbeddingClient` with `base_url="https://<project>.openai.azure.com/openai/v1/"` and a `credential` fails with 404 because `AsyncAzureOpenAI` prepends `/deployments/{model}/` to the path:

```
GET /openai/v1/deployments/text-embedding-3-large/embeddings?api-version=2024-10-21
```

The `/openai/v1` endpoint is Azure's OpenAI-compatible API and expects the standard path `/openai/v1/embeddings`. `OpenAIChatClient` with the same `base_url` works because the Responses API routes differently.

### Description

In `load_openai_service_settings`, detect when `base_url` contains `/openai/v1` and non-responses mode is active (i.e., the embedding client path). In that case, create `AsyncOpenAI` instead of `AsyncAzureOpenAI`, wiring the credential token provider as the `api_key` callable. This mirrors the recommended approach for `/openai/v1` endpoints and produces the correct path `/openai/v1/embeddings`.

The `responses_mode=True` branch (chat client) is unchanged.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No — existing configurations without `/openai/v1` in `base_url` are unaffected.

🤖 Generated with [Claude Code](https://claude.ai/code)