### PR TITLE
.NET: Support sub agent request approval passthrough and recovery

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
@@ -331,14 +331,22 @@ public abstract partial class AIAgent
     /// System-role messages must be developer-controlled and should never contain end-user input.
     /// </para>
     /// </remarks>
-    public Task<AgentResponse> RunAsync(
+    public async Task<AgentResponse> RunAsync(
         IEnumerable<ChatMessage> messages,
         AgentSession? session = null,
         AgentRunOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        var previousContext = CurrentRunContext;
         CurrentRunContext = new(this, session, messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList(), options);
-        return this.RunCoreAsync(messages, session, options, cancellationToken);
+        try
+        {
+            return await this.RunCoreAsync(messages, session, options, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CurrentRunContext = previousContext;
+        }
     }
 
     /// <summary>
@@ -467,14 +475,22 @@ public abstract partial class AIAgent
         AgentRunOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        var previousContext = CurrentRunContext;
         AgentRunContext context = new(this, session, messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList(), options);
         CurrentRunContext = context;
-        await foreach (var update in this.RunCoreStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
+        try
         {
-            yield return update;
+            await foreach (var update in this.RunCoreStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
+            {
+                yield return update;
 
-            // Restore context again when resuming after the caller code executes.
-            CurrentRunContext = context;
+                // Restore context again when resuming after the caller code executes.
+                CurrentRunContext = context;
+            }
+        }
+        finally
+        {
+            CurrentRunContext = previousContext;
         }
     }
 

--- a/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Abstractions/AIAgent.cs
@@ -338,10 +338,11 @@ public abstract partial class AIAgent
         CancellationToken cancellationToken = default)
     {
         var previousContext = CurrentRunContext;
-        CurrentRunContext = new(this, session, messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList(), options);
+        var materializedMessages = messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+        CurrentRunContext = new(this, session, materializedMessages, options);
         try
         {
-            return await this.RunCoreAsync(messages, session, options, cancellationToken).ConfigureAwait(false);
+            return await this.RunCoreAsync(materializedMessages, session, options, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -476,11 +477,12 @@ public abstract partial class AIAgent
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var previousContext = CurrentRunContext;
-        AgentRunContext context = new(this, session, messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList(), options);
+        var materializedMessages = messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+        AgentRunContext context = new(this, session, materializedMessages, options);
         CurrentRunContext = context;
         try
         {
-            await foreach (var update in this.RunCoreStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
+            await foreach (var update in this.RunCoreStreamingAsync(materializedMessages, session, options, cancellationToken).ConfigureAwait(false))
             {
                 yield return update;
 

--- a/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
@@ -20,6 +20,15 @@ namespace Microsoft.Agents.AI;
 public static partial class AIAgentExtensions
 {
     /// <summary>
+    ///Provides a global registry for tracking pending agent tool approvals.
+    /// Maps approval request IDs to clean up records that contain weak references
+    /// back to per-function pending approval dictionaries, enabling external
+    /// code (e.g., <see cref="ClearRejectedAgentToolApprovals"/>) to locate and remove
+    /// approval entries from closure-local state.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, PendingAgentToolApprovalCleanup> s_pendingAgentToolApprovalCleanups = [];
+
+    /// <summary>
     /// Creates a new <see cref="AIAgentBuilder"/> using the specified agent as the foundation for the builder pipeline.
     /// </summary>
     /// <param name="innerAgent">The <see cref="AIAgent"/> instance to use as the inner agent.</param>
@@ -72,6 +81,7 @@ public static partial class AIAgentExtensions
     {
         Throw.IfNull(agent);
 
+        // PendingAgentToolApproval object used to store sub-agents awaiting approval
         ConcurrentDictionary<string, PendingAgentToolApproval> pendingApprovals = [];
 
         [Description("Invoke an agent to retrieve some information.")]
@@ -84,7 +94,13 @@ public static partial class AIAgentExtensions
 
         async Task<object?> InvokeAgentAsync(string query, CancellationToken cancellationToken)
         {
+            // Retrieve the current function call context in case this agent is being invoked as a tool by a parent agent.
             var parentFunctionContext = FunctionInvokingChatClient.CurrentContext;
+
+            // Determine if the current invocation matches a parent function call.
+            // A match means this agent was invoked as a tool by a parent agent via FunctionInvokingChatClient.
+            // The name comparison ensures we're matching the correct tool when the same agent is
+            // registered under multiple names.
             FunctionCallContent? parentToolCall =
                 parentFunctionContext?.CallContent is { } callContent &&
                 string.Equals(callContent.Name, options?.Name, StringComparison.Ordinal)
@@ -99,9 +115,20 @@ public static partial class AIAgentExtensions
             AgentSession? agentSession = session;
             IEnumerable<ChatMessage> inputMessages = [new ChatMessage(ChatRole.User, query)];
 
+            // Resolve the session and input messages for the child agent invocation.
+            //
+            // Two scenarios are handled when invoked via a parent tool call:
+            //  1) Re-invocation after approval: A pending approval record exists for this CallId.
+            //     Restore the previous session and convert approval requests into "approved" messages
+            //     so the child agent can continue from where it left off.
+            //  2) First invocation with no session: No session was provided and there is no
+            //     pending approval. Create a fresh session to maintain conversation state across
+            //     future re-invocations of this agent-as-tool.
             if (parentToolCall is not null &&
                 pendingApprovals.TryRemove(parentToolCall.CallId, out PendingAgentToolApproval? pendingApproval))
             {
+                s_pendingAgentToolApprovalCleanups.TryRemove(CreateAgentToolApprovalRequestId(parentToolCall.CallId), out _);
+
                 agentSession = pendingApproval.Session;
                 inputMessages = pendingApproval.ApprovalRequests.ConvertAll(
                     request => new ChatMessage(ChatRole.User, [request.CreateResponse(approved: true)]));
@@ -113,16 +140,22 @@ public static partial class AIAgentExtensions
 
             var response = await agent.RunAsync(inputMessages, session: agentSession, options: agentRunOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            // After running the child agent, check if it requires human approval (HITL).
+            // If so, store the approval requests in persistent state keyed by the parent tool call's CallId,
+            // and return a special result that surfaces the approval request back to the parent agent's
+            // HITL pipeline rather than treating it as a regular tool output.
             if (parentToolCall is not null &&
                 agentSession is not null &&
                 response.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>().ToList() is { Count: > 0 } approvalRequests)
             {
                 pendingApprovals[parentToolCall.CallId] = new PendingAgentToolApproval(agentSession, approvalRequests);
+                string approvalRequestId = CreateAgentToolApprovalRequestId(parentToolCall.CallId);
+                s_pendingAgentToolApprovalCleanups[approvalRequestId] = new(parentToolCall.CallId, new(pendingApprovals));
 
                 // Agent-as-tool must surface the child agent's normal HITL pipeline; otherwise
                 // ToolApprovalRequestContent from the child would be flattened into a tool result.
                 return new AgentToolApprovalRequestResult(
-                    new ToolApprovalRequestContent(CreateAgentToolApprovalRequestId(parentToolCall.CallId), parentToolCall));
+                    new ToolApprovalRequestContent(approvalRequestId, parentToolCall));
             }
 
             return response.Text;
@@ -153,6 +186,34 @@ public static partial class AIAgentExtensions
         return approvalRequests.Count > 0;
     }
 
+    /// <summary>
+    /// Cleans up pending agent tool approvals that have been rejected.
+    /// </summary>
+    /// <remarks>
+    /// When a child agent invoked as a tool requests human approval (HITL), the approval state
+    /// is stored in closure-local dictionaries. If the user rejects the approval, those entries
+    /// must be cleaned up to prevent stale state from interfering with future invocations.
+    /// <para>
+    /// This method traverses the messages for rejected <see cref="ToolApprovalResponseContent"/>,
+    /// looks up the corresponding entry in <see cref="s_pendingAgentToolApprovalCleanups"/>,
+    /// and uses the stored <see cref="WeakReference{T}"/> to reach back into the closure-local
+    /// <c>pendingApprovals</c> dictionary and remove the stale approval record.
+    /// </para>
+    /// </remarks>
+    /// <param name="messages">The messages to scan for rejected approval responses.</param>
+    internal static void ClearRejectedAgentToolApprovals(IEnumerable<ChatMessage> messages)
+    {
+        foreach (ToolApprovalResponseContent approvalResponse in messages.SelectMany(m => m.Contents).OfType<ToolApprovalResponseContent>())
+        {
+            if (!approvalResponse.Approved &&
+                s_pendingAgentToolApprovalCleanups.TryRemove(approvalResponse.RequestId, out PendingAgentToolApprovalCleanup? cleanup) &&
+                cleanup.PendingApprovals.TryGetTarget(out ConcurrentDictionary<string, PendingAgentToolApproval>? pendingApprovals))
+            {
+                pendingApprovals.TryRemove(cleanup.CallId, out _);
+            }
+        }
+    }
+
     private static FunctionCallContent? CloneFunctionCall(FunctionCallContent? functionCall)
     {
         if (functionCall is null)
@@ -171,9 +232,34 @@ public static partial class AIAgentExtensions
         AgentSession Session,
         List<ToolApprovalRequestContent> ApprovalRequests);
 
+    private sealed record PendingAgentToolApprovalCleanup(
+        string CallId,
+        WeakReference<ConcurrentDictionary<string, PendingAgentToolApproval>> PendingApprovals);
+
     internal sealed record AgentToolApprovalRequestResult(
         ToolApprovalRequestContent ApprovalRequest);
 
+    /// <summary>
+    /// A delegating <see cref="AIFunction"/> that separates metadata from execution.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="metadataFunction"/> (derived from <c>InvokeAgentMetadataAsync</c>) provides
+    /// the AI-visible schema — name, description, and parameter definitions with
+    /// <see cref="DescriptionAttribute"/> annotations — while <paramref name="invokeAsync"/>
+    /// (the real <c>InvokeAgentAsync</c>) performs the actual agent invocation.
+    /// </para>
+    /// <para>
+    /// This indirection is necessary because <c>InvokeAgentAsync</c> returns <see cref="object"/>,
+    /// which can be either a <see cref="string"/> result or an
+    /// <see cref="AgentToolApprovalRequestResult"/> for HITL approval. By overriding
+    /// <see cref="InvokeCoreAsync"/> and calling <paramref name="invokeAsync"/> directly,
+    /// we preserve the original return type rather than letting the base class serialize
+    /// it, ensuring <see cref="AgentToolApprovalRequestResult"/> passes through intact.
+    /// </para>
+    /// </remarks>
+    /// <param name="metadataFunction">The function providing AI-visible metadata and schema.</param>
+    /// <param name="invokeAsync">The delegate that performs the actual agent invocation.</param>
     private sealed class AgentAIFunction(
         AIFunction metadataFunction,
         Func<string, CancellationToken, Task<object?>> invokeAsync) : DelegatingAIFunction(metadataFunction)

--- a/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
@@ -174,11 +174,14 @@ public static partial class AIAgentExtensions
 
         foreach (var message in messages)
         {
-            foreach (var content in message.Contents)
+            for (int i = 0; i < message.Contents.Count; i++)
             {
-                if (content is FunctionResultContent { Result: AgentToolApprovalRequestResult result })
+                if (message.Contents[i] is FunctionResultContent { Result: AgentToolApprovalRequestResult result })
                 {
+                    // Remap the FunctionResultContent in-place to the underlying ToolApprovalRequestContent,
+                    // preserving all other content in the message and all other messages in the response.
                     approvalRequests.Add(result.ApprovalRequest);
+                    message.Contents[i] = result.ApprovalRequest;
                 }
             }
         }

--- a/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,17 +72,59 @@ public static partial class AIAgentExtensions
     {
         Throw.IfNull(agent);
 
+        ConcurrentDictionary<string, PendingAgentToolApproval> pendingApprovals = [];
+
         [Description("Invoke an agent to retrieve some information.")]
-        async Task<string> InvokeAgentAsync(
+        async Task<string> InvokeAgentMetadataAsync(
             [Description("Input query to invoke the agent.")] string query,
             CancellationToken cancellationToken)
         {
+            return await InvokeAgentAsync(query, cancellationToken).ConfigureAwait(false) as string ?? string.Empty;
+        }
+
+        async Task<object?> InvokeAgentAsync(string query, CancellationToken cancellationToken)
+        {
+            var parentFunctionContext = FunctionInvokingChatClient.CurrentContext;
+            FunctionCallContent? parentToolCall =
+                parentFunctionContext?.CallContent is { } callContent &&
+                string.Equals(callContent.Name, options?.Name, StringComparison.Ordinal)
+                    ? CloneFunctionCall(callContent)
+                    : null;
+
             // Propagate any additional properties from the parent agent's run to the child agent if the parent is using a FunctionInvokingChatClient.
             AgentRunOptions? agentRunOptions = FunctionInvokingChatClient.CurrentContext?.Options?.AdditionalProperties is AdditionalPropertiesDictionary dict
                 ? new AgentRunOptions { AdditionalProperties = dict }
                 : null;
 
-            var response = await agent.RunAsync(query, session: session, options: agentRunOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+            AgentSession? agentSession = session;
+            IEnumerable<ChatMessage> inputMessages = [new ChatMessage(ChatRole.User, query)];
+
+            if (parentToolCall is not null &&
+                pendingApprovals.TryRemove(parentToolCall.CallId, out PendingAgentToolApproval? pendingApproval))
+            {
+                agentSession = pendingApproval.Session;
+                inputMessages = pendingApproval.ApprovalRequests.ConvertAll(
+                    request => new ChatMessage(ChatRole.User, [request.CreateResponse(approved: true)]));
+            }
+            else if (parentToolCall is not null && agentSession is null)
+            {
+                agentSession = await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var response = await agent.RunAsync(inputMessages, session: agentSession, options: agentRunOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (parentToolCall is not null &&
+                agentSession is not null &&
+                response.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>().ToList() is { Count: > 0 } approvalRequests)
+            {
+                pendingApprovals[parentToolCall.CallId] = new PendingAgentToolApproval(agentSession, approvalRequests);
+
+                // Agent-as-tool must surface the child agent's normal HITL pipeline; otherwise
+                // ToolApprovalRequestContent from the child would be flattened into a tool result.
+                return new AgentToolApprovalRequestResult(
+                    new ToolApprovalRequestContent(CreateAgentToolApprovalRequestId(parentToolCall.CallId), parentToolCall));
+            }
+
             return response.Text;
         }
 
@@ -86,7 +132,65 @@ public static partial class AIAgentExtensions
         options.Name ??= SanitizeAgentName(agent.Name);
         options.Description ??= agent.Description;
 
-        return AIFunctionFactory.Create(InvokeAgentAsync, options);
+        return new AgentAIFunction(AIFunctionFactory.Create(InvokeAgentMetadataAsync, options), InvokeAgentAsync);
+    }
+
+    internal static bool TryExtractAgentToolApprovalRequests(IList<ChatMessage> messages, out List<ToolApprovalRequestContent> approvalRequests)
+    {
+        approvalRequests = [];
+
+        foreach (var message in messages)
+        {
+            foreach (var content in message.Contents)
+            {
+                if (content is FunctionResultContent { Result: AgentToolApprovalRequestResult result })
+                {
+                    approvalRequests.Add(result.ApprovalRequest);
+                }
+            }
+        }
+
+        return approvalRequests.Count > 0;
+    }
+
+    private static FunctionCallContent? CloneFunctionCall(FunctionCallContent? functionCall)
+    {
+        if (functionCall is null)
+        {
+            return null;
+        }
+
+        return functionCall.Arguments is null
+            ? new FunctionCallContent(functionCall.CallId, functionCall.Name)
+            : new FunctionCallContent(functionCall.CallId, functionCall.Name, new Dictionary<string, object?>(functionCall.Arguments));
+    }
+
+    private static string CreateAgentToolApprovalRequestId(string callId) => $"agent_tool_{callId}";
+
+    private sealed record PendingAgentToolApproval(
+        AgentSession Session,
+        List<ToolApprovalRequestContent> ApprovalRequests);
+
+    internal sealed record AgentToolApprovalRequestResult(
+        ToolApprovalRequestContent ApprovalRequest);
+
+    private sealed class AgentAIFunction(
+        AIFunction metadataFunction,
+        Func<string, CancellationToken, Task<object?>> invokeAsync) : DelegatingAIFunction(metadataFunction)
+    {
+        protected override async ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            if (!arguments.TryGetValue("query", out object? queryValue) || queryValue is null)
+            {
+                throw new ArgumentException("The required 'query' argument was not provided.", nameof(arguments));
+            }
+
+            string query = queryValue is JsonElement { ValueKind: JsonValueKind.String } jsonString
+                ? jsonString.GetString()!
+                : queryValue.ToString() ?? string.Empty;
+
+            return await invokeAsync(query, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -207,6 +207,7 @@ public sealed partial class ChatClientAgent : AIAgent
         CancellationToken cancellationToken = default)
     {
         var inputMessages = Throw.IfNull(messages) as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+        AIAgentExtensions.ClearRejectedAgentToolApprovals(inputMessages);
 
         (ChatClientAgentSession safeSession,
          ChatOptions? chatOptions,
@@ -298,6 +299,7 @@ public sealed partial class ChatClientAgent : AIAgent
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var inputMessages = Throw.IfNull(messages) as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+        AIAgentExtensions.ClearRejectedAgentToolApprovals(inputMessages);
 
         (ChatClientAgentSession safeSession,
          ChatOptions? chatOptions,

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -250,10 +250,10 @@ public sealed partial class ChatClientAgent : AIAgent
             chatResponseMessage.AuthorName ??= this.Name;
         }
 
-        if (AIAgentExtensions.TryExtractAgentToolApprovalRequests(chatResponse.Messages, out var agentToolApprovalRequests))
-        {
-            chatResponse.Messages = [new ChatMessage(ChatRole.Assistant, [.. agentToolApprovalRequests]) { AuthorName = this.Name }];
-        }
+        // Remap child-agent approval results to surface them through the parent's HITL pipeline.
+        // FunctionResultContent entries wrapping AgentToolApprovalRequestResult are replaced
+        // in-place with the underlying ToolApprovalRequestContent, preserving all other content.
+        AIAgentExtensions.TryExtractAgentToolApprovalRequests(chatResponse.Messages, out _);
 
         // Notify providers of all new messages unless persistence is handled per-service-call by the decorator.
         // When background responses are allowed, force notification since per-service-call persistence

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -249,6 +249,11 @@ public sealed partial class ChatClientAgent : AIAgent
             chatResponseMessage.AuthorName ??= this.Name;
         }
 
+        if (AIAgentExtensions.TryExtractAgentToolApprovalRequests(chatResponse.Messages, out var agentToolApprovalRequests))
+        {
+            chatResponse.Messages = [new ChatMessage(ChatRole.Assistant, [.. agentToolApprovalRequests]) { AuthorName = this.Name }];
+        }
+
         // Notify providers of all new messages unless persistence is handled per-service-call by the decorator.
         // When background responses are allowed, force notification since per-service-call persistence
         // is unreliable (the caller may stop consuming the stream before the decorator can persist).

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentExtensionsTests.cs
@@ -433,6 +433,59 @@ public class AgentExtensionsTests
         Assert.Contains(finalResponse.Messages, m => m.Text.Contains("rejection", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task CreateFromAgent_ApprovalRequiredChildTool_RejectedParentApprovalClearsPendingApprovalAsync()
+    {
+        // Arrange
+        int dangerousFunctionCalls = 0;
+        var dangerousTool = new ApprovalRequiredAIFunction(AIFunctionFactory.Create(
+            () =>
+            {
+                dangerousFunctionCalls++;
+                return "Dangerous function completed.";
+            },
+            name: "DangerousFunction"));
+
+        var childAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("child-tool-call-1", "DangerousFunction")])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("child-tool-call-2", "DangerousFunction")]))).Object,
+            new ChatClientAgentOptions
+            {
+                Name = "AgentB",
+                ChatOptions = new() { Tools = [dangerousTool] },
+            });
+
+        var parentAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("reused-parent-agent-b-call", "AgentB", new Dictionary<string, object?> { ["query"] = "Run child agent." })])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent should wait for approval.")),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent handled the rejection.")),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("reused-parent-agent-b-call", "AgentB", new Dictionary<string, object?> { ["query"] = "Run child agent again." })])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent should wait for approval again."))).Object,
+            tools: [childAgent.AsAIFunction()]);
+
+        AgentSession parentSession = await parentAgent.CreateSessionAsync();
+
+        // Act - invoke child agent as parent tool and reject the surfaced approval.
+        AgentResponse firstApprovalResponse = await parentAgent.RunAsync("Ask AgentB to run.", parentSession);
+        ToolApprovalRequestContent firstApprovalRequest = Assert.Single(
+            firstApprovalResponse.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+
+        _ = await parentAgent.RunAsync(
+            [new ChatMessage(ChatRole.User, [firstApprovalRequest.CreateResponse(approved: false, reason: "Denied")])],
+            parentSession);
+
+        // Act - invoke the same parent tool call ID again.
+        AgentResponse secondApprovalResponse = await parentAgent.RunAsync("Ask AgentB to run again.", parentSession);
+
+        // Assert - the rejected pending approval was cleared, so the child tool is not auto-approved on reuse.
+        ToolApprovalRequestContent secondApprovalRequest = Assert.Single(
+            secondApprovalResponse.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+        Assert.Equal("AgentB", ((FunctionCallContent)secondApprovalRequest.ToolCall).Name);
+        Assert.Equal(0, dangerousFunctionCalls);
+    }
+
     [Theory]
     [InlineData("MyAgent", "MyAgent")]
     [InlineData("Agent123", "Agent123")]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentExtensionsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
@@ -306,17 +307,130 @@ public class AgentExtensionsTests
         };
         SetFunctionInvokingChatClientCurrentContext(context);
 
-        // Act
-        var arguments = new AIFunctionArguments() { ["query"] = "Test query" };
-        var result = await aiFunction.InvokeAsync(arguments);
+        try
+        {
+            // Act
+            var arguments = new AIFunctionArguments() { ["query"] = "Test query" };
+            var result = await aiFunction.InvokeAsync(arguments);
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal("Complex response", result.ToString());
-        Assert.NotNull(testAgent.ReceivedAgentRunOptions);
-        Assert.NotNull(testAgent.ReceivedAgentRunOptions!.AdditionalProperties);
-        Assert.Equal("value1", testAgent.ReceivedAgentRunOptions!.AdditionalProperties["customProperty1"]);
-        Assert.Equal(42, testAgent.ReceivedAgentRunOptions!.AdditionalProperties["customProperty2"]);
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Complex response", result.ToString());
+            Assert.NotNull(testAgent.ReceivedAgentRunOptions);
+            Assert.NotNull(testAgent.ReceivedAgentRunOptions!.AdditionalProperties);
+            Assert.Equal("value1", testAgent.ReceivedAgentRunOptions!.AdditionalProperties["customProperty1"]);
+            Assert.Equal(42, testAgent.ReceivedAgentRunOptions!.AdditionalProperties["customProperty2"]);
+        }
+        finally
+        {
+            SetFunctionInvokingChatClientCurrentContext(null);
+        }
+    }
+
+    [Fact]
+    public async Task CreateFromAgent_ApprovalRequiredChildTool_AsParentToolSurfacesAndResumesApprovalAsync()
+    {
+        // Arrange
+        int dangerousFunctionCalls = 0;
+        var dangerousTool = new ApprovalRequiredAIFunction(AIFunctionFactory.Create(
+            () =>
+            {
+                dangerousFunctionCalls++;
+                return "Dangerous function completed.";
+            },
+            name: "DangerousFunction"));
+
+        var childAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("child-direct-call", "DangerousFunction")])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("child-tool-call", "DangerousFunction")])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Child agent completed."))).Object,
+            new ChatClientAgentOptions
+            {
+                Name = "AgentB",
+                ChatOptions = new() { Tools = [dangerousTool] },
+            });
+
+        var childAsTool = childAgent.AsAIFunction();
+        var parentAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("parent-agent-b-call", "AgentB", new Dictionary<string, object?> { ["query"] = "Run child agent." })])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent should wait for approval.")),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent completed after child approval."))).Object,
+            tools: [childAsTool]);
+
+        // Act - direct child invocation.
+        AgentResponse directResponse = await childAgent.RunAsync("Run the dangerous function.");
+
+        // Assert - direct child invocation requires approval and does not execute the dangerous function.
+        ToolApprovalRequestContent directApprovalRequest = Assert.Single(
+            directResponse.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+        Assert.Equal("DangerousFunction", ((FunctionCallContent)directApprovalRequest.ToolCall).Name);
+        Assert.Equal(0, dangerousFunctionCalls);
+
+        // Act - invoke child agent as parent tool.
+        AgentSession parentSession = await parentAgent.CreateSessionAsync();
+        AgentResponse parentApprovalResponse = await parentAgent.RunAsync("Ask AgentB to run.", parentSession);
+
+        // Assert - the child approval is surfaced through the parent agent instead of being flattened into a tool result.
+        ToolApprovalRequestContent parentApprovalRequest = Assert.Single(
+            parentApprovalResponse.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+        Assert.Equal("AgentB", ((FunctionCallContent)parentApprovalRequest.ToolCall).Name);
+        Assert.Equal(0, dangerousFunctionCalls);
+
+        // Act - approve the parent-surfaced request.
+        AgentResponse finalResponse = await parentAgent.RunAsync(
+            [new ChatMessage(ChatRole.User, [parentApprovalRequest.CreateResponse(approved: true)])],
+            parentSession);
+
+        // Assert - approval is routed back through AgentB's normal invocation pipeline.
+        Assert.Equal(1, dangerousFunctionCalls);
+        Assert.Contains(finalResponse.Messages, m => m.Text.Contains("Parent completed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CreateFromAgent_ApprovalRequiredChildTool_RejectedParentApprovalDoesNotInvokeChildToolAsync()
+    {
+        // Arrange
+        int dangerousFunctionCalls = 0;
+        var dangerousTool = new ApprovalRequiredAIFunction(AIFunctionFactory.Create(
+            () =>
+            {
+                dangerousFunctionCalls++;
+                return "Dangerous function completed.";
+            },
+            name: "DangerousFunction"));
+
+        var childAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("child-tool-call", "DangerousFunction")]))).Object,
+            new ChatClientAgentOptions
+            {
+                Name = "AgentB",
+                ChatOptions = new() { Tools = [dangerousTool] },
+            });
+
+        var parentAgent = new ChatClientAgent(
+            CreateSequentialChatClient(
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("parent-agent-b-call", "AgentB", new Dictionary<string, object?> { ["query"] = "Run child agent." })])),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent should wait for approval.")),
+                new ChatResponse(new ChatMessage(ChatRole.Assistant, "Parent handled the rejection."))).Object,
+            tools: [childAgent.AsAIFunction()]);
+
+        // Act - invoke child agent as parent tool.
+        AgentSession parentSession = await parentAgent.CreateSessionAsync();
+        AgentResponse parentApprovalResponse = await parentAgent.RunAsync("Ask AgentB to run.", parentSession);
+        ToolApprovalRequestContent parentApprovalRequest = Assert.Single(
+            parentApprovalResponse.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+
+        // Act - reject the parent-surfaced request.
+        AgentResponse finalResponse = await parentAgent.RunAsync(
+            [new ChatMessage(ChatRole.User, [parentApprovalRequest.CreateResponse(approved: false, reason: "Denied")])],
+            parentSession);
+
+        // Assert - rejection does not resume AgentB or execute the dangerous function.
+        Assert.Equal(0, dangerousFunctionCalls);
+        Assert.Contains(finalResponse.Messages, m => m.Text.Contains("rejection", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -358,6 +472,20 @@ public class AgentExtensionsTests
         {
             asyncLocal.Value = context;
         }
+    }
+
+    private static Mock<IChatClient> CreateSequentialChatClient(params ChatResponse[] responses)
+    {
+        var responseQueue = new Queue<ChatResponse>(responses);
+        var mockChatClient = new Mock<IChatClient>();
+
+        mockChatClient.Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => responseQueue.Count > 0 ? responseQueue.Dequeue() : responses.Last());
+
+        return mockChatClient;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation and Context

1. **Why is this change required?**  
   When an agent is registered as a tool via `AsAIFunction()` and invoked by a parent agent via `FunctionInvokingChatClient`, the child agent may request human approval (HITL). Before this change, those approval requests were not surfaced to the parent agent's HITL pipeline — they were either lost during serialization or treated as opaque tool results. This made it impossible to build multi-agent workflows where a child agent requires user confirmation (e.g., "Are you sure you want to delete this resource?").

2. **What problem does it solve?**  
   - **Approval passthrough**: Child agent `ToolApprovalRequestContent` is now properly extracted from the tool result and surfaced through the parent agent's HITL pipeline, so the end user sees the approval prompt.  
   - **Session continuity**: When the user approves and the parent re-invokes the same child tool (same `CallId`), the child agent's session is restored and the approval is converted into a confirmation message, allowing the child to continue its conversation from where it paused — rather than starting over.  
   - **Rejected-approval cleanup**: If the user rejects the approval, stale state in the closure-local `pendingApprovals` dictionary is cleaned up proactively, preventing the rejected approval from being accidentally auto-approved on a future re-invocation, and avoiding memory leaks.  
   - **Context isolation**: `CurrentRunContext` is now properly saved and restored with `try/finally` in `RunAsync` / `RunStreamingAsync`, preventing context leakage when child agents run nested inside parent agent invocations.

3. **What scenario does it contribute to?**  
   Multi-agent orchestration with HITL. For example, an `OrchestratorAgent` calls a `DatabaseAdminAgent` as a tool; the child agent detects a dangerous operation and requests human confirmation. The parent surfaces the confirmation to the user, and upon approval, the child resumes and executes the operation. Upon rejection, the state is cleaned up so the same tool can be called again without interference.

4. **If it fixes an open issue, please link to the issue here.**  
  Fixes #6062
  
---

### Description

This PR implements a complete **agent-as-tool HITL (Human-In-The-Loop) approval lifecycle** spanning four changed files:

---

#### 1. Context isolation (`src/Microsoft.Agents.AI.Abstractions/AIAgent.cs`, +28 / -0)

`RunAsync` and `RunStreamingAsync` now wrap the `RunCoreAsync` / `RunCoreStreamingAsync` call in a `try/finally` block that saves `CurrentRunContext` before the call and restores it afterward. This ensures that when a parent agent invokes a child agent-as-tool (which internally calls `RunAsync` again), the parent's `CurrentRunContext` is not overwritten by the child's.

```csharp
var previousContext = CurrentRunContext;
CurrentRunContext = new(this, session, ...);
try
{
    return await this.RunCoreAsync(...).ConfigureAwait(false);
}
finally
{
    CurrentRunContext = previousContext;
}
```

The same pattern is applied to `RunStreamingAsync`, with the additional detail that `CurrentRunContext` is restored to `context` after each `yield return` to re-establish the correct context when the caller code resumes after consuming each streaming update.

---

#### 2. Core HITL approval logic (`src/Microsoft.Agents.AI/AgentExtensions.cs`, +196 / -1)

This file received the bulk of the changes, implementing the full approval lifecycle:

##### 2a. Parent tool call detection (lines ~90-95)
```csharp
var parentFunctionContext = FunctionInvokingChatClient.CurrentContext;
FunctionCallContent? parentToolCall =
    parentFunctionContext?.CallContent is { } callContent &&
    string.Equals(callContent.Name, options?.Name, StringComparison.Ordinal)
        ? CloneFunctionCall(callContent)
        : null;
```
Determines whether the current agent is being invoked as a tool by a parent agent. The name comparison (`callContent.Name == options.Name`) ensures correctness when the same agent is registered under multiple tool names.

##### 2b. Session resolution and approval restoration (lines ~118-130)
Two branches handle the agent-as-tool invocation path:
- **Re-invocation after approval**: If a `pendingApproval` record exists for this `CallId`, the previous session is restored, and all pending approval requests are converted into `ChatMessage(ChatRole.User, ...)` with `approved: true`. This lets the child agent continue from where it paused, with the user's confirmation as input.
- **First invocation with no session**: Creates a fresh `AgentSession` via `agent.CreateSessionAsync()` to maintain conversation state across future re-invocations.

##### 2c. Approval request surfacing (lines ~143-158)
After the child agent runs, if its response contains `ToolApprovalRequestContent`:
```csharp
pendingApprovals[parentToolCall.CallId] = new PendingAgentToolApproval(agentSession, approvalRequests);
string approvalRequestId = CreateAgentToolApprovalRequestId(parentToolCall.CallId);
s_pendingAgentToolApprovalCleanups[approvalRequestId] = new(parentToolCall.CallId, new(pendingApprovals));

return new AgentToolApprovalRequestResult(
    new ToolApprovalRequestContent(approvalRequestId, parentToolCall));
```
Three things happen simultaneously:
1. The approval state is stored in the closure-local `pendingApprovals` dictionary, keyed by the parent's `CallId`.
2. A global cleanup record is registered in `s_pendingAgentToolApprovalCleanups` (a static `ConcurrentDictionary`) with a `WeakReference` pointing back to the closure-local dictionary, enabling external cleanup code to reach into the closure.
3. An `AgentToolApprovalRequestResult` is returned (instead of a plain string), carrying the `ToolApprovalRequestContent` so the parent agent's `TryExtractAgentToolApprovalRequests` can detect and surface it.

##### 2d. Rejected approval cleanup (lines ~193-210)
```csharp
internal static void ClearRejectedAgentToolApprovals(IEnumerable<ChatMessage> messages)
{
    foreach (ToolApprovalResponseContent approvalResponse in messages
        .SelectMany(m => m.Contents).OfType<ToolApprovalResponseContent>())
    {
        if (!approvalResponse.Approved &&
            s_pendingAgentToolApprovalCleanups.TryRemove(approvalResponse.RequestId, out PendingAgentToolApprovalCleanup? cleanup) &&
            cleanup.PendingApprovals.TryGetTarget(out ConcurrentDictionary<string, PendingAgentToolApproval>? pendingApprovals))
        {
            pendingApprovals.TryRemove(cleanup.CallId, out _);
        }
    }
}
```
This static method is called at the start of every `RunCoreAsync` / `RunCoreStreamingAsync`. It scans incoming messages for rejected `ToolApprovalResponseContent`, looks up the corresponding entry in the global `s_pendingAgentToolApprovalCleanups` registry, dereferences the `WeakReference` to reach the closure-local `pendingApprovals` dictionary, and removes the stale entry. This prevents a rejected approval from being accidentally replayed as auto-approved on a future invocation.

##### 2e. ID scheme
Two IDs coordinate the flow, related by `CreateAgentToolApprovalRequestId(callId) => $"agent_tool_{callId}"`:

| ID | Scope | Purpose |
|----|-------|---------|
| `CallId` (e.g., `"call_001"`) | Closure-local `pendingApprovals` | Keys the approval state within the closure |
| `approvalRequestId` (e.g., `"agent_tool_call_001"`) | Global `s_pendingAgentToolApprovalCleanups` and user-facing `ToolApprovalRequestContent.RequestId` | Surfaces to the user and enables cross-closure lookup by `ClearRejectedAgentToolApprovals` |

The `"agent_tool_"` prefix acts as a namespace to avoid collision with other approval mechanisms in the framework.

##### 2f. `AgentAIFunction` — metadata/execution separation (lines ~242-259)
```csharp
private sealed class AgentAIFunction(
    AIFunction metadataFunction,
    Func<string, CancellationToken, Task<object?>> invokeAsync) : DelegatingAIFunction(metadataFunction)
```
A delegating `AIFunction` that separates concerns:
- **Metadata**: Delegated to `InvokeAgentMetadataAsync` (which has `[Description]` attributes for AI-visible schema).
- **Execution**: Overridden in `InvokeCoreAsync` to call `InvokeAgentAsync` directly, preserving the `object?` return type so `AgentToolApprovalRequestResult` passes through without serialization.

##### 2g. `TryExtractAgentToolApprovalRequests` (lines ~171-186)
```csharp
internal static bool TryExtractAgentToolApprovalRequests(
    IList<ChatMessage> messages, out List<ToolApprovalRequestContent> approvalRequests)
```
Scans messages for `FunctionResultContent` whose `Result` is `AgentToolApprovalRequestResult`, extracting the wrapped `ToolApprovalRequestContent`. Called by `ChatClientAgent` after tool execution.

---

#### 3. Parent agent integration (`src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs`, +7 / -0)

Two call sites in `RunCoreAsync` and `RunCoreStreamingAsync`:

1. **At the start**: `AIAgentExtensions.ClearRejectedAgentToolApprovals(inputMessages)` — cleans up any rejected approvals from previous invocations before processing.
2. **After tool execution**: `AIAgentExtensions.TryExtractAgentToolApprovalRequests(chatResponse.Messages, out var agentToolApprovalRequests)` — if the tool result contains a child approval request, replaces the response messages with the extracted approval requests, surfacing them to the user.

---

#### 4. Tests (`tests/Microsoft.Agents.AI.UnitTests/AgentExtensionsTests.cs`, +201 / -0)

Added comprehensive test coverage:
- **Approval passthrough**: Verifies that a child agent's `ToolApprovalRequestContent` is properly surfaced through the parent agent to the end user.
- **Session continuity**: Verifies that after user approval, the child agent resumes with the same session and confirmed input.
- **Rejected-approval cleanup**: Verifies that after a user rejects an approval, the stale state is cleared, and a subsequent invocation of the same tool requests approval again (not auto-approved).
- **`CreateSequentialChatClient` helper**: A utility that returns a `Mock<IChatClient>` producing a predefined sequence of `ChatResponse` objects, used to simulate multi-turn AI model interactions.

---

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.