### PR TITLE
.NET: Fix Magentic to share agent replies across team

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticConstants.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticConstants.cs
@@ -5,4 +5,5 @@ namespace Microsoft.Agents.AI.Workflows.Specialized.Magentic;
 internal static class MagenticConstants
 {
     public const string MagenticTaskContextKey = nameof(MagenticTaskContextKey);
+    public const string CurrentSpeakerStateKey = nameof(CurrentSpeakerStateKey);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
@@ -338,6 +338,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
     {
         bool wasStalled = taskContext.IsStalled;
         taskContext.Reset();
+        this._currentSpeakerExecutorId = null;
         await context.SendMessageAsync(new ResetChatSignal(), cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await this.UpdatePlanAndDelegateAsync(taskContext, context, cancellationToken, replanAfterStall: wasStalled).ConfigureAwait(false);
@@ -348,9 +349,8 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
         List<ChatMessage> messages = [await this._manager.PrepareFinalAnswerAsync(taskContext, context, cancellationToken).ConfigureAwait(false)];
         await context.YieldOutputAsync(messages, cancellationToken).ConfigureAwait(false);
         taskContext.IsTerminated = true;
+        this._currentSpeakerExecutorId = null;
     }
-
-    private const string CurrentSpeakerStateKey = "CurrentSpeakerStateKey";
 
     protected internal override async ValueTask OnCheckpointingAsync(IWorkflowContext context, CancellationToken cancellationToken = default)
     {
@@ -361,7 +361,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
                                                               cancellationToken: cancellationToken)
                                        .AsTask();
 
-        Task currentSpeakerTask = context.QueueStateUpdateAsync(CurrentSpeakerStateKey,
+        Task currentSpeakerTask = context.QueueStateUpdateAsync(MagenticConstants.CurrentSpeakerStateKey,
                                                             this._currentSpeakerExecutorId,
                                                             cancellationToken: cancellationToken)
                                         .AsTask();
@@ -390,7 +390,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
 
         async Task LoadCurrentSpeakerAsync()
         {
-            this._currentSpeakerExecutorId = await context.ReadStateAsync<string?>(CurrentSpeakerStateKey, cancellationToken: cancellationToken)
+            this._currentSpeakerExecutorId = await context.ReadStateAsync<string?>(MagenticConstants.CurrentSpeakerStateKey, cancellationToken: cancellationToken)
                                                         .ConfigureAwait(false);
         }
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
@@ -90,6 +90,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
 
     private MagenticTaskContext? _taskContext;
     private PortBinding? _planReviewPort;
+    private string? _currentSpeakerExecutorId;
 
     protected override ProtocolBuilder ConfigureProtocol(ProtocolBuilder protocolBuilder)
     {
@@ -196,13 +197,36 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
         else
         {
             // Subsequent turns: agent returned control, go directly to coordination (progress ledger only, no replan).
-            // Capture the participant's reply into the manager-visible chat history so the progress ledger can see it.
             if (messages is { Count: > 0 })
             {
+                // Capture the participant's reply into the manager-visible chat history so the progress ledger can see it.
                 this._taskContext.ChatHistory.AddRange(messages);
+
+                // Share the reply with the other participants except the replier
+                await this.BroadcastReplyToOtherParticipantsAsync(messages, context, cancellationToken).ConfigureAwait(false);
             }
             await this.RunCoordinationRoundAsync(this._taskContext, context, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Forwards a participant's reply to every other participant so they share the running conversation.
+    /// The messages are buffered (no <see cref="TurnToken"/> is sent) - they only become context for the participant's next turn.
+    /// </summary>
+    private ValueTask BroadcastReplyToOtherParticipantsAsync(
+        List<ChatMessage> messages, IWorkflowContext context, CancellationToken cancellationToken)
+    {
+        List<Task>? sendTasks = null;
+        foreach (AIAgent agent in team)
+        {
+            string executorId = AIAgentHostExecutor.IdFor(agent);
+            if (string.Equals(executorId, this._currentSpeakerExecutorId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            (sendTasks ??= []).Add(context.SendMessageAsync(messages, executorId, cancellationToken).AsTask());
+        }
+        return sendTasks is null ? default : new ValueTask(Task.WhenAll(sendTasks));
     }
 
     private ChatMessage? _fullTaskLedgerMessage;
@@ -287,15 +311,18 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
             return;
         }
 
+        string nextExecutorId = AIAgentHostExecutor.IdFor(nextAgent);
+
         if (!string.IsNullOrWhiteSpace(taskContext.ProgressLedger.InstructionOrQuestion))
         {
             ChatMessage instruction = new(ChatRole.Assistant, taskContext.ProgressLedger.InstructionOrQuestion);
             taskContext.ChatHistory.Add(instruction);
 
-            await context.SendMessageAsync(instruction, cancellationToken).ConfigureAwait(false);
+            // Target the instruction at the chosen speaker only.
+            await context.SendMessageAsync(instruction, nextExecutorId, cancellationToken).ConfigureAwait(false);
         }
 
-        string nextExecutorId = AIAgentHostExecutor.IdFor(nextAgent);
+        this._currentSpeakerExecutorId = nextExecutorId;
         await context.SendMessageAsync(new TurnToken(taskContext.EmitUpdateEvents), nextExecutorId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -316,6 +343,8 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
     }
 
     private const string CurrentTurnEmitUpdateEventsKey = nameof(CurrentTurnEmitUpdateEventsKey);
+    private const string CurrentSpeakerStateKey = nameof(_currentSpeakerExecutorId);
+
     protected internal override async ValueTask OnCheckpointingAsync(IWorkflowContext context, CancellationToken cancellationToken = default)
     {
         Task contextStateTask = this._taskContext == null
@@ -325,14 +354,21 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
                                                               cancellationToken: cancellationToken)
                                        .AsTask();
 
+        Task currentSpeakerTask = context.QueueStateUpdateAsync(CurrentSpeakerStateKey,
+                                                            this._currentSpeakerExecutorId,
+                                                            cancellationToken: cancellationToken)
+                                        .AsTask();
+
         await Task.WhenAll(base.OnCheckpointingAsync(context, cancellationToken).AsTask(),
-                           contextStateTask).ConfigureAwait(false);
+                           contextStateTask,
+                           currentSpeakerTask).ConfigureAwait(false);
     }
 
     protected internal override async ValueTask OnCheckpointRestoredAsync(IWorkflowContext context, CancellationToken cancellationToken = default)
     {
-        await Task.WhenAll(base.OnCheckpointRestoredAsync(context, cancellationToken).AsTask(), LoadContextStateAsync())
-                  .ConfigureAwait(false);
+        await Task.WhenAll(base.OnCheckpointRestoredAsync(context, cancellationToken).AsTask(),
+                            LoadContextStateAsync(),
+                            LoadCurrentSpeakerAsync()).ConfigureAwait(false);
 
         async Task LoadContextStateAsync()
         {
@@ -343,6 +379,12 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
             {
                 this._taskContext = new MagenticTaskContext(state, team, limits, []);
             }
+        }
+
+        async Task LoadCurrentSpeakerAsync()
+        {
+            this._currentSpeakerExecutorId = await context.ReadStateAsync<string?>(CurrentSpeakerStateKey, cancellationToken: cancellationToken)
+                                                        .ConfigureAwait(false);
         }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
@@ -216,6 +216,14 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
     private ValueTask BroadcastReplyToOtherParticipantsAsync(
         List<ChatMessage> messages, IWorkflowContext context, CancellationToken cancellationToken)
     {
+        // Without a known current speaker we cannot exclude the reply's author, so skip the broadcast
+        // rather than risk echoing the reply back to its own author. This covers the window after a
+        // checkpoint restore but before any delegation has set the current speaker.
+        if (string.IsNullOrEmpty(this._currentSpeakerExecutorId))
+        {
+            return default;
+        }
+
         List<Task>? sendTasks = null;
         foreach (AIAgent agent in team)
         {
@@ -342,8 +350,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
         taskContext.IsTerminated = true;
     }
 
-    private const string CurrentTurnEmitUpdateEventsKey = nameof(CurrentTurnEmitUpdateEventsKey);
-    private const string CurrentSpeakerStateKey = nameof(_currentSpeakerExecutorId);
+    private const string CurrentSpeakerStateKey = "CurrentSpeakerStateKey";
 
     protected internal override async ValueTask OnCheckpointingAsync(IWorkflowContext context, CancellationToken cancellationToken = default)
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
@@ -420,6 +420,84 @@ public class MagenticOrchestrationTests
     }
 
     [Fact]
+    public async Task Participant_Receives_Prior_Participant_Response_Not_InstructionAsync()
+    {
+        // Regression: each participant must see prior participants' *responses* (the running conversation),
+        // not their *instructions*. Previously the orchestrator broadcast the per-round instruction to every
+        // participant (untargeted fan-out) and never broadcast replies, so a later speaker received the earlier
+        // speaker's instruction and never its answer.
+        const string HealthInstruction = "HEALTH_CHECKER_INSTRUCTION_check_framework";
+        const string DatabaseInstruction = "DATABASE_CHECKER_INSTRUCTION_check_database";
+        const string HealthEchoPrefix = "HC_RESPONSE::";
+        const string DatabaseEchoPrefix = "DB_RESPONSE::";
+
+        List<ChatMessage> facts = CreatePlanResponse("Facts");
+        List<ChatMessage> plan = CreatePlanResponse("Plan");
+        List<ChatMessage> round1Ledger = CreateProgressLedgerResponse(
+            isRequestSatisfied: false,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "HealthChecker",
+            instructionOrQuestion: HealthInstruction);
+        List<ChatMessage> round2Ledger = CreateProgressLedgerResponse(
+            isRequestSatisfied: false,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "DatabaseChecker",
+            instructionOrQuestion: DatabaseInstruction);
+        List<ChatMessage> round3Ledger = CreateProgressLedgerResponse(
+            isRequestSatisfied: true,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "DatabaseChecker",
+            instructionOrQuestion: "Done");
+        List<ChatMessage> finalAnswer = CreateFinalAnswerResponse("All systems checked");
+
+        TestReplayAgent manager = new(
+            [facts, plan, round1Ledger, round2Ledger, round3Ledger, finalAnswer],
+            name: "Manager");
+        RecordingEchoAgent healthChecker = new(name: "HealthChecker", prefix: HealthEchoPrefix);
+        RecordingEchoAgent databaseChecker = new(name: "DatabaseChecker", prefix: DatabaseEchoPrefix);
+
+        Workflow workflow = new MagenticWorkflowBuilder(manager)
+            .AddParticipants(healthChecker, databaseChecker)
+            .RequirePlanSignoff(false)
+            .Build();
+
+        WorkflowRunResult runResult = await RunMagenticWorkflowAsync(
+            workflow,
+            [new ChatMessage(ChatRole.User, "Check system health")]);
+
+        runResult.Result.Should().NotBeNull();
+        runResult.Result![0].Text.Should().Contain("All systems checked");
+
+        // Each participant takes exactly one turn.
+        healthChecker.RecordedInputs.Should().ContainSingle();
+        databaseChecker.RecordedInputs.Should().ContainSingle();
+
+        // The first speaker must NOT see the instruction targeted at the other speaker.
+        List<ChatMessage> healthInput = healthChecker.RecordedInputs[0];
+        healthInput.Should().Contain(m => m.Text.Contains(HealthInstruction), "the first speaker receives its own instruction");
+        healthInput.Should().NotContain(m => m.Text.Contains(DatabaseInstruction),
+            "an idle agent must not receive an instruction addressed to a different speaker");
+
+        // The second speaker must see the first speaker's RESPONSE (authored by HealthChecker, carrying the echo
+        // prefix that only the response — not the raw instruction — has), plus its own instruction.
+        List<ChatMessage> databaseInput = databaseChecker.RecordedInputs[0];
+        databaseInput.Should().Contain(
+            m => m.AuthorName == "HealthChecker" && m.Text.Contains(HealthEchoPrefix),
+            "the next speaker must receive the prior participant's response (the running conversation)");
+        databaseInput.Should().Contain(m => m.Text.Contains(DatabaseInstruction),
+            "the next speaker must receive its own instruction");
+
+        // The leaked-instruction bug: the second speaker must not receive HealthChecker's instruction as a
+        // bare message (it should only appear, if at all, embedded in HealthChecker's prefixed response).
+        databaseInput.Should().NotContain(
+            m => m.AuthorName != "HealthChecker" && m.Text.Trim() == HealthInstruction,
+            "the prior speaker's instruction must not leak into the next speaker's context as a standalone message");
+    }
+
+    [Fact]
     public async Task PlanReview_Revised_Triggers_ReplanAsync()
     {
         // Arrange: Human rejects initial plan with revision, triggering a replan.

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
@@ -475,11 +475,9 @@ public class MagenticOrchestrationTests
         healthChecker.RecordedInputs.Should().ContainSingle();
         databaseChecker.RecordedInputs.Should().ContainSingle();
 
-        // The first speaker must NOT see the instruction targeted at the other speaker.
+        // The first speaker receives its own instruction.
         List<ChatMessage> healthInput = healthChecker.RecordedInputs[0];
         healthInput.Should().Contain(m => m.Text.Contains(HealthInstruction), "the first speaker receives its own instruction");
-        healthInput.Should().NotContain(m => m.Text.Contains(DatabaseInstruction),
-            "an idle agent must not receive an instruction addressed to a different speaker");
 
         // The second speaker must see the first speaker's RESPONSE (authored by HealthChecker, carrying the echo
         // prefix that only the response — not the raw instruction — has), plus its own instruction.

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/RecordingEchoAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/RecordingEchoAgent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/RecordingEchoAgent.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/RecordingEchoAgent.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+/// <summary>
+/// A <see cref="TestEchoAgent"/> that records the input messages it receives on each call.
+/// Used by tests that need to assert what context a participant was actually handed - for example,
+/// that a later speaker sees prior participants' <em>responses</em> (the running conversation) rather
+/// than their <em>instructions</em>.
+/// </summary>
+internal sealed class RecordingEchoAgent(string? id = null, string? name = null, string? prefix = null)
+    : TestEchoAgent(id, name, prefix)
+{
+    public List<List<ChatMessage>> RecordedInputs { get; } = [];
+
+    protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session = null,
+        AgentRunOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Materialize once so the deferred input is recorded and replayed identically.
+        List<ChatMessage> recorded = messages.ToList();
+        this.RecordedInputs.Add(recorded);
+
+        await foreach (AgentResponseUpdate update in base.RunCoreStreamingAsync(recorded, session, options, cancellationToken))
+        {
+            yield return update;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6223 

### Motivation and Context

`MagenticOrchestrator` sent the per-round instruction untargeted, so the fan-out edge
delivered it to every participant, and never relayed replies. A later speaker saw the
prior speaker's *instruction* but not its *response* — inverted from `GroupChatHost`
(same assembly) and the Python reference.

Net effect: an idle participant accumulated instructions addressed to *other*
agents but never saw other agents' *responses* - inverted from the intended
behavior, which breaks collaborative hand-offs and dilutes each agent's context.

The .NET `GroupChatHost` already implements the correct pattern (tracks the
current speaker, broadcasts replies to all others, persists that id across
checkpoints), and the Python orchestrator does the same. This PR aligns
Magentic with both.


### Description

- Target the per-round instruction/question at the selected speaker only, instead of an
  untargeted send.
- Broadcast each participant reply to the other participants as context
  (buffered, no `TurnToken`, so they do not act), excluding the responder via
  `_currentSpeakerExecutorId` - mirroring `GroupChatHost`.
- Persist `_currentSpeakerExecutorId` across checkpoints so the exclusion
  survives restore.
- Add a regression test (`RecordingEchoAgent`) asserting a later speaker
  receives the prior participant's *response* and not its *instruction*.

### Before / after:

**Before** - sees the first agent's instruction (leaked via fan-out), not its reply:

- System: "..."
- User: "Instruction meant for Agent1"  <-- ⚠️ LEAKED: Untargeted fan-out
- User: "Instruction meant for Agent2"

**After** - sees the first agent's response, plus its own instruction:

- System: "..."
- Assistant/Agent1: "Agent1's response"         <--  BROADCASTED: Correct context
- User: "Instruction meant for Agent2"    <-- 🎯 TARGETED: Direct instruction


### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.