### PR TITLE
Python: Add regression tests for MCP tool result event projection in GitHubCopilotAgent

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -2134,9 +2134,7 @@ class SkillsProvider(ContextProvider):
             ),
             FunctionTool(
                 name="read_skill_resource",
-                description=(
-                    "Reads a resource associated with a skill, such as references, assets, or dynamic data."
-                ),
+                description=("Reads a resource associated with a skill, such as references, assets, or dynamic data."),
                 func=_read_resource,
                 input_model={
                     "type": "object",
@@ -2173,8 +2171,7 @@ class SkillsProvider(ContextProvider):
                                     "type": "object",
                                     "additionalProperties": True,
                                     "description": (
-                                        "Named arguments as key-value pairs "
-                                        '(e.g. {"length": 24, "uppercase": true}).'
+                                        'Named arguments as key-value pairs (e.g. {"length": 24, "uppercase": true}).'
                                     ),
                                 },
                                 {

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -4086,8 +4086,8 @@ class TestClassSkill:
 
     async def test_content_is_cached(self) -> None:
         skill = _MinimalClassSkill()
-        content1 = (await skill.get_content())
-        content2 = (await skill.get_content())
+        content1 = await skill.get_content()
+        content2 = await skill.get_content()
         assert content1 is content2
 
     def test_resources_are_lazy_cached(self) -> None:
@@ -5587,8 +5587,8 @@ class TestInlineSkillContentCaching:
     async def test_content_cached_after_first_access(self) -> None:
         """InlineSkill.content returns the same object on subsequent accesses."""
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="test-skill", description="Test"), instructions="Body")
-        first = (await skill.get_content())
-        second = (await skill.get_content())
+        first = await skill.get_content()
+        second = await skill.get_content()
         assert first is second  # Same object (cached)
         assert "<name>test-skill</name>" in first
 

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -920,6 +920,87 @@ class TestGitHubCopilotAgentRunStreaming:
         assert responses[3].role == "assistant"
         assert responses[3].contents[0].type == "text"
 
+    async def test_run_streaming_multiple_tool_calls_with_json_results(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        session_idle_event: SessionEvent,
+    ) -> None:
+        """Test that multiple tool calls with JSON results are all projected correctly."""
+        json_payloads = [
+            '{"users": [{"id": "u1", "name": "Alice"}, {"id": "u2", "name": "Bob"}]}',
+            '{"tickets": [{"id": "INC001", "state": "open", "short_description": "VPN issue"}]}',
+            '{"groups": [{"id": "g1", "displayName": "IT Admins", "members": 42}]}',
+        ]
+        tool_names = ["msgraph_list_users", "sn_query_table", "msgraph_list_groups"]
+
+        events: list[SessionEvent] = []
+        for i, (name, payload) in enumerate(zip(tool_names, json_payloads)):
+            call_id = f"call_{i:03d}"
+
+            # Tool start
+            start_data = MagicMock()
+            start_data.tool_call_id = call_id
+            start_data.tool_name = name
+            start_data.arguments = {"query": f"test_{i}"}
+            events.append(
+                SessionEvent(
+                    data=start_data,
+                    id=uuid4(),
+                    timestamp=datetime.now(timezone.utc),
+                    type=SessionEventType.TOOL_EXECUTION_START,
+                )
+            )
+
+            # Tool complete
+            complete_data = MagicMock()
+            complete_data.tool_call_id = call_id
+            complete_data.result = ToolExecutionCompleteResult(content=payload)
+            complete_data.success = True
+            complete_data.error = None
+            events.append(
+                SessionEvent(
+                    data=complete_data,
+                    id=uuid4(),
+                    timestamp=datetime.now(timezone.utc),
+                    type=SessionEventType.TOOL_EXECUTION_COMPLETE,
+                )
+            )
+
+        events.append(session_idle_event)
+
+        def mock_on(handler: Any) -> Any:
+            for event in events:
+                handler(event)
+            return lambda: None
+
+        mock_session.on = mock_on
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        responses: list[AgentResponseUpdate] = []
+        async for update in agent.run("List users, tickets, and groups", stream=True):
+            responses.append(update)
+
+        # Should have 3 tool calls + 3 tool results = 6 updates
+        assert len(responses) == 6
+
+        # Verify each pair: function_call followed by function_result
+        for i in range(3):
+            call_update = responses[i * 2]
+            result_update = responses[i * 2 + 1]
+            call_id = f"call_{i:03d}"
+
+            assert call_update.role == "assistant"
+            assert call_update.contents[0].type == "function_call"
+            assert call_update.contents[0].call_id == call_id
+            assert call_update.contents[0].name == tool_names[i]
+
+            assert result_update.role == "tool"
+            assert result_update.contents[0].type == "function_result"
+            assert result_update.contents[0].call_id == call_id
+            assert result_update.contents[0].result == json_payloads[i]
+            assert result_update.contents[0].exception is None
+
 
 class TestGitHubCopilotAgentSessionManagement:
     """Test cases for session management."""

--- a/python/samples/02-agents/harness/harness_research.py
+++ b/python/samples/02-agents/harness/harness_research.py
@@ -109,7 +109,10 @@ async def main() -> None:
                         print(f"\n  [calling tool: {content.name}]", flush=True)
                         print("  ", end="", flush=True)
                     # Show web search activity when the result arrives with action details.
-                    elif content.type in ("search_tool_call", "search_tool_result") and getattr(content, "tool_name", None) == "web_search":
+                    elif (
+                        content.type in ("search_tool_call", "search_tool_result")
+                        and getattr(content, "tool_name", None) == "web_search"
+                    ):
                         action = None
                         if content.type == "search_tool_result" and isinstance(content.result, dict):
                             action = content.result.get("action", {})

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -606,7 +606,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = "<=1.0.0b2,>=1.0.0b2" },
+    { name = "github-copilot-sdk", marker = "python_full_version >= '3.11'", specifier = ">=1.0.0b2,<=1.0.0b2" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation and Context

The Python GitHubCopilotAgent already correctly projects MCP tool execution events into `FunctionCallContent` and `FunctionResultContent` (fixed in #4734, #4814, #4828), but there was no dedicated test covering the multi-tool-call scenario described in #5897. These tests prevent regression of the projection logic that, when broken, causes models to fabricate timeout errors because tool results appear as opaque content instead of semantically marked function results.

Fixes #5897

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Adds a streaming test (`test_run_streaming_multiple_tool_calls_with_json_results`) that exercises three consecutive MCP tool invocations returning JSON payloads, verifying that each `TOOL_EXECUTION_START` event is projected as a `function_call` content item and each `TOOL_EXECUTION_COMPLETE` event is projected as a `function_result` content item with the correct `call_id`, tool name, and result payload. This directly covers the scenario from issue #5897 where successful MCP tool returns were silently dropped as opaque `AIContent`.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.

---

> Note: PR autogenerated by giles17's agent

<!-- df:v1 keep this hidden block intact; used for internal DevFlow attribution and metrics.
{"issue":5897,"repo":"microsoft/agent-framework","rid":"079ddffd74194073a4ec2d2efe248848","rt":"fix","sf":"pr","ts":"2026-05-29T22:52:59.083660+00:00","u":"giles17","v":1}
-->
