### PR TITLE
Python: Fix harness console rendering one streamed tool call many times

### DIFF
--- a/python/samples/02-agents/harness/console/observers/tool_call_display.py
+++ b/python/samples/02-agents/harness/console/observers/tool_call_display.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from ..formatters import build_default_formatters, format_tool_call
@@ -12,6 +13,7 @@ from .base import ConsoleObserver
 if TYPE_CHECKING:
     from agent_framework import Agent, Content
 
+    from ..app_state import FollowUpAction
     from ..formatters import ToolCallFormatter
     from ..state_driver import IUXStateDriver
 
@@ -21,6 +23,16 @@ class ToolCallDisplayObserver(ConsoleObserver):
 
     Shows tool calls with a 🔧 prefix and uses the formatter system to
     display them in a user-friendly format.
+
+    Streaming clients (e.g. the OpenAI/Foundry Responses API) emit a separate
+    ``function_call`` content item for every ``arguments`` delta — each sharing
+    the same ``call_id`` and ``name`` but carrying only a partial fragment of the
+    JSON arguments. Printing one line per content item therefore repeats a single
+    tool call many times (scaling with argument size). To avoid that, this
+    observer buffers the argument fragments per ``call_id`` and emits exactly one
+    line once the accumulated arguments are complete (i.e. parse as valid JSON,
+    or arrive already-coalesced as a mapping). Any call that never reaches a
+    complete state is flushed when streaming completes.
     """
 
     def __init__(self, formatters: list[ToolCallFormatter] | None = None) -> None:
@@ -31,6 +43,10 @@ class ToolCallDisplayObserver(ConsoleObserver):
                 default formatters from build_default_formatters().
         """
         self._formatters = formatters or build_default_formatters()
+        # call_id -> {"name": str, "arguments": str | dict}
+        self._pending: dict[str, dict[str, Any]] = {}
+        # call_ids already displayed in the current stream (avoid duplicates).
+        self._displayed: set[str] = set()
 
     async def on_content(
         self,
@@ -39,7 +55,7 @@ class ToolCallDisplayObserver(ConsoleObserver):
         agent: Agent,
         session: Any,
     ) -> None:
-        """Display function call content.
+        """Buffer streamed function-call fragments and display each call once.
 
         Args:
             ux: The UX state driver for UI updates.
@@ -47,7 +63,86 @@ class ToolCallDisplayObserver(ConsoleObserver):
             agent: The AI agent.
             session: The agent session.
         """
-        # Check if this is a function call content type
-        if content.type == "function_call":
-            formatted = format_tool_call(self._formatters, content)
-            ux.append_info_line(f"🔧 {formatted}", "yellow")
+        if content.type != "function_call":
+            return
+
+        # Group streamed fragments by call_id. Some providers may omit a call_id;
+        # fall back to a name-derived key so distinct unnamed calls don't merge.
+        call_id = content.call_id or f"__noid_{content.name or 'unknown'}"
+
+        if call_id in self._displayed:
+            return
+
+        entry = self._pending.setdefault(call_id, {"name": content.name, "arguments": ""})
+        if content.name and not entry["name"]:
+            entry["name"] = content.name
+
+        args = content.arguments
+        if isinstance(args, str):
+            # Streaming delta fragment — concatenate.
+            entry["arguments"] = (entry["arguments"] or "") + args
+        elif args is not None:
+            # Already-coalesced arguments (e.g. a mapping) — use directly.
+            entry["arguments"] = args
+
+        if self._is_complete(entry["arguments"]):
+            self._flush(ux, call_id)
+
+    async def on_stream_complete(
+        self,
+        ux: IUXStateDriver,
+        agent: Agent,
+        session: Any,
+    ) -> list[FollowUpAction] | None:
+        """Flush buffered calls that never reached a complete state, then reset.
+
+        Args:
+            ux: The UX state driver for UI updates.
+            agent: The AI agent.
+            session: The agent session.
+
+        Returns:
+            Always None; this observer produces no follow-up actions.
+        """
+        for call_id in list(self._pending):
+            self._flush(ux, call_id)
+        self._pending.clear()
+        self._displayed.clear()
+        return None
+
+    @staticmethod
+    def _is_complete(arguments: Any) -> bool:
+        """Return True when the accumulated arguments form a complete payload.
+
+        A mapping is already complete. A string is complete once it parses as
+        JSON (partial fragments of a streamed JSON object will not parse until
+        the closing brace arrives; a no-argument call streams ``"{}"`` which
+        parses immediately).
+        """
+        if isinstance(arguments, str):
+            if not arguments:
+                return False
+            try:
+                json.loads(arguments)
+            except (json.JSONDecodeError, TypeError):
+                return False
+            return True
+        # Non-string (mapping / None handled by caller) is treated as complete.
+        return arguments is not None
+
+    def _flush(self, ux: IUXStateDriver, call_id: str) -> None:
+        """Format and display a buffered call exactly once."""
+        entry = self._pending.pop(call_id, None)
+        if entry is None or call_id in self._displayed:
+            return
+        self._displayed.add(call_id)
+
+        from agent_framework import Content
+
+        call = Content.from_function_call(
+            call_id=call_id,
+            name=entry["name"] or "Unknown",
+            arguments=entry["arguments"] or None,
+        )
+        formatted = format_tool_call(self._formatters, call)
+        ux.append_info_line(f"🔧 {formatted}", "yellow")

--- a/python/samples/02-agents/harness/console/observers/tool_call_display.py
+++ b/python/samples/02-agents/harness/console/observers/tool_call_display.py
@@ -66,9 +66,14 @@ class ToolCallDisplayObserver(ConsoleObserver):
         if content.type != "function_call":
             return
 
-        # Group streamed fragments by call_id. Some providers may omit a call_id;
-        # fall back to a name-derived key so distinct unnamed calls don't merge.
-        call_id = content.call_id or f"__noid_{content.name or 'unknown'}"
+        # Streamed fragments are coalesced by call_id. If a provider omits the
+        # call_id, fragments cannot be reliably grouped, so fall back to the
+        # original behavior — display the item as-is — rather than risk merging
+        # (and then dropping) distinct calls under a shared synthetic key.
+        call_id = content.call_id
+        if not call_id:
+            self._display(ux, content)
+            return
 
         if call_id in self._displayed:
             return
@@ -120,10 +125,17 @@ class ToolCallDisplayObserver(ConsoleObserver):
         parses immediately).
         """
         if isinstance(arguments, str):
-            if not arguments:
+            stripped = arguments.strip()
+            if not stripped:
+                return False
+            # Cheap structural gate: a complete JSON object/array opens and
+            # closes with matching brackets. This rejects growing partial
+            # fragments in O(1) so json.loads only runs on a plausibly-complete
+            # payload, avoiding O(n^2) re-parsing across many streamed deltas.
+            if not ((stripped[0] == "{" and stripped[-1] == "}") or (stripped[0] == "[" and stripped[-1] == "]")):
                 return False
             try:
-                json.loads(arguments)
+                json.loads(stripped)
             except (json.JSONDecodeError, TypeError):
                 return False
             return True
@@ -139,10 +151,20 @@ class ToolCallDisplayObserver(ConsoleObserver):
 
         from agent_framework import Content
 
+        # Preserve an empty mapping ("{}") as-is; only treat an empty *string*
+        # (no arguments were ever streamed) as "no arguments".
+        arguments = entry["arguments"]
+        if arguments == "":
+            arguments = None
+
         call = Content.from_function_call(
             call_id=call_id,
             name=entry["name"] or "Unknown",
-            arguments=entry["arguments"] or None,
+            arguments=arguments,
         )
+        self._display(ux, call)
+
+    def _display(self, ux: IUXStateDriver, call: Content) -> None:
+        """Format and write a single tool-call line."""
         formatted = format_tool_call(self._formatters, call)
         ux.append_info_line(f"🔧 {formatted}", "yellow")


### PR DESCRIPTION
### Motivation & Context

In the harness console sample, a single tool call was rendered many times in the
output (repeated `🔧` lines), even though the tool was only invoked once. The
number of repeats scaled with the size of the tool's arguments — e.g. a
`file_access_save_file` writing a large file produced a long run of duplicate
lines.

Root cause: the OpenAI/Foundry Responses **streaming** client emits a separate
`function_call` content item for every `response.function_call_arguments.delta`
event — each sharing the same `call_id`/`name` but carrying only a partial
fragment of the JSON arguments. This is intentional streaming-delta behavior
(the analog of text deltas); `ChatResponse.from_updates` coalesces the fragments
by `call_id` for the final response. The defect was consumer-side: the console's
`ToolCallDisplayObserver` printed one line per streamed content item, so one call
with N argument deltas produced N lines.

### Description & Review Guide

- **What are the major changes?**
  - Reworked `samples/02-agents/harness/console/observers/tool_call_display.py`
    so `ToolCallDisplayObserver` buffers streamed `function_call` argument
    fragments per `call_id` and displays each call **exactly once**, once its
    accumulated arguments are complete (parse as valid JSON, or arrive already
    coalesced as a mapping). No-argument calls (`"{}"`) flush immediately; any
    call that never reaches a complete state is flushed on stream completion,
    which also resets the per-stream buffers.

- **What is the impact of these changes?**
  - Each tool call now renders a single `🔧` line with its complete arguments,
    regardless of how the underlying client chunks the argument stream. Behavior
    is unchanged for non-streaming/coalesced content. This is a sample-only
    change (no core/library changes). The `ToolApprovalObserver` is unaffected —
    it handles `function_approval_request` content, which the function-invocation
    layer emits once from the coalesced call rather than per delta.

- **What do you want reviewers to focus on?**
  - The completeness heuristic (JSON-parseable accumulated arguments) and the
    buffer lifecycle/reset across streams and across multiple tool calls in a
    single run.

### Related Issue

No tracked issue — this is a small, self-contained fix for a rendering bug
observed in the harness console sample. There is no other open PR for this change.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
