### PR TITLE
.NET: Only use the output from the last message for structured output

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -53,7 +53,11 @@ public sealed class PlanningOutputObserver : ConsoleObserver
     {
         if (!this.IsPlanningMode(ux.CurrentMode))
         {
-            await ux.WriteTextAsync(update.Text).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(update.Text))
+            {
+                await ux.WriteTextAsync(update.Text).ConfigureAwait(false);
+            }
+
             return;
         }
 

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -72,6 +72,7 @@ public sealed class PlanningOutputObserver : ConsoleObserver
         }
 
         this._textCollector.Clear();
+        this._textCollector.Append(update.Text);
         this._lastResponseId = update.ResponseId;
         this._lastMessageId = update.MessageId;
     }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -51,6 +51,7 @@ public sealed class PlanningOutputObserver : ConsoleObserver
     /// <inheritdoc/>
     public override async Task OnResponseUpdateAsync(IUXStateDriver ux, AgentResponseUpdate update, AIAgent agent, AgentSession session)
     {
+        // We aren't in planning mode, so we can just stream the output directly.
         if (!this.IsPlanningMode(ux.CurrentMode))
         {
             if (!string.IsNullOrWhiteSpace(update.Text))
@@ -61,14 +62,15 @@ public sealed class PlanningOutputObserver : ConsoleObserver
             return;
         }
 
-        if (this.IsPlanningMode(ux.CurrentMode) && this._lastResponseId == update.ResponseId && this._lastMessageId == update.MessageId)
+        // We are still accumulating the same response/message.
+        if (this._lastResponseId == update.ResponseId && this._lastMessageId == update.MessageId)
         {
             this._textCollector.Append(update.Text);
             return;
         }
 
-        // New response/message, clear the text collector for the next JSON response/message
-        // and write the previous response/message.
+        // New response/message, write the previous response/message and
+        // clear the text collector for the next JSON response/message.
         string collectedText = this._textCollector.ToString();
         if (!string.IsNullOrWhiteSpace(collectedText))
         {

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -21,6 +21,8 @@ public sealed class PlanningOutputObserver : ConsoleObserver
     private readonly string _planModeName;
     private readonly string _executionModeName;
     private readonly IReadOnlyDictionary<string, ConsoleColor>? _modeColors;
+    private string? _lastResponseId;
+    private string? _lastMessageId;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlanningOutputObserver"/> class.
@@ -47,17 +49,31 @@ public sealed class PlanningOutputObserver : ConsoleObserver
     }
 
     /// <inheritdoc/>
-    public override Task OnTextAsync(IUXStateDriver ux, string text, AIAgent agent, AgentSession session)
+    public override async Task OnResponseUpdateAsync(IUXStateDriver ux, AgentResponseUpdate update, AIAgent agent, AgentSession session)
     {
-        if (this.IsPlanningMode(ux.CurrentMode))
+        if (!this.IsPlanningMode(ux.CurrentMode))
         {
-            // Planning mode: collect text silently for JSON parsing after the stream.
-            this._textCollector.Append(text);
-            return Task.CompletedTask;
+            await ux.WriteTextAsync(update.Text).ConfigureAwait(false);
+            return;
         }
 
-        // Execution mode: stream text directly to the console.
-        return ux.WriteTextAsync(text);
+        if (this.IsPlanningMode(ux.CurrentMode) && this._lastResponseId == update.ResponseId && this._lastMessageId == update.MessageId)
+        {
+            this._textCollector.Append(update.Text);
+            return;
+        }
+
+        // New response/message, clear the text collector for the next JSON response/message
+        // and write the previous response/message.
+        string collectedText = this._textCollector.ToString();
+        if (!string.IsNullOrWhiteSpace(collectedText))
+        {
+            await ux.WriteTextAsync(collectedText).ConfigureAwait(false);
+        }
+
+        this._textCollector.Clear();
+        this._lastResponseId = update.ResponseId;
+        this._lastMessageId = update.MessageId;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Motivation and Context

Some models return multiple messages when requesting structured output, where only the last one actually has structured output in it, and the others contain unstructured text, so only using the last message by default

### Description

- Only use the output from the last message for structured output

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** If yes, add "[BREAKING]" prefix to the title of the PR.