### PR TITLE
CI: Ignore all dotnet.microsoft.com links in markdown link check

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -20,7 +20,10 @@ ignorePatterns:
   - pattern: "https://your-resource.openai.azure.com/"
   - pattern: "http://host.docker.internal"
   - pattern: "https://openai.github.io/openai-agents-js/openai/agents/classes/"
-  - pattern: "https:\/\/dotnet.microsoft.com\/download"
+  # dotnet.microsoft.com bot-blocks CI link checkers with intermittent 403s on any
+  # path (including localized variants like /en-us/download/...), so ignore the
+  # whole domain rather than just /download.
+  - pattern: "https:\/\/dotnet.microsoft.com"
   - pattern: "https://github.com/Rel1cx/eslint-react"
 # excludedDirs:
   # Folders which include links to localhost, since it's not ignored with regular expressions


### PR DESCRIPTION
### Motivation and Context

The markdown-link-check workflow is intermittently failing on unrelated pull requests with:

```
Cannot reach https://dotnet.microsoft.com/en-us/download/dotnet/10.0 Status: 403
location: dotnet/samples/05-end-to-end/DevUIAspireIntegration/README.md:12
```

linkspector scans the whole repository, so this single link fails CI for every open PR whenever dotnet.microsoft.com decides to bot-block the checker. Several PRs are currently red because of it.

### Description

The config already ignores `https://dotnet.microsoft.com/download`, but Microsoft sites insert a locale segment between host and path (`/en-us/download/...`), so localized links slip past the pattern. The 403 bot blocking applies to the whole site, not just download paths, so this broadens the ignore pattern to the domain, matching how `https://platform.openai.com` is already handled for the same reason.

Tradeoff: links to dotnet.microsoft.com are no longer validated. The checker cannot produce a meaningful signal for this domain anyway, since a 403 from bot blocking is indistinguishable from a removed page. Adding 403 to `aliveStatusCodes` was rejected as it would mask genuinely dead links on every other domain.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [x] **Is this a breaking change?** No