### PR TITLE
.NET: Fix typo in XML doc comment for workflow outputs param

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs
@@ -23,7 +23,7 @@ public static class WorkflowHostingExtensions
     /// <param name="includeExceptionDetails">If <see langword="true"/>, will include <see cref="System.Exception.Message"/>
     /// in the <see cref="ErrorContent"/> representing the workflow error.</param>
     /// <param name="includeWorkflowOutputsInResponse">If <see langword="true"/>, will transform outgoing workflow outputs
-    /// into into content in <see cref="AgentResponseUpdate"/>s or the <see cref="AgentResponse"/> as appropriate.</param>
+    /// into content in <see cref="AgentResponseUpdate"/>s or the <see cref="AgentResponse"/> as appropriate.</param>
     /// <returns></returns>
     public static AIAgent AsAIAgent(
         this Workflow workflow,


### PR DESCRIPTION
Corrected a duplicated word (_into into_) in the XML documentation of [WorkflowHostingExtensions.cs](https://github.com/microsoft/agent-framework/blob/dotnet-1.9.0/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowHostingExtensions.cs#L25-L26) file for the `includeWorkflowOutputsInResponse` parameter.

Fixes #6325

