### PR TITLE
.NET: mark empty skill capabilities in content

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -114,6 +114,7 @@ public abstract class AgentClassSkill<
             this.Frontmatter.Name,
             this.Frontmatter.Description,
             this.Instructions,
+            this.Resources,
             this.Scripts));
     }
 

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkill.cs
@@ -95,7 +95,12 @@ public sealed class AgentInlineSkill : AgentSkill
     /// <inheritdoc/>
     public override ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
     {
-        return new(this._cachedContent ??= AgentInlineSkillContentBuilder.Build(this.Frontmatter.Name, this.Frontmatter.Description, this._instructions, this._scripts));
+        return new(this._cachedContent ??= AgentInlineSkillContentBuilder.Build(
+            this.Frontmatter.Name,
+            this.Frontmatter.Description,
+            this._instructions,
+            this._resources,
+            this._scripts));
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
@@ -17,12 +17,14 @@ internal static class AgentInlineSkillContentBuilder
     /// <param name="name">The skill name.</param>
     /// <param name="description">The skill description.</param>
     /// <param name="instructions">The raw instructions text.</param>
+    /// <param name="resources">Optional resources associated with the skill.</param>
     /// <param name="scripts">Optional scripts associated with the skill.</param>
     /// <returns>An XML-structured content string.</returns>
     public static string Build(
         string name,
         string description,
         string instructions,
+        IReadOnlyList<AgentSkillResource>? resources,
         IReadOnlyList<AgentSkillScript>? scripts)
     {
         _ = Throw.IfNullOrWhitespace(name);
@@ -37,10 +39,19 @@ internal static class AgentInlineSkillContentBuilder
         .Append(EscapeXmlString(instructions))
         .Append("\n</instructions>");
 
+        if (resources is not { Count: > 0 })
+        {
+            sb.Append("\n<resources />");
+        }
+
         if (scripts is { Count: > 0 })
         {
             sb.Append('\n');
             sb.Append(BuildScriptSchemasBlock(scripts));
+        }
+        else
+        {
+            sb.Append("\n<script_schemas />");
         }
 
         return sb.ToString();

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -398,6 +398,22 @@ public sealed class AgentClassSkillTests
     }
 
     [Fact]
+    public async Task Content_NoResourcesOrScripts_EmitsEmptyCapabilityMarkersAsync()
+    {
+        // Arrange
+        var skill = new NoAttributesNoOverridesSkill();
+
+        // Act
+        var content = await skill.GetContentAsync();
+
+        // Assert
+        Assert.Contains("<resources />", content);
+        Assert.Contains("<script_schemas />", content);
+        Assert.DoesNotContain("<resources>", content);
+        Assert.DoesNotContain("<script_schemas>", content);
+    }
+
+    [Fact]
     public void NoAttributedMembers_NoOverrides_ReturnsNull()
     {
         // Arrange — skill with no attributes and no overrides; base discovery returns null (not empty list)

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
@@ -417,7 +417,7 @@ public sealed class AgentInlineSkillTests
     }
 
     [Fact]
-    public async Task Content_NoResourcesOrScripts_DoesNotContainResourcesOrScriptsTagsAsync()
+    public async Task Content_NoResourcesOrScripts_EmitsEmptyCapabilityMarkersAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("my-skill", "A valid skill.", "Instructions.");
@@ -426,6 +426,8 @@ public sealed class AgentInlineSkillTests
         var content = await skill.GetContentAsync();
 
         // Assert
+        Assert.Contains("<resources />", content);
+        Assert.Contains("<script_schemas />", content);
         Assert.DoesNotContain("<resources>", content);
         Assert.DoesNotContain("<script_schemas>", content);
     }
@@ -443,6 +445,7 @@ public sealed class AgentInlineSkillTests
 
         // Assert — the late resource should not appear because content was cached
         Assert.DoesNotContain("late-resource", content);
+        Assert.Contains("<resources />", content);
     }
 
     [Fact]
@@ -458,6 +461,7 @@ public sealed class AgentInlineSkillTests
 
         // Assert — the late script should not appear because content was cached
         Assert.DoesNotContain("late-script", content);
+        Assert.Contains("<script_schemas />", content);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #6371.

`AgentInlineSkillContentBuilder` now makes an empty inline/class skill explicit by emitting self-closing markers for missing resources and script schemas:

```xml
<resources />
<script_schemas />
```

When resources exist, they still are not rendered into the skill body; callers can access them through `GetResourceAsync` as before. When scripts exist, the existing `<script_schemas>` block is still used.

## To verify

- `dotnet restore dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --verbosity minimal`
- `dotnet dotnet\tests\Microsoft.Agents.AI.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.UnitTests.dll --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillTests Microsoft.Agents.AI.UnitTests.AgentSkills.AgentClassSkillTests --results-directory dotnet\TestResults\local-6371-net10`
- `dotnet\tests\Microsoft.Agents.AI.UnitTests\bin\Debug\net472\Microsoft.Agents.AI.UnitTests.exe --filter-class Microsoft.Agents.AI.UnitTests.AgentSkills.AgentInlineSkillTests Microsoft.Agents.AI.UnitTests.AgentSkills.AgentClassSkillTests --results-directory dotnet\TestResults\local-6371-net472`
- `dotnet format dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj --include dotnet\src\Microsoft.Agents.AI\Skills\Programmatic\AgentInlineSkillContentBuilder.cs dotnet\src\Microsoft.Agents.AI\Skills\Programmatic\AgentInlineSkill.cs dotnet\src\Microsoft.Agents.AI\Skills\Programmatic\AgentClassSkill.cs dotnet\tests\Microsoft.Agents.AI.UnitTests\AgentSkills\AgentInlineSkillTests.cs dotnet\tests\Microsoft.Agents.AI.UnitTests\AgentSkills\AgentClassSkillTests.cs --verify-no-changes --verbosity minimal`
- `git diff --check`

Note: `dotnet test ... --filter ...` on my local .NET 10 SDK hits the repository's Microsoft.Testing.Platform/VSTest compatibility error, so I ran the built MTP test assemblies directly for both target frameworks.
