### PR TITLE
Python: parse final structured response message

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2119,6 +2119,13 @@ def _parse_structured_response_value(text: str, response_format: Any | None) -> 
     return None
 
 
+def _structured_response_text(messages: Sequence[Message]) -> str:
+    for msg in reversed(messages):
+        if text := msg.text:
+            return text
+    return ""
+
+
 class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
     """Represents the response to a chat request.
 
@@ -2391,7 +2398,10 @@ class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            self._value = cast(
+                ResponseModelT,
+                _parse_structured_response_value(_structured_response_text(self.messages), self._response_format),
+            )
             self._value_parsed = True
         return self._value
 
@@ -2655,7 +2665,10 @@ class AgentResponse(SerializationMixin, Generic[ResponseModelT]):
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            self._value = cast(
+                ResponseModelT,
+                _parse_structured_response_value(_structured_response_text(self.messages), self._response_format),
+            )
             self._value_parsed = True
         return self._value
 

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -831,6 +831,34 @@ def test_chat_response_with_mapping_response_format() -> None:
     assert response.value["response"] == "Hello"
 
 
+def test_chat_response_value_parses_final_message() -> None:
+    response = ChatResponse(
+        messages=[
+            Message(role="assistant", contents=['{"response": "intermediate"}']),
+            Message(role="assistant", contents=['{"response": "final"}']),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.text == '{"response": "intermediate"}\n{"response": "final"}'
+    assert response.value is not None
+    assert response.value.response == "final"
+
+
+def test_agent_response_value_parses_final_message() -> None:
+    response = AgentResponse(
+        messages=[
+            Message(role="assistant", contents=['{"response": "intermediate"}']),
+            Message(role="assistant", contents=['{"response": "final"}']),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.text == '{"response": "intermediate"}{"response": "final"}'
+    assert response.value is not None
+    assert response.value.response == "final"
+
+
 def test_parse_structured_response_value_empty_text_with_pydantic_model() -> None:
     """Empty text should return None instead of raising when response_format is a Pydantic model."""
     result = _parse_structured_response_value("", OutputModel)


### PR DESCRIPTION
Fixes #6366

## What changed
- Keep `response.text` behavior unchanged for multi-message responses.
- Parse structured `ChatResponse.value` and `AgentResponse.value` from the last non-empty response message instead of the concatenated conversation text.
- Add regression coverage for both response types so intermediate JSON no longer corrupts the final structured result.

## To verify
- python -m pytest tests\core\test_types.py -q -k "final_message or empty_text or invalid_schema or chat_response_with_format"
- python -m pytest tests\core\test_types.py -q
- python -m ruff check agent_framework\_types.py tests\core\test_types.py
- python -m mypy --config-file pyproject.toml agent_framework\_types.py
- python -m py_compile agent_framework\_types.py tests\core\test_types.py
- git diff --check
