### PR TITLE
Python: preserve explicit conversation id with sessions

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -1288,10 +1288,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):  # type: ignore[misc]
         model = opts.pop("model", None)
 
         # Build options dict from run() options merged with provided options
+        session_conversation_id = active_session.service_session_id if active_session else None
         run_opts: dict[str, Any] = {
-            "conversation_id": active_session.service_session_id
-            if active_session
-            else opts.pop("conversation_id", None),
+            "conversation_id": session_conversation_id or opts.pop("conversation_id", None),
             "allow_multiple_tool_calls": opts.pop("allow_multiple_tool_calls", None),
             "frequency_penalty": opts.pop("frequency_penalty", None),
             "logit_bias": opts.pop("logit_bias", None),

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -435,6 +435,26 @@ async def test_prepare_run_context_handles_function_kwargs(
     assert ctx["client_kwargs"]["session"] is session
 
 
+async def test_prepare_run_context_keeps_explicit_conversation_id_with_session(
+    chat_client_base: SupportsChatGetResponse,
+) -> None:
+    agent = Agent(client=chat_client_base)
+    session = agent.create_session()
+
+    ctx = await agent._prepare_run_context(  # type: ignore[reportPrivateUsage]
+        messages="Hello",
+        session=session,
+        tools=None,
+        options={"conversation_id": "resp_manual_123", "store": True},
+        compaction_strategy=None,
+        tokenizer=None,
+        function_invocation_kwargs=None,
+        client_kwargs=None,
+    )
+
+    assert ctx["chat_options"]["conversation_id"] == "resp_manual_123"
+
+
 async def test_chat_agent_persists_history_per_service_call(
     chat_client_base: SupportsChatGetResponse,
 ) -> None:


### PR DESCRIPTION
### Motivation and Context

Fixes #6419.

When an agent run receives a session, `_prepare_run_context` currently takes `conversation_id` only from `session.service_session_id`. If the session exists but has not captured a service-side id yet, an explicit `conversation_id` passed in the run options is dropped.

That breaks callers that manually continue an OpenAI Responses conversation with a response id while also passing a session.

### Description

This keeps the existing precedence for live sessions: `session.service_session_id` still wins once it is available. When the session has no service-side id, the run-level `conversation_id` is preserved and reaches the chat client options.

I added a regression test around `_prepare_run_context` so the explicit continuation id is not lost when a fresh session is present.

Targeted local checks run:

- `python -m py_compile python/packages/core/agent_framework/_agents.py python/packages/core/tests/core/test_agents.py`
- `PYTHONPATH=python/packages/core python -m pytest python/packages/core/tests/core/test_agents.py::test_prepare_run_context_keeps_explicit_conversation_id_with_session python/packages/core/tests/core/test_agents.py::test_chat_client_agent_run_with_session python/packages/core/tests/core/test_agents.py::test_chat_client_agent_updates_existing_session_id_non_streaming python/packages/core/tests/core/test_agents.py::test_chat_client_agent_updates_existing_session_id_streaming -q`
- `python -m ruff check python/packages/core/agent_framework/_agents.py python/packages/core/tests/core/test_agents.py`
- `git diff --check`

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.
