### PR TITLE
.NET: feat(Agent Skill Scripts): bubble up error details

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -357,7 +357,7 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         catch (Exception ex)
         {
             LogScriptExecutionError(this._logger, skillName, scriptName, ex);
-            return $"Error: Failed to execute script '{scriptName}' from skill '{skillName}'.";
+            throw;
         }
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -722,6 +722,33 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task RunSkillScript_ExecutorThrows_ExceptionBubblesUpAsync()
+    {
+        // Arrange
+        string skillDir = Path.Combine(this._testRoot, "throw-script-skill");
+        Directory.CreateDirectory(Path.Combine(skillDir, "scripts"));
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), "---\nname: throw-script-skill\ndescription: Test\n---\nBody.");
+        File.WriteAllText(Path.Combine(skillDir, "scripts", "run.py"), "print('hi')");
+
+        var expectedException = new InvalidOperationException("Script execution failed with details the LLM can use to self-correct.");
+        var provider = new AgentSkillsProvider(new AgentFileSkillsSource(this._testRoot,
+            (skill, script, args, sp, ct) => throw expectedException));
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+        var runScriptTool = result.Tools!.First(t => t.Name == "run_skill_script") as AIFunction;
+
+        // Act & Assert — exception must bubble up so the LLM can self-correct from the error details
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            runScriptTool!.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["skillName"] = "throw-script-skill",
+                ["scriptName"] = "scripts/run.py",
+            })).AsTask());
+
+        Assert.Same(expectedException, ex);
+    }
+
+    [Fact]
     public async Task Builder_UseFileScriptRunnerAfterUseFileSkills_RunnerIsUsedAsync()
     {
         // Arrange — create a skill with a script file


### PR DESCRIPTION
### Motivation and Context

Fixes https://github.com/microsoft/agent-framework/issues/6304

`AgentSkillsProvider` provides a `run_skill_script` tool, whose implementation swallows exceptions and never returns the error details to the agent. This prevents the agent from self-correcting itself, because it does not know what failed.

### Description

In Microsoft.Extensions.AI, the behavior of tools regarding errors is configurable with `FunctionInvokingChatClient.IncludeDetailedErrors`: https://github.com/dotnet/extensions/blob/d6451f303b4142f9e6b6706e901dc1e43d12933c/src/Libraries/Microsoft.Extensions.AI/ChatCompletion/FunctionInvokingChatClient.cs#L1269

`run_skill_script` is adjusted to rethrow errors rather than swallowing them, so that users have the opportunity to choose to turn on `FunctionInvokingChatClient.IncludeDetailedErrors` and have the LLM self-correct its errors.

We believe it's not a breaking change, since `FunctionInvokingChatClient.IncludeDetailedErrors` defaults to `false`.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.