### PR TITLE
Python: fix(python): reject invalid OpenAI provider responses

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1992,6 +1992,18 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         options: dict[str, Any],
     ) -> ChatResponse:
         """Parse an OpenAI Responses API response into a ChatResponse."""
+        if not hasattr(response, "output"):
+            preview = repr(response)
+            if len(preview) > 500:
+                preview = f"{preview[:500]}..."
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid OpenAI Responses API response: "
+                    f"expected an object with 'output', got {type(response).__name__}: {preview}",
+                    azure_endpoint=self.azure_endpoint,
+                )
+            )
+
         structured_response: BaseModel | None = response.output_parsed if isinstance(response, ParsedResponse) else None  # type: ignore[reportUnknownMemberType]
 
         metadata: dict[str, Any] = response.metadata or {}

--- a/python/packages/openai/agent_framework_openai/_chat_completion_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_completion_client.py
@@ -684,6 +684,18 @@ class RawOpenAIChatCompletionClient(  # type: ignore[misc]
 
     def _parse_response_from_openai(self, response: ChatCompletion, options: Mapping[str, Any]) -> ChatResponse:
         """Parse a response from OpenAI into a ChatResponse."""
+        if not hasattr(response, "choices"):
+            preview = repr(response)
+            if len(preview) > 500:
+                preview = f"{preview[:500]}..."
+            raise ChatClientException(
+                maybe_append_azure_endpoint_guidance(
+                    f"{type(self)} service returned an invalid OpenAI Chat Completions API response: "
+                    f"expected an object with 'choices', got {type(response).__name__}: {preview}",
+                    azure_endpoint=self.azure_endpoint,
+                )
+            )
+
         response_metadata = self._get_metadata_from_chat_response(response)
         messages: list[Message] = []
         finish_reason: FinishReason | None = None

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -574,6 +574,33 @@ async def test_response_format_parse_path_with_conversation_id() -> None:
         assert response.model == "test-model"
 
 
+@pytest.mark.parametrize(
+    ("options", "raw_method"),
+    [
+        ({"response_format": OutputStruct}, "parse"),
+        ({}, "create"),
+    ],
+)
+async def test_non_response_payload_raises_actionable_error(options: dict[str, Any], raw_method: str) -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    raw_response = MagicMock()
+    raw_response.headers = {}
+    raw_response.parse = MagicMock(return_value="backend returned plain text")
+
+    with (
+        patch.object(client.client.responses, raw_method, return_value=raw_response),
+        pytest.raises(ChatClientException) as exc_info,
+    ):
+        await client.get_response(messages=[Message(role="user", contents=["Hi"])], options=options)
+
+    message = str(exc_info.value)
+    assert "invalid OpenAI Responses API response" in message
+    assert "got str" in message
+    assert "backend returned plain text" in message
+    assert "'str' object has no attribute 'output'" not in message
+
+
 async def test_response_format_dict_parse_path() -> None:
     """Test get_response response_format parsing path for runtime JSON schema mappings."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")
@@ -3628,6 +3655,19 @@ async def test_service_response_exception_includes_original_error_details() -> N
     exception_message = str(exc_info.value)
     assert "service failed to complete the prompt:" in exception_message
     assert original_error_message in exception_message
+
+
+def test_parse_response_rejects_non_openai_response_object() -> None:
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+    response: Any = "plain backend error"
+
+    with pytest.raises(ChatClientException) as exc_info:
+        client._parse_response_from_openai(response, options={})
+
+    exception_message = str(exc_info.value)
+    assert "invalid OpenAI Responses API response" in exception_message
+    assert "expected an object with 'output'" in exception_message
+    assert "plain backend error" in exception_message
 
 
 async def test_get_response_streaming_with_response_format() -> None:

--- a/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
@@ -61,6 +61,19 @@ def test_get_response_is_defined_on_openai_class() -> None:
     assert all(parameter.kind != inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
 
 
+def test_parse_response_rejects_non_chat_completion_object() -> None:
+    client = OpenAIChatCompletionClient(model="test-model", api_key="test-key")
+    response: Any = "plain backend error"
+
+    with pytest.raises(ChatClientException) as exc_info:
+        client._parse_response_from_openai(response, options={})
+
+    exception_message = str(exc_info.value)
+    assert "invalid OpenAI Chat Completions API response" in exception_message
+    assert "expected an object with 'choices'" in exception_message
+    assert "plain backend error" in exception_message
+
+
 def test_init_uses_explicit_parameters() -> None:
     signature = inspect.signature(RawOpenAIChatCompletionClient.__init__)
 


### PR DESCRIPTION
## Summary

Raise clear `ChatClientException`s when an OpenAI-compatible backend returns a non-OpenAI response object on either Python OpenAI client path.

The current code assumes the parsed payload is a proper OpenAI object and can leak internal `AttributeError`s such as `'str' object has no attribute 'system_fingerprint'` or `'str' object has no attribute 'output'`. This makes proxy/gateway failures hard to diagnose.

## Details

- Guards the Responses API parser before reading `response.output`.
- Guards the Chat Completions parser before reading `response.choices` / metadata.
- Includes a short preview of the invalid payload in the actionable error, capped to avoid dumping huge responses.
- Adds direct parser regression coverage and `get_response` coverage for both `responses.parse` and `responses.create` returning a plain string.

Fixes #6234.
Fixes #6235.

## Validation

Ran from `python/packages/openai` on Windows:

```bash
uv run pytest tests\openai\test_openai_chat_client.py::test_parse_response_rejects_non_openai_response_object tests\openai\test_openai_chat_client.py::test_non_response_payload_raises_actionable_error tests\openai\test_openai_chat_completion_client.py::test_parse_response_rejects_non_chat_completion_object -q
uv run ruff check agent_framework_openai\_chat_client.py agent_framework_openai\_chat_completion_client.py tests\openai\test_openai_chat_client.py tests\openai\test_openai_chat_completion_client.py
uv run ruff format --check agent_framework_openai\_chat_client.py agent_framework_openai\_chat_completion_client.py tests\openai\test_openai_chat_client.py tests\openai\test_openai_chat_completion_client.py
python -m py_compile agent_framework_openai\_chat_client.py agent_framework_openai\_chat_completion_client.py tests\openai\test_openai_chat_client.py tests\openai\test_openai_chat_completion_client.py
git diff --check upstream/main..HEAD
```
