### PR TITLE
Python: fix: preserve AG-UI snapshot text message IDs

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -678,7 +678,7 @@ def _build_messages_snapshot(
     # Add assistant message with tool calls only (no content)
     if flow.pending_tool_calls:
         tool_call_message = {
-            "id": flow.message_id or generate_event_id(),
+            "id": generate_event_id() if flow.accumulated_text else (flow.message_id or generate_event_id()),
             "role": "assistant",
             "tool_calls": flow.pending_tool_calls.copy(),
         }
@@ -691,10 +691,7 @@ def _build_messages_snapshot(
     # This is a separate message from the tool calls message to maintain
     # the expected AG-UI protocol format (see issue #3619)
     if flow.accumulated_text:
-        # Use a new ID for the content message if we had tool calls (separate message)
-        content_message_id = (
-            generate_event_id() if flow.pending_tool_calls else (flow.message_id or generate_event_id())
-        )
+        content_message_id = flow.message_id or generate_event_id()
         all_messages.append(
             {
                 "id": content_message_id,

--- a/python/packages/ag-ui/tests/ag_ui/test_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run.py
@@ -684,6 +684,8 @@ class TestBuildMessagesSnapshot:
 
         # The text message should have a different ID than the tool call message
         assert assistant_text_msg.id != assistant_tool_msg.id
+        assert assistant_text_msg.id == "msg-123"
+        assert assistant_tool_msg.id != "msg-123"
 
     def test_only_tool_calls_no_text(self):
         """Test snapshot with only tool calls and no accumulated text."""


### PR DESCRIPTION
﻿## Summary
- preserve the streamed text message id when a single assistant turn has both tool calls and trailing text
- give the synthetic tool-call assistant snapshot message a fresh id in the mixed turn case
- add a regression assertion so `MESSAGES_SNAPSHOT` reconciles with the earlier `TEXT_MESSAGE_*` id

Fixes #6266.

## To verify
- `uv run --group dev pytest packages/ag-ui/tests/ag_ui/test_run.py::TestBuildMessagesSnapshot -q`
- `uv run ruff check packages/ag-ui/agent_framework_ag_ui/_agent_run.py packages/ag-ui/tests/ag_ui/test_run.py`
- `uv run python -m py_compile packages/ag-ui/agent_framework_ag_ui/_agent_run.py packages/ag-ui/tests/ag_ui/test_run.py`
- `uv run pyright packages/ag-ui/agent_framework_ag_ui/_agent_run.py`
