### PR TITLE
.NET: make OpenTelemetry constants public

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryConsts.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryConsts.cs
@@ -3,28 +3,41 @@
 namespace Microsoft.Agents.AI;
 
 /// <summary>Provides constants used by various telemetry services.</summary>
-internal static class OpenTelemetryConsts
+public static class OpenTelemetryConsts
 {
+    /// <summary>The default <see cref="System.Diagnostics.ActivitySource"/> name used by agent telemetry.</summary>
     public const string DefaultSourceName = "Experimental.Microsoft.Agents.AI";
 
+    /// <summary>OpenTelemetry semantic convention values for generative AI telemetry.</summary>
     public static class GenAI
     {
+        /// <summary>The GenAI operation name used for agent invocation spans.</summary>
         public const string InvokeAgent = "invoke_agent";
 
+        /// <summary>GenAI agent attribute names.</summary>
         public static class Agent
         {
+            /// <summary>The agent identifier attribute name.</summary>
             public const string Id = "gen_ai.agent.id";
+
+            /// <summary>The agent display name attribute name.</summary>
             public const string Name = "gen_ai.agent.name";
+
+            /// <summary>The agent description attribute name.</summary>
             public const string Description = "gen_ai.agent.description";
         }
 
+        /// <summary>GenAI operation attribute names.</summary>
         public static class Operation
         {
+            /// <summary>The operation name attribute name.</summary>
             public const string Name = "gen_ai.operation.name";
         }
 
+        /// <summary>GenAI provider attribute names.</summary>
         public static class Provider
         {
+            /// <summary>The provider name attribute name.</summary>
             public const string Name = "gen_ai.provider.name";
         }
     }


### PR DESCRIPTION
## Summary

Makes `Microsoft.Agents.AI.OpenTelemetryConsts` public so consumers can reuse the same agent telemetry source name and GenAI semantic-convention attribute keys that the package emits.

The nested public constants already existed for in-package use; this change only exposes the container type and adds XML documentation for the newly public API surface.

Fixes #6452

## Validation

- `dotnet restore dotnet\src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj`
- `dotnet build dotnet\src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj --no-restore`
- `dotnet restore dotnet\tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj`
- `dotnet test --project tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj -f net10.0 --no-build --filter-query "/*UnitTests*/*/*/*" --ignore-exit-code 8`
- `dotnet test --project tests\Microsoft.Agents.AI.UnitTests\Microsoft.Agents.AI.UnitTests.csproj -f net472 --no-build --filter-query "/*UnitTests*/*/*/*" --ignore-exit-code 8`
- `git diff --check`

Note: a first `dotnet test --filter ...` attempt failed before running tests because this repo uses Microsoft.Testing.Platform and requires `--filter-query`; reran with the repo-documented MTP query above.