### PR TITLE
.NET: forward Responses API request tools

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Converters;
 using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
 using Microsoft.Extensions.AI;
 
@@ -34,23 +35,7 @@ internal sealed class AIAgentResponseExecutor : IResponseExecutor
         IReadOnlyList<ChatMessage>? conversationHistory = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Create options with properties from the request
-        var chatOptions = new ChatOptions
-        {
-            // Note: We intentionally do NOT set ConversationId on ChatOptions here.
-            // The conversation ID from the client request is used by the hosting layer
-            // to manage conversation storage, but should not be forwarded to the underlying
-            // IChatClient as it has its own concept of conversations (or none at all).
-            // ---
-            // ConversationId = request.Conversation?.Id,
-
-            Temperature = (float?)request.Temperature,
-            TopP = (float?)request.TopP,
-            MaxOutputTokens = request.MaxOutputTokens,
-            Instructions = request.Instructions,
-            ModelId = request.Model,
-        };
-        var options = new ChatClientAgentRunOptions(chatOptions);
+        var options = request.BuildOptions();
 
         // Convert input to chat messages, prepending conversation history if available
         var messages = new List<ChatMessage>();

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/CreateResponseChatClientAgentRunOptionsConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/CreateResponseChatClientAgentRunOptionsConverter.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses.Converters;
+
+internal static class CreateResponseChatClientAgentRunOptionsConverter
+{
+    private static readonly JsonElement s_emptyJson = JsonElement.Parse("{}");
+
+    public static ChatClientAgentRunOptions BuildOptions(this CreateResponse request)
+    {
+        ChatOptions chatOptions = new()
+        {
+            // The hosting layer owns response/conversation ids. Do not forward them
+            // to the underlying IChatClient, which may use a different id model.
+            Temperature = (float?)request.Temperature,
+            TopP = (float?)request.TopP,
+            MaxOutputTokens = request.MaxOutputTokens,
+            Instructions = request.Instructions,
+            ModelId = request.Model,
+            AllowMultipleToolCalls = request.ParallelToolCalls,
+        };
+
+        if (request.ToolChoice is { } toolChoice)
+        {
+            chatOptions.ToolMode = toolChoice.ToChatToolMode();
+        }
+
+        if (request.Tools is { Count: > 0 })
+        {
+            List<AITool> tools = [];
+            foreach (JsonElement tool in request.Tools)
+            {
+                if (tool.ToAITool() is { } aiTool)
+                {
+                    tools.Add(aiTool);
+                }
+            }
+
+            if (tools.Count > 0)
+            {
+                chatOptions.Tools = tools;
+            }
+        }
+
+        return new ChatClientAgentRunOptions(chatOptions);
+    }
+
+    private static AITool? ToAITool(this JsonElement tool)
+    {
+        if (tool.ValueKind != JsonValueKind.Object ||
+            !tool.TryGetProperty("type", out JsonElement typeProperty) ||
+            typeProperty.GetString() is not { } type)
+        {
+            return null;
+        }
+
+        if (string.Equals(type, "function", StringComparison.Ordinal))
+        {
+            return tool.ToAIFunctionDeclaration();
+        }
+
+        if (string.Equals(type, "custom", StringComparison.Ordinal) &&
+            tool.TryGetToolName(out string? name))
+        {
+            return new ResponseCustomAITool(name, tool.TryGetStringProperty("description"));
+        }
+
+        return null;
+    }
+
+    private static AIFunctionDeclaration? ToAIFunctionDeclaration(this JsonElement tool)
+    {
+        JsonElement function = tool.TryGetProperty("function", out JsonElement functionProperty) &&
+            functionProperty.ValueKind == JsonValueKind.Object
+            ? functionProperty
+            : tool;
+
+        if (!function.TryGetToolName(out string? name))
+        {
+            return null;
+        }
+
+        JsonElement parameters = function.TryGetProperty("parameters", out JsonElement parametersProperty)
+            ? parametersProperty
+            : s_emptyJson;
+
+        return AIFunctionFactory.CreateDeclaration(
+            name,
+            function.TryGetStringProperty("description"),
+            parameters);
+    }
+
+    private static ChatToolMode? ToChatToolMode(this JsonElement toolChoice)
+    {
+        if (toolChoice.ValueKind == JsonValueKind.String)
+        {
+            return toolChoice.GetString() switch
+            {
+                "auto" => ChatToolMode.Auto,
+                "none" => ChatToolMode.None,
+                "required" => ChatToolMode.RequireAny,
+                _ => null
+            };
+        }
+
+        if (toolChoice.ValueKind != JsonValueKind.Object ||
+            !toolChoice.TryGetProperty("type", out JsonElement typeProperty) ||
+            typeProperty.GetString() is not { } type)
+        {
+            return null;
+        }
+
+        if (string.Equals(type, "allowed_tools", StringComparison.Ordinal))
+        {
+            return toolChoice.TryReadAllowedToolsMode();
+        }
+
+        return toolChoice.TryGetToolName(out string? name) ? ChatToolMode.RequireSpecific(name) : null;
+    }
+
+    private static ChatToolMode? TryReadAllowedToolsMode(this JsonElement toolChoice)
+    {
+        JsonElement modeSource = toolChoice;
+        if (toolChoice.TryGetProperty("allowed_tools", out JsonElement allowedTools) &&
+            allowedTools.ValueKind == JsonValueKind.Object)
+        {
+            modeSource = allowedTools;
+        }
+
+        if (!modeSource.TryGetProperty("mode", out JsonElement modeProperty))
+        {
+            return null;
+        }
+
+        return modeProperty.GetString() switch
+        {
+            "auto" => ChatToolMode.Auto,
+            "required" => ChatToolMode.RequireAny,
+            _ => null
+        };
+    }
+
+    private static bool TryGetToolName(this JsonElement element, out string name)
+    {
+        if (element.TryGetProperty("name", out JsonElement nameProperty) &&
+            nameProperty.ValueKind == JsonValueKind.String &&
+            nameProperty.GetString() is { } directName)
+        {
+            name = directName;
+            return true;
+        }
+
+        if (element.TryGetProperty("function", out JsonElement functionProperty) &&
+            functionProperty.ValueKind == JsonValueKind.Object &&
+            functionProperty.TryGetProperty("name", out JsonElement functionNameProperty) &&
+            functionNameProperty.ValueKind == JsonValueKind.String &&
+            functionNameProperty.GetString() is { } functionName)
+        {
+            name = functionName;
+            return true;
+        }
+
+        if (element.TryGetProperty("custom", out JsonElement customProperty) &&
+            customProperty.ValueKind == JsonValueKind.Object &&
+            customProperty.TryGetProperty("name", out JsonElement customNameProperty) &&
+            customNameProperty.ValueKind == JsonValueKind.String &&
+            customNameProperty.GetString() is { } customName)
+        {
+            name = customName;
+            return true;
+        }
+
+        name = string.Empty;
+        return false;
+    }
+
+    private static string? TryGetStringProperty(this JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out JsonElement property) &&
+            property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private sealed class ResponseCustomAITool : AITool
+    {
+        public ResponseCustomAITool(string name, string? description)
+        {
+            this.Name = name;
+            this.Description = description ?? string.Empty;
+            this.AdditionalProperties = new Dictionary<string, object?>();
+        }
+
+        public override string Name { get; }
+
+        public override string Description { get; }
+
+        public override IReadOnlyDictionary<string, object?> AdditionalProperties { get; }
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Converters;
 using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -88,22 +89,7 @@ internal sealed class HostedAgentResponseExecutor : IResponseExecutor
         string agentName = GetAgentName(request)!;
         AIAgent agent = this._serviceProvider.GetRequiredKeyedService<AIAgent>(agentName);
 
-        var chatOptions = new ChatOptions
-        {
-            // Note: We intentionally do NOT set ConversationId on ChatOptions here.
-            // The conversation ID from the client request is used by the hosting layer
-            // to manage conversation storage, but should not be forwarded to the underlying
-            // IChatClient as it has its own concept of conversations (or none at all).
-            // ---
-            // ConversationId = request.Conversation?.Id,
-
-            Temperature = (float?)request.Temperature,
-            TopP = (float?)request.TopP,
-            MaxOutputTokens = request.MaxOutputTokens,
-            Instructions = request.Instructions,
-            ModelId = request.Model,
-        };
-        var options = new ChatClientAgentRunOptions(chatOptions);
+        var options = request.BuildOptions();
         var messages = new List<ChatMessage>();
 
         if (conversationHistory is not null)

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesAgentResolutionIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesAgentResolutionIntegrationTests.cs
@@ -113,6 +113,61 @@ public sealed class OpenAIResponsesAgentResolutionIntegrationTests : IAsyncDispo
         Assert.Equal(ExpectedResponse, actualResponse);
     }
 
+    [Fact]
+    public async Task CreateResponse_WithRequestTool_ForwardsToolOptionsToResolvedAgentAsync()
+    {
+        // Arrange
+        const string AgentName = "tool-agent";
+
+        this._httpClient = await this.CreateTestServerWithAgentResolutionAsync(
+            (AgentName, "You are a helpful assistant.", "Tool options captured"));
+        var mockChatClient = this.ResolveMockChatClient(AgentName);
+
+        using StringContent requestContent = new(
+            $$"""
+            {
+              "agent": { "name": "{{AgentName}}" },
+              "input": "What is the weather in Valencia?",
+              "tools": [
+                {
+                  "type": "function",
+                  "name": "get_weather",
+                  "description": "Retrieves current weather.",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "location": { "type": "string" }
+                    },
+                    "required": [ "location" ],
+                    "additionalProperties": false
+                  }
+                }
+              ],
+              "tool_choice": "required",
+              "parallel_tool_calls": false
+            }
+            """,
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        using HttpResponseMessage httpResponse = await this._httpClient!.PostAsync(
+            new Uri("/v1/responses", UriKind.Relative),
+            requestContent);
+
+        // Assert
+        Assert.True(httpResponse.IsSuccessStatusCode, $"Request failed with status {httpResponse.StatusCode}");
+        await httpResponse.Content.ReadAsStringAsync();
+
+        Assert.NotNull(mockChatClient.LastChatOptions);
+        Assert.Equal(ChatToolMode.RequireAny, mockChatClient.LastChatOptions.ToolMode);
+        Assert.False(mockChatClient.LastChatOptions.AllowMultipleToolCalls);
+
+        AITool tool = Assert.Single(mockChatClient.LastChatOptions.Tools!);
+        Assert.Equal("get_weather", tool.Name);
+        Assert.Equal("Retrieves current weather.", tool.Description);
+    }
+
     /// <summary>
     /// Verifies that agent resolution can distinguish between multiple agents.
     /// </summary>
@@ -470,5 +525,18 @@ public sealed class OpenAIResponsesAgentResolutionIntegrationTests : IAsyncDispo
             ?? throw new InvalidOperationException("TestServer not found");
 
         return testServer.CreateClient();
+    }
+
+    private TestHelpers.SimpleMockChatClient ResolveMockChatClient(string agentName)
+    {
+        ArgumentNullException.ThrowIfNull(this._app, nameof(this._app));
+
+        var chatClient = this._app.Services.GetRequiredKeyedService<IChatClient>($"chat-client-{agentName}");
+        if (chatClient is not TestHelpers.SimpleMockChatClient mockChatClient)
+        {
+            throw new InvalidOperationException("Mock chat client not found or of incorrect type.");
+        }
+
+        return mockChatClient;
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesIntegrationTests.cs
@@ -1144,6 +1144,62 @@ public sealed class OpenAIResponsesIntegrationTests : IAsyncDisposable
         Assert.Null(mockChatClient.LastChatOptions.ConversationId);
     }
 
+    [Fact]
+    public async Task CreateResponse_WithRequestTool_ForwardsToolOptionsToChatClientAsync()
+    {
+        // Arrange
+        const string AgentName = "request-tool-agent";
+        const string Instructions = "You are a helpful assistant.";
+
+        this._httpClient = await this.CreateTestServerAsync(AgentName, Instructions);
+        var mockChatClient = this.ResolveMockChatClient();
+
+        using StringContent content = new(
+            """
+            {
+              "input": "What is the weather in Valencia?",
+              "tools": [
+                {
+                  "type": "function",
+                  "name": "get_weather",
+                  "description": "Retrieves current weather.",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "location": { "type": "string" }
+                    },
+                    "required": [ "location" ],
+                    "additionalProperties": false
+                  },
+                  "strict": true
+                }
+              ],
+              "tool_choice": "required",
+              "parallel_tool_calls": false,
+              "stream": false
+            }
+            """,
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        using HttpResponseMessage httpResponse = await this._httpClient!.PostAsync(
+            new Uri($"/{AgentName}/v1/responses", UriKind.Relative),
+            content);
+
+        // Assert
+        Assert.True(httpResponse.IsSuccessStatusCode, $"Response status: {httpResponse.StatusCode}");
+        await httpResponse.Content.ReadAsStringAsync();
+
+        Assert.NotNull(mockChatClient.LastChatOptions);
+        Assert.Equal(ChatToolMode.RequireAny, mockChatClient.LastChatOptions.ToolMode);
+        Assert.False(mockChatClient.LastChatOptions.AllowMultipleToolCalls);
+
+        AITool tool = Assert.Single(mockChatClient.LastChatOptions.Tools!);
+        Assert.Equal("get_weather", tool.Name);
+        Assert.Equal("Retrieves current weather.", tool.Description);
+    }
+
     /// <summary>
     /// Verifies that when a client provides a conversation ID in streaming mode, the underlying
     /// IChatClient does NOT receive that conversation ID via ChatOptions.ConversationId.


### PR DESCRIPTION
## Summary
- build `ChatClientAgentRunOptions` for Responses requests in one converter
- forward request `tools`, `tool_choice`, and `parallel_tool_calls` into `ChatOptions`
- cover both `MapOpenAIResponses(agent)` and keyed hosted-agent resolution

Fixes #6416.

## To verify
- `dotnet restore dotnet\tests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.csproj`
- `dotnet build dotnet\tests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.csproj --no-restore`
- `dotnet\tests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.exe --filter-method "*CreateResponse_WithRequestTool_ForwardsToolOptions*"`
- `dotnet\tests\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests\bin\Debug\net10.0\Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.exe --filter-class Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.OpenAIResponsesIntegrationTests Microsoft.Agents.AI.Hosting.OpenAI.UnitTests.OpenAIResponsesAgentResolutionIntegrationTests`
- `git diff --check`
