### PR TITLE
docs: fix typo in agent run response decision

### DIFF
--- a/docs/decisions/0001-agent-run-response.md
+++ b/docs/decisions/0001-agent-run-response.md
@@ -200,7 +200,7 @@ var primaryContentOnly = response.Messages.FirstOrDefault();
 ```
 
 - **PROS**: Simple getting started experience, Reusing IChatClient response types.
-- **CONS**: Intermediate updates are only availble in streaming mode.
+- **CONS**: Intermediate updates are only available in streaming mode.
 
 ### Option 4: Remove Run API and retain RunStreaming API only, which returns a Stream of Primary + Secondary
 


### PR DESCRIPTION
Fixes a small typo in the agent run response decision document: `availble` → `available`.

This is a documentation-only change.