### PR TITLE
Python: guard invalid OpenAI response payloads

### DIFF
--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -1992,6 +1992,17 @@ class RawOpenAIChatClient(  # type: ignore[misc]
         options: dict[str, Any],
     ) -> ChatResponse:
         """Parse an OpenAI Responses API response into a ChatResponse."""
+        if not hasattr(response, "output"):
+            payload = repr(response)
+            if len(payload) > 500:
+                payload = f"{payload[:497]}..."
+            self._handle_request_error(
+                TypeError(
+                    "OpenAI Responses API returned an invalid response object; "
+                    f"expected an object with an 'output' field, got {type(response).__name__}: {payload}"
+                )
+            )
+
         structured_response: BaseModel | None = response.output_parsed if isinstance(response, ParsedResponse) else None  # type: ignore[reportUnknownMemberType]
 
         metadata: dict[str, Any] = response.metadata or {}

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -574,6 +574,34 @@ async def test_response_format_parse_path_with_conversation_id() -> None:
         assert response.model == "test-model"
 
 
+@pytest.mark.parametrize(
+    ("options", "raw_method"),
+    [
+        ({"response_format": OutputStruct}, "parse"),
+        ({}, "create"),
+    ],
+)
+async def test_non_response_payload_raises_actionable_error(options: dict[str, Any], raw_method: str) -> None:
+    """Non-conformant OpenAI-compatible backends should not leak AttributeError."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    raw_response = MagicMock()
+    raw_response.headers = {}
+    raw_response.parse = MagicMock(return_value="backend returned plain text")
+
+    with (
+        patch.object(client.client.responses, raw_method, return_value=raw_response),
+        pytest.raises(ChatClientException) as exc_info,
+    ):
+        await client.get_response(messages=[Message(role="user", contents=["Hi"])], options=options)
+
+    message = str(exc_info.value)
+    assert "invalid response object" in message
+    assert "got str" in message
+    assert "backend returned plain text" in message
+    assert "'str' object has no attribute 'output'" not in message
+
+
 async def test_response_format_dict_parse_path() -> None:
     """Test get_response response_format parsing path for runtime JSON schema mappings."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")


### PR DESCRIPTION
Fixes #6235.

## Summary

`OpenAIChatClient` assumed that the value returned by the OpenAI Responses API helpers was always a response object. Some OpenAI-compatible backends can return a plain string or another non-conformant payload from the `raw_response.parse()` path, which then leaked as an unhelpful `AttributeError`.

This patch adds a small guard before parsing response metadata/output. If the payload does not look like a Responses API object, the client now raises the existing `ChatClientException` path with an actionable message that includes the unexpected type and a bounded payload preview.

## Validation

```console
$env:PYTHONPATH='C:\dev\GITHUB-clean\agent-framework-6235\python\packages\openai;C:\dev\GITHUB-clean\agent-framework-6235\python\packages\core'
python -m pytest packages\openai\tests\openai\test_openai_chat_client.py -q -k non_response_payload_raises_actionable_error
python -m py_compile packages\openai\agent_framework_openai\_chat_client.py packages\openai\tests\openai\test_openai_chat_client.py
git diff --check upstream/main...HEAD
```
