### PR TITLE
.NET: Rebuild Hyperlight sandbox after tool registry updates

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightCodeActProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightCodeActProvider.cs
@@ -59,6 +59,7 @@ public sealed class HyperlightCodeActProvider : AIContextProvider, IDisposable
     private readonly Dictionary<string, AIFunction> _tools = new(StringComparer.Ordinal);
     private readonly Dictionary<string, FileMount> _fileMounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, AllowedDomain> _allowedDomains = new(StringComparer.Ordinal);
+    private long _toolRegistryVersion;
     private bool _disposed;
 
     /// <summary>
@@ -116,9 +117,19 @@ public sealed class HyperlightCodeActProvider : AIContextProvider, IDisposable
         lock (this._gate)
         {
             this.ThrowIfDisposed();
+            var changed = false;
             foreach (var tool in tools.Where(t => t is not null))
             {
                 this._tools[tool.Name] = tool;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                unchecked
+                {
+                    this._toolRegistryVersion++;
+                }
             }
         }
     }
@@ -272,7 +283,8 @@ public sealed class HyperlightCodeActProvider : AIContextProvider, IDisposable
                 this._tools.Values.ToList(),
                 this._fileMounts.Values.ToList(),
                 this._allowedDomains.Values.ToList(),
-                this._options.HostInputDirectory);
+                this._options.HostInputDirectory,
+                this._toolRegistryVersion);
         }
 
         var approvalRequired = ComputeApprovalRequired(this._options.ApprovalMode, snapshot.Tools);

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightCodeActProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightCodeActProvider.cs
@@ -59,7 +59,7 @@ public sealed class HyperlightCodeActProvider : AIContextProvider, IDisposable
     private readonly Dictionary<string, AIFunction> _tools = new(StringComparer.Ordinal);
     private readonly Dictionary<string, FileMount> _fileMounts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, AllowedDomain> _allowedDomains = new(StringComparer.Ordinal);
-    private long _toolRegistryVersion;
+    private Guid _toolRegistryVersion;
     private bool _disposed;
 
     /// <summary>
@@ -126,10 +126,7 @@ public sealed class HyperlightCodeActProvider : AIContextProvider, IDisposable
 
             if (changed)
             {
-                unchecked
-                {
-                    this._toolRegistryVersion++;
-                }
+                this._toolRegistryVersion = Guid.NewGuid();
             }
         }
     }

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightExecuteCodeFunction.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightExecuteCodeFunction.cs
@@ -71,7 +71,12 @@ public sealed class HyperlightExecuteCodeFunction : AIFunction, IDisposable
         var fileMounts = (effective.FileMounts?.Where(m => m is not null) ?? []).ToList();
         var allowedDomains = (effective.AllowedDomains?.Where(d => d is not null) ?? []).ToList();
 
-        this._snapshot = new SandboxExecutor.RunSnapshot(tools, fileMounts, allowedDomains, effective.HostInputDirectory);
+        this._snapshot = new SandboxExecutor.RunSnapshot(
+            tools,
+            fileMounts,
+            allowedDomains,
+            effective.HostInputDirectory,
+            toolRegistryVersion: 0);
 
         this._description = InstructionBuilder.BuildExecuteCodeDescription(
             this._snapshot.Tools,

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightExecuteCodeFunction.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/HyperlightExecuteCodeFunction.cs
@@ -76,7 +76,7 @@ public sealed class HyperlightExecuteCodeFunction : AIFunction, IDisposable
             fileMounts,
             allowedDomains,
             effective.HostInputDirectory,
-            toolRegistryVersion: 0);
+            toolRegistryVersion: Guid.Empty);
 
         this._description = InstructionBuilder.BuildExecuteCodeDescription(
             this._snapshot.Tools,

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/ExecuteCodeFunction.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/ExecuteCodeFunction.cs
@@ -56,6 +56,8 @@ internal sealed class ExecuteCodeFunction : AIFunction
     /// <inheritdoc />
     public override JsonElement JsonSchema => s_schema;
 
+    internal string ConfigFingerprint => this._snapshot.ConfigFingerprint;
+
     /// <inheritdoc />
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/SandboxExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/SandboxExecutor.cs
@@ -46,7 +46,7 @@ internal sealed class SandboxExecutor : IDisposable
             IReadOnlyList<FileMount> fileMounts,
             IReadOnlyList<AllowedDomain> allowedDomains,
             string? hostInputDirectory,
-            long toolRegistryVersion = 0)
+            Guid toolRegistryVersion = default)
         {
             this.Tools = tools;
             this.FileMounts = fileMounts;
@@ -69,7 +69,7 @@ internal sealed class SandboxExecutor : IDisposable
 
         public string? HostInputDirectory { get; }
 
-        public long ToolRegistryVersion { get; }
+        public Guid ToolRegistryVersion { get; }
 
         /// <summary>
         /// Stable fingerprint of the configuration that materially affects how
@@ -84,7 +84,7 @@ internal sealed class SandboxExecutor : IDisposable
             IReadOnlyList<FileMount> fileMounts,
             IReadOnlyList<AllowedDomain> allowedDomains,
             string? hostInputDirectory,
-            long toolRegistryVersion = 0)
+            Guid toolRegistryVersion = default)
         {
             var sb = new StringBuilder();
             sb.Append("tools=");
@@ -93,7 +93,7 @@ internal sealed class SandboxExecutor : IDisposable
                 sb.Append(name).Append('|');
             }
 
-            sb.Append(";toolVersion=").Append(toolRegistryVersion.ToString(CultureInfo.InvariantCulture));
+            sb.Append(";toolVersion=").Append(toolRegistryVersion.ToString("D", CultureInfo.InvariantCulture));
 
             sb.Append(";mounts=");
             foreach (var m in fileMounts

--- a/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/SandboxExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hyperlight/Internal/SandboxExecutor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -44,13 +45,20 @@ internal sealed class SandboxExecutor : IDisposable
             IReadOnlyList<AIFunction> tools,
             IReadOnlyList<FileMount> fileMounts,
             IReadOnlyList<AllowedDomain> allowedDomains,
-            string? hostInputDirectory)
+            string? hostInputDirectory,
+            long toolRegistryVersion = 0)
         {
             this.Tools = tools;
             this.FileMounts = fileMounts;
             this.AllowedDomains = allowedDomains;
             this.HostInputDirectory = hostInputDirectory;
-            this.ConfigFingerprint = ComputeFingerprint(tools, fileMounts, allowedDomains, hostInputDirectory);
+            this.ToolRegistryVersion = toolRegistryVersion;
+            this.ConfigFingerprint = ComputeFingerprint(
+                tools,
+                fileMounts,
+                allowedDomains,
+                hostInputDirectory,
+                toolRegistryVersion);
         }
 
         public IReadOnlyList<AIFunction> Tools { get; }
@@ -60,6 +68,8 @@ internal sealed class SandboxExecutor : IDisposable
         public IReadOnlyList<AllowedDomain> AllowedDomains { get; }
 
         public string? HostInputDirectory { get; }
+
+        public long ToolRegistryVersion { get; }
 
         /// <summary>
         /// Stable fingerprint of the configuration that materially affects how
@@ -73,7 +83,8 @@ internal sealed class SandboxExecutor : IDisposable
             IReadOnlyList<AIFunction> tools,
             IReadOnlyList<FileMount> fileMounts,
             IReadOnlyList<AllowedDomain> allowedDomains,
-            string? hostInputDirectory)
+            string? hostInputDirectory,
+            long toolRegistryVersion = 0)
         {
             var sb = new StringBuilder();
             sb.Append("tools=");
@@ -81,6 +92,8 @@ internal sealed class SandboxExecutor : IDisposable
             {
                 sb.Append(name).Append('|');
             }
+
+            sb.Append(";toolVersion=").Append(toolRegistryVersion.ToString(CultureInfo.InvariantCulture));
 
             sb.Append(";mounts=");
             foreach (var m in fileMounts

--- a/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/ProvideAIContextTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/ProvideAIContextTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hyperlight.Internal;
 using Microsoft.Extensions.AI;
 using Moq;
 
@@ -81,5 +82,23 @@ public sealed class ProvideAIContextTests
         var function = Assert.IsAssignableFrom<AIFunction>(context!.Tools!.First());
         Assert.Contains("first_tool", function.Description);
         Assert.DoesNotContain("second_tool", function.Description);
+    }
+
+    [Fact]
+    public async Task ProvideAIContextAsync_AddToolsSameNameReplacement_ChangesSnapshotFingerprintAsync()
+    {
+        // Arrange
+        using var provider = new HyperlightCodeActProvider(new HyperlightCodeActProviderOptions());
+        provider.AddTools(AIFunctionFactory.Create(() => "one", name: "same_tool"));
+
+        // Act
+        var firstContext = await provider.InvokingAsync(NewInvokingContext());
+        provider.AddTools(AIFunctionFactory.Create(() => "two", name: "same_tool"));
+        var secondContext = await provider.InvokingAsync(NewInvokingContext());
+
+        // Assert
+        var firstFunction = Assert.IsType<ExecuteCodeFunction>(firstContext!.Tools!.First());
+        var secondFunction = Assert.IsType<ExecuteCodeFunction>(secondContext!.Tools!.First());
+        Assert.NotEqual(firstFunction.ConfigFingerprint, secondFunction.ConfigFingerprint);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
@@ -38,11 +38,13 @@ public sealed class SandboxExecutorTests
     }
 
     [Fact]
-    public void Fingerprint_SameNameDifferentToolRegistryVersions_DifferentFingerprints()
+    public void Fingerprint_SameNameDifferentToolRegistryVersionIds_DifferentFingerprints()
     {
         // Arrange
         var t1 = AIFunctionFactory.Create(() => "a", name: "t");
         var t2 = AIFunctionFactory.Create(() => "b", name: "t");
+        var firstVersion = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var secondVersion = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
         // Act
         var fp1 = SandboxExecutor.RunSnapshot.ComputeFingerprint(
@@ -50,13 +52,13 @@ public sealed class SandboxExecutorTests
             [],
             [],
             hostInputDirectory: null,
-            toolRegistryVersion: 1);
+            toolRegistryVersion: firstVersion);
         var fp2 = SandboxExecutor.RunSnapshot.ComputeFingerprint(
             [t2],
             [],
             [],
             hostInputDirectory: null,
-            toolRegistryVersion: 2);
+            toolRegistryVersion: secondVersion);
 
         // Assert
         Assert.NotEqual(fp1, fp2);

--- a/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using Microsoft.Agents.AI.Hyperlight.Internal;
 using Microsoft.Extensions.AI;
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hyperlight.UnitTests/SandboxExecutorTests.cs
@@ -38,6 +38,31 @@ public sealed class SandboxExecutorTests
     }
 
     [Fact]
+    public void Fingerprint_SameNameDifferentToolRegistryVersions_DifferentFingerprints()
+    {
+        // Arrange
+        var t1 = AIFunctionFactory.Create(() => "a", name: "t");
+        var t2 = AIFunctionFactory.Create(() => "b", name: "t");
+
+        // Act
+        var fp1 = SandboxExecutor.RunSnapshot.ComputeFingerprint(
+            [t1],
+            [],
+            [],
+            hostInputDirectory: null,
+            toolRegistryVersion: 1);
+        var fp2 = SandboxExecutor.RunSnapshot.ComputeFingerprint(
+            [t2],
+            [],
+            [],
+            hostInputDirectory: null,
+            toolRegistryVersion: 2);
+
+        // Assert
+        Assert.NotEqual(fp1, fp2);
+    }
+
+    [Fact]
     public void Fingerprint_DifferentMounts_DifferentFingerprints()
     {
         // Act


### PR DESCRIPTION
### Motivation & Context

Hyperlight CodeAct providers should keep the reusable sandbox aligned with the provider-owned tool registry. When a tool registration is updated, subsequent run snapshots need to ensure sandbox callbacks are refreshed instead of relying only on stable tool names in the reuse key.

This change makes tool registry updates participate in sandbox reuse decisions while preserving the existing per-run snapshot behavior.

### Description & Review Guide

- **What are the major changes?**
  - Add a tool registry version to Hyperlight run snapshots and include it in the sandbox configuration fingerprint.
  - Increment the provider registry version when `AddTools(...)` accepts tool registrations, including same-name replacements.
  - Keep the standalone `HyperlightExecuteCodeFunction` on a fixed version because it captures immutable options at construction time.
  - Add unit coverage proving same-name tool snapshots with different registry versions produce different fingerprints.
- **What is the impact of these changes?**
  - Subsequent provider snapshots after `AddTools(...)` force a lazy sandbox rebuild before execution, so registered callbacks match the current provider registry.
  - Existing snapshots remain isolated from later provider mutations.
  - No public API or breaking behavior change.
- **What do you want reviewers to focus on?**
  - Whether the registry version is captured at the right boundary and whether the lazy rebuild behavior preserves the intended snapshot contract.


### Related Issue

No public issue. No matching open PR found.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.