### PR TITLE
Python: fix: reject invalid chat completion payloads

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_completion_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_completion_client.py
@@ -684,6 +684,18 @@ class RawOpenAIChatCompletionClient(  # type: ignore[misc]
 
     def _parse_response_from_openai(self, response: ChatCompletion, options: Mapping[str, Any]) -> ChatResponse:
         """Parse a response from OpenAI into a ChatResponse."""
+        if not hasattr(response, "choices"):
+            preview = repr(response)
+            if len(preview) > 500:
+                preview = f"{preview[:497]}..."
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid OpenAI Chat Completions API response: "
+                    f"expected an object with 'choices', got {type(response).__name__}: {preview}",
+                    azure_endpoint=self.azure_endpoint,
+                )
+            )
+
         response_metadata = self._get_metadata_from_chat_response(response)
         messages: list[Message] = []
         finish_reason: FinishReason | None = None

--- a/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
@@ -61,6 +61,21 @@ def test_get_response_is_defined_on_openai_class() -> None:
     assert all(parameter.kind != inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
 
 
+def test_parse_response_rejects_non_chat_completion_object() -> None:
+    client = OpenAIChatCompletionClient(model="test-model", api_key="test-key")
+    response: Any = "plain backend error"
+
+    with pytest.raises(ChatClientException) as exc_info:
+        client._parse_response_from_openai(response, options={})
+
+    exception_message = str(exc_info.value)
+    assert "invalid OpenAI Chat Completions API response" in exception_message
+    assert "expected an object with 'choices'" in exception_message
+    assert "got str" in exception_message
+    assert "plain backend error" in exception_message
+    assert "'str' object has no attribute 'system_fingerprint'" not in exception_message
+
+
 def test_init_uses_explicit_parameters() -> None:
     signature = inspect.signature(RawOpenAIChatCompletionClient.__init__)
 


### PR DESCRIPTION
﻿## Summary
- reject non-ChatCompletion payloads before metadata parsing touches `response.system_fingerprint`
- surface a `ChatClientException` with the unexpected payload type and a bounded preview
- add a regression test for the plain-string backend response reported in #6234

Fixes #6234.

## To verify
- `uv run --group dev pytest packages/openai/tests/openai/test_openai_chat_completion_client.py::test_parse_response_rejects_non_chat_completion_object -q`
- `uv run --group dev pytest packages/openai/tests/openai/test_openai_chat_completion_client.py::test_parse_response_rejects_non_chat_completion_object packages/openai/tests/openai/test_openai_chat_completion_client.py::test_parse_response_with_dict_response_format -q`
- `uv run ruff check packages/openai/agent_framework_openai/_chat_completion_client.py packages/openai/tests/openai/test_openai_chat_completion_client.py`
- `uv run python -m py_compile packages/openai/agent_framework_openai/_chat_completion_client.py packages/openai/tests/openai/test_openai_chat_completion_client.py`
- `uv run pyright packages/openai/agent_framework_openai/_chat_completion_client.py`
- `git diff --check`
