### PR TITLE
Python: Fix as_agent function invocation config

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Mapping, MutableMapping, Sequen
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
 from copy import deepcopy
 from functools import partial
+from inspect import signature
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
@@ -40,7 +41,14 @@ from ._sessions import (
     SessionContext,
     is_local_history_conversation_id,
 )
-from ._tools import FunctionInvocationLayer, FunctionTool, ToolTypes, normalize_tools
+from ._tools import (
+    FunctionInvocationConfiguration,
+    FunctionInvocationLayer,
+    FunctionTool,
+    ToolTypes,
+    normalize_function_invocation_configuration,
+    normalize_tools,
+)
 from ._types import (
     AgentResponse,
     AgentResponseUpdate,
@@ -163,6 +171,14 @@ def _sanitize_agent_name(agent_name: str | None) -> str | None:
     return sanitized
 
 
+def _accepts_function_invocation_configuration(client: SupportsChatGetResponse[Any]) -> bool:
+    """Return whether the client's get_response accepts per-call function invocation config."""
+    try:
+        return "function_invocation_configuration" in signature(client.get_response).parameters
+    except (TypeError, ValueError):
+        return False
+
+
 class _RunContext(TypedDict):
     session: AgentSession | None
     session_context: SessionContext
@@ -174,6 +190,7 @@ class _RunContext(TypedDict):
     compaction_strategy: CompactionStrategy | None
     tokenizer: TokenizerProtocol | None
     client_kwargs: Mapping[str, Any]
+    function_invocation_configuration: FunctionInvocationConfiguration
     function_invocation_kwargs: Mapping[str, Any]
 
 
@@ -669,6 +686,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         context_providers: Sequence[ContextProvider] | None = None,
         middleware: Sequence[MiddlewareTypes] | None = None,
         require_per_service_call_history_persistence: bool = False,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         additional_properties: MutableMapping[str, Any] | None = None,
@@ -691,6 +709,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
                 is not already storing history. If service-side storage is active for
                 the run, the agent skips local history providers and relies on the
                 service-managed conversation instead.
+            function_invocation_configuration: Optional agent-level function invocation configuration.
             default_options: A TypedDict containing chat options. When using a typed agent like
                 ``Agent[OpenAIChatOptions]``, this enables IDE autocomplete for
                 provider-specific options including temperature, max_tokens, model,
@@ -724,6 +743,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         self.compaction_strategy = compaction_strategy
         self.require_per_service_call_history_persistence = require_per_service_call_history_persistence
         self.tokenizer = tokenizer
+        self.function_invocation_configuration = normalize_function_invocation_configuration(
+            function_invocation_configuration
+        )
 
         # Get tools from options or named parameter (named param takes precedence)
         tools_ = tools if tools is not None else opts.pop("tools", None)
@@ -989,8 +1011,14 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         stream: bool,
     ) -> Awaitable[ChatResponse[Any]] | ResponseStream[ChatResponseUpdate, ChatResponse[Any]]:
         """Invoke the downstream chat client for a prepared run context."""
+        function_invocation_configuration_kwargs: dict[str, Any] = {}
+        if isinstance(self.client, FunctionInvocationLayer) and _accepts_function_invocation_configuration(self.client):
+            function_invocation_configuration_kwargs["function_invocation_configuration"] = context[
+                "function_invocation_configuration"
+            ]
+
         if stream:
-            return self.client.get_response(  # type: ignore[call-overload, no-any-return]
+            return cast(Any, self.client).get_response(
                 messages=context["session_messages"],
                 stream=True,
                 options=context["chat_options"],  # type: ignore[reportArgumentType]
@@ -998,9 +1026,10 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
                 tokenizer=context["tokenizer"],
                 function_invocation_kwargs=context["function_invocation_kwargs"],
                 client_kwargs=context["client_kwargs"],
+                **function_invocation_configuration_kwargs,
             )
 
-        return self.client.get_response(  # type: ignore[call-overload, no-any-return]
+        return cast(Any, self.client).get_response(
             messages=context["session_messages"],
             stream=False,
             options=context["chat_options"],  # type: ignore[reportArgumentType]
@@ -1008,6 +1037,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
             tokenizer=context["tokenizer"],
             function_invocation_kwargs=context["function_invocation_kwargs"],
             client_kwargs=context["client_kwargs"],
+            **function_invocation_configuration_kwargs,
         )
 
     async def _parse_non_streaming_response(
@@ -1324,6 +1354,7 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
             "compaction_strategy": compaction_strategy or self.compaction_strategy,
             "tokenizer": tokenizer or self.tokenizer,
             "client_kwargs": effective_client_kwargs,
+            "function_invocation_configuration": self.function_invocation_configuration,
             "function_invocation_kwargs": additional_function_arguments,
         }
 
@@ -1689,6 +1720,7 @@ class Agent(
         context_providers: Sequence[ContextProvider] | None = None,
         middleware: Sequence[MiddlewareTypes] | None = None,
         require_per_service_call_history_persistence: bool = False,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         additional_properties: MutableMapping[str, Any] | None = None,
@@ -1705,6 +1737,7 @@ class Agent(
             context_providers=context_providers,
             middleware=middleware,
             require_per_service_call_history_persistence=require_per_service_call_history_persistence,
+            function_invocation_configuration=function_invocation_configuration,
             compaction_strategy=compaction_strategy,
             tokenizer=tokenizer,
             additional_properties=additional_properties,

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -2294,6 +2294,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         function_invocation_kwargs: Mapping[str, Any] | None = None,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         client_kwargs: Mapping[str, Any] | None = None,
     ) -> Awaitable[ChatResponse[ResponseModelBoundT]]: ...
 
@@ -2308,6 +2309,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         function_invocation_kwargs: Mapping[str, Any] | None = None,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         client_kwargs: Mapping[str, Any] | None = None,
     ) -> Awaitable[ChatResponse[Any]]: ...
 
@@ -2322,6 +2324,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         function_invocation_kwargs: Mapping[str, Any] | None = None,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         client_kwargs: Mapping[str, Any] | None = None,
     ) -> ResponseStream[ChatResponseUpdate, ChatResponse[Any]]: ...
 
@@ -2335,6 +2338,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         compaction_strategy: CompactionStrategy | None = None,
         tokenizer: TokenizerProtocol | None = None,
         function_invocation_kwargs: Mapping[str, Any] | None = None,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         client_kwargs: Mapping[str, Any] | None = None,
     ) -> Awaitable[ChatResponse[Any]] | ResponseStream[ChatResponseUpdate, ChatResponse[Any]]:
         from ._middleware import categorize_middleware
@@ -2358,11 +2362,16 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                 *middleware,
             ]
         runtime_middleware = categorize_middleware(effective_client_kwargs.pop("middleware", []))
+        effective_function_invocation_configuration = (
+            normalize_function_invocation_configuration(function_invocation_configuration)
+            if function_invocation_configuration is not None
+            else self.function_invocation_configuration
+        )
 
         function_middleware_pipeline = self._get_function_middleware_pipeline(runtime_middleware["function"])
         if runtime_middleware["chat"]:
             effective_client_kwargs["middleware"] = runtime_middleware["chat"]
-        max_errors = self.function_invocation_configuration.get(
+        max_errors = effective_function_invocation_configuration.get(
             "max_consecutive_errors_per_request", DEFAULT_MAX_CONSECUTIVE_ERRORS_PER_REQUEST
         )
         additional_function_arguments = (
@@ -2377,7 +2386,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         execute_function_calls = partial(
             _execute_function_calls,
             custom_args=additional_function_arguments,
-            config=self.function_invocation_configuration,
+            config=effective_function_invocation_configuration,
             invocation_session=invocation_session,
             middleware_pipeline=function_middleware_pipeline,
         )
@@ -2388,7 +2397,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
         # Remove additional_function_arguments from options passed to underlying chat client
         # It's for tool invocation only and not recognized by chat service APIs
         mutable_options.pop("additional_function_arguments", None)
-        if not self.function_invocation_configuration.get("enabled", True):
+        if not effective_function_invocation_configuration.get("enabled", True):
             return super_get_response(  # type: ignore[no-any-return]
                 messages=messages,
                 stream=stream,
@@ -2412,14 +2421,16 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                 nonlocal filtered_kwargs
                 errors_in_a_row: int = 0
                 total_function_calls: int = 0
-                max_function_calls: int | None = self.function_invocation_configuration.get("max_function_calls")
+                max_function_calls: int | None = effective_function_invocation_configuration.get("max_function_calls")
                 prepped_messages = list(messages)
                 fcc_messages: list[Message] = []
                 response: ChatResponse[Any] | None = None
                 aggregated_usage: UsageDetails | None = None
 
-                loop_enabled = self.function_invocation_configuration.get("enabled", True)
-                max_iterations = self.function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+                loop_enabled = effective_function_invocation_configuration.get("enabled", True)
+                max_iterations = effective_function_invocation_configuration.get(
+                    "max_iterations", DEFAULT_MAX_ITERATIONS
+                )
                 for attempt_idx in range(max_iterations if loop_enabled else 0):
                     approval_result = await _process_function_requests(
                         response=None,
@@ -2509,10 +2520,10 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                 # Make a final model call with tool_choice="none" so the model
                 # produces a plain text answer instead of leaving orphaned
                 # function_call items without matching results.
-                if response is not None and self.function_invocation_configuration.get("enabled", True):
+                if response is not None and effective_function_invocation_configuration.get("enabled", True):
                     logger.info(
                         "Maximum iterations reached (%d). Requesting final response without tools.",
-                        self.function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+                        effective_function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS),
                     )
                 mutable_options["tool_choice"] = "none"
                 response = cast(
@@ -2550,13 +2561,13 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
             nonlocal stream_result_hooks
             errors_in_a_row: int = 0
             total_function_calls: int = 0
-            max_function_calls: int | None = self.function_invocation_configuration.get("max_function_calls")
+            max_function_calls: int | None = effective_function_invocation_configuration.get("max_function_calls")
             prepped_messages = list(messages)
             fcc_messages: list[Message] = []
             response: ChatResponse[Any] | None = None
 
-            loop_enabled = self.function_invocation_configuration.get("enabled", True)
-            max_iterations = self.function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            loop_enabled = effective_function_invocation_configuration.get("enabled", True)
+            max_iterations = effective_function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS)
             for attempt_idx in range(max_iterations if loop_enabled else 0):
                 approval_result = await _process_function_requests(
                     response=None,
@@ -2667,10 +2678,10 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
             # Make a final model call with tool_choice="none" so the model
             # produces a plain text answer instead of leaving orphaned
             # function_call items without matching results.
-            if response is not None and self.function_invocation_configuration.get("enabled", True):
+            if response is not None and effective_function_invocation_configuration.get("enabled", True):
                 logger.info(
                     "Maximum iterations reached (%d). Requesting final response without tools.",
-                    self.function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+                    effective_function_invocation_configuration.get("max_iterations", DEFAULT_MAX_ITERATIONS),
                 )
             mutable_options["tool_choice"] = "none"
             final_inner_stream = cast(

--- a/python/packages/core/tests/core/test_clients.py
+++ b/python/packages/core/tests/core/test_clients.py
@@ -77,6 +77,31 @@ async def test_base_client_get_response_uses_explicit_client_kwargs(chat_client_
         mock_inner_get_response.assert_called_once()
 
 
+async def test_base_client_as_agent_forwards_function_invocation_configuration(
+    chat_client_base: SupportsChatGetResponse,
+) -> None:
+    captured_config: dict[str, Any] = {}
+
+    async def fake_get_response(
+        *,
+        function_invocation_configuration: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> ChatResponse:
+        assert function_invocation_configuration is not None
+        captured_config.update(function_invocation_configuration)
+        return ChatResponse(messages=[Message(role="assistant", contents=["ok"])])
+
+    chat_client_base.get_response = fake_get_response  # type: ignore[method-assign,attr-defined]
+
+    agent = chat_client_base.as_agent(function_invocation_configuration={"include_detailed_errors": True})
+
+    await agent.run("hello")
+
+    assert captured_config["include_detailed_errors"] is True
+    assert captured_config["enabled"] is True
+    assert chat_client_base.function_invocation_configuration["include_detailed_errors"] is False  # type: ignore[attr-defined]
+
+
 async def test_base_client_get_response(chat_client_base: SupportsChatGetResponse):
     response = await chat_client_base.get_response([Message(role="user", contents=["Hello"])])
     assert response.messages[0].role == "assistant"


### PR DESCRIPTION
### Motivation and Context

Fixes #6313.

`BaseChatClient.as_agent()` accepts `function_invocation_configuration`, but passing it currently raises `Agent.__init__() got an unexpected keyword argument 'function_invocation_configuration'` before an agent can be created.

### Description

- Add agent-level function invocation configuration support to `RawAgent` and `Agent`.
- Forward the normalized agent-level config to clients whose `get_response()` accepts a per-call function invocation override, without mutating shared client defaults.
- Use a per-call effective configuration inside `FunctionInvocationLayer.get_response()`.
- Add a regression test for `as_agent(function_invocation_configuration=...)`.

Focused local tests for core clients, agents, and function invocation passed, and targeted Ruff format/lint checks passed. A local `pyright -P core` run is blocked in this environment by missing optional OTLP exporter imports in `observability.py`.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
