### PR TITLE
.NET: Fix single-column value unwrap in declarative workflow

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/ForeachExecutor.cs
@@ -49,7 +49,7 @@ internal sealed class ForeachExecutor : DeclarativeActionExecutor<Foreach>
         EvaluationResult<DataValue> expressionResult = this.Evaluator.GetValue(this.Model.Items);
         if (expressionResult.Value is TableDataValue tableValue)
         {
-            this._values = [.. tableValue.Values.Select(value => value.ToFormula())];
+            this._values = [.. tableValue.Values.Select(ToLoopValue)];
         }
         else
         {
@@ -98,6 +98,15 @@ internal sealed class ForeachExecutor : DeclarativeActionExecutor<Foreach>
             await context.QueueStateResetAsync(this.Model.Index, cancellationToken).ConfigureAwait(false);
         }
     }
+
+    // Power Fx wraps scalar array literals (`=[1, 2, 3]`) as `Table({Value: 1}, ...)`. Unwrap that single-column
+    // `Value`-record shape so `Local.LoopValue` is the scalar; multi-field and other shapes pass through unchanged.
+    private static FormulaValue ToLoopValue(DataValue value) =>
+        value is RecordDataValue record
+            && record.Properties.Count == 1
+            && record.Properties.TryGetValue("Value", out DataValue? singleColumn)
+                ? singleColumn.ToFormula()
+                : value.ToFormula();
 
     /// <inheritdoc/>
     /// <remarks>

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
@@ -202,6 +202,35 @@ public sealed class ForeachExecutorTest(ITestOutputHelper output) : WorkflowActi
         Assert.Equal(1m, currentValue.ToObject());
     }
 
+    /// <summary>
+    /// Single-field records whose only field is NOT named <c>Value</c> are not Power Fx auto-wraps;
+    /// they are preserved as records so the field name remains accessible inside the loop body.
+    /// </summary>
+    [Fact]
+    public async Task ForeachTakeNextWithSingleFieldNonValueRecordAsync()
+    {
+        // Arrange
+        const string CurrentValueName = "CurrentValue";
+        this.SetVariableState(CurrentValueName);
+
+        TableDataValue tableValue = DataValue.TableFromRecords(
+            DataValue.RecordFromFields(new KeyValuePair<string, DataValue>("name", new StringDataValue("Alice"))));
+
+        Foreach model = this.CreateModel(
+            displayName: nameof(ForeachTakeNextWithSingleFieldNonValueRecordAsync),
+            items: ValueExpression.Literal(tableValue),
+            valueName: CurrentValueName,
+            indexName: null);
+        ForeachExecutor action = new(model, this.State);
+
+        // Act
+        await this.ExecuteAsync(action, ForeachExecutor.Steps.Next(action.Id), action.TakeNextAsync);
+
+        // Assert
+        RecordValue currentValue = Assert.IsType<RecordValue>(this.State.Get(CurrentValueName), exactMatch: false);
+        Assert.Equal("Alice", currentValue.GetField("name").ToObject());
+    }
+
     [Fact]
     public async Task ForeachTakeLastAsync()
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/ForeachExecutorTest.cs
@@ -170,6 +170,38 @@ public sealed class ForeachExecutorTest(ITestOutputHelper output) : WorkflowActi
         Assert.Equal("Engineer", currentValue.GetField("role").ToObject());
     }
 
+    /// <summary>
+    /// Power Fx wraps scalar array literals such as <c>=[1, 2, 3]</c> as <c>Table({Value: 1}, ...)</c>;
+    /// the loop value must expose the bare scalar, not the single-column wrapper record.
+    /// </summary>
+    [Fact]
+    public async Task ForeachTakeNextWithSingleColumnValueRecordAsync()
+    {
+        // Arrange
+        const string CurrentValueName = "CurrentValue";
+        this.SetVariableState(CurrentValueName);
+
+        TableDataValue tableValue = DataValue.TableFromRecords(
+            DataValue.RecordFromFields(new KeyValuePair<string, DataValue>("Value", new NumberDataValue(1))),
+            DataValue.RecordFromFields(new KeyValuePair<string, DataValue>("Value", new NumberDataValue(2))),
+            DataValue.RecordFromFields(new KeyValuePair<string, DataValue>("Value", new NumberDataValue(3))));
+
+        Foreach model = this.CreateModel(
+            displayName: nameof(ForeachTakeNextWithSingleColumnValueRecordAsync),
+            items: ValueExpression.Literal(tableValue),
+            valueName: CurrentValueName,
+            indexName: null);
+        ForeachExecutor action = new(model, this.State);
+
+        // Act
+        await this.ExecuteAsync(action, ForeachExecutor.Steps.Next(action.Id), action.TakeNextAsync);
+
+        // Assert
+        FormulaValue currentValue = this.State.Get(CurrentValueName);
+        Assert.IsNotType<RecordValue>(currentValue, exactMatch: false);
+        Assert.Equal(1m, currentValue.ToObject());
+    }
+
     [Fact]
     public async Task ForeachTakeLastAsync()
     {


### PR DESCRIPTION
### Motivation and Context

Power Fx wraps scalar array literals like =[1, 2, 3] as Table({Value: 1}, {Value: 2}, {Value: 3}).

This PR preserves the multi-field fix and additionally unwraps the single-column {Value: ...} shape so `Local.LoopValue` reads as the scalar the author wrote. Mirrors the convention already applied in `DataValueExtensions.ToObject`.

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.