### PR TITLE
Python: pass Ollama sample tools through options

### DIFF
--- a/python/samples/02-agents/providers/ollama/ollama_chat_client.py
+++ b/python/samples/02-agents/providers/ollama/ollama_chat_client.py
@@ -40,12 +40,12 @@ async def main() -> None:
     print(f"User: {message}")
     if stream:
         print("Assistant: ", end="")
-        async for chunk in client.get_response(messages, tools=get_time, stream=True):
+        async for chunk in client.get_response(messages, options={"tools": get_time}, stream=True):
             if str(chunk):
                 print(str(chunk), end="")
         print("")
     else:
-        response = await client.get_response(messages, tools=get_time)
+        response = await client.get_response(messages, options={"tools": get_time})
         print(f"Assistant: {response}")
 
 


### PR DESCRIPTION
## Summary
- pass Ollama sample tools through `options={"tools": ...}` instead of the unsupported `tools=` keyword
- update both streaming and non-streaming sample calls

Fixes #6411.

## Test plan
- `python -m py_compile python/samples/02-agents/providers/ollama/ollama_chat_client.py`
- `rg -n "get_response\([^\n]*tools=" python/samples/02-agents/providers/ollama/ollama_chat_client.py python/packages -S`
- AST check that the sample has no `tools=` get_response calls and both sample calls pass `options`
- `git diff --check upstream/main..HEAD`
