### PR TITLE
Python: fix: pass Ollama sample tools through options

### DIFF
--- a/python/samples/02-agents/providers/ollama/ollama_chat_client.py
+++ b/python/samples/02-agents/providers/ollama/ollama_chat_client.py
@@ -40,12 +40,12 @@ async def main() -> None:
     print(f"User: {message}")
     if stream:
         print("Assistant: ", end="")
-        async for chunk in client.get_response(messages, tools=get_time, stream=True):
+        async for chunk in client.get_response(messages, options={"tools": get_time}, stream=True):
             if str(chunk):
                 print(str(chunk), end="")
         print("")
     else:
-        response = await client.get_response(messages, tools=get_time)
+        response = await client.get_response(messages, options={"tools": get_time})
         print(f"Assistant: {response}")
 
 


### PR DESCRIPTION
Fixes #6411.

The Ollama chat-client sample was still passing `tools=` directly to `get_response()`. That keyword is not accepted by the function invocation layer, while the rest of the samples already pass tools through the chat options dictionary.

This updates both the streaming and non-streaming paths to use `options={"tools": get_time}`.

Validation:
- `python -m py_compile python\samples\02-agents\providers\ollama\ollama_chat_client.py`
- `rg -n 'get_response\(messages, tools=' python\samples\02-agents\providers\ollama\ollama_chat_client.py` returned no matches
- `git diff --check`
- `$env:PYTHONPATH = "C:\dev\GITHUB-clean\agent-framework-6411\python\packages\core;C:\dev\GITHUB-clean\agent-framework-6411\python\packages\ollama"; python -m pytest python\packages\ollama\tests\test_ollama_chat_client.py -q`

Note: running the Ollama test without the local `PYTHONPATH` first picked up another editable checkout and failed collection with `ModuleNotFoundError: agent_framework_ollama`; the same test passed with this worktree's packages on `PYTHONPATH`.