### PR TITLE
.NET: Make GitHub.Copilot.SDK build targets reach transitive consumers (#6455)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
@@ -42,12 +42,21 @@
     adapter .dll, no copilot.exe in their output, and a runtime failure at the
     first RunAsync call.
 
-    The targets file in buildTransitive/ is static; the .props file is generated
-    here at pack time so the SDK version we were built against is baked in and
-    consumers don't have to discover it from the nuspec. See the targets file
-    for the full design rationale.
+    The targets file in buildTransitive/ is static and contains all of the
+    Condition / Import logic. The .props file generated here just bakes the
+    SDK version this package was built against into a dedicated property
+    ($(_MicrosoftAgentsAICopilotSdkPackagedVersion)) — no Condition or
+    inner $(...) reference in the generated file, so we avoid any MSBuild
+    escape gymnastics during string construction. The static targets file
+    then defaults $(_MicrosoftAgentsAICopilotSdkVersion) to the packaged
+    version unless the consumer overrides it.
   -->
-  <Target Name="_GenerateBuildTransitiveProps" BeforeTargets="_GetPackageFiles">
+  <ItemGroup>
+    <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.targets" Pack="true" PackagePath="buildTransitive\" />
+    <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.props" Pack="true" PackagePath="buildTransitive\" />
+  </ItemGroup>
+
+  <Target Name="_GenerateBuildTransitiveProps" BeforeTargets="Build;Pack;_GetPackageFiles">
     <ItemGroup>
       <_CopilotSdkPackageVersion Include="@(PackageVersion)" Condition="'%(Identity)' == 'GitHub.Copilot.SDK'" />
     </ItemGroup>
@@ -58,24 +67,17 @@
            Text="Could not resolve GitHub.Copilot.SDK version from PackageVersion items. Ensure the central package version is declared in Directory.Packages.props." />
     <PropertyGroup>
       <_BuildTransitivePropsContent>
-&lt;Project&gt;
-  &lt;PropertyGroup&gt;
-    &lt;_MicrosoftAgentsAICopilotSdkVersion Condition=&quot;'%24(_MicrosoftAgentsAICopilotSdkVersion)' == ''&quot;&gt;$(_CopilotSdkResolvedVersion)&lt;/_MicrosoftAgentsAICopilotSdkVersion&gt;
-  &lt;/PropertyGroup&gt;
-&lt;/Project&gt;
+<![CDATA[<Project>
+  <PropertyGroup>
+    <_MicrosoftAgentsAICopilotSdkPackagedVersion>$(_CopilotSdkResolvedVersion)</_MicrosoftAgentsAICopilotSdkPackagedVersion>
+  </PropertyGroup>
+</Project>]]>
       </_BuildTransitivePropsContent>
     </PropertyGroup>
     <WriteLinesToFile File="$(MSBuildThisFileDirectory)buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.props"
                       Lines="$(_BuildTransitivePropsContent)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
-    <ItemGroup>
-      <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.props" Pack="true" PackagePath="buildTransitive\" />
-    </ItemGroup>
   </Target>
-
-  <ItemGroup>
-    <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.targets" Pack="true" PackagePath="buildTransitive\" />
-  </ItemGroup>
 
 </Project>

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
@@ -32,4 +32,50 @@
     <Description>Provides Microsoft Agent Framework support for GitHub Copilot SDK.</Description>
   </PropertyGroup>
 
+  <!--
+    buildTransitive bridge for GitHub.Copilot.SDK's CLI binary-download targets.
+
+    GitHub.Copilot.SDK ships its CLI download targets under build/, which NuGet
+    only auto-imports for projects with a DIRECT PackageReference to the SDK.
+    Consumers of this package (who reference Microsoft.Agents.AI.GitHub.Copilot
+    instead of GitHub.Copilot.SDK directly) would otherwise get only the managed
+    adapter .dll, no copilot.exe in their output, and a runtime failure at the
+    first RunAsync call.
+
+    The targets file in buildTransitive/ is static; the .props file is generated
+    here at pack time so the SDK version we were built against is baked in and
+    consumers don't have to discover it from the nuspec. See the targets file
+    for the full design rationale.
+  -->
+  <Target Name="_GenerateBuildTransitiveProps" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <_CopilotSdkPackageVersion Include="@(PackageVersion)" Condition="'%(Identity)' == 'GitHub.Copilot.SDK'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_CopilotSdkResolvedVersion>@(_CopilotSdkPackageVersion->'%(Version)')</_CopilotSdkResolvedVersion>
+    </PropertyGroup>
+    <Error Condition="'$(_CopilotSdkResolvedVersion)' == ''"
+           Text="Could not resolve GitHub.Copilot.SDK version from PackageVersion items. Ensure the central package version is declared in Directory.Packages.props." />
+    <PropertyGroup>
+      <_BuildTransitivePropsContent>
+&lt;Project&gt;
+  &lt;PropertyGroup&gt;
+    &lt;_MicrosoftAgentsAICopilotSdkVersion Condition=&quot;'%24(_MicrosoftAgentsAICopilotSdkVersion)' == ''&quot;&gt;$(_CopilotSdkResolvedVersion)&lt;/_MicrosoftAgentsAICopilotSdkVersion&gt;
+  &lt;/PropertyGroup&gt;
+&lt;/Project&gt;
+      </_BuildTransitivePropsContent>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(MSBuildThisFileDirectory)buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.props"
+                      Lines="$(_BuildTransitivePropsContent)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.props" Pack="true" PackagePath="buildTransitive\" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <None Include="buildTransitive\Microsoft.Agents.AI.GitHub.Copilot.targets" Pack="true" PackagePath="buildTransitive\" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/.gitignore
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/.gitignore
@@ -1,0 +1,3 @@
+# Auto-generated at pack time by _GenerateBuildTransitiveProps in the csproj.
+Microsoft.Agents.AI.GitHub.Copilot.props
+

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.targets
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.targets
@@ -1,0 +1,31 @@
+<Project>
+  <!--
+    Bridge GitHub.Copilot.SDK's build/ targets to transitive consumers.
+
+    GitHub.Copilot.SDK ships its CLI download / binary-copy MSBuild targets under
+    build/, which means they only auto-import for projects with a DIRECT
+    PackageReference to GitHub.Copilot.SDK. Consumers of this package
+    (Microsoft.Agents.AI.GitHub.Copilot) would otherwise get only the managed
+    adapter .dll, no copilot CLI binary in their output, and the SDK would fail
+    at runtime with:
+
+        Copilot CLI not found at 'bin/{config}/{tfm}/runtimes/{rid}/native/copilot.exe'
+
+    This file ships under buildTransitive/ so NuGet auto-imports it for every
+    transitive consumer, locates the SDK in the NuGet package cache, and imports
+    the SDK's build/ targets so the CLI binary gets downloaded and copied to the
+    consumer's output as expected.
+
+    The companion .props file is generated at this package's pack time and sets
+    $(_MicrosoftAgentsAICopilotSdkVersion) to the SDK version this package was
+    built against. Consumers may opt out via $(CopilotSkipCliDownload)=true (also
+    honored by the SDK's own targets) or override the SDK version path by
+    setting $(_MicrosoftAgentsAICopilotSdkVersion) before this file is imported.
+  -->
+  <PropertyGroup>
+    <_MicrosoftAgentsAICopilotSdkBuildDir Condition="'$(_MicrosoftAgentsAICopilotSdkVersion)' != ''">$([System.IO.Path]::Combine('$(NuGetPackageRoot)', 'github.copilot.sdk', '$(_MicrosoftAgentsAICopilotSdkVersion)', 'build'))</_MicrosoftAgentsAICopilotSdkBuildDir>
+  </PropertyGroup>
+
+  <Import Project="$(_MicrosoftAgentsAICopilotSdkBuildDir)/GitHub.Copilot.SDK.targets"
+          Condition="'$(_MicrosoftAgentsAICopilotSdkBuildDir)' != '' And Exists('$(_MicrosoftAgentsAICopilotSdkBuildDir)/GitHub.Copilot.SDK.targets')" />
+</Project>

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.targets
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.targets
@@ -17,15 +17,18 @@
     consumer's output as expected.
 
     The companion .props file is generated at this package's pack time and sets
-    $(_MicrosoftAgentsAICopilotSdkVersion) to the SDK version this package was
-    built against. Consumers may opt out via $(CopilotSkipCliDownload)=true (also
-    honored by the SDK's own targets) or override the SDK version path by
-    setting $(_MicrosoftAgentsAICopilotSdkVersion) before this file is imported.
+    $(_MicrosoftAgentsAICopilotSdkPackagedVersion) to the SDK version this
+    package was built against. The Condition below uses that as the default for
+    $(_MicrosoftAgentsAICopilotSdkVersion), so consumers may override the SDK
+    version path by setting $(_MicrosoftAgentsAICopilotSdkVersion) before this
+    file is imported. Consumers may also opt out of the binary download via the
+    SDK's own $(CopilotSkipCliDownload)=true, which the SDK targets honor.
   -->
   <PropertyGroup>
-    <_MicrosoftAgentsAICopilotSdkBuildDir Condition="'$(_MicrosoftAgentsAICopilotSdkVersion)' != ''">$([System.IO.Path]::Combine('$(NuGetPackageRoot)', 'github.copilot.sdk', '$(_MicrosoftAgentsAICopilotSdkVersion)', 'build'))</_MicrosoftAgentsAICopilotSdkBuildDir>
+    <_MicrosoftAgentsAICopilotSdkVersion Condition="'$(_MicrosoftAgentsAICopilotSdkVersion)' == ''">$(_MicrosoftAgentsAICopilotSdkPackagedVersion)</_MicrosoftAgentsAICopilotSdkVersion>
+    <_MicrosoftAgentsAICopilotSdkTargetsPath Condition="'$(_MicrosoftAgentsAICopilotSdkVersion)' != ''">$([System.IO.Path]::Combine('$(NuGetPackageRoot)', 'github.copilot.sdk', '$(_MicrosoftAgentsAICopilotSdkVersion)', 'build', 'GitHub.Copilot.SDK.targets'))</_MicrosoftAgentsAICopilotSdkTargetsPath>
   </PropertyGroup>
 
-  <Import Project="$(_MicrosoftAgentsAICopilotSdkBuildDir)/GitHub.Copilot.SDK.targets"
-          Condition="'$(_MicrosoftAgentsAICopilotSdkBuildDir)' != '' And Exists('$(_MicrosoftAgentsAICopilotSdkBuildDir)/GitHub.Copilot.SDK.targets')" />
+  <Import Project="$(_MicrosoftAgentsAICopilotSdkTargetsPath)"
+          Condition="'$(_MicrosoftAgentsAICopilotSdkTargetsPath)' != '' And Exists('$(_MicrosoftAgentsAICopilotSdkTargetsPath)')" />
 </Project>


### PR DESCRIPTION
### Motivation and Context

Fixes #6455.

Consumers who reference `Microsoft.Agents.AI.GitHub.Copilot` (the normal way to use the adapter) currently get only the managed `.dll` — no `copilot.exe` in their output, and the SDK throws `InvalidOperationException: Copilot CLI not found at runtimes\{rid}\native\copilot.exe` on the first `RunAsync`. Root cause is purely packaging: `GitHub.Copilot.SDK` ships its CLI binary-download MSBuild targets under `build/`, which NuGet only auto-imports for projects with a **direct** `PackageReference` to the SDK. Transitive consumers never see those targets and the binary never lands.

The SDK targets themselves are correct — adding `<PackageReference Include="GitHub.Copilot.SDK" />` directly to a consumer alongside the MAF reference makes the SDK targets fire and `~115 MB copilot.exe` shows up at the right path. So the fix here is to make those targets reachable to consumers of the adapter package as well.

Long-term, relocating the targets from `build/` to `buildTransitive/` in `github/copilot-sdk` itself is the cleaner SDK-side fix and would benefit every downstream package, not just this one. Issue #6455 covers both options; this PR implements the adapter-side fix (Option A) so MAF users get unblocked immediately without an SDK-side coordination cycle.

### Description

Adds a tiny `buildTransitive/` bridge to `Microsoft.Agents.AI.GitHub.Copilot` so the SDK's binary-download targets reach transitive consumers.

**Files added:**

- `dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.targets` — static bridge. Imports the SDK's `build/GitHub.Copilot.SDK.targets` from the NuGet cache (`$(NuGetPackageRoot)/github.copilot.sdk/$(_MicrosoftAgentsAICopilotSdkVersion)/build/...`). The version-pin condition no-ops gracefully when the resolved SDK version differs from what we baked, so this is **purely additive** — consumers already pinning the SDK directly see no behavior change.
- `dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/buildTransitive/.gitignore` — ignores the auto-generated props file (regenerated on every pack, similar to how `GitHub.Copilot.SDK` itself generates `build/GitHub.Copilot.SDK.props` at pack time).

**Files modified:**

- `dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj` — adds a `_GenerateBuildTransitiveProps` target that runs `BeforeTargets="_GetPackageFiles"`. It resolves the SDK version from `@(PackageVersion)` items (Central Package Management surface) and writes `buildTransitive/Microsoft.Agents.AI.GitHub.Copilot.props` setting `$(_MicrosoftAgentsAICopilotSdkVersion)`. Both files are then packed under `buildTransitive/`. Same pattern the SDK uses for its own props (`_GenerateVersionProps` in `GitHub.Copilot.SDK.csproj`).

**Compatibility:**

- No API surface change — public surface of the assembly is untouched.
- No behavior change for projects with a direct `<PackageReference Include="GitHub.Copilot.SDK" />`. The SDK's `build/` targets still fire for them as today; our bridge's condition `Exists($(_MicrosoftAgentsAICopilotSdkBuildDir)/GitHub.Copilot.SDK.targets)` succeeds and re-imports the same file — `<Import>` is idempotent in MSBuild and only schedules each target once.
- Consumers can opt out of the binary download via the SDK's existing `$(CopilotSkipCliDownload)=true`, which our bridge passes through unchanged.

**Verification:**

Built the package locally on this branch (`Microsoft.Agents.AI.GitHub.Copilot 1.9.0-preview.260603.1`), confirmed both `buildTransitive/*.props` and `buildTransitive/*.targets` ship in the resulting nupkg, then created a brand-new console app with only:

```xml
<PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.9.0-preview.260603.1" />
```

(no direct SDK reference) restored from a local feed pointed at the freshly-built nupkgs. On `dotnet build`, the bridge fired, the SDK's `_DownloadCopilotCli` target downloaded `@github/copilot-win32-x64/1.0.57.tgz` from npm, extracted, and `copilot.exe` (141.8 MB) landed at `bin\Debug\net10.0\runtimes\win-x64\native\copilot.exe`. `copilot --version` reports `1.0.61` as expected (the npm subpackage version differs from the bundled binary's self-reported version, both correct).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible (MSBuild packaging change — no managed surface to unit-test; verification covered end-to-end via the consumer test above)
- [x] **Is this a breaking change?** No. Pure addition, no API surface change, no behavior change for existing consumers.