### PR TITLE
Python: preserve AG-UI snapshot text message IDs

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -678,7 +678,7 @@ def _build_messages_snapshot(
     # Add assistant message with tool calls only (no content)
     if flow.pending_tool_calls:
         tool_call_message = {
-            "id": flow.message_id or generate_event_id(),
+            "id": generate_event_id() if flow.accumulated_text else (flow.message_id or generate_event_id()),
             "role": "assistant",
             "tool_calls": flow.pending_tool_calls.copy(),
         }
@@ -691,10 +691,7 @@ def _build_messages_snapshot(
     # This is a separate message from the tool calls message to maintain
     # the expected AG-UI protocol format (see issue #3619)
     if flow.accumulated_text:
-        # Use a new ID for the content message if we had tool calls (separate message)
-        content_message_id = (
-            generate_event_id() if flow.pending_tool_calls else (flow.message_id or generate_event_id())
-        )
+        content_message_id = flow.message_id or generate_event_id()
         all_messages.append(
             {
                 "id": content_message_id,

--- a/python/packages/ag-ui/tests/ag_ui/test_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run.py
@@ -684,6 +684,8 @@ class TestBuildMessagesSnapshot:
 
         # The text message should have a different ID than the tool call message
         assert assistant_text_msg.id != assistant_tool_msg.id
+        assert assistant_text_msg.id == "msg-123"
+        assert assistant_tool_msg.id != "msg-123"
 
     def test_only_tool_calls_no_text(self):
         """Test snapshot with only tool calls and no accumulated text."""


### PR DESCRIPTION
Fixes #6266.

## Summary

Mixed AG-UI assistant turns can contain both pending tool calls and streamed text. The snapshot builder was assigning the streamed message id to the tool-call-only assistant message, then minting a new id for the actual text message. That makes `MessagesSnapshotEvent` disagree with the streamed text lifecycle.

This keeps the existing split-message shape, but preserves `flow.message_id` for the accumulated text message. When a separate tool-call assistant message is needed, it now gets its own generated id.

## Validation

```console
python -m pip install "ag-ui-protocol>=0.1.16,<0.2"
$env:PYTHONPATH='C:\dev\GITHUB-clean\agent-framework-6266\python\packages\ag-ui;C:\dev\GITHUB-clean\agent-framework-6266\python\packages\core'
python -m pytest packages\ag-ui\tests\ag_ui\test_run.py -q -k "BuildMessagesSnapshot"
python -m py_compile packages\ag-ui\agent_framework_ag_ui\_agent_run.py packages\ag-ui\tests\ag_ui\test_run.py
git diff --check upstream/main...HEAD
```
