### PR TITLE
Python: parse structured response value from final message

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2187,6 +2187,16 @@ def _parse_structured_response_value(text: str, response_format: Any | None) -> 
     return None
 
 
+def _last_non_empty_assistant_message_text(messages: Sequence[Message]) -> str:
+    for message in reversed(messages):
+        if message.role != "assistant":
+            continue
+        text = message.text
+        if text.strip():
+            return text
+    return ""
+
+
 class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
     """Represents the response to a chat request.
 
@@ -2372,7 +2382,7 @@ class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
 
         Keyword Args:
             output_format_type: Optional Pydantic model type or JSON schema mapping used to parse the
-                response text into structured data.
+                final non-empty assistant message text into structured data.
         """
         msg = cls(messages=[], response_format=output_format_type)
         for update in updates:
@@ -2432,7 +2442,7 @@ class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
 
         Keyword Args:
             output_format_type: Optional Pydantic model type or JSON schema mapping used to parse the
-                response text into structured data.
+                final non-empty assistant message text into structured data.
         """
         msg = cls(messages=[], response_format=output_format_type)
         async for update in updates:
@@ -2450,16 +2460,22 @@ class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
         """Get the parsed structured output value.
 
         If a response_format was provided and parsing hasn't been attempted yet,
-        this will attempt to parse the text into the specified type.
+        this will attempt to parse the last non-empty assistant message text into the specified type.
 
         Raises:
-            ValidationError: If the response text doesn't match the expected schema.
-            ValueError: If the response text is not valid JSON for a non-Pydantic structured format.
+            ValidationError: If the assistant message text doesn't match the expected schema.
+            ValueError: If the assistant message text is not valid JSON for a non-Pydantic structured format.
         """
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            self._value = cast(
+                ResponseModelT,
+                _parse_structured_response_value(
+                    _last_non_empty_assistant_message_text(self.messages),
+                    self._response_format,
+                ),
+            )
             self._value_parsed = True
         return self._value
 
@@ -2714,16 +2730,22 @@ class AgentResponse(SerializationMixin, Generic[ResponseModelT]):
         """Get the parsed structured output value.
 
         If a response_format was provided and parsing hasn't been attempted yet,
-        this will attempt to parse the text into the specified type.
+        this will attempt to parse the last non-empty assistant message text into the specified type.
 
         Raises:
-            ValidationError: If the response text doesn't match the expected schema.
-            ValueError: If the response text is not valid JSON for a non-Pydantic structured format.
+            ValidationError: If the assistant message text doesn't match the expected schema.
+            ValueError: If the assistant message text is not valid JSON for a non-Pydantic structured format.
         """
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            self._value = cast(
+                ResponseModelT,
+                _parse_structured_response_value(
+                    _last_non_empty_assistant_message_text(self.messages),
+                    self._response_format,
+                ),
+            )
             self._value_parsed = True
         return self._value
 
@@ -2782,7 +2804,7 @@ class AgentResponse(SerializationMixin, Generic[ResponseModelT]):
 
         Keyword Args:
             output_format_type: Optional Pydantic model type or JSON schema mapping used to parse the
-                response text into structured data.
+                final non-empty assistant message text into structured data.
             value: Optional pre-parsed structured output value to set directly on the response.
         """
         msg = cls(messages=[], response_format=output_format_type, value=value)
@@ -2832,7 +2854,7 @@ class AgentResponse(SerializationMixin, Generic[ResponseModelT]):
 
         Keyword Args:
             output_format_type: Optional Pydantic model type or JSON schema mapping used to parse the
-                response text into structured data.
+                final non-empty assistant message text into structured data.
         """
         msg = cls(messages=[], response_format=output_format_type)
         async for update in updates:

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -869,6 +869,79 @@ def test_chat_response_with_mapping_response_format() -> None:
     assert response.value["response"] == "Hello"
 
 
+def test_chat_response_value_parses_final_message_with_response_format() -> None:
+    """ChatResponse.value should ignore intermediate messages when parsing structured output."""
+    response = ChatResponse(
+        messages=[
+            Message(role="assistant", contents=['{"skill_name": "building-permit-compliance"}']),
+            Message(role="assistant", contents=['{"response": "Hello"}']),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.text == '{"skill_name": "building-permit-compliance"}\n{"response": "Hello"}'
+    assert response.value is not None
+    assert response.value.response == "Hello"
+
+
+def test_agent_response_value_parses_final_message_with_response_format() -> None:
+    """AgentResponse.value should ignore intermediate messages when parsing structured output."""
+    response = AgentResponse(
+        messages=[
+            Message(role="assistant", contents=['{"skill_name": "building-permit-compliance"}']),
+            Message(role="assistant", contents=['{"response": "Hello"}']),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.text == '{"skill_name": "building-permit-compliance"}{"response": "Hello"}'
+    assert response.value is not None
+    assert response.value.response == "Hello"
+
+
+def test_agent_response_mapping_value_parses_final_message() -> None:
+    """AgentResponse.value should parse the final message for JSON schema mappings."""
+    response = AgentResponse(
+        messages=[
+            Message(role="assistant", contents=['{"skill_name": "building-permit-compliance"}']),
+            Message(role="assistant", contents=['{"response": "Hello"}']),
+        ],
+        response_format={"type": "object", "properties": {"response": {"type": "string"}}},
+    )
+
+    assert response.value is not None
+    assert isinstance(response.value, dict)
+    assert response.value["response"] == "Hello"
+
+
+def test_chat_response_value_ignores_trailing_non_assistant_message() -> None:
+    """ChatResponse.value should parse the final assistant message when later tool output exists."""
+    response = ChatResponse(
+        messages=[
+            Message(role="assistant", contents=['{"response": "Hello"}']),
+            Message(role="tool", contents=["tool output is not structured JSON"]),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.value is not None
+    assert response.value.response == "Hello"
+
+
+def test_agent_response_value_ignores_trailing_non_assistant_message() -> None:
+    """AgentResponse.value should parse the final assistant message when later tool output exists."""
+    response = AgentResponse(
+        messages=[
+            Message(role="assistant", contents=['{"response": "Hello"}']),
+            Message(role="tool", contents=["tool output is not structured JSON"]),
+        ],
+        response_format=OutputModel,
+    )
+
+    assert response.value is not None
+    assert response.value.response == "Hello"
+
+
 def test_parse_structured_response_value_empty_text_with_pydantic_model() -> None:
     """Empty text should return None instead of raising when response_format is a Pydantic model."""
     result = _parse_structured_response_value("", OutputModel)
@@ -1113,6 +1186,37 @@ async def test_chat_response_from_async_generator_mapping_response_format() -> N
     assert resp.value is not None
     assert isinstance(resp.value, dict)
     assert resp.value["response"] == "Hello"
+
+
+def test_chat_response_from_streaming_updates_parses_final_assistant_message() -> None:
+    """Combined streaming updates should parse the final assistant message, not trailing tool output."""
+    updates = [
+        ChatResponseUpdate(
+            role="assistant",
+            message_id="skill-message",
+            contents=[Content.from_text('{"skill_name": "building-permit-compliance"}')],
+        ),
+        ChatResponseUpdate(
+            role="assistant",
+            message_id="final-message",
+            contents=[Content.from_text('{"respon')],
+        ),
+        ChatResponseUpdate(
+            message_id="final-message",
+            contents=[Content.from_text('se": "Hello"}')],
+        ),
+        ChatResponseUpdate(
+            role="tool",
+            message_id="tool-message",
+            contents=[Content.from_text("tool output is not structured JSON")],
+        ),
+    ]
+
+    response = ChatResponse.from_updates(updates, output_format_type=OutputModel)
+
+    assert [message.role for message in response.messages] == ["assistant", "assistant", "tool"]
+    assert response.value is not None
+    assert response.value.response == "Hello"
 
 
 # region ToolMode


### PR DESCRIPTION
### Motivation and Context

Fixes #6366.

When an agent response contains intermediate messages and a final structured JSON payload, `AgentResponse.value` currently parses `self.text`, which concatenates all message text. That can join intermediate tool/context JSON with the final response JSON and cause `ValidationError` / `JSONDecodeError` from trailing characters.

### Description

- Parse structured `ChatResponse.value` and `AgentResponse.value` from the last non-empty message text instead of the public concatenated `.text` value.
- Keep `.text` behavior unchanged for callers that want the full concatenated response text.
- Add regression coverage for Pydantic response formats and JSON schema mapping response formats.

### Testing

```bash
uv run --group dev pytest packages/core/tests/core/test_types.py -q -k 'final_message or empty_text or invalid_schema or chat_response_with_format or mapping_response_format'\nuv run pytest packages/core/tests/core/test_types.py -q\nuv run pytest packages/core/tests/core/test_middleware.py -q\nuv run pytest packages/core/tests/workflow/test_workflow.py -q -k 'AgentResponse or response or output'\nuv run ruff format --check packages/core/agent_framework/_types.py packages/core/tests/core/test_types.py\nuv run ruff check packages/core/agent_framework/_types.py packages/core/tests/core/test_types.py\ngit diff --check\n```\n\n### Contribution Checklist\n\n- [x] The code builds clean without any errors or warnings\n- [x] The PR follows the Contribution Guidelines\n- [x] All unit tests pass, and I have added new tests where possible\n- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.