### PR TITLE
Python: Defensively strip pickle markers on internal deserialize paths

### DIFF
--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -300,7 +300,7 @@ class AgentFunctionApp(DFAppBase):
 
             # Reconstruct message - deserialize_value restores the original typed objects
             # from the encoded data (with type markers)
-            message = deserialize_value(message_data)
+            message = deserialize_value(strip_pickle_markers(message_data))
 
             # Check if this is a HITL response message by examining source_executor_ids
             is_hitl_response = any(s.startswith(SOURCE_HITL_RESPONSE) for s in source_executor_ids)
@@ -324,7 +324,7 @@ class AgentFunctionApp(DFAppBase):
 
                 # Deserialize shared state values to reconstruct dataclasses/Pydantic models
                 deserialized_state: dict[str, Any] = {
-                    str(k): deserialize_value(v) for k, v in shared_state_snapshot.items()
+                    str(k): deserialize_value(strip_pickle_markers(v)) for k, v in shared_state_snapshot.items()
                 }
                 original_snapshot = _create_state_snapshot(deserialized_state)
                 shared_state.import_state(deserialized_state)

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -298,8 +298,8 @@ class AgentFunctionApp(DFAppBase):
             if not executor:
                 raise ValueError(f"Unknown executor: {captured_executor_id}")
 
-            # Reconstruct message - deserialize_value restores the original typed objects
-            # from the encoded data (with type markers)
+            # Reconstruct message: strip untrusted pickle/type markers first
+            # (defense-in-depth), then deserialize_value restores typed objects.
             message = deserialize_value(strip_pickle_markers(message_data))
 
             # Check if this is a HITL response message by examining source_executor_ids


### PR DESCRIPTION
### Summary
This is a defense-in-depth hardening change, not a fix for a known exploit.

strip_pickle_markers() (in _serialization.py) is the control that prevents untrusted __pickled__ / __type__ markers from reaching pickle.loads() via deserialize_value. It is applied at the HTTP entry points today (e.g. send_hitl_response), but the internal deserialize_value() calls in _app.py — reconstructing message_data and shared_state_snapshot values — do not strip.

I traced the current entry points and did not find an attacker-reachable path to these internal sinks, so this is not a reported vulnerability. The intent is purely to remove the design's reliance on every present and future entry point remembering to sanitize: a new untrusted entry point or a refactor could otherwise silently route external data into one of these unprotected deserialize_value() calls.

### Description
Wrap the two internal deserialize_value() calls in _app.py with strip_pickle_markers() (already imported in this file). Negligible runtime cost.

Honest framing: no PoC, no known exploit — defense-in-depth only.

Signed-off-by: Biswajeet Ray <raybiswajeet2@gmail.com>