### PR TITLE
.NET: Fix local variable naming conventions

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Evaluation/LocalEvaluator.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Evaluation/LocalEvaluator.cs
@@ -42,18 +42,18 @@ public sealed class LocalEvaluator : IAgentEvaluator
 
             foreach (var check in this._checks)
             {
-                var EvalCheckResult = check(item);
-                evalResult.Metrics[EvalCheckResult.CheckName] = new BooleanMetric(
-                    EvalCheckResult.CheckName,
-                    EvalCheckResult.Passed,
-                    reason: EvalCheckResult.Reason)
+                var evalCheckResult = check(item);
+                evalResult.Metrics[evalCheckResult.CheckName] = new BooleanMetric(
+                    evalCheckResult.CheckName,
+                    evalCheckResult.Passed,
+                    reason: evalCheckResult.Reason)
                 {
                     Interpretation = new EvaluationMetricInterpretation
                     {
-                        Rating = EvalCheckResult.Passed
+                        Rating = evalCheckResult.Passed
                             ? EvaluationRating.Good
                             : EvaluationRating.Unacceptable,
-                        Failed = !EvalCheckResult.Passed,
+                        Failed = !evalCheckResult.Passed,
                     },
                 };
             }


### PR DESCRIPTION
### Motivation and Context

In `src/Microsoft.Agents.AI/Evaluation/LocalEvaluator.cs`, the local variable EvalCheckResult in the EvaluateAsync method uses PascalCase naming, which violates the C# naming convention — local variables should use camelCase. PascalCase for a local variable can mislead reviewers into thinking it's a type name, reducing readability.

### Description

Fixed the local variable name in `src/Microsoft.Agents.AI/Evaluation/LocalEvaluator.cs` from EvalCheckResult to evalCheckResult (6 occurrences in the EvaluateAsync method) to conform to .NET camelCase naming conventions. This is a pure style fix with no logic changes.

Fixes: #6532 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.；