### PR TITLE
.NET: Integrate LoopAgent into HarnessAgent with TodoCompletionLoopEvaluator

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/Program.cs
@@ -89,6 +89,13 @@ AIAgent agent =
         OpenTelemetrySourceName = TracingSourceName,        // Use our custom source name so spans are captured by the TracerProvider above.
         FileMemoryStore = new FileSystemAgentFileStore(     // Configure the file memory provider to store files in a local folder called "agent-files".
             Path.Combine(AppContext.BaseDirectory, "agent-files")),
+        // The built in ModeProvider has two default modes: "plan" and "execute".
+        // Adding a loop evaluator so that in "execute" mode, the harness keeps re-invoking itself until every todo item is complete.
+        LoopEvaluators =
+        [
+            new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] }),
+        ],
+        LoopAgentOptions = new LoopAgentOptions { MaxIterations = 10 }, // Safety cap on the number of autonomous passes per turn.
         ChatOptions = new ChatOptions
         {
             Instructions = instructions,

--- a/dotnet/samples/02-agents/Harness/Harness_Step01_Research/README.md
+++ b/dotnet/samples/02-agents/Harness/Harness_Step01_Research/README.md
@@ -9,6 +9,7 @@ Key features showcased:
 - **Web Search** — the agent can search the web for current information via `ResponseTool.CreateWebSearchTool()`
 - **TodoProvider** — the agent creates and manages a todo list to track research questions
 - **AgentModeProvider** — the agent switches between "plan" mode (breaking down the topic) and "execute" mode (answering each research question)
+- **TodoCompletionLoopEvaluator** — in "execute" mode the agent loops automatically, re-invoking itself until every todo item is complete (capped by `LoopAgentOptions.MaxIterations`). The loop is scoped to "execute" mode, so "plan" mode stays interactive. The `HarnessAgent` wraps itself in a `LoopAgent` automatically whenever `LoopEvaluators` is supplied.
 - **Interactive conversation** — you can review the agent's plan, provide feedback, and approve before execution begins
 - **Streaming output** — responses are streamed token-by-token for a natural experience
 - **`/todos` command** — view the current todo list at any time without invoking the agent
@@ -47,7 +48,7 @@ The sample starts an interactive conversation loop. You can:
 1. **Enter a research topic** — the agent will analyze it and create a plan with todos
 2. **Review and adjust** — provide feedback on the plan, ask for changes, or approve it
 3. **Type `/todos`** — to see the current todo list at any time
-4. **Watch execution** — once approved, tell the agent to proceed and it will work through each todo
+4. **Watch execution** — once approved, the agent will switch to "execute" mode and process each todo autonomously until the whole plan is complete
 5. **Type `exit`** — to end the session
 
 The prompt and agent output are colored by the current mode: **cyan** during planning, **green** during execution.

--- a/dotnet/samples/02-agents/Harness/Harness_Step05_Loop/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step05_Loop/Program.cs
@@ -116,7 +116,7 @@ async Task TodoLoopAsync()
         {
             var todoProvider = context.Agent.GetService<TodoProvider>()
                 ?? throw new InvalidOperationException("The agent did not expose a TodoProvider.");
-            var remaining = await todoProvider.GetRemainingTodosAsync(context.Session).ConfigureAwait(false);
+            var remaining = await todoProvider.GetRemainingTodosAsync(context.Session, cancellationToken).ConfigureAwait(false);
             return remaining.Count > 0
                 ? LoopEvaluation.Continue($"Not all todos are complete yet ({remaining.Count} remaining). Please complete the remaining todo items.")
                 : LoopEvaluation.Stop();

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Agents.AI;
 /// <list type="bullet">
 /// <item><description><see cref="ToolApprovalAgent"/> — "don't ask again" tool approval rules enabling safe unattended execution. Disable with <see cref="HarnessAgentOptions.DisableToolApproval"/>.</description></item>
 /// <item><description><see cref="OpenTelemetryAgent"/> — OpenTelemetry instrumentation following semantic conventions for generative AI. Disable with <see cref="HarnessAgentOptions.DisableOpenTelemetry"/>.</description></item>
+/// <item><description><see cref="LoopAgent"/> — re-invokes the agent until the configured evaluators are satisfied. Applied as the outermost decorator (so each iteration is a complete agent run) and only when <see cref="HarnessAgentOptions.LoopEvaluators"/> supplies at least one evaluator; otherwise omitted.</description></item>
 /// </list>
 /// </para>
 /// <para>
@@ -141,6 +142,18 @@ public sealed class HarnessAgent : DelegatingAIAgent
         ChatClientAgent innerAgent = BuildInnerAgent(chatClient, options, loggerFactory, services);
 
         AIAgentBuilder builder = innerAgent.AsBuilder();
+
+        // Register the loop decorator first so it ends up outermost (AIAgentBuilder applies factories in reverse): the
+        // loop drives complete agent runs, each independently tool-approved and OpenTelemetry-traced. Only added when at
+        // least one evaluator is supplied; otherwise the agent behaves as a single-shot agent.
+        if (options?.LoopEvaluators is IEnumerable<LoopEvaluator> loopEvaluators)
+        {
+            List<LoopEvaluator> evaluatorList = loopEvaluators.ToList();
+            if (evaluatorList.Count > 0)
+            {
+                builder.Use((inner, _) => new LoopAgent(inner, evaluatorList, options.LoopAgentOptions, loggerFactory));
+            }
+        }
 
         if (options?.DisableToolApproval is not true)
         {

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
@@ -147,6 +147,33 @@ public sealed class HarnessAgentOptions
     public IEnumerable<AIContextProvider>? AIContextProviders { get; set; }
 
     /// <summary>
+    /// Gets or sets the ordered set of <see cref="LoopEvaluator"/> instances that, when supplied, cause the
+    /// <see cref="HarnessAgent"/> to be wrapped in a <see cref="LoopAgent"/> decorator.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When this collection is non-<see langword="null"/> and contains at least one evaluator, the harness agent is
+    /// wrapped in a <see cref="LoopAgent"/> that re-invokes the agent until the evaluators are satisfied. The loop is
+    /// applied as the outermost decorator, so each iteration is a complete agent run (including tool approval and
+    /// OpenTelemetry instrumentation).
+    /// </para>
+    /// <para>
+    /// When <see langword="null"/> or empty (the default), no <see cref="LoopAgent"/> is added and the agent behaves
+    /// as a single-shot agent.
+    /// </para>
+    /// </remarks>
+    public IEnumerable<LoopEvaluator>? LoopEvaluators { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional configuration for the <see cref="LoopAgent"/> created from <see cref="LoopEvaluators"/>.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, the <see cref="LoopAgent"/> uses its default settings. This property is ignored
+    /// when <see cref="LoopEvaluators"/> is <see langword="null"/> or empty.
+    /// </remarks>
+    public LoopAgentOptions? LoopAgentOptions { get; set; }
+
+    /// <summary>
     /// Gets or sets the maximum number of function-invocation loop iterations per request.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
@@ -147,7 +147,7 @@ public sealed class HarnessAgentOptions
     public IEnumerable<AIContextProvider>? AIContextProviders { get; set; }
 
     /// <summary>
-    /// Gets or sets the ordered set of <see cref="LoopEvaluator"/> instances that, when supplied, cause the
+    /// Gets or sets the ordered collection of <see cref="LoopEvaluator"/> instances that, when supplied, cause the
     /// <see cref="HarnessAgent"/> to be wrapped in a <see cref="LoopAgent"/> decorator.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/LoopAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/LoopAgent.cs
@@ -95,7 +95,7 @@ public sealed class LoopAgent : DelegatingAIAgent
     /// </summary>
     /// <param name="innerAgent">The underlying agent to invoke in a loop.</param>
     /// <param name="evaluators">
-    /// The ordered set of <see cref="LoopEvaluator"/> that decide whether to re-invoke the agent. They are evaluated in
+    /// The ordered collection of <see cref="LoopEvaluator"/> that decide whether to re-invoke the agent. They are evaluated in
     /// order after each iteration and the first that asks to re-invoke wins.
     /// </param>
     /// <param name="options">Optional configuration for the loop. When <see langword="null"/>, defaults are used.</param>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/LoopEvaluator.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/LoopEvaluator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Agents.AI;
 /// </para>
 /// <para>
 /// Out-of-the-box implementations include <see cref="AIJudgeLoopEvaluator"/>, <see cref="DelegateLoopEvaluator"/>,
-/// and <see cref="CompletionMarkerLoopEvaluator"/>. Implementations should be stateless and safe to share across
+/// <see cref="CompletionMarkerLoopEvaluator"/>, and <see cref="TodoCompletionLoopEvaluator"/>. Implementations should be stateless and safe to share across
 /// concurrent loop runs; any per-run state must be stored on the supplied <see cref="LoopContext"/>.
 /// </para>
 /// </remarks>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// A <see cref="LoopEvaluator"/> that keeps re-invoking the wrapped agent until a <see cref="TodoProvider"/> has no
+/// remaining (incomplete) todo items, optionally only while the agent is operating in one of a configured set of modes
+/// tracked by an <see cref="AgentModeProvider"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The required <see cref="TodoProvider"/> — and, when modes are configured, the <see cref="AgentModeProvider"/> — are
+/// not supplied directly. They are resolved at evaluation time from the looped agent via
+/// <see cref="AIAgent.GetService{TService}(object?)"/>. This works because an agent surfaces its registered
+/// <see cref="AIContextProvider"/> instances through <c>GetService</c>, so a single <see cref="TodoProvider"/> (and
+/// <see cref="AgentModeProvider"/>) attached to the agent's session is discovered automatically. It also means this
+/// evaluator can be added directly to a harness agent's loop without any additional wiring.
+/// </para>
+/// <para>
+/// When one or more modes are configured, the evaluator only requests re-invocation while the session's current mode is
+/// one of those modes; in any other mode it returns <see cref="LoopEvaluation.Stop"/> (which, per <see cref="LoopAgent"/>
+/// semantics, declines to drive continuation rather than vetoing other evaluators). When no modes are configured the
+/// evaluator applies in every mode and no <see cref="AgentModeProvider"/> is required.
+/// </para>
+/// <para>
+/// While incomplete todos remain the evaluator continues with feedback built from a template (see
+/// <see cref="TodoCompletionLoopEvaluatorOptions.FeedbackMessageTemplate"/>) with the remaining todo list substituted
+/// for <see cref="RemainingTodosPlaceholder"/>. How that feedback is delivered to the agent (and whether the session is
+/// reset) is decided by the <see cref="LoopAgent"/> that consumes this evaluator.
+/// </para>
+/// </remarks>
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class TodoCompletionLoopEvaluator : LoopEvaluator
+{
+    /// <summary>
+    /// The placeholder token within <see cref="DefaultFeedbackMessageTemplate"/> (or a custom
+    /// <see cref="TodoCompletionLoopEvaluatorOptions.FeedbackMessageTemplate"/>) that is replaced, on each evaluation,
+    /// with a formatted list of the remaining (incomplete) todo items.
+    /// </summary>
+    public const string RemainingTodosPlaceholder = "{remaining_todos}";
+
+    /// <summary>The default template used to build the feedback produced while incomplete todo items remain.</summary>
+    public const string DefaultFeedbackMessageTemplate =
+        "You still have incomplete todo items. Continue working until every item is complete, marking each item as " +
+        "complete when finished. The following items are still open:\n" + RemainingTodosPlaceholder;
+
+    private readonly HashSet<string>? _modes;
+    private readonly string _feedbackMessageTemplate;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TodoCompletionLoopEvaluator"/> class.
+    /// </summary>
+    /// <param name="options">
+    /// Optional configuration for the evaluator, including <see cref="TodoCompletionLoopEvaluatorOptions.Modes"/> and
+    /// the feedback message template. When <see langword="null"/>, defaults are used (applies in every mode).
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// <see cref="TodoCompletionLoopEvaluatorOptions.Modes"/> is non-<see langword="null"/> but empty, or contains a
+    /// <see langword="null"/>, empty, or whitespace mode name.
+    /// </exception>
+    public TodoCompletionLoopEvaluator(TodoCompletionLoopEvaluatorOptions? options = null)
+    {
+        if (options?.Modes is not null)
+        {
+            var modeSet = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string mode in options.Modes)
+            {
+                if (string.IsNullOrWhiteSpace(mode))
+                {
+                    throw new ArgumentException("Mode names must not be null, empty, or whitespace.", nameof(options));
+                }
+
+                modeSet.Add(mode);
+            }
+
+            if (modeSet.Count == 0)
+            {
+                throw new ArgumentException("At least one mode must be supplied when modes are specified. Leave Modes null to apply in every mode.", nameof(options));
+            }
+
+            this._modes = modeSet;
+        }
+
+        this._feedbackMessageTemplate = options?.FeedbackMessageTemplate ?? DefaultFeedbackMessageTemplate;
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<LoopEvaluation> EvaluateAsync(LoopContext context, CancellationToken cancellationToken = default)
+    {
+        _ = Throw.IfNull(context);
+
+        TodoProvider todoProvider = context.Agent.GetService<TodoProvider>()
+            ?? throw new InvalidOperationException(
+                $"{nameof(TodoCompletionLoopEvaluator)} requires a {nameof(TodoProvider)} to be registered on the agent, but none could be resolved via GetService.");
+
+        // When modes are configured, only drive re-invocation while the current mode is one of them.
+        if (this._modes is not null)
+        {
+            AgentModeProvider modeProvider = context.Agent.GetService<AgentModeProvider>()
+                ?? throw new InvalidOperationException(
+                    $"{nameof(TodoCompletionLoopEvaluator)} was configured with modes but no {nameof(AgentModeProvider)} could be resolved from the agent via GetService.");
+
+            string currentMode = modeProvider.GetMode(context.Session);
+            if (!this._modes.Contains(currentMode))
+            {
+                return LoopEvaluation.Stop();
+            }
+        }
+
+        List<TodoItem> remaining = await todoProvider.GetRemainingTodosAsync(context.Session).ConfigureAwait(false);
+        if (remaining.Count == 0)
+        {
+            return LoopEvaluation.Stop();
+        }
+
+        string feedback = this._feedbackMessageTemplate.Replace(RemainingTodosPlaceholder, FormatRemainingTodos(remaining));
+        return LoopEvaluation.Continue(feedback);
+    }
+
+    private static string FormatRemainingTodos(List<TodoItem> remaining)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < remaining.Count; i++)
+        {
+            TodoItem item = remaining[i];
+            sb.Append("- ").Append(item.Id).Append(": ").Append(item.Title);
+            if (!string.IsNullOrWhiteSpace(item.Description))
+            {
+                sb.Append(" — ").Append(item.Description);
+            }
+
+            if (i < remaining.Count - 1)
+            {
+                sb.Append('\n');
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
@@ -116,7 +116,7 @@ public sealed class TodoCompletionLoopEvaluator : LoopEvaluator
             }
         }
 
-        List<TodoItem> remaining = await todoProvider.GetRemainingTodosAsync(context.Session).ConfigureAwait(false);
+        List<TodoItem> remaining = await todoProvider.GetRemainingTodosAsync(context.Session, cancellationToken).ConfigureAwait(false);
         if (remaining.Count == 0)
         {
             return LoopEvaluation.Stop();

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluatorOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluatorOptions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Shared.DiagnosticIds;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// Provides configuration options for <see cref="TodoCompletionLoopEvaluator"/>.
+/// </summary>
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class TodoCompletionLoopEvaluatorOptions
+{
+    /// <summary>
+    /// Gets or sets the set of mode names for which the evaluator drives re-invocation, or <see langword="null"/> to
+    /// apply in every mode.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, the evaluator applies in every mode and no <see cref="AgentModeProvider"/> is
+    /// required. When non-<see langword="null"/> it must contain at least one non-empty mode name; mode names are
+    /// matched ordinally and an <see cref="AgentModeProvider"/> must be resolvable from the agent at evaluation time.
+    /// </remarks>
+    public IEnumerable<string>? Modes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the template used to build the feedback produced while incomplete todo items remain,
+    /// or <see langword="null"/> to use <see cref="TodoCompletionLoopEvaluator.DefaultFeedbackMessageTemplate"/>.
+    /// </summary>
+    /// <remarks>
+    /// Any occurrence of <see cref="TodoCompletionLoopEvaluator.RemainingTodosPlaceholder"/> in the template is
+    /// replaced, on each evaluation, with a formatted list of the remaining (incomplete) todo items. When the
+    /// placeholder is absent the rendered list is not appended.
+    /// </remarks>
+    public string? FeedbackMessageTemplate { get; set; }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs
@@ -100,11 +100,12 @@ public sealed class TodoProvider : AIContextProvider, IDisposable
     /// Modifying their properties will mutate the provider's state directly.
     /// </remarks>
     /// <param name="session">The agent session to read todos from.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A list of all todo items. The items are live references to internal state.</returns>
-    public async Task<IReadOnlyList<TodoItem>> GetAllTodosAsync(AgentSession? session)
+    public async Task<IReadOnlyList<TodoItem>> GetAllTodosAsync(AgentSession? session, CancellationToken cancellationToken = default)
     {
         SemaphoreSlim sessionLock = this.GetSessionLock(session);
-        await sessionLock.WaitAsync().ConfigureAwait(false);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             TodoState state = this._sessionState.GetOrInitializeState(session);
@@ -124,11 +125,12 @@ public sealed class TodoProvider : AIContextProvider, IDisposable
     /// Modifying their properties will mutate the provider's state directly.
     /// </remarks>
     /// <param name="session">The agent session to read todos from.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A list of incomplete todo items. The items are live references to internal state.</returns>
-    public async Task<List<TodoItem>> GetRemainingTodosAsync(AgentSession? session)
+    public async Task<List<TodoItem>> GetRemainingTodosAsync(AgentSession? session, CancellationToken cancellationToken = default)
     {
         SemaphoreSlim sessionLock = this.GetSessionLock(session);
-        await sessionLock.WaitAsync().ConfigureAwait(false);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             TodoState state = this._sessionState.GetOrInitializeState(session);

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentOptionsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Threading.Tasks;
 using Moq;
 #if NET
 using Microsoft.Agents.AI.Tools.Shell;
@@ -26,6 +27,8 @@ public class HarnessAgentOptionsTests
         Assert.Null(options.HarnessInstructions);
         Assert.Null(options.ChatHistoryProvider);
         Assert.Null(options.AIContextProviders);
+        Assert.Null(options.LoopEvaluators);
+        Assert.Null(options.LoopAgentOptions);
         Assert.False(options.DisableToolApproval);
         Assert.False(options.DisableNonApprovalRequiredFunctionBypassing);
         Assert.False(options.DisableFileMemory);
@@ -64,6 +67,8 @@ public class HarnessAgentOptionsTests
         var skillsSource = new Mock<AgentSkillsSource>().Object;
         var backgroundAgents = new AIAgent[] { new Mock<AIAgent>().Object };
         var backgroundAgentsOptions = new BackgroundAgentsProviderOptions();
+        var loopEvaluators = new LoopEvaluator[] { new DelegateLoopEvaluator((_, _) => new ValueTask<LoopEvaluation>(LoopEvaluation.Stop())) };
+        var loopAgentOptions = new LoopAgentOptions();
 #if NET
         var shellExecutor = new Mock<ShellExecutor>().Object;
         var shellEnvOptions = new ShellEnvironmentProviderOptions();
@@ -96,6 +101,8 @@ public class HarnessAgentOptionsTests
             OpenTelemetrySourceName = "custom-source",
             BackgroundAgents = backgroundAgents,
             BackgroundAgentsProviderOptions = backgroundAgentsOptions,
+            LoopEvaluators = loopEvaluators,
+            LoopAgentOptions = loopAgentOptions,
 #if NET
             ShellExecutor = shellExecutor,
             ShellEnvironmentProviderOptions = shellEnvOptions,
@@ -129,6 +136,8 @@ public class HarnessAgentOptionsTests
         Assert.Equal("custom-source", options.OpenTelemetrySourceName);
         Assert.Same(backgroundAgents, options.BackgroundAgents);
         Assert.Same(backgroundAgentsOptions, options.BackgroundAgentsProviderOptions);
+        Assert.Same(loopEvaluators, options.LoopEvaluators);
+        Assert.Same(loopAgentOptions, options.LoopAgentOptions);
 #if NET
         Assert.Same(shellExecutor, options.ShellExecutor);
         Assert.Same(shellEnvOptions, options.ShellEnvironmentProviderOptions);

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -1820,4 +1820,118 @@ public class HarnessAgentTests
     }
 
     #endregion
+
+    #region Feature: Loop
+
+    /// <summary>
+    /// Verify that no <see cref="LoopAgent"/> is added when no loop evaluators are supplied.
+    /// </summary>
+    [Fact]
+    public void Loop_ExcludedByDefault()
+    {
+        // Arrange
+        var chatClient = new Mock<IChatClient>().Object;
+
+        // Act
+        var agent = new HarnessAgent(chatClient, CreateAllDisabledOptions());
+
+        // Assert
+        Assert.Null(agent.GetService<LoopAgent>());
+    }
+
+    /// <summary>
+    /// Verify that an empty loop evaluator collection does not add a <see cref="LoopAgent"/>.
+    /// </summary>
+    [Fact]
+    public void Loop_EmptyEvaluators_Excluded()
+    {
+        // Arrange
+        var chatClient = new Mock<IChatClient>().Object;
+        var options = CreateAllDisabledOptions();
+        options.LoopEvaluators = [];
+
+        // Act
+        var agent = new HarnessAgent(chatClient, options);
+
+        // Assert
+        Assert.Null(agent.GetService<LoopAgent>());
+    }
+
+    /// <summary>
+    /// Verify that a <see cref="LoopAgent"/> is added when at least one evaluator is supplied, while the inner
+    /// <see cref="ChatClientAgent"/> remains resolvable through the decorator chain.
+    /// </summary>
+    [Fact]
+    public void Loop_IncludedWhenEvaluatorsProvided()
+    {
+        // Arrange
+        var chatClient = new Mock<IChatClient>().Object;
+        var options = CreateAllDisabledOptions();
+        options.LoopEvaluators = [new DelegateLoopEvaluator((_, _) => new ValueTask<LoopEvaluation>(LoopEvaluation.Stop()))];
+
+        // Act
+        var agent = new HarnessAgent(chatClient, options);
+
+        // Assert
+        Assert.NotNull(agent.GetService<LoopAgent>());
+        Assert.NotNull(agent.GetService<ChatClientAgent>());
+    }
+
+    /// <summary>
+    /// Verify that the <see cref="LoopAgent"/> is the outermost decorator, wrapping the <see cref="ToolApprovalAgent"/>
+    /// (which is itself resolvable through the loop).
+    /// </summary>
+    [Fact]
+    public void Loop_IsOutermost_WrappingToolApproval()
+    {
+        // Arrange
+        var chatClient = new Mock<IChatClient>().Object;
+        var options = CreateAllDisabledOptions();
+        options.DisableToolApproval = false;
+        options.LoopEvaluators = [new DelegateLoopEvaluator((_, _) => new ValueTask<LoopEvaluation>(LoopEvaluation.Stop()))];
+
+        // Act
+        var agent = new HarnessAgent(chatClient, options);
+
+        // Assert — the loop is present and the tool approval agent it wraps is still resolvable underneath it.
+        Assert.NotNull(agent.GetService<LoopAgent>());
+        Assert.NotNull(agent.GetService<ToolApprovalAgent>());
+    }
+
+    /// <summary>
+    /// Verify that the loop actually drives re-invocation: an evaluator that continues once before stopping causes the
+    /// inner chat client to be invoked twice.
+    /// </summary>
+    [Fact]
+    public async Task Loop_DrivesReinvocationAsync()
+    {
+        // Arrange — inner client returns a response on each call.
+        var mockClient = new Mock<IChatClient>();
+        mockClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "working")));
+
+        var options = CreateAllDisabledOptions();
+        // Continue once (iteration 1), then stop on the second evaluation.
+        options.LoopEvaluators = [new DelegateLoopEvaluator((ctx, _) =>
+            new ValueTask<LoopEvaluation>(ctx.Iteration < 2 ? LoopEvaluation.Continue() : LoopEvaluation.Stop()))];
+        var agent = new HarnessAgent(mockClient.Object, options);
+        var session = await agent.CreateSessionAsync();
+
+        // Act
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "go")], session);
+
+        // Assert — the inner client was invoked once per iteration (two iterations).
+        mockClient.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    #endregion
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -1893,9 +1893,12 @@ public class HarnessAgentTests
         // Act
         var agent = new HarnessAgent(chatClient, options);
 
-        // Assert — the loop is present and the tool approval agent it wraps is still resolvable underneath it.
+        // Assert — the loop is the outermost decorator: it is resolvable, it wraps the tool approval agent, and
+        // looking *down* from the tool approval agent does not surface the loop (proving the loop sits above it).
         Assert.NotNull(agent.GetService<LoopAgent>());
-        Assert.NotNull(agent.GetService<ToolApprovalAgent>());
+        var toolApproval = agent.GetService<ToolApprovalAgent>();
+        Assert.NotNull(toolApproval);
+        Assert.Null(toolApproval.GetService<LoopAgent>());
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/Loop/TodoCompletionLoopEvaluatorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/Loop/TodoCompletionLoopEvaluatorTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Moq;
+
+namespace Microsoft.Agents.AI.UnitTests;
+
+/// <summary>
+/// Unit tests for the <see cref="TodoCompletionLoopEvaluator"/> class.
+/// </summary>
+public class TodoCompletionLoopEvaluatorTests
+{
+    /// <summary>
+    /// Verify that the constructor throws when a non-null but empty modes collection is supplied.
+    /// </summary>
+    [Fact]
+    public void TodoCompletionLoopEvaluator_EmptyModes_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = [] }));
+    }
+
+    /// <summary>
+    /// Verify that the constructor throws when a mode name is null, empty, or whitespace.
+    /// </summary>
+    /// <param name="mode">The invalid mode name.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TodoCompletionLoopEvaluator_InvalidModeName_Throws(string? mode)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = [mode!] }));
+    }
+
+    /// <summary>
+    /// Verify that the constructor succeeds with null modes (applies in every mode) and with a valid mode set.
+    /// </summary>
+    [Fact]
+    public void TodoCompletionLoopEvaluator_ValidConstruction_Succeeds()
+    {
+        // Act & Assert
+        _ = new TodoCompletionLoopEvaluator();
+        _ = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
+    }
+
+    /// <summary>
+    /// Verify that evaluation throws when no <see cref="TodoProvider"/> can be resolved from the agent.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_NoTodoProvider_ThrowsAsync()
+    {
+        // Arrange — a bare agent that resolves no providers.
+        var evaluator = new TodoCompletionLoopEvaluator();
+        var context = CreateContext(new Mock<AIAgent>().Object, new ChatClientAgentSession());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await evaluator.EvaluateAsync(context));
+    }
+
+    /// <summary>
+    /// Verify that evaluation throws when modes are configured but no <see cref="AgentModeProvider"/> can be resolved.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ModesConfiguredButNoModeProvider_ThrowsAsync()
+    {
+        // Arrange — agent has a TodoProvider but no AgentModeProvider.
+        var todoProvider = new TodoProvider();
+        var session = new ChatClientAgentSession();
+        SeedTodos(session, (1, "Task one", null, false));
+        AIAgent agent = CreateAgent(todoProvider);
+        var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
+        LoopContext context = CreateContext(agent, session);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await evaluator.EvaluateAsync(context));
+    }
+
+    /// <summary>
+    /// Verify that, with no modes configured, the evaluator continues while incomplete todos remain and the feedback
+    /// lists those todos.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_NoModes_RemainingTodos_ContinuesWithFeedbackAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var session = new ChatClientAgentSession();
+        SeedTodos(session, (1, "Write code", null, false), (2, "Add tests", "cover edge cases", false), (3, "Done item", null, true));
+        AIAgent agent = CreateAgent(todoProvider);
+        var evaluator = new TodoCompletionLoopEvaluator();
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.True(evaluation.ShouldReinvoke);
+        Assert.NotNull(evaluation.Feedback);
+        Assert.Contains("Write code", evaluation.Feedback!);
+        Assert.Contains("Add tests", evaluation.Feedback!);
+        Assert.Contains("cover edge cases", evaluation.Feedback!);
+        // Completed items must not appear in the feedback list.
+        Assert.DoesNotContain("Done item", evaluation.Feedback!);
+    }
+
+    /// <summary>
+    /// Verify that, with no modes configured, the evaluator stops when there are no incomplete todos.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_NoModes_NoRemainingTodos_StopsAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var session = new ChatClientAgentSession();
+        SeedTodos(session, (1, "Completed", null, true));
+        AIAgent agent = CreateAgent(todoProvider);
+        var evaluator = new TodoCompletionLoopEvaluator();
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.False(evaluation.ShouldReinvoke);
+    }
+
+    /// <summary>
+    /// Verify that, when the current mode is one of the configured modes and incomplete todos remain, the evaluator
+    /// continues.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ModeMatches_RemainingTodos_ContinuesAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var modeProvider = new AgentModeProvider();
+        var session = new ChatClientAgentSession();
+        modeProvider.SetMode(session, "execute");
+        SeedTodos(session, (1, "Work item", null, false));
+        AIAgent agent = CreateAgent(todoProvider, modeProvider);
+        var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.True(evaluation.ShouldReinvoke);
+    }
+
+    /// <summary>
+    /// Verify that, when the current mode is one of the configured modes but no incomplete todos remain, the evaluator
+    /// stops.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ModeMatches_NoRemainingTodos_StopsAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var modeProvider = new AgentModeProvider();
+        var session = new ChatClientAgentSession();
+        modeProvider.SetMode(session, "execute");
+        SeedTodos(session, (1, "Already done", null, true));
+        AIAgent agent = CreateAgent(todoProvider, modeProvider);
+        var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.False(evaluation.ShouldReinvoke);
+    }
+
+    /// <summary>
+    /// Verify that, when the current mode is not one of the configured modes, the evaluator stops even if incomplete
+    /// todos remain.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_ModeDoesNotMatch_StopsEvenWithRemainingTodosAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var modeProvider = new AgentModeProvider();
+        var session = new ChatClientAgentSession();
+        modeProvider.SetMode(session, "plan");
+        SeedTodos(session, (1, "Still open", null, false));
+        AIAgent agent = CreateAgent(todoProvider, modeProvider);
+        var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.False(evaluation.ShouldReinvoke);
+    }
+
+    /// <summary>
+    /// Verify that a custom feedback template with the remaining-todos placeholder is honored.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_CustomTemplate_IsHonoredAsync()
+    {
+        // Arrange
+        var todoProvider = new TodoProvider();
+        var session = new ChatClientAgentSession();
+        SeedTodos(session, (1, "Remaining task", null, false));
+        AIAgent agent = CreateAgent(todoProvider);
+        var options = new TodoCompletionLoopEvaluatorOptions
+        {
+            FeedbackMessageTemplate = "Keep going. Open:\n" + TodoCompletionLoopEvaluator.RemainingTodosPlaceholder,
+        };
+        var evaluator = new TodoCompletionLoopEvaluator(options: options);
+        LoopContext context = CreateContext(agent, session);
+
+        // Act
+        LoopEvaluation evaluation = await evaluator.EvaluateAsync(context);
+
+        // Assert
+        Assert.True(evaluation.ShouldReinvoke);
+        Assert.StartsWith("Keep going. Open:", evaluation.Feedback);
+        Assert.Contains("Remaining task", evaluation.Feedback!);
+    }
+
+    private static ChatClientAgent CreateAgent(params AIContextProvider[] providers)
+    {
+        var chatClient = new Mock<IChatClient>().Object;
+        return new ChatClientAgent(chatClient, new ChatClientAgentOptions { AIContextProviders = providers });
+    }
+
+    private static LoopContext CreateContext(AIAgent agent, AgentSession session) => new(
+        agent,
+        session,
+        [new ChatMessage(ChatRole.User, "do the work")],
+        new AgentResponse([new ChatMessage(ChatRole.Assistant, "in progress")]));
+
+    private static void SeedTodos(AgentSession session, params (int Id, string Title, string? Description, bool IsComplete)[] items)
+    {
+        var state = new TodoState { NextId = items.Length + 1 };
+        foreach ((int id, string title, string? description, bool isComplete) in items)
+        {
+            state.Items.Add(new TodoItem
+            {
+                Id = id,
+                Title = title,
+                Description = description,
+                IsComplete = isComplete,
+            });
+        }
+
+        // Persist under the TodoProvider's state key so the provider reads it back via GetRemainingTodosAsync.
+        session.StateBag.SetValue(nameof(TodoProvider), state, AgentJsonUtilities.DefaultOptions);
+    }
+}


### PR DESCRIPTION
### Motivation & Context

The core `LoopAgent` (added in #6384) makes it possible to re-invoke an agent until configurable criteria are met. This PR builds on that to make looping a first-class, opt-in capability of `HarnessAgent`, delivering the "loop until completion" enforcement scenario for harnesses.

It also adds a `TodoCompletionLoopEvaluator` so a harness can keep working autonomously until every todo item is complete — optionally scoped to specific agent modes — which is exactly the kind of completion-enforcement behavior the harness experience needs.

### Description & Review Guide

- **What are the major changes?**
  - `HarnessAgentOptions` gains `LoopEvaluators` (`IEnumerable<LoopEvaluator>?`) and `LoopAgentOptions`. When at least one evaluator is supplied, `HarnessAgent.BuildAgent` wraps the harness in a `LoopAgent` as the outermost decorator; when none are supplied, behavior is unchanged.
  - New `TodoCompletionLoopEvaluator` (+ `TodoCompletionLoopEvaluatorOptions`): resolves `TodoProvider` (and `AgentModeProvider` when `Modes` is set) from `context.Agent.GetService<T>()`, and re-invokes with a customizable feedback message while incomplete todos remain. `Modes == null` applies in all modes; a non-null empty set is an error; mode matching is ordinal.
  - The `Harness_Step01_Research` sample now demonstrates the evaluator scoped to `"execute"` mode with a `MaxIterations` safety cap.
- **What is the impact of these changes?**
  - Purely additive and opt-in. Existing harnesses with no `LoopEvaluators` behave exactly as before.
- **What do you want reviewers to focus on?**
  - Provider resolution via the `GetService` decorator chain (no provider constructor params), and the decorator ordering that makes `LoopAgent` outermost.
  - The null-vs-empty `Modes` semantics.

### Related Issue

Fixes #6478

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
