### PR TITLE
Python: Capture context provider instructions in agent telemetry

### DIFF
--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -2344,7 +2344,7 @@ def _instructions_preserve_existing_agent_instructions(
 
     if not isinstance(existing_items_obj, list):
         return False
-    existing_items = cast(list[Any], existing_items_obj)
+    existing_items = cast(list[object], existing_items_obj)
 
     existing_contents: list[str] = []
     for item in existing_items:

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -112,10 +112,6 @@ INNER_ACCUMULATED_USAGE: Final[contextvars.ContextVar[UsageDetails | None]] = co
     "inner_accumulated_usage", default=None
 )
 
-ACTIVE_AGENT_SPAN: Final[contextvars.ContextVar[trace.Span | None]] = contextvars.ContextVar(
-    "active_agent_span", default=None
-)
-
 OTEL_METRICS: Final[str] = "__otel_metrics__"
 TOKEN_USAGE_BUCKET_BOUNDARIES: Final[tuple[float, ...]] = (
     1,
@@ -1492,14 +1488,15 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
         )
 
         if stream:
+            agent_span = trace.get_current_span()
             span = _start_streaming_span(attributes, OtelAttr.REQUEST_MODEL)
 
             if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                 system_instructions = _get_instructions_from_options(opts)
-                _capture_active_agent_system_instructions(
+                _capture_current_agent_system_instructions(
+                    agent_span,
                     span,
                     system_instructions,
-                    is_agent_chat_call=merged_client_kwargs.get("session") is not None,
                 )
                 _capture_messages(
                     span=span,
@@ -1595,13 +1592,14 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
             return wrapped_stream
 
         async def _get_response() -> ChatResponse:
+            agent_span = trace.get_current_span()
             with _get_span(attributes=attributes, span_name_attribute=OtelAttr.REQUEST_MODEL) as span:
                 if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                     system_instructions = _get_instructions_from_options(opts)
-                    _capture_active_agent_system_instructions(
+                    _capture_current_agent_system_instructions(
+                        agent_span,
                         span,
                         system_instructions,
-                        is_agent_chat_call=merged_client_kwargs.get("session") is not None,
                     )
                     _capture_messages(
                         span=span,
@@ -1777,10 +1775,8 @@ class AgentTelemetryLayer:
             inner_response_telemetry_captured_fields
         )
         inner_accumulated_usage_token = INNER_ACCUMULATED_USAGE.set({})
-
         if stream:
             span = _start_streaming_span(attributes, OtelAttr.AGENT_NAME)
-            active_agent_span_token = ACTIVE_AGENT_SPAN.set(span)
 
             if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                 _capture_messages(
@@ -1815,7 +1811,6 @@ class AgentTelemetryLayer:
                 capture_exception(span=span, exception=exception, timestamp=time_ns())
                 INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                 INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
-                ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
                 _close_span()
                 raise
 
@@ -1857,7 +1852,6 @@ class AgentTelemetryLayer:
                 finally:
                     INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                     INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
-                    ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
                     _close_span()
 
             # The pull context manager attaches the span around each underlying iterator pull so
@@ -1878,7 +1872,6 @@ class AgentTelemetryLayer:
         async def _run() -> AgentResponse[Any]:
             try:
                 with _get_span(attributes=attributes, span_name_attribute=OtelAttr.AGENT_NAME) as span:
-                    active_agent_span_token = ACTIVE_AGENT_SPAN.set(span)
                     try:
                         if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                             _capture_messages(
@@ -1917,8 +1910,6 @@ class AgentTelemetryLayer:
                     except Exception as exception:
                         capture_exception(span=span, exception=exception, timestamp=time_ns())
                         raise
-                    finally:
-                        ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
             finally:
                 INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                 INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
@@ -2295,24 +2286,29 @@ def _capture_system_instructions(span: trace.Span, system_instructions: str | li
     """Capture system instructions on a span."""
     if not system_instructions:
         return
-    if not isinstance(system_instructions, list):
-        system_instructions = [system_instructions]
-    otel_sys_instructions = [{"type": "text", "content": instruction} for instruction in system_instructions]
+    otel_sys_instructions = [
+        {"type": "text", "content": instruction} for instruction in _normalize_instructions(system_instructions)
+    ]
     span.set_attribute(OtelAttr.SYSTEM_INSTRUCTIONS, json.dumps(otel_sys_instructions, ensure_ascii=False))
 
 
-def _capture_active_agent_system_instructions(
+def _capture_current_agent_system_instructions(
+    agent_span: trace.Span,
     chat_span: trace.Span,
     system_instructions: str | list[str] | None,
-    *,
-    is_agent_chat_call: bool,
 ) -> None:
-    """Capture final chat instructions on the active agent span when the chat span belongs to it."""
-    if not is_agent_chat_call:
+    """Capture final chat instructions on the current agent span when the chat span belongs to it."""
+    if not system_instructions or not agent_span.is_recording():
         return
 
-    agent_span = ACTIVE_AGENT_SPAN.get()
-    if agent_span is None or not agent_span.is_recording():
+    agent_attributes_obj = getattr(agent_span, "attributes", None)
+    if not isinstance(agent_attributes_obj, Mapping):
+        return
+    agent_attributes = cast(Mapping[str, Any], agent_attributes_obj)
+    if agent_attributes.get(OtelAttr.OPERATION.value) != OtelAttr.AGENT_INVOKE_OPERATION:
+        return
+
+    if not _instructions_preserve_existing_agent_instructions(agent_attributes, system_instructions):
         return
 
     chat_parent = getattr(chat_span, "parent", None)
@@ -2325,6 +2321,42 @@ def _capture_active_agent_system_instructions(
         return
 
     _capture_system_instructions(agent_span, system_instructions)
+
+
+def _normalize_instructions(system_instructions: str | list[str]) -> list[str]:
+    """Normalize system instructions to telemetry text items."""
+    return system_instructions if isinstance(system_instructions, list) else [system_instructions]
+
+
+def _instructions_preserve_existing_agent_instructions(
+    agent_attributes: Mapping[str, Any],
+    system_instructions: str | list[str],
+) -> bool:
+    """Return True when chat instructions preserve the agent span's existing instructions."""
+    existing = agent_attributes.get(OtelAttr.SYSTEM_INSTRUCTIONS)
+    if not isinstance(existing, str):
+        return True
+
+    try:
+        existing_items_obj = json.loads(existing)
+    except json.JSONDecodeError:
+        return False
+
+    if not isinstance(existing_items_obj, list):
+        return False
+    existing_items = cast(list[Any], existing_items_obj)
+
+    existing_contents: list[str] = []
+    for item in existing_items:
+        if not isinstance(item, Mapping):
+            continue
+        content = cast(Mapping[str, Any], item).get("content")
+        if isinstance(content, str):
+            existing_contents.append(content)
+
+    existing_text = "\n".join(existing_contents)
+    new_text = "\n".join(_normalize_instructions(system_instructions))
+    return new_text == existing_text or new_text.startswith(f"{existing_text}\n")
 
 
 def _capture_messages(

--- a/python/packages/core/agent_framework/observability.py
+++ b/python/packages/core/agent_framework/observability.py
@@ -112,6 +112,10 @@ INNER_ACCUMULATED_USAGE: Final[contextvars.ContextVar[UsageDetails | None]] = co
     "inner_accumulated_usage", default=None
 )
 
+ACTIVE_AGENT_SPAN: Final[contextvars.ContextVar[trace.Span | None]] = contextvars.ContextVar(
+    "active_agent_span", default=None
+)
+
 OTEL_METRICS: Final[str] = "__otel_metrics__"
 TOKEN_USAGE_BUCKET_BOUNDARIES: Final[tuple[float, ...]] = (
     1,
@@ -1491,11 +1495,17 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
             span = _start_streaming_span(attributes, OtelAttr.REQUEST_MODEL)
 
             if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
+                system_instructions = _get_instructions_from_options(opts)
+                _capture_active_agent_system_instructions(
+                    span,
+                    system_instructions,
+                    is_agent_chat_call=merged_client_kwargs.get("session") is not None,
+                )
                 _capture_messages(
                     span=span,
                     provider_name=provider_name,
                     messages=messages,
-                    system_instructions=opts.get("instructions"),
+                    system_instructions=system_instructions,
                 )
 
             span_state = {"closed": False}
@@ -1587,11 +1597,17 @@ class ChatTelemetryLayer(Generic[OptionsCoT]):
         async def _get_response() -> ChatResponse:
             with _get_span(attributes=attributes, span_name_attribute=OtelAttr.REQUEST_MODEL) as span:
                 if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
+                    system_instructions = _get_instructions_from_options(opts)
+                    _capture_active_agent_system_instructions(
+                        span,
+                        system_instructions,
+                        is_agent_chat_call=merged_client_kwargs.get("session") is not None,
+                    )
                     _capture_messages(
                         span=span,
                         provider_name=provider_name,
                         messages=messages,
-                        system_instructions=opts.get("instructions"),
+                        system_instructions=system_instructions,
                     )
                 start_time_stamp = perf_counter()
                 try:
@@ -1764,6 +1780,7 @@ class AgentTelemetryLayer:
 
         if stream:
             span = _start_streaming_span(attributes, OtelAttr.AGENT_NAME)
+            active_agent_span_token = ACTIVE_AGENT_SPAN.set(span)
 
             if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                 _capture_messages(
@@ -1798,6 +1815,7 @@ class AgentTelemetryLayer:
                 capture_exception(span=span, exception=exception, timestamp=time_ns())
                 INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                 INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
+                ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
                 _close_span()
                 raise
 
@@ -1839,6 +1857,7 @@ class AgentTelemetryLayer:
                 finally:
                     INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                     INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
+                    ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
                     _close_span()
 
             # The pull context manager attaches the span around each underlying iterator pull so
@@ -1859,38 +1878,47 @@ class AgentTelemetryLayer:
         async def _run() -> AgentResponse[Any]:
             try:
                 with _get_span(attributes=attributes, span_name_attribute=OtelAttr.AGENT_NAME) as span:
-                    if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
-                        _capture_messages(
-                            span=span,
-                            provider_name=provider_name,
-                            messages=messages,
-                            system_instructions=_get_instructions_from_options(dict(merged_options)),
-                        )
-                    start_time_stamp = perf_counter()
+                    active_agent_span_token = ACTIVE_AGENT_SPAN.set(span)
                     try:
-                        response: AgentResponse[Any] = await execute()
-                    except Exception as exception:
-                        capture_exception(span=span, exception=exception, timestamp=time_ns())
-                        raise
-                    duration = perf_counter() - start_time_stamp
-                    if response:
-                        response_attributes = _get_response_attributes(
-                            attributes,
-                            response,
-                            capture_response_id=INNER_RESPONSE_ID_CAPTURED_FIELD
-                            not in inner_response_telemetry_captured_fields,
-                            capture_usage=INNER_USAGE_CAPTURED_FIELD not in inner_response_telemetry_captured_fields,
-                        )
-                        _apply_accumulated_usage(response_attributes, inner_response_telemetry_captured_fields)
-                        _capture_response(span=span, attributes=response_attributes, duration=duration)
-                        if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and response.messages and span.is_recording():
+                        if OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED and messages and span.is_recording():
                             _capture_messages(
                                 span=span,
                                 provider_name=provider_name,
-                                messages=response.messages,
-                                output=True,
+                                messages=messages,
+                                system_instructions=_get_instructions_from_options(dict(merged_options)),
                             )
-                    return response  # type: ignore[return-value,no-any-return]
+                        start_time_stamp = perf_counter()
+                        response: AgentResponse[Any] = await execute()
+                        duration = perf_counter() - start_time_stamp
+                        if response:
+                            response_attributes = _get_response_attributes(
+                                attributes,
+                                response,
+                                capture_response_id=INNER_RESPONSE_ID_CAPTURED_FIELD
+                                not in inner_response_telemetry_captured_fields,
+                                capture_usage=(
+                                    INNER_USAGE_CAPTURED_FIELD not in inner_response_telemetry_captured_fields
+                                ),
+                            )
+                            _apply_accumulated_usage(response_attributes, inner_response_telemetry_captured_fields)
+                            _capture_response(span=span, attributes=response_attributes, duration=duration)
+                            if (
+                                OBSERVABILITY_SETTINGS.SENSITIVE_DATA_ENABLED
+                                and response.messages
+                                and span.is_recording()
+                            ):
+                                _capture_messages(
+                                    span=span,
+                                    provider_name=provider_name,
+                                    messages=response.messages,
+                                    output=True,
+                                )
+                        return response  # type: ignore[return-value,no-any-return]
+                    except Exception as exception:
+                        capture_exception(span=span, exception=exception, timestamp=time_ns())
+                        raise
+                    finally:
+                        ACTIVE_AGENT_SPAN.reset(active_agent_span_token)
             finally:
                 INNER_RESPONSE_TELEMETRY_CAPTURED_FIELDS.reset(inner_response_telemetry_captured_fields_token)
                 INNER_ACCUMULATED_USAGE.reset(inner_accumulated_usage_token)
@@ -2263,6 +2291,42 @@ def capture_exception(span: trace.Span, exception: Exception, timestamp: int | N
     span.set_status(status=trace.StatusCode.ERROR, description=repr(exception))
 
 
+def _capture_system_instructions(span: trace.Span, system_instructions: str | list[str] | None) -> None:
+    """Capture system instructions on a span."""
+    if not system_instructions:
+        return
+    if not isinstance(system_instructions, list):
+        system_instructions = [system_instructions]
+    otel_sys_instructions = [{"type": "text", "content": instruction} for instruction in system_instructions]
+    span.set_attribute(OtelAttr.SYSTEM_INSTRUCTIONS, json.dumps(otel_sys_instructions, ensure_ascii=False))
+
+
+def _capture_active_agent_system_instructions(
+    chat_span: trace.Span,
+    system_instructions: str | list[str] | None,
+    *,
+    is_agent_chat_call: bool,
+) -> None:
+    """Capture final chat instructions on the active agent span when the chat span belongs to it."""
+    if not is_agent_chat_call:
+        return
+
+    agent_span = ACTIVE_AGENT_SPAN.get()
+    if agent_span is None or not agent_span.is_recording():
+        return
+
+    chat_parent = getattr(chat_span, "parent", None)
+    agent_context = agent_span.get_span_context()
+    if (
+        chat_parent is None
+        or chat_parent.span_id != agent_context.span_id
+        or chat_parent.trace_id != agent_context.trace_id
+    ):
+        return
+
+    _capture_system_instructions(agent_span, system_instructions)
+
+
 def _capture_messages(
     span: trace.Span,
     provider_name: str,
@@ -2294,11 +2358,7 @@ def _capture_messages(
     span.set_attribute(
         OtelAttr.OUTPUT_MESSAGES if output else OtelAttr.INPUT_MESSAGES, json.dumps(otel_messages, ensure_ascii=False)
     )
-    if system_instructions:
-        if not isinstance(system_instructions, list):
-            system_instructions = [system_instructions]
-        otel_sys_instructions = [{"type": "text", "content": instruction} for instruction in system_instructions]
-        span.set_attribute(OtelAttr.SYSTEM_INSTRUCTIONS, json.dumps(otel_sys_instructions, ensure_ascii=False))
+    _capture_system_instructions(span, system_instructions)
 
 
 def _to_otel_message(message: Message) -> dict[str, Any]:

--- a/python/packages/core/tests/core/test_observability.py
+++ b/python/packages/core/tests/core/test_observability.py
@@ -17,6 +17,7 @@ from agent_framework import (
     ChatResponse,
     ChatResponseUpdate,
     Content,
+    ContextProvider,
     Message,
     RawAgent,
     ResponseStream,
@@ -3645,6 +3646,123 @@ async def test_agent_streaming_instructions_merged_from_default_and_options(
     assert len(system_instructions) == 1
     assert "Default instructions." in system_instructions[0]["content"]
     assert "Stream override." in system_instructions[0]["content"]
+
+
+@pytest.mark.parametrize("enable_sensitive_data", [True], indirect=True)
+@pytest.mark.parametrize("stream", [False, True])
+async def test_agent_instructions_include_context_provider_extensions(
+    mock_chat_client,
+    span_exporter: InMemorySpanExporter,
+    enable_sensitive_data,
+    stream: bool,
+) -> None:
+    """Agent span instructions include instructions added by context providers."""
+    import json
+
+    class UserMemoryProvider(ContextProvider):
+        def __init__(self) -> None:
+            super().__init__(source_id="user-memory")
+
+        async def before_run(
+            self,
+            *,
+            agent: Any,
+            session: Any,
+            context: Any,
+            state: dict[str, Any],
+        ) -> None:
+            context.extend_instructions(self.source_id, "The user's name is Alice.")
+
+    agent = Agent(
+        client=mock_chat_client(),
+        name="memory_agent",
+        instructions="You are a friendly assistant.",
+        context_providers=[UserMemoryProvider()],
+    )
+
+    span_exporter.clear()
+    if stream:
+        result_stream = agent.run("Hello", stream=True)
+        async for _ in result_stream:
+            pass
+        await result_stream.get_final_response()
+    else:
+        await agent.run("Hello")
+
+    spans = span_exporter.get_finished_spans()
+    agent_spans = [
+        span for span in spans if span.attributes.get(OtelAttr.OPERATION.value) == OtelAttr.AGENT_INVOKE_OPERATION
+    ]
+    assert len(agent_spans) == 1
+
+    system_instructions = json.loads(agent_spans[0].attributes[OtelAttr.SYSTEM_INSTRUCTIONS])
+    contents = [item["content"] for item in system_instructions]
+    assert any("You are a friendly assistant." in content for content in contents)
+    assert any("The user's name is Alice." in content for content in contents)
+
+
+@pytest.mark.parametrize("enable_sensitive_data", [True], indirect=True)
+async def test_agent_instructions_not_overwritten_by_unrelated_nested_chat(
+    mock_chat_client,
+    span_exporter: InMemorySpanExporter,
+    enable_sensitive_data,
+) -> None:
+    """Unrelated nested chat calls must not overwrite agent span instructions."""
+    import json
+
+    class NestedChatProvider(ContextProvider):
+        def __init__(self, nested_client: BaseChatClient[Any]) -> None:
+            super().__init__(source_id="nested-chat")
+            self.nested_client = nested_client
+
+        async def before_run(
+            self,
+            *,
+            agent: Any,
+            session: Any,
+            context: Any,
+            state: dict[str, Any],
+        ) -> None:
+            context.extend_instructions(self.source_id, "Context-provided instructions.")
+
+        async def after_run(
+            self,
+            *,
+            agent: Any,
+            session: Any,
+            context: Any,
+            state: dict[str, Any],
+        ) -> None:
+            await self.nested_client.get_response(
+                messages=[Message(role="user", contents=["Nested request"])],
+                options={"model": "NestedModel", "instructions": "Unrelated nested instructions."},
+            )
+
+    agent = Agent(
+        client=mock_chat_client(),
+        name="guarded_agent",
+        instructions="Base agent instructions.",
+        context_providers=[NestedChatProvider(mock_chat_client())],
+    )
+
+    span_exporter.clear()
+    await agent.run("Hello")
+
+    spans = span_exporter.get_finished_spans()
+    agent_spans = [
+        span for span in spans if span.attributes.get(OtelAttr.OPERATION.value) == OtelAttr.AGENT_INVOKE_OPERATION
+    ]
+    assert len(agent_spans) == 1
+    chat_spans = [
+        span for span in spans if span.attributes.get(OtelAttr.OPERATION.value) == OtelAttr.CHAT_COMPLETION_OPERATION
+    ]
+    assert len(chat_spans) == 2
+
+    system_instructions = json.loads(agent_spans[0].attributes[OtelAttr.SYSTEM_INSTRUCTIONS])
+    contents = [item["content"] for item in system_instructions]
+    assert any("Base agent instructions." in content for content in contents)
+    assert any("Context-provided instructions." in content for content in contents)
+    assert all("Unrelated nested instructions." not in content for content in contents)
 
 
 @pytest.mark.parametrize("enable_sensitive_data", [True], indirect=True)

--- a/python/packages/core/tests/core/test_observability.py
+++ b/python/packages/core/tests/core/test_observability.py
@@ -3736,6 +3736,7 @@ async def test_agent_instructions_not_overwritten_by_unrelated_nested_chat(
             await self.nested_client.get_response(
                 messages=[Message(role="user", contents=["Nested request"])],
                 options={"model": "NestedModel", "instructions": "Unrelated nested instructions."},
+                client_kwargs={"session": session},
             )
 
     agent = Agent(


### PR DESCRIPTION
### Motivation & Context

`AgentTelemetryLayer` captured `gen_ai.system_instructions` before context providers ran, so the `invoke_agent` span only reported base instructions and missed instructions added through `ContextProvider.before_run()`.

Fixes #5291

### Description & Review Guide

- **What are the major changes?**
  - Track the active `invoke_agent` span while agent telemetry is running.
  - Let agent-owned chat telemetry update that span with the final system instructions once context providers have contributed instructions.
  - Add regression coverage for non-streaming, streaming, and unrelated nested chat calls.
- **What is the impact of these changes?**
  - Agent telemetry now reports the same final system instructions sent to the chat client, including context-provider additions.
  - Unrelated nested chat telemetry is guarded from overwriting the agent span instructions.
- **What do you want reviewers to focus on?**
  - The active agent span guard in `observability.py`, especially the parent/session checks that limit updates to agent-owned chat spans.

### Related Issue

Fixes #5291

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.