### PR TITLE
.NET: test: add AgentResponse coverage for protected constructor, message property propagation, and [JsonIgnore] fields

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
@@ -401,11 +401,10 @@ public class AgentResponseTests
 
         // Assert
         using JsonDocument doc = JsonDocument.Parse(json);
-        foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
-        {
-            Assert.NotEqual("text", prop.Name, StringComparer.OrdinalIgnoreCase);
-            Assert.NotEqual("rawRepresentation", prop.Name, StringComparer.OrdinalIgnoreCase);
-        }
+        JsonElement root = doc.RootElement;
+        Assert.True(root.TryGetProperty("messages", out _));
+        Assert.False(root.TryGetProperty("text", out _));
+        Assert.False(root.TryGetProperty("rawRepresentation", out _));
     }
 
     private sealed class DerivedAgentResponse(AgentResponse response) : AgentResponse(response);

--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
@@ -323,4 +323,88 @@ public class AgentResponseTests
         Assert.NotNull(update.AdditionalProperties);
         Assert.Equal("value", update.AdditionalProperties!["key"]);
     }
+
+    [Fact]
+    public void ProtectedCopyConstructor_WithNullAgentResponse_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("response", () => new DerivedAgentResponse(null!));
+    }
+
+    [Fact]
+    public void ProtectedCopyConstructor_WithAgentResponse_CopiesAllProperties()
+    {
+        // Arrange
+        AgentResponse original = new(new ChatMessage(ChatRole.Assistant, "hello"))
+        {
+            AdditionalProperties = new() { ["key"] = "value" },
+            CreatedAt = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            FinishReason = ChatFinishReason.Stop,
+            ResponseId = "responseId",
+            Usage = new UsageDetails { TotalTokenCount = 42 },
+            ContinuationToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 }),
+        };
+
+        // Act
+        DerivedAgentResponse copy = new(original);
+
+        // Assert
+        Assert.Same(original.AdditionalProperties, copy.AdditionalProperties);
+        Assert.Equal(original.CreatedAt, copy.CreatedAt);
+        Assert.Equal(original.FinishReason, copy.FinishReason);
+        Assert.Same(original.Messages, copy.Messages);
+        Assert.Same(original, copy.RawRepresentation);
+        Assert.Equal(original.ResponseId, copy.ResponseId);
+        Assert.Same(original.Usage, copy.Usage);
+        Assert.Equivalent(original.ContinuationToken, copy.ContinuationToken);
+    }
+
+    [Fact]
+    public void ToAgentResponseUpdates_PropagatesMessageAuthorName()
+    {
+        // Arrange
+        AgentResponse response = new(new ChatMessage(ChatRole.Assistant, "Text") { AuthorName = "bot" });
+
+        // Act
+        AgentResponseUpdate[] updates = response.ToAgentResponseUpdates();
+
+        // Assert
+        Assert.Equal("bot", updates[0].AuthorName);
+    }
+
+    [Fact]
+    public void ToAgentResponseUpdates_PropagatesMessageAdditionalProperties()
+    {
+        // Arrange
+        AdditionalPropertiesDictionary messageProps = new() { ["msgKey"] = "msgValue" };
+        AgentResponse response = new(new ChatMessage(ChatRole.Assistant, "Text") { AdditionalProperties = messageProps });
+
+        // Act
+        AgentResponseUpdate[] updates = response.ToAgentResponseUpdates();
+
+        // Assert
+        Assert.Same(messageProps, updates[0].AdditionalProperties);
+    }
+
+    [Fact]
+    public void JsonSerialization_ExcludesTextAndRawRepresentation()
+    {
+        // Arrange
+        AgentResponse response = new(new ChatMessage(ChatRole.Assistant, "hello"))
+        {
+            RawRepresentation = new object(),
+        };
+
+        // Act
+        string json = JsonSerializer.Serialize(response, AgentAbstractionsJsonUtilities.DefaultOptions);
+
+        // Assert
+        using JsonDocument doc = JsonDocument.Parse(json);
+        foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
+        {
+            Assert.NotEqual("text", prop.Name, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEqual("rawRepresentation", prop.Name, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed class DerivedAgentResponse(AgentResponse response) : AgentResponse(response);
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Abstractions.UnitTests/AgentResponseTests.cs
@@ -368,6 +368,7 @@ public class AgentResponseTests
         AgentResponseUpdate[] updates = response.ToAgentResponseUpdates();
 
         // Assert
+        Assert.Single(updates);
         Assert.Equal("bot", updates[0].AuthorName);
     }
 
@@ -382,6 +383,7 @@ public class AgentResponseTests
         AgentResponseUpdate[] updates = response.ToAgentResponseUpdates();
 
         // Assert
+        Assert.Single(updates);
         Assert.Same(messageProps, updates[0].AdditionalProperties);
     }
 


### PR DESCRIPTION
### Motivation and Context
AgentResponse had no tests covering the protected copy constructor (null guard or property copying), ToAgentResponseUpdates message-level field propagation (AuthorName, AdditionalProperties), or [JsonIgnore] exclusion of Text and RawRepresentation from serialized output. These are gaps in critical response construction and serialization paths.

### Description

  - Add test verifying null `AgentResponse` passed to protected copy constructor throws `ArgumentNullException`
  - Add test verifying protected copy constructor copies all properties and sets `RawRepresentation` to the original instance
  - Add test verifying` ToAgentResponseUpdates` propagates message-level `AuthorName `to the update
  - Add test verifying `ToAgentResponseUpdates `propagates message-level `AdditionalProperties` to the update
  - Add test verifying Text and `RawRepresentation `are excluded from JSON serialization output

### Contribution Checklist
  - [x] The code builds clean without any errors or warnings
  - [x] The PR follows the Contribution Guidelines
  - [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
- No breaking change test only, no production code modified