### PR TITLE
.NET: fix Magentic participant message routing

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/Magentic/MagenticOrchestrator.cs
@@ -90,6 +90,7 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
 
     private MagenticTaskContext? _taskContext;
     private PortBinding? _planReviewPort;
+    private string? _currentSpeakerExecutorId;
 
     protected override ProtocolBuilder ConfigureProtocol(ProtocolBuilder protocolBuilder)
     {
@@ -200,7 +201,16 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
             if (messages is { Count: > 0 })
             {
                 this._taskContext.ChatHistory.AddRange(messages);
+                try
+                {
+                    await this.BroadcastToOtherParticipantsAsync(messages, context, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    this._currentSpeakerExecutorId = null;
+                }
             }
+
             await this.RunCoordinationRoundAsync(this._taskContext, context, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -287,16 +297,35 @@ internal class MagenticOrchestrator(AIAgent managerAgent, List<AIAgent> team, Ta
             return;
         }
 
+        string nextExecutorId = AIAgentHostExecutor.IdFor(nextAgent);
+
         if (!string.IsNullOrWhiteSpace(taskContext.ProgressLedger.InstructionOrQuestion))
         {
             ChatMessage instruction = new(ChatRole.Assistant, taskContext.ProgressLedger.InstructionOrQuestion);
             taskContext.ChatHistory.Add(instruction);
 
-            await context.SendMessageAsync(instruction, cancellationToken).ConfigureAwait(false);
+            await context.SendMessageAsync(instruction, nextExecutorId, cancellationToken).ConfigureAwait(false);
         }
 
-        string nextExecutorId = AIAgentHostExecutor.IdFor(nextAgent);
+        this._currentSpeakerExecutorId = nextExecutorId;
         await context.SendMessageAsync(new TurnToken(taskContext.EmitUpdateEvents), nextExecutorId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private ValueTask BroadcastToOtherParticipantsAsync(List<ChatMessage> messages, IWorkflowContext context, CancellationToken cancellationToken)
+    {
+        List<Task>? sendTasks = null;
+        foreach (AIAgent participant in team)
+        {
+            string participantId = AIAgentHostExecutor.IdFor(participant);
+            if (string.Equals(participantId, this._currentSpeakerExecutorId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            (sendTasks ??= []).Add(context.SendMessageAsync(messages, participantId, cancellationToken).AsTask());
+        }
+
+        return sendTasks is null ? default : new ValueTask(Task.WhenAll(sendTasks));
     }
 
     private async ValueTask ResetAndReplanAsync(MagenticTaskContext taskContext, IWorkflowContext context, CancellationToken cancellationToken)

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MagenticOrchestrationTests.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Agents.AI.Workflows.InProc;
@@ -986,6 +988,58 @@ public class MagenticOrchestrationTests
     }
 
     [Fact]
+    public async Task Participant_Response_Is_Shared_With_Next_SpeakerAsync()
+    {
+        List<ChatMessage> factsResponse = CreatePlanResponse("Task delegation facts");
+        List<ChatMessage> planResponse = CreatePlanResponse("Delegate across participants");
+        List<ChatMessage> workerALedger = CreateProgressLedgerResponse(
+            isRequestSatisfied: false,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "WorkerA",
+            instructionOrQuestion: "WorkerA private instruction");
+        List<ChatMessage> workerBLedger = CreateProgressLedgerResponse(
+            isRequestSatisfied: false,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "WorkerB",
+            instructionOrQuestion: "WorkerB private instruction");
+        List<ChatMessage> satisfiedLedger = CreateProgressLedgerResponse(
+            isRequestSatisfied: true,
+            isInLoop: false,
+            isProgressBeingMade: true,
+            nextSpeaker: "WorkerB",
+            instructionOrQuestion: "Done");
+        List<ChatMessage> finalAnswerResponse = CreateFinalAnswerResponse("Routed correctly");
+
+        TestReplayAgent manager = new(
+            [factsResponse, planResponse, workerALedger, workerBLedger, satisfiedLedger, finalAnswerResponse],
+            name: "Manager");
+        RecordingAgent workerA = new("WorkerA", "WorkerA response");
+        RecordingAgent workerB = new("WorkerB", "WorkerB response");
+
+        Workflow workflow = new MagenticWorkflowBuilder(manager)
+            .AddParticipants(workerA, workerB)
+            .RequirePlanSignoff(false)
+            .Build();
+
+        WorkflowRunResult runResult = await RunMagenticWorkflowAsync(
+            workflow,
+            [new ChatMessage(ChatRole.User, "Route task")]);
+
+        workerA.Turns.Should().ContainSingle();
+        workerB.Turns.Should().ContainSingle();
+        string workerBInput = string.Join("\n", workerB.Turns[0].Select(message => message.Text));
+
+        workerBInput.Should().Contain("WorkerB private instruction");
+        workerBInput.Should().Contain("WorkerA response");
+        workerBInput.Should().NotContain("WorkerA private instruction");
+
+        runResult.Result.Should().NotBeNull();
+        runResult.Result![0].Text.Should().Contain("Routed correctly");
+    }
+
+    [Fact]
     public async Task Progress_Made_Decrements_StallCountAsync()
     {
         // Arrange: MaxStallCount=3, so a single stall won't trigger reset.
@@ -1323,6 +1377,55 @@ public class MagenticOrchestrationTests
         List<ChatMessage>? Result,
         CheckpointInfo? LastCheckpoint,
         List<RequestInfoEvent> PendingRequests);
+
+    private sealed class RecordingAgent(string name, string responseText) : AIAgent
+    {
+        public override string? Name => name;
+
+        public List<List<ChatMessage>> Turns { get; } = [];
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default) =>
+            new(new RecordingAgentSession());
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            new(new RecordingAgentSession());
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(AgentSession session, JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) =>
+            new(JsonSerializer.SerializeToElement<object?>(null));
+
+        protected override Task<AgentResponse> RunCoreAsync(IEnumerable<ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            ChatMessage response = this.RecordAndCreateResponse(messages);
+            return Task.FromResult(new AgentResponse([response]));
+        }
+
+        protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(IEnumerable<ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ChatMessage response = this.RecordAndCreateResponse(messages);
+            yield return new AgentResponseUpdate(ChatRole.Assistant, response.Contents)
+            {
+                AuthorName = this.Name,
+                MessageId = response.MessageId,
+                ResponseId = Guid.NewGuid().ToString("N"),
+                CreatedAt = response.CreatedAt,
+            };
+        }
+
+        private ChatMessage RecordAndCreateResponse(IEnumerable<ChatMessage> messages)
+        {
+            this.Turns.Add([.. messages]);
+            return new ChatMessage(ChatRole.Assistant, responseText)
+            {
+                AuthorName = this.Name,
+                MessageId = Guid.NewGuid().ToString("N"),
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+        }
+
+        private sealed class RecordingAgentSession : AgentSession
+        {
+        }
+    }
 
     private static List<ChatMessage> CreatePlanResponse(string plan)
     {


### PR DESCRIPTION
## Summary
- target Magentic progress-ledger instructions only to the selected next speaker
- broadcast a participant's reply to the other participants before the next coordination round
- add a regression test that verifies WorkerB receives WorkerA's reply but not WorkerA's private instruction

Fixes #6223

## To verify
- `dotnet restore dotnet\tests\Microsoft.Agents.AI.Workflows.UnitTests\Microsoft.Agents.AI.Workflows.UnitTests.csproj`
- `dotnet build dotnet\tests\Microsoft.Agents.AI.Workflows.UnitTests\Microsoft.Agents.AI.Workflows.UnitTests.csproj --no-restore`
- `dotnet dotnet\tests\Microsoft.Agents.AI.Workflows.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.Workflows.UnitTests.dll --filter-method Microsoft.Agents.AI.Workflows.UnitTests.MagenticOrchestrationTests.Participant_Response_Is_Shared_With_Next_SpeakerAsync --no-progress`
- `dotnet dotnet\tests\Microsoft.Agents.AI.Workflows.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.Workflows.UnitTests.dll --filter-method Microsoft.Agents.AI.Workflows.UnitTests.MagenticOrchestrationTests.Task_Delegates_To_Correct_AgentAsync --no-progress`
- `dotnet dotnet\tests\Microsoft.Agents.AI.Workflows.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.Workflows.UnitTests.dll --filter-class Microsoft.Agents.AI.Workflows.UnitTests.MagenticOrchestrationTests --no-progress`
- `git diff --check`