### PR TITLE
Python: Fix ollama_chat_client.py sample: pass tools via options dict

### DIFF
--- a/python/samples/02-agents/providers/ollama/ollama_chat_client.py
+++ b/python/samples/02-agents/providers/ollama/ollama_chat_client.py
@@ -40,12 +40,12 @@ async def main() -> None:
     print(f"User: {message}")
     if stream:
         print("Assistant: ", end="")
-        async for chunk in client.get_response(messages, options={"tools": get_time}, stream=True):
+        async for chunk in client.get_response(messages, options={"tools": [get_time]}, stream=True):
             if str(chunk):
                 print(str(chunk), end="")
         print("")
     else:
-        response = await client.get_response(messages, options={"tools": get_time})
+        response = await client.get_response(messages, options={"tools": [get_time]})
         print(f"Assistant: {response}")
 
 

--- a/python/samples/02-agents/providers/ollama/ollama_chat_client.py
+++ b/python/samples/02-agents/providers/ollama/ollama_chat_client.py
@@ -40,12 +40,12 @@ async def main() -> None:
     print(f"User: {message}")
     if stream:
         print("Assistant: ", end="")
-        async for chunk in client.get_response(messages, tools=get_time, stream=True):
+        async for chunk in client.get_response(messages, options={"tools": get_time}, stream=True):
             if str(chunk):
                 print(str(chunk), end="")
         print("")
     else:
-        response = await client.get_response(messages, tools=get_time)
+        response = await client.get_response(messages, options={"tools": get_time})
         print(f"Assistant: {response}")
 
 


### PR DESCRIPTION
## Description

Fixes the `ollama_chat_client.py` sample which was passing `tools` as a direct keyword argument to `get_response()`, causing a `TypeError`. The `tools` parameter must be passed inside the `options` dict per the `SupportsChatGetResponse` protocol.

## Changes

- `python/samples/02-agents/providers/ollama/ollama_chat_client.py`: Changed `tools=get_time` to `options={"tools": get_time}` in both the streaming and non-streaming `get_response()` calls.

## Testing

Ran the sample locally with Ollama (mistral model) - no TypeError, runs successfully.

Fixes #6411