### PR TITLE
Python: guard invalid OpenAI provider responses

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1966,6 +1966,18 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         options: dict[str, Any],
     ) -> ChatResponse:
         """Parse an OpenAI Responses API response into a ChatResponse."""
+        if not hasattr(response, "output"):
+            preview = repr(response)
+            if len(preview) > 500:
+                preview = f"{preview[:500]}..."
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid OpenAI Responses API response: "
+                    f"expected an object with 'output', got {type(response).__name__}: {preview}",
+                    azure_endpoint=self.azure_endpoint,
+                )
+            )
+
         structured_response: BaseModel | None = response.output_parsed if isinstance(response, ParsedResponse) else None  # type: ignore[reportUnknownMemberType]
 
         metadata: dict[str, Any] = response.metadata or {}

--- a/python/packages/openai/agent_framework_openai/_chat_completion_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_completion_client.py
@@ -684,6 +684,18 @@ class RawOpenAIChatCompletionClient(  # type: ignore[misc]
 
     def _parse_response_from_openai(self, response: ChatCompletion, options: Mapping[str, Any]) -> ChatResponse:
         """Parse a response from OpenAI into a ChatResponse."""
+        if not hasattr(response, "choices"):
+            preview = repr(response)
+            if len(preview) > 500:
+                preview = f"{preview[:500]}..."
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid OpenAI Chat Completions API response: "
+                    f"expected an object with 'choices', got {type(response).__name__}: {preview}",
+                    azure_endpoint=self.azure_endpoint,
+                )
+            )
+
         response_metadata = self._get_metadata_from_chat_response(response)
         messages: list[Message] = []
         finish_reason: FinishReason | None = None

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -3610,6 +3610,19 @@ async def test_service_response_exception_includes_original_error_details() -> N
     assert original_error_message in exception_message
 
 
+def test_parse_response_rejects_non_openai_response_object() -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+    response: Any = "plain backend error"
+
+    with pytest.raises(ChatClientException) as exc_info:
+        client._parse_response_from_openai(response, options={})
+
+    exception_message = str(exc_info.value)
+    assert "invalid OpenAI Responses API response" in exception_message
+    assert "expected an object with 'output'" in exception_message
+    assert "plain backend error" in exception_message
+
+
 async def test_get_response_streaming_with_response_format() -> None:
     """Test get_response streaming with response_format."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")

--- a/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
@@ -61,6 +61,19 @@ def test_get_response_is_defined_on_openai_class() -> None:
     assert all(parameter.kind != inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
 
 
+def test_parse_response_rejects_non_chat_completion_object() -> None:
+    client = OpenAIChatCompletionClient(model="test-model", api_key="test-key")
+    response: Any = "plain backend error"
+
+    with pytest.raises(ChatClientException) as exc_info:
+        client._parse_response_from_openai(response, options={})
+
+    exception_message = str(exc_info.value)
+    assert "invalid OpenAI Chat Completions API response" in exception_message
+    assert "expected an object with 'choices'" in exception_message
+    assert "plain backend error" in exception_message
+
+
 def test_init_uses_explicit_parameters() -> None:
     signature = inspect.signature(RawOpenAIChatCompletionClient.__init__)
 


### PR DESCRIPTION
## Summary

- guard OpenAI Responses API parsing when an OpenAI-compatible backend returns a non-response object
- guard Chat Completions parsing for the same invalid-provider-response class
- surface a targeted `ChatClientException` with a short payload preview instead of leaking internal `AttributeError`s

Fixes #6235.
Fixes #6234.

## To verify

- `uv run --dev python -m pytest packages\openai\tests\openai\test_openai_chat_client.py::test_parse_response_rejects_non_openai_response_object packages\openai\tests\openai\test_openai_chat_completion_client.py::test_parse_response_rejects_non_chat_completion_object -q`
- `uv run --dev ruff check packages\openai\agent_framework_openai\_chat_client.py packages\openai\agent_framework_openai\_chat_completion_client.py packages\openai\tests\openai\test_openai_chat_client.py packages\openai\tests\openai\test_openai_chat_completion_client.py`
- `uv run --dev ruff format --check packages\openai\agent_framework_openai\_chat_client.py packages\openai\agent_framework_openai\_chat_completion_client.py packages\openai\tests\openai\test_openai_chat_client.py packages\openai\tests\openai\test_openai_chat_completion_client.py`
- `uv run --dev pyright packages\openai\agent_framework_openai\_chat_client.py packages\openai\agent_framework_openai\_chat_completion_client.py`
- `uv run --dev mypy --config-file pyproject.toml packages\openai\agent_framework_openai\_chat_client.py packages\openai\agent_framework_openai\_chat_completion_client.py`
- `git diff --check`
