### PR TITLE
.NET: Upgrade GitHub.Copilot.SDK to 1.0.0 GA + preserve caller-supplied SessionConfig.SessionId

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -99,7 +99,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.67.0-preview" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.67.0-preview" />
     <!-- Agent SDKs -->
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.2" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Agents.CopilotStudio.Client" Version="1.3.171-beta" />
     <!-- M365 Agents SDK -->
     <PackageVersion Include="AdaptiveCards" Version="3.1.0" />

--- a/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Agent_With_GitHubCopilot.csproj
+++ b/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Agent_With_GitHubCopilot.csproj
@@ -6,6 +6,14 @@
 
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+      GitHub.Copilot.SDK marks several types in the GitHub.Copilot.Rpc
+      namespace (e.g., PermissionDecision and its subclasses) as
+      [Experimental("GHCP001")]. Samples must reference these types to build
+      permission handlers, so suppress the experimental diagnostic here
+      mirroring how the SDK itself suppresses it project-wide.
+    -->
+    <NoWarn>$(NoWarn);GHCP001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Program.cs
@@ -2,21 +2,22 @@
 
 // This sample shows how to create a GitHub Copilot agent with shell command permissions.
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
+using GitHub.Copilot.Rpc;
 using Microsoft.Agents.AI;
 
 // Permission handler that prompts the user for approval
-static Task<PermissionRequestResult> PromptPermission(PermissionRequest request, PermissionInvocation invocation)
+static Task<PermissionDecision> PromptPermission(PermissionRequest request, PermissionInvocation invocation)
 {
     Console.WriteLine($"\n[Permission Request: {request.Kind}]");
     Console.Write("Approve? (y/n): ");
 
     string? input = Console.ReadLine()?.Trim().ToUpperInvariant();
-    PermissionRequestResultKind kind = input is "Y" or "YES"
-                                     ? PermissionRequestResultKind.Approved
-                                     : PermissionRequestResultKind.Rejected;
+    PermissionDecision decision = input is "Y" or "YES"
+                                  ? PermissionDecision.ApproveOnce()
+                                  : PermissionDecision.Reject();
 
-    return Task.FromResult(new PermissionRequestResult { Kind = kind });
+    return Task.FromResult(decision);
 }
 
 // Create and start a Copilot client

--- a/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/README.md
@@ -36,7 +36,7 @@ dotnet run
 You can customize the agent by providing additional configuration:
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using Microsoft.Agents.AI;
 
 // Create and start a Copilot client

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/CopilotClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/CopilotClientExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Agents.AI.GitHub.Copilot;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
-namespace GitHub.Copilot.SDK;
+namespace GitHub.Copilot;
 
 /// <summary>
 /// Provides extension methods for <see cref="CopilotClient"/>

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using Microsoft.Extensions.AI;
 using Microsoft.Shared.Diagnostics;
 
@@ -169,7 +169,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
             Channel<AgentResponseUpdate> channel = Channel.CreateUnbounded<AgentResponseUpdate>();
 
             // Subscribe to session events
-            using IDisposable subscription = copilotSession.On(evt =>
+            using IDisposable subscription = copilotSession.On<SessionEvent>(evt =>
             {
                 switch (evt)
                 {
@@ -210,7 +210,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
                 string prompt = string.Join("\n", messages.Select(m => m.Text));
 
                 // Handle DataContent as attachments
-                (List<UserMessageAttachmentFile>? attachments, tempDir) = await ProcessDataContentAttachmentsAsync(
+                (List<AttachmentFile>? attachments, tempDir) = await ProcessDataContentAttachmentsAsync(
                     messages,
                     cancellationToken).ConfigureAwait(false);
 
@@ -262,10 +262,9 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
 
     private async Task EnsureClientStartedAsync(CancellationToken cancellationToken)
     {
-        if (this._copilotClient.State != ConnectionState.Connected)
-        {
-            await this._copilotClient.StartAsync(cancellationToken).ConfigureAwait(false);
-        }
+        // CopilotClient.StartAsync caches the connection task internally,
+        // so calling it repeatedly is safe and idempotent.
+        await this._copilotClient.StartAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private ResumeSessionConfig CreateResumeConfig()
@@ -275,7 +274,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
 
     /// <summary>
     /// Copies all supported properties from a source <see cref="SessionConfig"/> into a new instance
-    /// with <see cref="SessionConfig.Streaming"/> set to <c>true</c>.
+    /// with <see cref="SessionConfigBase.Streaming"/> set to <c>true</c>.
     /// </summary>
     internal static SessionConfig CopySessionConfig(SessionConfig source)
     {
@@ -292,19 +291,21 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
             OnUserInputRequest = source.OnUserInputRequest,
             Hooks = source.Hooks,
             WorkingDirectory = source.WorkingDirectory,
-            ConfigDir = source.ConfigDir,
+            ConfigDirectory = source.ConfigDirectory,
             McpServers = source.McpServers,
             CustomAgents = source.CustomAgents,
             SkillDirectories = source.SkillDirectories,
             DisabledSkills = source.DisabledSkills,
             InfiniteSessions = source.InfiniteSessions,
+            SessionId = source.SessionId,
+            Cloud = source.Cloud,
             Streaming = true
         };
     }
 
     /// <summary>
     /// Copies all supported properties from a source <see cref="SessionConfig"/> into a new
-    /// <see cref="ResumeSessionConfig"/> with <see cref="ResumeSessionConfig.Streaming"/> set to <c>true</c>.
+    /// <see cref="ResumeSessionConfig"/> with <see cref="SessionConfigBase.Streaming"/> set to <c>true</c>.
     /// </summary>
     internal static ResumeSessionConfig CopyResumeSessionConfig(SessionConfig? source)
     {
@@ -321,7 +322,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
             OnUserInputRequest = source?.OnUserInputRequest,
             Hooks = source?.Hooks,
             WorkingDirectory = source?.WorkingDirectory,
-            ConfigDir = source?.ConfigDir,
+            ConfigDirectory = source?.ConfigDirectory,
             McpServers = source?.McpServers,
             CustomAgents = source?.CustomAgents,
             SkillDirectories = source?.SkillDirectories,
@@ -366,10 +367,10 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
     {
         UsageDetails usageDetails = new()
         {
-            InputTokenCount = (int?)(usageEvent.Data?.InputTokens),
-            OutputTokenCount = (int?)(usageEvent.Data?.OutputTokens),
+            InputTokenCount = (int?)usageEvent.Data?.InputTokens,
+            OutputTokenCount = (int?)usageEvent.Data?.OutputTokens,
             TotalTokenCount = (int?)((usageEvent.Data?.InputTokens ?? 0) + (usageEvent.Data?.OutputTokens ?? 0)),
-            CachedInputTokenCount = (int?)(usageEvent.Data?.CacheReadTokens),
+            CachedInputTokenCount = (int?)usageEvent.Data?.CacheReadTokens,
             AdditionalCounts = GetAdditionalCounts(usageEvent),
         };
 
@@ -394,22 +395,24 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
 
         AdditionalPropertiesDictionary<long>? additionalCounts = null;
 
-        if (usageEvent.Data.CacheWriteTokens is double cacheWriteTokens)
+        if (usageEvent.Data.CacheWriteTokens is long cacheWriteTokens)
         {
             additionalCounts ??= [];
-            additionalCounts[nameof(AssistantUsageData.CacheWriteTokens)] = (long)cacheWriteTokens;
+            additionalCounts[nameof(AssistantUsageData.CacheWriteTokens)] = cacheWriteTokens;
         }
 
+#pragma warning disable GHCP001 // AssistantUsageData.Cost is experimental
         if (usageEvent.Data.Cost is double cost)
         {
             additionalCounts ??= [];
             additionalCounts[nameof(AssistantUsageData.Cost)] = (long)cost;
         }
+#pragma warning restore GHCP001
 
-        if (usageEvent.Data.Duration is double duration)
+        if (usageEvent.Data.Duration is TimeSpan duration)
         {
             additionalCounts ??= [];
-            additionalCounts[nameof(AssistantUsageData.Duration)] = (long)duration;
+            additionalCounts[nameof(AssistantUsageData.Duration)] = (long)duration.TotalMilliseconds;
         }
 
         return additionalCounts;
@@ -432,7 +435,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
 
     private static SessionConfig? GetSessionConfig(IList<AITool>? tools, string? instructions)
     {
-        List<AIFunction>? mappedTools = tools is { Count: > 0 } ? tools.OfType<AIFunction>().ToList() : null;
+        List<AIFunctionDeclaration>? mappedTools = tools is { Count: > 0 } ? [.. tools.OfType<AIFunction>()] : null;
         SystemMessageConfig? systemMessage = instructions is not null ? new SystemMessageConfig { Mode = SystemMessageMode.Append, Content = instructions } : null;
 
         if (mappedTools is null && systemMessage is null)
@@ -443,11 +446,11 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
         return new SessionConfig { Tools = mappedTools, SystemMessage = systemMessage };
     }
 
-    private static async Task<(List<UserMessageAttachmentFile>? Attachments, string? TempDir)> ProcessDataContentAttachmentsAsync(
+    private static async Task<(List<AttachmentFile>? Attachments, string? TempDir)> ProcessDataContentAttachmentsAsync(
         IEnumerable<ChatMessage> messages,
         CancellationToken cancellationToken)
     {
-        List<UserMessageAttachmentFile>? attachments = null;
+        List<AttachmentFile>? attachments = null;
         string? tempDir = null;
         foreach (ChatMessage message in messages)
         {
@@ -461,7 +464,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
                     string tempFilePath = await dataContent.SaveToAsync(tempDir, cancellationToken).ConfigureAwait(false);
 
                     attachments ??= [];
-                    attachments.Add(new UserMessageAttachmentFile
+                    attachments.Add(new AttachmentFile
                     {
                         Path = tempFilePath,
                         DisplayName = Path.GetFileName(tempFilePath)

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
@@ -4,7 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
+using GitHub.Copilot.Rpc;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests;
@@ -13,8 +14,8 @@ public class GitHubCopilotAgentTests
 {
     private const string SkipReason = "Integration tests require GitHub Copilot CLI installed. For local execution only.";
 
-    private static Task<PermissionRequestResult> OnPermissionRequestAsync(PermissionRequest request, PermissionInvocation invocation)
-        => Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved });
+    private static Task<PermissionDecision> OnPermissionRequestAsync(PermissionRequest request, PermissionInvocation invocation)
+        => Task.FromResult(PermissionDecision.ApproveOnce());
 
     [Fact(Skip = SkipReason)]
     public async Task RunAsync_WithSimplePrompt_ReturnsResponseAsync()

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests.csproj
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests.csproj
@@ -3,6 +3,14 @@
   <PropertyGroup>
     <!-- GitHub.Copilot.SDK only supports .NET 8.0+ -->
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
+    <!--
+      GitHub.Copilot.SDK marks several types in the GitHub.Copilot.Rpc
+      namespace (e.g., PermissionDecision and its subclasses) as
+      [Experimental("GHCP001")]. Integration tests must reference these types
+      to build permission handlers, so suppress the experimental diagnostic
+      here mirroring how the SDK itself suppresses it project-wide.
+    -->
+    <NoWarn>$(NoWarn);GHCP001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/CopilotClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/CopilotClientExtensionsTests.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.GitHub.Copilot.UnitTests;
@@ -16,7 +16,7 @@ public sealed class CopilotClientExtensionsTests
     public void AsAIAgent_WithAllParameters_ReturnsGitHubCopilotAgentWithSpecifiedProperties()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
 
         const string TestId = "test-agent-id";
         const string TestName = "Test Agent";
@@ -37,7 +37,7 @@ public sealed class CopilotClientExtensionsTests
     public void AsAIAgent_WithMinimalParameters_ReturnsGitHubCopilotAgent()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
 
         // Act
         var agent = copilotClient.AsAIAgent(ownsClient: false, tools: null);
@@ -61,7 +61,7 @@ public sealed class CopilotClientExtensionsTests
     public void AsAIAgent_WithOwnsClient_ReturnsAgentThatOwnsClient()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
 
         // Act
         var agent = copilotClient.AsAIAgent(ownsClient: true, tools: null);
@@ -75,7 +75,7 @@ public sealed class CopilotClientExtensionsTests
     public void AsAIAgent_WithTools_ReturnsAgentWithTools()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         List<AITool> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
 
         // Act

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentTests.cs
@@ -3,7 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
+using GitHub.Copilot.Rpc;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.GitHub.Copilot.UnitTests;
@@ -17,7 +18,7 @@ public sealed class GitHubCopilotAgentTests
     public void Constructor_WithCopilotClient_InitializesPropertiesCorrectly()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         const string TestId = "test-id";
         const string TestName = "test-name";
         const string TestDescription = "test-description";
@@ -42,7 +43,7 @@ public sealed class GitHubCopilotAgentTests
     public void Constructor_WithDefaultParameters_UsesBaseProperties()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
 
         // Act
         var agent = new GitHubCopilotAgent(copilotClient, ownsClient: false, tools: null);
@@ -58,7 +59,7 @@ public sealed class GitHubCopilotAgentTests
     public async Task CreateSessionAsync_ReturnsGitHubCopilotAgentSessionAsync()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         var agent = new GitHubCopilotAgent(copilotClient, ownsClient: false, tools: null);
 
         // Act
@@ -73,7 +74,7 @@ public sealed class GitHubCopilotAgentTests
     public async Task CreateSessionAsync_WithSessionId_ReturnsSessionWithSessionIdAsync()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         var agent = new GitHubCopilotAgent(copilotClient, ownsClient: false, tools: null);
         const string TestSessionId = "test-session-id";
 
@@ -90,7 +91,7 @@ public sealed class GitHubCopilotAgentTests
     public void Constructor_WithTools_InitializesCorrectly()
     {
         // Arrange
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         List<AITool> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
 
         // Act
@@ -105,16 +106,21 @@ public sealed class GitHubCopilotAgentTests
     public void CopySessionConfig_CopiesAllProperties()
     {
         // Arrange
-        List<AIFunction> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
+        const string PreAllocatedId = "preallocated-id";
+        List<AIFunctionDeclaration> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
         var hooks = new SessionHooks();
         var infiniteSessions = new InfiniteSessionConfig();
         var systemMessage = new SystemMessageConfig { Mode = SystemMessageMode.Append, Content = "Be helpful" };
-        PermissionRequestHandler permissionHandler = (_, _) => Task.FromResult(new PermissionRequestResult());
-        UserInputHandler userInputHandler = (_, _) => Task.FromResult(new UserInputResponse { Answer = "input" });
+        Func<PermissionRequest, PermissionInvocation, Task<PermissionDecision>> permissionHandler =
+            (_, _) => Task.FromResult(PermissionDecision.ApproveOnce());
+        Func<UserInputRequest, UserInputInvocation, Task<UserInputResponse>> userInputHandler =
+            (_, _) => Task.FromResult(new UserInputResponse { Answer = "input" });
         var mcpServers = new Dictionary<string, McpServerConfig> { ["server1"] = new McpStdioServerConfig() };
+        var cloud = new CloudSessionOptions();
 
         var source = new SessionConfig
         {
+            SessionId = PreAllocatedId,
             Model = "gpt-4o",
             ReasoningEffort = "high",
             Tools = tools,
@@ -122,19 +128,21 @@ public sealed class GitHubCopilotAgentTests
             AvailableTools = ["tool1", "tool2"],
             ExcludedTools = ["tool3"],
             WorkingDirectory = "/workspace",
-            ConfigDir = "/config",
+            ConfigDirectory = "/config",
             Hooks = hooks,
             InfiniteSessions = infiniteSessions,
             OnPermissionRequest = permissionHandler,
             OnUserInputRequest = userInputHandler,
             McpServers = mcpServers,
             DisabledSkills = ["skill1"],
+            Cloud = cloud,
         };
 
         // Act
         SessionConfig result = GitHubCopilotAgent.CopySessionConfig(source);
 
         // Assert
+        Assert.Equal(PreAllocatedId, result.SessionId);
         Assert.Equal("gpt-4o", result.Model);
         Assert.Equal("high", result.ReasoningEffort);
         Assert.Same(tools, result.Tools);
@@ -142,26 +150,81 @@ public sealed class GitHubCopilotAgentTests
         Assert.Equal(new List<string> { "tool1", "tool2" }, result.AvailableTools);
         Assert.Equal(new List<string> { "tool3" }, result.ExcludedTools);
         Assert.Equal("/workspace", result.WorkingDirectory);
-        Assert.Equal("/config", result.ConfigDir);
+        Assert.Equal("/config", result.ConfigDirectory);
         Assert.Same(hooks, result.Hooks);
         Assert.Same(infiniteSessions, result.InfiniteSessions);
         Assert.Same(permissionHandler, result.OnPermissionRequest);
         Assert.Same(userInputHandler, result.OnUserInputRequest);
         Assert.Same(mcpServers, result.McpServers);
         Assert.Equal(new List<string> { "skill1" }, result.DisabledSkills);
+        Assert.Same(cloud, result.Cloud);
         Assert.True(result.Streaming);
+    }
+
+    [Fact]
+    public void CopySessionConfig_PreservesCloudSessionOptions()
+    {
+        // Arrange
+        var cloud = new CloudSessionOptions();
+        var source = new SessionConfig
+        {
+            Cloud = cloud,
+            OnPermissionRequest = (_, _) => Task.FromResult(PermissionDecision.ApproveOnce()),
+        };
+
+        // Act
+        SessionConfig copy = GitHubCopilotAgent.CopySessionConfig(source);
+
+        // Assert
+        Assert.Same(cloud, copy.Cloud);
+    }
+
+    [Fact]
+    public void CopySessionConfig_PreservesCallerSuppliedSessionId()
+    {
+        // Arrange
+        const string PreAllocatedId = "11111111-2222-3333-4444-555555555555";
+        var source = new SessionConfig
+        {
+            SessionId = PreAllocatedId,
+            OnPermissionRequest = (_, _) => Task.FromResult(PermissionDecision.ApproveOnce()),
+        };
+
+        // Act
+        SessionConfig copy = GitHubCopilotAgent.CopySessionConfig(source);
+
+        // Assert
+        Assert.Equal(PreAllocatedId, copy.SessionId);
+    }
+
+    [Fact]
+    public void CopySessionConfig_PassesThroughNullSessionId()
+    {
+        // Arrange
+        var source = new SessionConfig
+        {
+            OnPermissionRequest = (_, _) => Task.FromResult(PermissionDecision.ApproveOnce()),
+        };
+
+        // Act
+        SessionConfig copy = GitHubCopilotAgent.CopySessionConfig(source);
+
+        // Assert
+        Assert.Null(copy.SessionId);
     }
 
     [Fact]
     public void CopyResumeSessionConfig_CopiesAllProperties()
     {
         // Arrange
-        List<AIFunction> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
+        List<AIFunctionDeclaration> tools = [AIFunctionFactory.Create(() => "test", "TestFunc", "Test function")];
         var hooks = new SessionHooks();
         var infiniteSessions = new InfiniteSessionConfig();
         var systemMessage = new SystemMessageConfig { Mode = SystemMessageMode.Append, Content = "Be helpful" };
-        PermissionRequestHandler permissionHandler = (_, _) => Task.FromResult(new PermissionRequestResult());
-        UserInputHandler userInputHandler = (_, _) => Task.FromResult(new UserInputResponse { Answer = "input" });
+        Func<PermissionRequest, PermissionInvocation, Task<PermissionDecision>> permissionHandler =
+            (_, _) => Task.FromResult(PermissionDecision.ApproveOnce());
+        Func<UserInputRequest, UserInputInvocation, Task<UserInputResponse>> userInputHandler =
+            (_, _) => Task.FromResult(new UserInputResponse { Answer = "input" });
         var mcpServers = new Dictionary<string, McpServerConfig> { ["server1"] = new McpStdioServerConfig() };
 
         var source = new SessionConfig
@@ -173,7 +236,7 @@ public sealed class GitHubCopilotAgentTests
             AvailableTools = ["tool1", "tool2"],
             ExcludedTools = ["tool3"],
             WorkingDirectory = "/workspace",
-            ConfigDir = "/config",
+            ConfigDirectory = "/config",
             Hooks = hooks,
             InfiniteSessions = infiniteSessions,
             OnPermissionRequest = permissionHandler,
@@ -193,7 +256,7 @@ public sealed class GitHubCopilotAgentTests
         Assert.Equal(new List<string> { "tool1", "tool2" }, result.AvailableTools);
         Assert.Equal(new List<string> { "tool3" }, result.ExcludedTools);
         Assert.Equal("/workspace", result.WorkingDirectory);
-        Assert.Equal("/config", result.ConfigDir);
+        Assert.Equal("/config", result.ConfigDirectory);
         Assert.Same(hooks, result.Hooks);
         Assert.Same(infiniteSessions, result.InfiniteSessions);
         Assert.Same(permissionHandler, result.OnPermissionRequest);
@@ -218,7 +281,7 @@ public sealed class GitHubCopilotAgentTests
         Assert.Null(result.OnUserInputRequest);
         Assert.Null(result.Hooks);
         Assert.Null(result.WorkingDirectory);
-        Assert.Null(result.ConfigDir);
+        Assert.Null(result.ConfigDirectory);
         Assert.True(result.Streaming);
     }
 
@@ -233,7 +296,7 @@ public sealed class GitHubCopilotAgentTests
                 Content = "Some streamed content that was already delivered via delta events"
             }
         };
-        CopilotClient copilotClient = new(new CopilotClientOptions { AutoStart = false });
+        CopilotClient copilotClient = new(new CopilotClientOptions());
         const string TestId = "agent-id";
         var agent = new GitHubCopilotAgent(copilotClient, ownsClient: false, id: TestId, tools: null);
         AgentResponseUpdate result = agent.ConvertToAgentResponseUpdate(assistantMessage);

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests.csproj
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests.csproj
@@ -3,10 +3,18 @@
   <PropertyGroup>
     <!-- GitHub.Copilot.SDK only supports .NET 8.0+ -->
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
+    <!--
+      GitHub.Copilot.SDK marks several types in the GitHub.Copilot.Rpc
+      namespace (e.g., PermissionDecision and its subclasses) as
+      [Experimental("GHCP001")]. Test fixtures must reference these types to
+      build permission handlers, so suppress the experimental diagnostic here
+      mirroring how the SDK itself suppresses it project-wide.
+    -->
+    <NoWarn>$(NoWarn);GHCP001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Agents.AI.GitHub.Copilot\Microsoft.Agents.AI.GitHub.Copilot.csproj" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
### Motivation and Context

The .NET bridge `Microsoft.Agents.AI.GitHub.Copilot` pinned `GitHub.Copilot.SDK` to `1.0.0-beta.2`. The SDK shipped GA as `1.0.0` on 2026-06-02, but the bridge directory received no updates across the 6 betas and the GA.

Additionally, callers who pre-allocate a Copilot CLI session id via `SessionConfig.SessionId` (which `CopilotClient.CreateSessionAsync` honors per [`Client.cs:869`](https://github.com/github/copilot-sdk/blob/v1.0.0/dotnet/src/Client.cs#L869)) had it silently dropped by the bridge's `CopySessionConfig` helper, so the CLI always minted a fresh GUID instead. This breaks scenarios where the host wants to correlate Copilot session ids with its own identifiers up-front (e.g., HTTP request ids, telemetry correlation ids, durable workflow ids).

### Description

#### Goal 1 — SDK 1.0.0 upgrade

Bump `GitHub.Copilot.SDK` from `1.0.0-beta.2` to `1.0.0` in `dotnet/Directory.Packages.props` and adapt the bridge to the v1.0.0 API drift:

| Change | Beta.2 | 1.0.0 |
| --- | --- | --- |
| Namespace | `GitHub.Copilot.SDK` | `GitHub.Copilot` |
| `SessionConfig.Tools` | `List<AIFunction>` | `ICollection<AIFunctionDeclaration>` |
| Config directory property | `ConfigDir` | `ConfigDirectory` |
| Attachment type | `UserMessageAttachmentFile` | `AttachmentFile` |
| `AssistantUsageData` token counts | `double?` | `long?` |
| `AssistantUsageData.Duration` | `double?` (ms) | `TimeSpan?` |
| Client state check | `_copilotClient.State != ConnectionState.Connected` | _removed_ — rely on `StartAsync`'s internal idempotent task cache |
| Permission handler return | `Task<PermissionRequestResult>` | `Task<PermissionDecision>` (in `GitHub.Copilot.Rpc`) |

Test, integration-test, and sample projects were updated for the new namespace and the `PermissionRequestResult` → `PermissionDecision` migration. The SDK marks `PermissionDecision` and its variants `[Experimental("GHCP001")]`, so test and sample csproj files add `<NoWarn>$(NoWarn);GHCP001</NoWarn>` — mirroring the SDK's own project-wide suppression in [`GitHub.Copilot.SDK.csproj`](https://github.com/github/copilot-sdk/blob/v1.0.0/dotnet/src/GitHub.Copilot.SDK.csproj). The bridge code itself never names these experimental types, so the bridge does not need to suppress.

#### Goal 2 — preserve caller-supplied `SessionConfig.SessionId`

Add `SessionId = source.SessionId` to `CopySessionConfig`. `ResumeSessionConfig` does NOT expose a `SessionId` property in v1.0.0 (resume takes the session id as a separate argument), so `CopyResumeSessionConfig` is intentionally left unchanged.

This is non-breaking: callers that never set `SessionConfig.SessionId` continue to pass `null` through, and the SDK still mints a fresh GUID via `config.SessionId ?? Guid.NewGuid().ToString()`.

#### Code-review follow-up — preserve `SessionConfig.Cloud`

A GPT-5.5 review of the diff caught a second silently-dropped property: `SessionConfig.Cloud` (newly added in v1.0.0). Without it, a caller-supplied `CloudSessionOptions` would silently degrade to a local session. Now copied through with matching test coverage.

#### New / updated tests

- Augmented `CopySessionConfig_CopiesAllProperties` to assert `SessionId` and `Cloud` survive the copy.
- Added `CopySessionConfig_PreservesCallerSuppliedSessionId`.
- Added `CopySessionConfig_PassesThroughNullSessionId`.
- Added `CopySessionConfig_PreservesCloudSessionOptions`.

#### Files touched

```
dotnet/Directory.Packages.props
dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/CopilotClientExtensions.cs
dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/CopilotClientExtensionsTests.cs
dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/GitHubCopilotAgentTests.cs
dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests.csproj
dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests.csproj
dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Program.cs
dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/Agent_With_GitHubCopilot.csproj
dotnet/samples/02-agents/AgentProviders/Agent_With_GitHubCopilot/README.md
```

### Validation

| Command | Result |
| --- | --- |
| `dotnet build src/Microsoft.Agents.AI.GitHub.Copilot --tl:off` | 0 errors, 0 warnings (net8.0 / net9.0 / net10.0) |
| `dotnet build tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests --tl:off` | 0 errors, 0 warnings |
| `dotnet build tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests --tl:off` | 0 errors, 0 warnings |
| `dotnet build samples/02-agents/AgentProviders/Agent_With_GitHubCopilot --tl:off` | 0 errors, 0 warnings |
| `dotnet test --project tests/Microsoft.Agents.AI.GitHub.Copilot.UnitTests --no-build` | **54/54 passing** (18 tests × 3 TFMs) |
| `dotnet format --verify-no-changes` | clean on bridge, tests, integration tests, sample |

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No — the bridge's public API (`GitHubCopilotAgent`, `AsAIAgent` extension methods, `SessionConfig` constructor parameter) is unchanged. The underlying SDK upgrade is binary-compatible for the bridge's own surface; transitive type changes (e.g. `SessionConfig.Tools` element type) come from the SDK GA itself, not from the bridge.

### Known limitation (out of scope)

The v1.0.0 SDK's `CopilotClient.StartAsync` uses `_connectionTask ??= StartCoreAsync(...)` without a lock, so concurrent first calls on a cold client can theoretically race. The previous `if (State != Connected) StartAsync(...)` guard had the same race (and arguably worse — a thread seeing `Connecting` would skip the await entirely). Hardening this belongs in the SDK or in a separate bridge PR.
