### PR TITLE
Python: fix: split Mem0 user and agent searches

### DIFF
--- a/python/packages/mem0/agent_framework_mem0/_context_provider.py
+++ b/python/packages/mem0/agent_framework_mem0/_context_provider.py
@@ -106,26 +106,12 @@ class Mem0ContextProvider(ContextProvider):
         if not input_text.strip():
             return
 
-        filters = self._build_filters()
+        memories = []
+        for filters in self._build_search_filter_sets():
+            search_response = await self._search(input_text, filters)
+            memories.extend(self._coerce_search_response(search_response))
 
-        # AsyncMemory (OSS) expects user_id/agent_id/run_id as direct kwargs
-        # AsyncMemoryClient (Platform) expects them in a filters dict
-        search_kwargs: dict[str, Any] = {"query": input_text}
-        if isinstance(self.mem0_client, AsyncMemory):
-            search_kwargs.update(filters)
-        else:
-            search_kwargs["filters"] = filters
-
-        search_response: _MemorySearchResponse_v1_1 | _MemorySearchResponse_v2 = await self.mem0_client.search(  # type: ignore[misc]
-            **search_kwargs,
-        )
-
-        if isinstance(search_response, list):
-            memories = search_response
-        elif isinstance(search_response, dict) and "results" in search_response:
-            memories = search_response["results"]
-        else:
-            memories = [search_response]
+        memories = self._dedupe_memories(memories)
 
         line_separated_memories = "\n".join(memory.get("memory", "") for memory in memories)
         if line_separated_memories:
@@ -159,12 +145,10 @@ class Mem0ContextProvider(ContextProvider):
         ]
 
         if messages:
-            await self.mem0_client.add(  # type: ignore[misc]
-                messages=messages,
-                user_id=self.user_id,
-                agent_id=self.agent_id,
-                metadata={"application_id": self.application_id},
-            )
+            add_kwargs: dict[str, Any] = {"messages": messages, "user_id": self.user_id, "agent_id": self.agent_id}
+            if self.application_id:
+                add_kwargs["app_id"] = self.application_id
+            await self.mem0_client.add(**add_kwargs)  # type: ignore[misc]
 
     # -- Internal methods ------------------------------------------------------
 
@@ -183,6 +167,59 @@ class Mem0ContextProvider(ContextProvider):
         if self.application_id:
             filters["app_id"] = self.application_id
         return filters
+
+    def _build_search_filter_sets(self) -> list[dict[str, Any]]:
+        """Build Mem0 search filters.
+
+        Mem0 stores facts in either the user bucket or the agent bucket. Query
+        them separately; a combined user_id+agent_id filter is an empty
+        intersection for those records.
+        """
+        if not (self.user_id and self.agent_id):
+            return [self._build_filters()]
+
+        base: dict[str, Any] = {}
+        if self.application_id:
+            base["app_id"] = self.application_id
+        return [
+            {**base, "user_id": self.user_id},
+            {**base, "agent_id": self.agent_id},
+        ]
+
+    async def _search(
+        self, input_text: str, filters: dict[str, Any]
+    ) -> _MemorySearchResponse_v1_1 | _MemorySearchResponse_v2:
+        # AsyncMemory (OSS) expects user_id/agent_id/app_id as direct kwargs.
+        # AsyncMemoryClient (Platform) expects them in a filters dict.
+        search_kwargs: dict[str, Any] = {"query": input_text}
+        if isinstance(self.mem0_client, AsyncMemory):
+            search_kwargs.update(filters)
+        else:
+            search_kwargs["filters"] = filters
+        return await self.mem0_client.search(**search_kwargs)  # type: ignore[misc,no-any-return]
+
+    @staticmethod
+    def _coerce_search_response(
+        search_response: _MemorySearchResponse_v1_1 | _MemorySearchResponse_v2,
+    ) -> list[dict[str, Any]]:
+        if isinstance(search_response, list):
+            return search_response
+        if isinstance(search_response, dict) and "results" in search_response:
+            return search_response["results"]
+        return [search_response]
+
+    @staticmethod
+    def _dedupe_memories(memories: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        deduped = []
+        seen_ids = set()
+        for memory in memories:
+            memory_id = memory.get("id")
+            if memory_id is not None:
+                if memory_id in seen_ids:
+                    continue
+                seen_ids.add(memory_id)
+            deduped.append(memory)
+        return deduped
 
 
 __all__ = ["Mem0ContextProvider"]

--- a/python/packages/mem0/tests/test_mem0_context_provider.py
+++ b/python/packages/mem0/tests/test_mem0_context_provider.py
@@ -193,9 +193,9 @@ class TestBeforeRun:
         assert call_kwargs["user_id"] == "u1"
         assert "filters" not in call_kwargs
 
-    async def test_oss_client_all_scoping_params(self, mock_oss_mem0_client: AsyncMock) -> None:
-        """OSS client with all scoping parameters passes them as direct kwargs."""
-        mock_oss_mem0_client.search.return_value = []
+    async def test_oss_client_splits_user_and_agent_scope(self, mock_oss_mem0_client: AsyncMock) -> None:
+        """OSS client searches user and agent buckets independently."""
+        mock_oss_mem0_client.search.side_effect = [[{"memory": "user memory"}], [{"memory": "agent memory"}]]
         provider = Mem0ContextProvider(
             source_id="mem0", mem0_client=mock_oss_mem0_client, user_id="u1", agent_id="a1", application_id="app1"
         )
@@ -206,10 +206,11 @@ class TestBeforeRun:
             agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
         )  # type: ignore[arg-type]
 
-        call_kwargs = mock_oss_mem0_client.search.call_args.kwargs
-        assert call_kwargs["user_id"] == "u1"
-        assert call_kwargs["agent_id"] == "a1"
-        assert "filters" not in call_kwargs
+        first_call, second_call = mock_oss_mem0_client.search.await_args_list
+        assert first_call.kwargs == {"query": "Hello", "app_id": "app1", "user_id": "u1"}
+        assert second_call.kwargs == {"query": "Hello", "app_id": "app1", "agent_id": "a1"}
+        assert "user memory" in ctx.context_messages["mem0"][0].text  # type: ignore[operator]
+        assert "agent memory" in ctx.context_messages["mem0"][0].text  # type: ignore[operator]
 
     async def test_platform_client_passes_filters_dict(self, mock_mem0_client: AsyncMock) -> None:
         """Platform AsyncMemoryClient should receive scoping params in a filters dict."""
@@ -226,6 +227,46 @@ class TestBeforeRun:
         assert call_kwargs["query"] == "Hello"
         assert "filters" in call_kwargs
         assert call_kwargs["filters"]["user_id"] == "u1"
+
+    async def test_platform_client_splits_user_and_agent_filters(self, mock_mem0_client: AsyncMock) -> None:
+        """Platform client searches user and agent buckets independently."""
+        mock_mem0_client.search.side_effect = [
+            {"results": [{"id": "u", "memory": "user memory"}]},
+            {"results": [{"id": "a", "memory": "agent memory"}]},
+        ]
+        provider = Mem0ContextProvider(
+            source_id="mem0", mem0_client=mock_mem0_client, user_id="u1", agent_id="a1", application_id="app1"
+        )
+        session = AgentSession(session_id="test-session")
+        ctx = SessionContext(input_messages=[Message(role="user", contents=["Hello"])], session_id="s1")
+
+        await provider.before_run(
+            agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
+        )  # type: ignore[arg-type]
+
+        first_call, second_call = mock_mem0_client.search.await_args_list
+        assert first_call.kwargs == {"query": "Hello", "filters": {"app_id": "app1", "user_id": "u1"}}
+        assert second_call.kwargs == {"query": "Hello", "filters": {"app_id": "app1", "agent_id": "a1"}}
+        assert "user memory" in ctx.context_messages["mem0"][0].text  # type: ignore[operator]
+        assert "agent memory" in ctx.context_messages["mem0"][0].text  # type: ignore[operator]
+
+    async def test_split_search_deduplicates_memory_ids(self, mock_mem0_client: AsyncMock) -> None:
+        """The same memory returned from both buckets is added once."""
+        mock_mem0_client.search.side_effect = [
+            {"results": [{"id": "same", "memory": "shared memory"}]},
+            {"results": [{"id": "same", "memory": "shared memory"}]},
+        ]
+        provider = Mem0ContextProvider(
+            source_id="mem0", mem0_client=mock_mem0_client, user_id="u1", agent_id="a1", application_id="app1"
+        )
+        session = AgentSession(session_id="test-session")
+        ctx = SessionContext(input_messages=[Message(role="user", contents=["Hello"])], session_id="s1")
+
+        await provider.before_run(
+            agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
+        )  # type: ignore[arg-type]
+
+        assert ctx.context_messages["mem0"][0].text.count("shared memory") == 1  # type: ignore[union-attr]
 
 
 # -- after_run tests -----------------------------------------------------------
@@ -318,8 +359,8 @@ class TestAfterRun:
         with pytest.raises(ValueError, match="At least one of the filters"):
             await provider.after_run(agent=None, session=session, context=ctx, state=session.state)  # type: ignore[arg-type]
 
-    async def test_stores_with_application_id_metadata(self, mock_mem0_client: AsyncMock) -> None:
-        """application_id is passed in metadata."""
+    async def test_stores_with_application_id_app_id(self, mock_mem0_client: AsyncMock) -> None:
+        """application_id is passed as Mem0's native app_id."""
         provider = Mem0ContextProvider(
             source_id="mem0", mem0_client=mock_mem0_client, user_id="u1", application_id="app1"
         )
@@ -331,7 +372,9 @@ class TestAfterRun:
             agent=None, session=session, context=ctx, state=session.state.setdefault(provider.source_id, {})
         )  # type: ignore[arg-type]
 
-        assert mock_mem0_client.add.call_args.kwargs["metadata"] == {"application_id": "app1"}
+        call_kwargs = mock_mem0_client.add.call_args.kwargs
+        assert call_kwargs["app_id"] == "app1"
+        assert "metadata" not in call_kwargs
 
 
 # -- _validate_filters tests --------------------------------------------------


### PR DESCRIPTION
﻿## Summary
- store `application_id` as Mem0's native `app_id` instead of custom metadata
- search user and agent memory buckets separately when both scopes are configured, then merge and deduplicate results
- cover platform and OSS Mem0 clients, including duplicate memory IDs across split searches

Fixes #6237.

## To verify
- `uv run --package agent-framework-mem0 python -c "import agent_framework_mem0, mem0, agent_framework"`
- `.\.venv\Scripts\python.exe -m pytest packages\mem0\tests\test_mem0_context_provider.py -q --basetemp ..\.tmp\pytest-mem0`
- `.\.venv\Scripts\python.exe -m ruff check packages\mem0\agent_framework_mem0\_context_provider.py packages\mem0\tests\test_mem0_context_provider.py`
- `.\.venv\Scripts\python.exe -m ruff format --check packages\mem0\agent_framework_mem0\_context_provider.py packages\mem0\tests\test_mem0_context_provider.py`
- `python -m py_compile python\packages\mem0\agent_framework_mem0\_context_provider.py python\packages\mem0\tests\test_mem0_context_provider.py`
- `git diff --check`

Notes: I installed `pytest==9.0.3`, `pytest-asyncio==1.3.0`, `pytest-timeout==2.4.0`, and `ruff==0.15.8` into the local workspace `.venv` because the initial environment had the runtime dependencies but not test tools.
