### PR TITLE
Python: fix(python): emit per-tool otel definitions

### DIFF
--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -2129,7 +2129,7 @@ OTEL_ATTR_MAP: dict[str | tuple[str, ...], tuple[str, Callable[[Any], Any] | Non
     "tools": (
         OtelAttr.TOOL_DEFINITIONS,
         lambda tools: (
-            json.dumps(tools_dict, ensure_ascii=False)
+            [json.dumps(tool_dict, ensure_ascii=False) for tool_dict in tools_dict]
             if (tools_dict := __import__("agent_framework._tools", fromlist=["_tools_to_dict"])._tools_to_dict(tools))
             else None
         ),

--- a/python/packages/core/tests/core/test_observability.py
+++ b/python/packages/core/tests/core/test_observability.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import json
 import logging
 from collections.abc import AsyncIterable, Awaitable, MutableSequence, Sequence
 from typing import Any
@@ -235,6 +236,45 @@ async def test_chat_client_observability_accepts_model_option(
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes[OtelAttr.REQUEST_MODEL] == "Test"
+
+
+async def test_chat_client_observability_emits_per_tool_definitions(
+    mock_chat_client, span_exporter: InMemorySpanExporter
+):
+    @tool(name="weather_tool", description="Gets weather")
+    def weather_tool(location: str) -> str:
+        return f"Weather for {location}"
+
+    @tool(name="time_tool", description="Gets time")
+    def time_tool(city: str) -> str:
+        return f"Time in {city}"
+
+    client = mock_chat_client()
+    messages = [Message(role="user", contents=["Test message"])]
+    span_exporter.clear()
+
+    await client.get_response(
+        messages=messages,
+        options={"model": "Test"},
+        client_kwargs={"tools": [weather_tool, time_tool]},
+    )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes is not None
+    tool_definitions = attributes[OtelAttr.TOOL_DEFINITIONS]
+    assert isinstance(tool_definitions, tuple)
+    assert len(tool_definitions) == 2
+
+    tool_definition_strings: list[str] = []
+    for tool_definition in tool_definitions:
+        assert isinstance(tool_definition, str)
+        tool_definition_strings.append(tool_definition)
+
+    tools = [json.loads(tool_definition) for tool_definition in tool_definition_strings]
+    assert [tool["function"]["name"] for tool in tools] == ["weather_tool", "time_tool"]
+    assert all(tool["type"] == "function" for tool in tools)
 
 
 @pytest.mark.parametrize("enable_sensitive_data", [True, False], indirect=True)


### PR DESCRIPTION
## Summary

Fixes the Python telemetry value for `gen_ai.tool.definitions` so each tool is emitted as its own JSON string instead of serializing the whole tools array into one JSON blob.

Aspire and other GenAI telemetry viewers expect this attribute to be a sequence of per-tool JSON strings. With the current single-blob value, the raw data is present on the span, but the structured Tools view cannot recover tool names, descriptions, or parameters.

## Details

- Keeps the existing `_tools_to_dict()` conversion path.
- Serializes each tool dictionary separately with `ensure_ascii=False`.
- Adds regression coverage that verifies the emitted attribute is a list and that each element parses back to one tool definition.

Fixes #6300.

## Validation

Ran from `python/packages/core` on Windows:

```bash
uv run pytest tests\core\test_observability.py -q
uv run ruff check agent_framework\observability.py tests\core\test_observability.py
uv run ruff format --check agent_framework\observability.py tests\core\test_observability.py
python -m py_compile agent_framework\observability.py tests\core\test_observability.py
git diff --check upstream/main..HEAD
```
