### PR TITLE
Docs: Remove broken Atomic Agents link

### DIFF
--- a/docs/decisions/0007-agent-filtering-middleware.md
+++ b/docs/decisions/0007-agent-filtering-middleware.md
@@ -1125,7 +1125,7 @@ Naming (Python): N/A (Composable Components)
 Supports: N  
 Observation: No explicit middleware/filters; modularity allows composable units but no dedicated interception hooks or callbacks for custom reading/modification mid-execution.
 
-For more details, see the official documentation: [Atomic Agents Docs](https://brainblend-ai.github.io/atomic-agents/). No specific code examples available for interception.
+No specific code examples available for interception.
 
 #### Smolagents (Hugging Face)
 


### PR DESCRIPTION
### Motivation and Context

The Atomic Agents documentation link in ADR 0007 now returns 404, causing markdown link checks to fail.

### Description

- Remove the broken Atomic Agents documentation link from `docs/decisions/0007-agent-filtering-middleware.md` while leaving the surrounding observation intact.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
