### PR TITLE
.NET: Bump ModelContextProtocol from 1.1.0 to 1.2.0 (#3956)

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -109,7 +109,7 @@
     <PackageVersion Include="A2A" Version="1.0.0-preview2" />
     <PackageVersion Include="A2A.AspNetCore" Version="1.0.0-preview2" />
     <!-- MCP -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <!-- Hyperlight -->
     <PackageVersion Include="Hyperlight.HyperlightSandbox.Api" Version="0.4.0" />
     <PackageVersion Include="Hyperlight.HyperlightSandbox.Guest.Python" Version="0.4.0" />

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-McpTools/HostedMcpTools.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-McpTools/HostedMcpTools.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="ModelContextProtocol" VersionOverride="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="DotNetEnv" />
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation and Context

Fixes #3956.

The `Agent_MCP_Server_Auth` sample currently fails with:

> `ModelContextProtocol.McpException: Failed to handle unauthorized response with 'Bearer' scheme. The AuthorizationRedirectDelegate returned a null or empty authorization code.`

Root cause is the trailing slash in the OAuth `resource` parameter (`resource=http://localhost:7071/`), tracked upstream in `modelcontextprotocol/csharp-sdk#1122` and fixed in the 1.2.x line of the MCP C# SDK. This PR picks up that fix by bumping the centrally-managed package version.

### Description

Two small changes:

1. **`dotnet/Directory.Packages.props`** — bump central `ModelContextProtocol` pin from 1.1.0 to 1.2.0.
2. **`dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-McpTools/HostedMcpTools.csproj`** — remove the now-redundant `VersionOverride="1.2.0"` so the central pin is the single source of truth.

**Why 1.2.0 and not 1.3.0:** `ModelContextProtocol.Core 1.3.0` transitively requires `Microsoft.Extensions.*` 10.0.7 and `Microsoft.Extensions.AI.Abstractions` 10.5.2, neither of which are currently in the central pins. Coordinating those bumps is a larger change than #3956 asks for; happy to follow up in a separate PR.

**Breaking change check:** The 1.2 line includes API breaks on `ProtectedResourceMetadata`, `ToolResultContentBlock`, `ListTasksResult`, and `DynamicClientRegistrationResponse`. Grepped `dotnet/` for usages of all four — zero references, so this bump is non-breaking for this repo.

**Verification (local, macOS, .NET 10.0.8):**
- `dotnet restore` — clean
- `dotnet build` (Debug) — clean
- `dotnet build -c Release` — clean (Package Validation passes; no CP0001/CP0002)
- `dotnet test tests/Microsoft.Agents.AI.Mcp.UnitTests -f net10.0` — 20 passed, 0 failed

No regression test added; reproducing the original failure requires the upstream `TestOAuthServer` + `ProtectedMCPServer` harness, and the fix itself is a pure dependency version bump.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title