### PR TITLE
Python: fix: handle string response in _get_metadata_from_chat_response (Closes #6234)

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_completion_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_completion_client.py
@@ -684,6 +684,13 @@ class RawOpenAIChatCompletionClient(  # type: ignore[misc]
 
     def _parse_response_from_openai(self, response: ChatCompletion, options: Mapping[str, Any]) -> ChatResponse:
         """Parse a response from OpenAI into a ChatResponse."""
+        if isinstance(response, str):
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid response (str instead of ChatCompletion): {response!r}",
+                    azure_endpoint=self.azure_endpoint,
+                ),
+            )
         response_metadata = self._get_metadata_from_chat_response(response)
         messages: list[Message] = []
         finish_reason: FinishReason | None = None
@@ -788,7 +795,7 @@ class RawOpenAIChatCompletionClient(  # type: ignore[misc]
     def _get_metadata_from_chat_response(self, response: ChatCompletion) -> dict[str, Any]:
         """Get metadata from a chat response."""
         return {
-            "system_fingerprint": response.system_fingerprint,
+            "system_fingerprint": getattr(response, "system_fingerprint", None),
         }
 
     def _get_metadata_from_streaming_chat_response(self, response: ChatCompletionChunk) -> dict[str, Any]:


### PR DESCRIPTION
Closes #6234

## Problem

When a non-conformant OpenAI-compatible backend returns a plain string instead of a `ChatCompletion` object, `_parse_response_from_openai()` passes it directly to `_get_metadata_from_chat_response()`, which crashes with:

```
AttributeError: 'str' object has no attribute 'system_fingerprint'
```

## Fix

Two defensive changes:

1. **`_parse_response_from_openai()`**: Added an `isinstance(response, str)` check at the top of the method. If the response is a string, a descriptive `ChatClientException` is raised with the invalid payload included for debugging — following the same pattern used elsewhere in this file for error handling.

2. **`_get_metadata_from_chat_response()`**: Changed `response.system_fingerprint` to `getattr(response, "system_fingerprint", None)` as defense-in-depth, so even if an unexpected non-ChatCompletion object slips through, it won't crash with an `AttributeError`.

## Testing

- The change follows existing error-handling patterns already used in `_parse_response_from_openai` (see `BadRequestError` handling at lines 557-571).
- The `getattr` guard is consistent with how `logprobs` is already handled in `_get_metadata_from_chat_choice` (line 810).

Co-authored-by: lingxiu58 <86288566+lingxiu58@users.noreply.github.com>
Co-authored-by: pojian68 <232320289+pojian68@users.noreply.github.com>