### PR TITLE
Python: fix: reject invalid OpenAI response payloads

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1966,6 +1966,17 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         options: dict[str, Any],
     ) -> ChatResponse:
         """Parse an OpenAI Responses API response into a ChatResponse."""
+        if not hasattr(response, "output"):
+            payload = repr(response)
+            if len(payload) > 500:
+                payload = f"{payload[:497]}..."
+            self._handle_request_error(
+                TypeError(
+                    "OpenAI Responses API returned an invalid response object; "
+                    f"expected an object with an 'output' field, got {type(response).__name__}: {payload}"
+                )
+            )
+
         structured_response: BaseModel | None = response.output_parsed if isinstance(response, ParsedResponse) else None  # type: ignore[reportUnknownMemberType]
 
         metadata: dict[str, Any] = response.metadata or {}

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -554,6 +554,34 @@ async def test_response_format_parse_path_with_conversation_id() -> None:
         assert response.model == "test-model"
 
 
+@pytest.mark.parametrize(
+    ("options", "raw_method"),
+    [
+        ({"response_format": OutputStruct}, "parse"),
+        ({}, "create"),
+    ],
+)
+async def test_non_response_payload_raises_actionable_error(options: dict[str, Any], raw_method: str) -> None:
+    """Non-conformant OpenAI-compatible backends should not leak AttributeError."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    raw_response = MagicMock()
+    raw_response.headers = {}
+    raw_response.parse = MagicMock(return_value="backend returned plain text")
+
+    with (
+        patch.object(client.client.responses, raw_method, return_value=raw_response),
+        pytest.raises(ChatClientException) as exc_info,
+    ):
+        await client.get_response(messages=[Message(role="user", contents=["Hi"])], options=options)
+
+    message = str(exc_info.value)
+    assert "invalid response object" in message
+    assert "got str" in message
+    assert "backend returned plain text" in message
+    assert "'str' object has no attribute 'output'" not in message
+
+
 async def test_response_format_dict_parse_path() -> None:
     """Test get_response response_format parsing path for runtime JSON schema mappings."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")


### PR DESCRIPTION
﻿## Summary
- detect non-Response payloads returned by OpenAI-compatible Responses backends before parsing `response.output`
- raise the existing `ChatClientException` path with the payload type and a short payload preview instead of leaking `AttributeError`
- cover both `responses.parse` and `responses.create` raw-response paths

Fixes #6235.

## To verify
- `uv run --group dev pytest packages/openai/tests/openai/test_openai_chat_client.py::test_response_format_parse_path packages/openai/tests/openai/test_openai_chat_client.py::test_response_format_parse_path_with_conversation_id packages/openai/tests/openai/test_openai_chat_client.py::test_non_response_payload_raises_actionable_error -q`
- `uv run ruff check packages/openai/agent_framework_openai/_chat_client.py packages/openai/tests/openai/test_openai_chat_client.py`
- `uv run python -m py_compile packages/openai/agent_framework_openai/_chat_client.py packages/openai/tests/openai/test_openai_chat_client.py`
- `uv run pyright packages/openai/agent_framework_openai/_chat_client.py`
