### PR TITLE
Stop failing held issue triage runs

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -153,8 +153,7 @@ jobs:
         if: ${{ steps.spam.outputs.allow_triage != 'true' }}
         shell: bash
         run: |
-          echo "Stopping: issue triage preflight did not allow automation."
-          exit 1
+          echo "Issue triage preflight withheld automation; maintainer review is required."
 
       - name: Reproduce reported issue
         if: ${{ steps.spam.outputs.allow_triage == 'true' }}


### PR DESCRIPTION
## Summary
- keep issue triage automation withheld when the spam gate does not allow triage
- stop marking those maintainer-review holds as failed Actions runs

## Verification
- Parsed .github/workflows/issue-triage.yml with PyYAML
- Confirmed the spam-gate stop step no longer exits 1
- Confirmed the only remaining exit 1 is the invalid issue-number guard