### PR TITLE
Python: fix(python): preserve AG-UI snapshot text IDs

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -678,7 +678,7 @@ def _build_messages_snapshot(
     # Add assistant message with tool calls only (no content)
     if flow.pending_tool_calls:
         tool_call_message = {
-            "id": flow.message_id or generate_event_id(),
+            "id": generate_event_id() if flow.accumulated_text else (flow.message_id or generate_event_id()),
             "role": "assistant",
             "tool_calls": flow.pending_tool_calls.copy(),
         }
@@ -691,10 +691,7 @@ def _build_messages_snapshot(
     # This is a separate message from the tool calls message to maintain
     # the expected AG-UI protocol format (see issue #3619)
     if flow.accumulated_text:
-        # Use a new ID for the content message if we had tool calls (separate message)
-        content_message_id = (
-            generate_event_id() if flow.pending_tool_calls else (flow.message_id or generate_event_id())
-        )
+        content_message_id = flow.message_id or generate_event_id()
         all_messages.append(
             {
                 "id": content_message_id,

--- a/python/packages/ag-ui/tests/ag_ui/test_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run.py
@@ -684,6 +684,8 @@ class TestBuildMessagesSnapshot:
 
         # The text message should have a different ID than the tool call message
         assert assistant_text_msg.id != assistant_tool_msg.id
+        assert assistant_text_msg.id == "msg-123"
+        assert assistant_tool_msg.id != "msg-123"
 
     def test_only_tool_calls_no_text(self):
         """Test snapshot with only tool calls and no accumulated text."""


### PR DESCRIPTION
## Summary

Preserve the streamed assistant text message ID in `MESSAGES_SNAPSHOT` when an AG-UI turn contains both tool calls and trailing assistant text.

Previously `_build_messages_snapshot` reused `flow.message_id` for the tool-call assistant message, then generated a fresh ID for the text message. In a mixed turn, `flow.message_id` belongs to the streamed text, so clients that reconcile by message ID see the final snapshot as a different text message.

## Details

- Tool-call-only turns keep the existing behavior.
- Mixed tool-call + text turns give the tool-call message a generated ID and keep `flow.message_id` on the text message.
- Extends the existing snapshot unit test to assert both sides of that ID split.

Fixes #6266.

## Validation

Ran from `python/packages/ag-ui` on Windows:

```bash
uv run --extra dev pytest tests\ag_ui\test_run.py::TestBuildMessagesSnapshot -q
uv run ruff check agent_framework_ag_ui\_agent_run.py tests\ag_ui\test_run.py
uv run ruff format --check agent_framework_ag_ui\_agent_run.py tests\ag_ui\test_run.py
python -m py_compile agent_framework_ag_ui\_agent_run.py tests\ag_ui\test_run.py
```

I also ran the full `tests\ag_ui\test_run.py`; the synchronous tests passed, but 10 async tests failed because this local environment does not have a pytest async plugin installed (`pytest-asyncio` / equivalent). The direct snapshot regression class passes.
