### PR TITLE
.NET: Fix #6466: make workflow checkpoint TypeId version-insensitive

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/TypeId.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/TypeId.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Reflection;
 using System.Text.Json.Serialization;
 using Microsoft.Shared.Diagnostics;
 
@@ -11,11 +12,37 @@ namespace Microsoft.Agents.AI.Workflows.Checkpointing;
 /// </summary>
 public sealed class TypeId : IEquatable<TypeId>
 {
+    private string? _assemblySimpleName;
+
     /// <inheritdoc cref="System.Reflection.Assembly.FullName"/>
     public string AssemblyName { get; }
 
     /// <inheritdoc cref="Type.FullName"/>
     public string TypeName { get; }
+
+    /// <summary>
+    /// Gets the simple (version-, culture-, and public-key-token-independent) name of the assembly,
+    /// derived from <see cref="AssemblyName"/>. This is used for identity comparisons and type
+    /// resolution so that checkpoints remain compatible across assembly version changes.
+    /// </summary>
+    internal string AssemblySimpleName => this._assemblySimpleName ??= NormalizeAssemblyName(this.AssemblyName);
+
+    /// <summary>
+    /// Extracts the simple assembly name from a (possibly fully-qualified) assembly name string,
+    /// discarding version, culture, and public key token. Falls back to the original value if it
+    /// cannot be parsed.
+    /// </summary>
+    private static string NormalizeAssemblyName(string assemblyName)
+    {
+        try
+        {
+            return new AssemblyName(assemblyName).Name ?? assemblyName;
+        }
+        catch (Exception)
+        {
+            return assemblyName;
+        }
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeId"/> class.
@@ -58,11 +85,11 @@ public sealed class TypeId : IEquatable<TypeId>
             return true;
         }
 
-        return this.AssemblyName == other.AssemblyName && this.TypeName == other.TypeName;
+        return this.AssemblySimpleName == other.AssemblySimpleName && this.TypeName == other.TypeName;
     }
 
     /// <inheritdoc />
-    public override int GetHashCode() => HashCode.Combine(this.AssemblyName, this.TypeName);
+    public override int GetHashCode() => HashCode.Combine(this.AssemblySimpleName, this.TypeName);
 
     /// <inheritdoc />
     public static bool operator ==(TypeId? left, TypeId? right) => left is null ? right is null : left.Equals(right);
@@ -78,7 +105,7 @@ public sealed class TypeId : IEquatable<TypeId>
     /// false.</returns>
     public bool IsMatch(Type type)
     {
-        return this.AssemblyName == type.Assembly.FullName
+        return this.AssemblySimpleName == type.Assembly.GetName().Name
             && this.TypeName == type.FullName;
     }
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
@@ -302,7 +302,7 @@ internal sealed class WorkflowSession : AgentSession
         envelope = null;
 
         TypeId requestType = request.PortInfo.RequestType;
-        Type? concreteType = Type.GetType($"{requestType.TypeName}, {requestType.AssemblyName}", throwOnError: false);
+        Type? concreteType = Type.GetType($"{requestType.TypeName}, {requestType.AssemblySimpleName}", throwOnError: false);
         if (concreteType is null || !typeof(IExternalRequestEnvelope).IsAssignableFrom(concreteType))
         {
             return false;

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TypeIdVersionMismatchTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/TypeIdVersionMismatchTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+/// <summary>
+/// Verifies that <see cref="TypeId"/> identity is independent of the assembly version, culture,
+/// and public key token, so that checkpoints written by one SDK version can be restored by another.
+/// See issue #6466.
+/// </summary>
+public class TypeIdVersionMismatchTests
+{
+    private static string FullNameWithVersion(Type type, string version)
+        => $"{type.Assembly.GetName().Name}, Version={version}, Culture=neutral, PublicKeyToken=null";
+
+    [Fact]
+    public void IsMatch_IgnoresAssemblyVersion()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        // Simulate a TypeId that was serialized by a different SDK version.
+        TypeId legacy = new(FullNameWithVersion(type, "1.8.0.0"), type.FullName!);
+
+        legacy.IsMatch(type).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_IgnoresAssemblyVersion()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        TypeId legacy = new(FullNameWithVersion(type, "1.8.0.0"), type.FullName!);
+        TypeId current = new(type);
+
+        legacy.Equals(current).Should().BeTrue();
+        (legacy == current).Should().BeTrue();
+        legacy.GetHashCode().Should().Be(current.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_DifferentVersions_AreEqual()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        TypeId a = new(FullNameWithVersion(type, "1.3.0.0"), type.FullName!);
+        TypeId b = new(FullNameWithVersion(type, "1.10.0.0"), type.FullName!);
+
+        a.Equals(b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void DictionaryLookup_SucceedsAcrossVersionForms()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        // Map keyed by the current (simple-name) TypeId.
+        Dictionary<TypeId, string> map = new()
+        {
+            [new TypeId(type)] = "value",
+        };
+
+        // Lookup using a legacy fully-qualified TypeId must still resolve.
+        TypeId legacy = new(FullNameWithVersion(type, "1.8.0.0"), type.FullName!);
+
+        map.TryGetValue(legacy, out string? value).Should().BeTrue();
+        value.Should().Be("value");
+    }
+
+    [Fact]
+    public void Equals_DifferentTypeName_NotEqual()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        TypeId a = new(type);
+        TypeId b = new(FullNameWithVersion(type, "1.8.0.0"), typeof(TypeId).FullName!);
+
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentSimpleAssemblyName_NotEqual()
+    {
+        Type type = typeof(TypeIdVersionMismatchTests);
+
+        TypeId a = new(type);
+        TypeId b = new("Some.Other.Assembly, Version=1.8.0.0, Culture=neutral, PublicKeyToken=null", type.FullName!);
+
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MalformedAssemblyName_FallsBackToRawValue()
+    {
+        // An unparseable assembly name should not throw; it should compare on the raw value.
+        TypeId a = new("not a valid, assembly name", "Some.Type");
+        TypeId b = new("not a valid, assembly name", "Some.Type");
+
+        a.Equals(b).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6466.

Workflow checkpoint restore failed with `System.IO.InvalidDataException: The specified checkpoint is not compatible with the workflow associated with this runner.` whenever the assembly version changed between the run that wrote a checkpoint and the run that restored it (i.e. after any package upgrade and redeploy), even when the workflow topology, executor IDs, and state shape were identical.

### Root cause

`TypeId` identity was derived from `Assembly.FullName`, which embeds `Version`, `Culture`, and `PublicKeyToken`:

```csharp
public bool IsMatch(Type type)
{
    if (AssemblyName == type.Assembly.FullName)   // version-sensitive
        return TypeName == type.FullName;
    return false;
}
```

`TypeId` is serialized into checkpoints and re-derived from the currently loaded assemblies on restore, so any version bump made the strings differ and invalidated every previously persisted checkpoint. The same `AssemblyName` comparison also backs `TypeId.Equals`/`GetHashCode`, which matters because `TypeId` is used as a **dictionary key** in `MessageTypeTranslator`, `MessageRouter`, and the executor yield-type set — so in-flight message type lookups would also fail across versions.

## Changes

- **`TypeId`** — Comparison and hashing are now based on the *simple* assembly name (version-, culture-, and public-key-token-independent) plus the type full name:
  - Added `NormalizeAssemblyName` (parses the simple name via `System.Reflection.AssemblyName`, with a safe fallback to the raw value if it can't be parsed) and a lazily-cached internal `AssemblySimpleName`.
  - `Equals`, `GetHashCode`, and `IsMatch(Type)` now use the simple assembly name.
  - The `TypeId(Type)` constructor, the public `AssemblyName` property, and `ToString()` are **unchanged** — the serialized checkpoint shape and public API are preserved, and legacy (version-qualified) checkpoints remain matchable via normalization.
- **`WorkflowSession.TryGetRequestEnvelope`** — Fixes a latent second version-sensitivity where `Type.GetType($"{TypeName}, {AssemblyName}")` used the version-qualified assembly name (which can fail to resolve after an upgrade for strong-named assemblies). It now uses the simple name for robust resolution.

## Approach / compatibility

This is the most conservative fix: the stored `AssemblyName` value, the serialized JSON shape, and the public `AssemblyName` property are all unchanged. Only the comparison/hash/resolution paths are normalized. As a result:

- Existing checkpoints (full version-qualified names) continue to match.
- New checkpoints have an identical shape — no schema change and no migration required.

## Tests

- Added `TypeIdVersionMismatchTests` (7 tests) covering:
  - `IsMatch`, `Equals`, and `GetHashCode` ignore assembly version.
  - `Dictionary<TypeId, T>` lookups succeed across version forms (legacy full name vs. current simple name).
  - Negative cases: different type name and different simple assembly name are not equal.
  - Malformed assembly names fall back to the raw value without throwing.
- Full `Microsoft.Agents.AI.Workflows.UnitTests` suite passes: **652 passed, 0 failed** (net10.0), including the existing `JsonSerializationTests`, checkpointing, and executor tests.
