### PR TITLE
Exclude dependabot prs as part of the limit

### DIFF
--- a/.github/scripts/pr_limit_moderation.js
+++ b/.github/scripts/pr_limit_moderation.js
@@ -8,6 +8,7 @@ function getPullRequest(context) {
 
   return {
     author: pullRequest.user.login,
+    authorType: pullRequest.user.type,
     labels: pullRequest.labels?.map((label) => label.name).filter(Boolean) ?? [],
     number: pullRequest.number,
   };
@@ -49,6 +50,10 @@ function hasLabel(labels, labelName) {
   return labels.some((label) => label.toLowerCase() === labelName.toLowerCase());
 }
 
+function isDependabotAuthor({ author, authorType }) {
+  return authorType === 'Bot' && author.toLowerCase() === 'dependabot[bot]';
+}
+
 function buildLimitMessage({ author, exemptLabelName, maxOpenPrs, openPrCount }) {
   return [
     `Thank you for your contribution, @${author}.`,
@@ -83,7 +88,17 @@ async function getOpenPrCount({ github, owner, repo, author, pullRequestNumber }
 
 async function enforcePrLimit({ github, context, core, exemptLabelName, maxOpenPrs, labelName }) {
   const { owner, repo } = context.repo;
-  const { author, labels, number } = getPullRequest(context);
+  const { author, authorType, labels, number } = getPullRequest(context);
+
+  if (isDependabotAuthor({ author, authorType })) {
+    core.info(`Author ${author} is Dependabot; skipping open PR limit enforcement.`);
+    return {
+      author,
+      closed: false,
+      dependabotExempt: true,
+      openPrCount: null,
+    };
+  }
 
   if (hasLabel(labels, exemptLabelName)) {
     core.info(`PR #${number} has the ${exemptLabelName} label; skipping open PR limit enforcement.`);

--- a/.github/tests/test_pr_limit_moderation.js
+++ b/.github/tests/test_pr_limit_moderation.js
@@ -16,7 +16,7 @@ const { enforcePrLimit } = require('../scripts/pr_limit_moderation.js');
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createContext({ author = 'community-user', labels = [], number = 123 } = {}) {
+function createContext({ author = 'community-user', authorType = 'User', labels = [], number = 123 } = {}) {
   return {
     repo: {
       owner: 'microsoft',
@@ -28,6 +28,7 @@ function createContext({ author = 'community-user', labels = [], number = 123 } 
         labels: labels.map((name) => ({ name })),
         user: {
           login: author,
+          type: authorType,
         },
       },
     },
@@ -292,6 +293,30 @@ describe('PR limit enforcement', () => {
 
     assert.equal(result.closed, false);
     assert.equal(result.exempt, true);
+    assert.equal(result.openPrCount, null);
+    assert.deepEqual(github.calls, []);
+  });
+
+  it('does not close Dependabot PRs', async () => {
+    const github = createGithub({
+      itemNumbers: [123, ...Array.from({ length: 25 }, (_, index) => index + 1)],
+      pullRequests: createPullRequestPage({
+        author: 'dependabot[bot]',
+        numbers: [123, ...Array.from({ length: 25 }, (_, index) => index + 1)],
+      }),
+    });
+
+    const result = await enforcePrLimit({
+      github,
+      context: createContext({ author: 'dependabot[bot]', authorType: 'Bot' }),
+      core: createCore(),
+      exemptLabelName: 'pr-limit-exempt',
+      maxOpenPrs: 10,
+      labelName: 'too-many-prs',
+    });
+
+    assert.equal(result.closed, false);
+    assert.equal(result.dependabotExempt, true);
     assert.equal(result.openPrCount, null);
     assert.deepEqual(github.calls, []);
   });


### PR DESCRIPTION
### Motivation and Context

Exclude dependabot prs as part of the limit

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

Exclude dependabot prs as part of the limit

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.