### PR TITLE
.NET: Enabling sequential orchestration to pass entire conversation or only previous output.

### DIFF
--- a/dotnet/samples/03-workflows/_StartHere/03_AgentWorkflowPatterns/Program.cs
+++ b/dotnet/samples/03-workflows/_StartHere/03_AgentWorkflowPatterns/Program.cs
@@ -27,12 +27,20 @@ public static class Program
         var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
         var client = new AzureOpenAIClient(new Uri(endpoint), new AzureCliCredential()).GetChatClient(deploymentName).AsIChatClient();
 
-        Console.Write("Choose workflow type ('sequential', 'concurrent', 'handoffs', 'groupchat'): ");
+        Console.Write("Choose workflow type ('sequential', 'sequential-chain-only', 'concurrent', 'handoffs', 'groupchat'): ");
         switch (Console.ReadLine())
         {
             case "sequential":
                 await RunWorkflowAsync(
                     AgentWorkflowBuilder.BuildSequential(from lang in (string[])["French", "Spanish", "English"] select GetTranslationAgent(lang, client)),
+                    [new(ChatRole.User, "Hello, world!")]);
+                break;
+
+            case "sequential-chain-only":
+                await RunWorkflowAsync(
+                    AgentWorkflowBuilder.BuildSequential(
+                        chainOnlyAgentResponses: true,
+                        from lang in (string[])["French", "Spanish", "English"] select GetTranslationAgent(lang, client)),
                     [new(ChatRole.User, "Hello, world!")]);
                 break;
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
@@ -18,6 +18,9 @@ public static partial class AgentWorkflowBuilder
     /// <param name="chainOnlyAgentResponses">
     /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
     /// <see langword="false"/> to pass the full accumulated conversation.
+    /// When enabled, the workflow output also reflects only the final agent's messages,
+    /// because the sequential builder stops forwarding the incoming messages to the
+    /// terminal output executor.
     /// </param>
     /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
     /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>
@@ -39,6 +42,9 @@ public static partial class AgentWorkflowBuilder
     /// <param name="chainOnlyAgentResponses">
     /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
     /// <see langword="false"/> to pass the full accumulated conversation.
+    /// When enabled, the workflow output also reflects only the final agent's messages,
+    /// because the sequential builder stops forwarding the incoming messages to the
+    /// terminal output executor.
     /// </param>
     /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
     /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
@@ -15,10 +15,35 @@ public static partial class AgentWorkflowBuilder
     /// <summary>
     /// Builds a <see cref="Workflow"/> composed of a pipeline of agents where the output of one agent is the input to the next.
     /// </summary>
+    /// <param name="chainOnlyAgentResponses">
+    /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
+    /// <see langword="false"/> to pass the full accumulated conversation.
+    /// </param>
+    /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
+    /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>
+    public static Workflow BuildSequential(bool chainOnlyAgentResponses, params IEnumerable<AIAgent> agents)
+        => BuildSequentialCore(workflowName: null, chainOnlyAgentResponses, agents);
+
+    /// <summary>
+    /// Builds a <see cref="Workflow"/> composed of a pipeline of agents where the output of one agent is the input to the next.
+    /// </summary>
     /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
     /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>
     public static Workflow BuildSequential(params IEnumerable<AIAgent> agents)
-        => BuildSequentialCore(workflowName: null, agents);
+        => BuildSequentialCore(workflowName: null, chainOnlyAgentResponses: false, agents);
+
+    /// <summary>
+    /// Builds a <see cref="Workflow"/> composed of a pipeline of agents where the output of one agent is the input to the next.
+    /// </summary>
+    /// <param name="workflowName">The name of workflow.</param>
+    /// <param name="chainOnlyAgentResponses">
+    /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
+    /// <see langword="false"/> to pass the full accumulated conversation.
+    /// </param>
+    /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
+    /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>
+    public static Workflow BuildSequential(string workflowName, bool chainOnlyAgentResponses, params IEnumerable<AIAgent> agents)
+        => BuildSequentialCore(workflowName, chainOnlyAgentResponses, agents);
 
     /// <summary>
     /// Builds a <see cref="Workflow"/> composed of a pipeline of agents where the output of one agent is the input to the next.
@@ -27,13 +52,14 @@ public static partial class AgentWorkflowBuilder
     /// <param name="agents">The sequence of agents to compose into a sequential workflow.</param>
     /// <returns>The built workflow composed of the supplied <paramref name="agents"/>, in the order in which they were yielded from the source.</returns>
     public static Workflow BuildSequential(string workflowName, params IEnumerable<AIAgent> agents)
-        => BuildSequentialCore(workflowName, agents);
+        => BuildSequentialCore(workflowName, chainOnlyAgentResponses: false, agents);
 
-    private static Workflow BuildSequentialCore(string? workflowName, params IEnumerable<AIAgent> agents)
+    private static Workflow BuildSequentialCore(string? workflowName, bool chainOnlyAgentResponses, params IEnumerable<AIAgent> agents)
     {
         Throw.IfNullOrEmpty(agents);
 
-        SequentialWorkflowBuilder builder = new(agents);
+        SequentialWorkflowBuilder builder = new SequentialWorkflowBuilder(agents)
+            .WithChainOnlyAgentResponses(chainOnlyAgentResponses);
         if (workflowName is not null)
         {
             builder.WithName(workflowName);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/AgentWorkflowBuilder.cs
@@ -16,7 +16,7 @@ public static partial class AgentWorkflowBuilder
     /// Builds a <see cref="Workflow"/> composed of a pipeline of agents where the output of one agent is the input to the next.
     /// </summary>
     /// <param name="chainOnlyAgentResponses">
-    /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
+    /// <see langword="true"/> to pass only each agent's output messages to the next agent in the sequence;
     /// <see langword="false"/> to pass the full accumulated conversation.
     /// When enabled, the workflow output also reflects only the final agent's messages,
     /// because the sequential builder stops forwarding the incoming messages to the
@@ -40,7 +40,7 @@ public static partial class AgentWorkflowBuilder
     /// </summary>
     /// <param name="workflowName">The name of workflow.</param>
     /// <param name="chainOnlyAgentResponses">
-    /// <see langword="true"/> to pass only each agent's response to the next agent in the sequence;
+    /// <see langword="true"/> to pass only each agent's output messages to the next agent in the sequence;
     /// <see langword="false"/> to pass the full accumulated conversation.
     /// When enabled, the workflow output also reflects only the final agent's messages,
     /// because the sequential builder stops forwarding the incoming messages to the

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
@@ -49,7 +49,9 @@ public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<Sequent
         AIAgentHostOptions options = new()
         {
             ReassignOtherAgentsAsUsers = true,
-            ForwardIncomingMessages = true,
+            // Sequential orchestration should pass only the prior step's output to the next
+            // agent, not replay the entire incoming history at each hop.
+            ForwardIncomingMessages = false,
         };
 
         Dictionary<AIAgent, ExecutorBinding> agentMap = new(AIAgentIDEqualityComparer.Instance);

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
@@ -46,6 +46,9 @@ public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<Sequent
     /// <param name="enabled">
     /// <see langword="true"/> to pass only the previous agent response to the next agent;
     /// <see langword="false"/> to pass the full conversation context.
+    /// When enabled, the workflow's terminal output also contains only the final agent's
+    /// messages, because incoming messages are no longer forwarded to the terminal
+    /// <see cref="OutputMessagesExecutor"/>.
     /// </param>
     /// <returns>The builder instance.</returns>
     public SequentialWorkflowBuilder WithChainOnlyAgentResponses(bool enabled = true)

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
@@ -44,7 +44,7 @@ public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<Sequent
     /// instead of the full accumulated conversation.
     /// </summary>
     /// <param name="enabled">
-    /// <see langword="true"/> to pass only the previous agent response to the next agent;
+    /// <see langword="true"/> to pass only the previous agent's output messages to the next agent;
     /// <see langword="false"/> to pass the full conversation context.
     /// When enabled, the workflow's terminal output also contains only the final agent's
     /// messages, because incoming messages are no longer forwarded to the terminal

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/SequentialWorkflowBuilder.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Agents.AI.Workflows;
 public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<SequentialWorkflowBuilder>
 {
     private readonly List<AIAgent> _agents = [];
+    private bool _chainOnlyAgentResponses;
 
     /// <summary>
     /// Initializes a new <see cref="SequentialWorkflowBuilder"/> with the given pipeline
@@ -38,6 +39,21 @@ public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<Sequent
         }
     }
 
+    /// <summary>
+    /// Configures whether each downstream agent should receive only the previous agent's output,
+    /// instead of the full accumulated conversation.
+    /// </summary>
+    /// <param name="enabled">
+    /// <see langword="true"/> to pass only the previous agent response to the next agent;
+    /// <see langword="false"/> to pass the full conversation context.
+    /// </param>
+    /// <returns>The builder instance.</returns>
+    public SequentialWorkflowBuilder WithChainOnlyAgentResponses(bool enabled = true)
+    {
+        this._chainOnlyAgentResponses = enabled;
+        return this;
+    }
+
     /// <summary>Builds the configured sequential workflow.</summary>
     public Workflow Build()
     {
@@ -49,9 +65,7 @@ public sealed class SequentialWorkflowBuilder : OrchestrationBuilderBase<Sequent
         AIAgentHostOptions options = new()
         {
             ReassignOtherAgentsAsUsers = true,
-            // Sequential orchestration should pass only the prior step's output to the next
-            // agent, not replay the entire incoming history at each hop.
-            ForwardIncomingMessages = false,
+            ForwardIncomingMessages = !this._chainOnlyAgentResponses,
         };
 
         Dictionary<AIAgent, ExecutorBinding> agentMap = new(AIAgentIDEqualityComparer.Instance);

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
@@ -46,8 +46,24 @@ public class AgentWorkflowBuilderTests
             await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "abc")]);
 
         Assert.NotNull(result);
-        Assert.Single(result);
+        Assert.Equal(numAgents + 1, result.Count);
         Assert.NotEmpty(updateText);
+    }
+
+    [Fact]
+    public async Task Test_AgentWorkflowBuilder_BuildSequential_ChainOnlyAgentResponsesAsync()
+    {
+        Workflow workflow = AgentWorkflowBuilder.BuildSequential(
+            chainOnlyAgentResponses: true,
+            new OrchestrationTestHelpers.DoubleEchoAgent("agent1"),
+            new OrchestrationTestHelpers.DoubleEchoAgent("agent2"));
+
+        (_, List<ChatMessage>? result, _, _) =
+            await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "abc")]);
+
+        result.Should().NotBeNull();
+        result!.Should().ContainSingle();
+        result[0].AuthorName.Should().Be("agent2");
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/AgentWorkflowBuilderTests.cs
@@ -46,7 +46,7 @@ public class AgentWorkflowBuilderTests
             await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "abc")]);
 
         Assert.NotNull(result);
-        Assert.Equal(numAgents + 1, result.Count);
+        Assert.Single(result);
         Assert.NotEmpty(updateText);
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SequentialWorkflowBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SequentialWorkflowBuilderTests.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Agents.AI.Workflows.UnitTests.Futures;
@@ -43,30 +45,47 @@ public class SequentialWorkflowBuilderTests
                 await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, UserInput)]);
 
             Assert.NotNull(result);
-            Assert.Equal(numAgents + 1, result.Count);
+            Assert.Single(result);
 
-            Assert.Equal(ChatRole.User, result[0].Role);
-            Assert.Null(result[0].AuthorName);
-            Assert.Equal(UserInput, result[0].Text);
-
-            string[] texts = new string[numAgents + 1];
-            texts[0] = UserInput;
-            string expectedTotal = string.Empty;
-            for (int i = 1; i < numAgents + 1; i++)
+            string[] texts = new string[numAgents];
+            for (int i = 0; i < numAgents; i++)
             {
-                string id = $"agent{((i - 1) % numAgents) + 1}";
-                texts[i] = $"{id}{Double(string.Concat(texts.Take(i)))}";
-                Assert.Equal(ChatRole.Assistant, result[i].Role);
-                Assert.Equal(id, result[i].AuthorName);
-                Assert.Equal(texts[i], result[i].Text);
-                expectedTotal += texts[i];
+                string id = $"agent{i + 1}";
+                if (i == 0)
+                {
+                    texts[i] = $"{id}{Double(UserInput)}";
+                }
+                else
+                {
+                    texts[i] = $"{id}{Double(texts[i - 1])}";
+                }
             }
 
-            Assert.Equal(expectedTotal, updateText);
-            Assert.Equal(UserInput + expectedTotal, string.Concat(result));
+            ChatMessage finalMessage = result[0];
+            Assert.Equal(ChatRole.Assistant, finalMessage.Role);
+            Assert.Equal($"agent{numAgents}", finalMessage.AuthorName);
+            Assert.Equal(texts[^1], finalMessage.Text);
+            Assert.Equal(texts[^1], string.Concat(result.Select(m => m.Text)));
+            Assert.Equal(string.Concat(texts), updateText);
 
             static string Double(string s) => s + s;
         }
+    }
+
+    [Fact]
+    public async Task Test_SequentialWorkflowBuilder_NextAgentReceivesOnlyPreviousOutputAsync()
+    {
+        CapturingAgent first = new("agent1", "step-one");
+        CapturingAgent second = new("agent2", "step-two");
+
+        Workflow workflow = new SequentialWorkflowBuilder(first, second).Build();
+
+        _ = await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "start")]);
+
+        second.MessagesSeen.Should().NotBeNull();
+        second.MessagesSeen.Should().ContainSingle();
+        second.MessagesSeen![0].Role.Should().Be(ChatRole.User);
+        second.MessagesSeen[0].Text.Should().Be("step-one");
     }
 
     [Fact]
@@ -138,6 +157,51 @@ public class SequentialWorkflowBuilderTests
             .Build();
 
         workflow.Description.Should().Be("describes the sequential pipeline");
+    }
+
+    private sealed class CapturingAgent(string name, string responseText) : AIAgent
+    {
+        public List<ChatMessage>? MessagesSeen { get; private set; }
+
+        public override string Name => name;
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default)
+            => new(new CapturingAgentSession());
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(System.Text.Json.JsonElement serializedState, System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => new(new CapturingAgentSession());
+
+        protected override ValueTask<System.Text.Json.JsonElement> SerializeSessionCoreAsync(AgentSession session, System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default)
+            => default;
+
+        protected override Task<AgentResponse> RunCoreAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session = null,
+            AgentRunOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            this.MessagesSeen = messages.ToList();
+            return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        }
+
+        protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+            IEnumerable<ChatMessage> messages,
+            AgentSession? session = null,
+            AgentRunOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            this.MessagesSeen = messages.ToList();
+            await Task.Yield();
+
+            string messageId = Guid.NewGuid().ToString("N");
+            yield return new AgentResponseUpdate(ChatRole.Assistant, responseText)
+            {
+                AuthorName = this.Name,
+                MessageId = messageId,
+            };
+        }
+
+        private sealed class CapturingAgentSession() : AgentSession;
     }
 
     [Collection(FuturesSerialCollection.Name)]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SequentialWorkflowBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/SequentialWorkflowBuilderTests.cs
@@ -45,40 +45,59 @@ public class SequentialWorkflowBuilderTests
                 await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, UserInput)]);
 
             Assert.NotNull(result);
-            Assert.Single(result);
+            Assert.Equal(numAgents + 1, result.Count);
 
-            string[] texts = new string[numAgents];
-            for (int i = 0; i < numAgents; i++)
+            Assert.Equal(ChatRole.User, result[0].Role);
+            Assert.Null(result[0].AuthorName);
+            Assert.Equal(UserInput, result[0].Text);
+
+            string[] texts = new string[numAgents + 1];
+            texts[0] = UserInput;
+            string expectedTotal = string.Empty;
+            for (int i = 1; i < numAgents + 1; i++)
             {
-                string id = $"agent{i + 1}";
-                if (i == 0)
-                {
-                    texts[i] = $"{id}{Double(UserInput)}";
-                }
-                else
-                {
-                    texts[i] = $"{id}{Double(texts[i - 1])}";
-                }
+                string id = $"agent{((i - 1) % numAgents) + 1}";
+                texts[i] = $"{id}{Double(string.Concat(texts.Take(i)))}";
+                Assert.Equal(ChatRole.Assistant, result[i].Role);
+                Assert.Equal(id, result[i].AuthorName);
+                Assert.Equal(texts[i], result[i].Text);
+                expectedTotal += texts[i];
             }
 
-            ChatMessage finalMessage = result[0];
-            Assert.Equal(ChatRole.Assistant, finalMessage.Role);
-            Assert.Equal($"agent{numAgents}", finalMessage.AuthorName);
-            Assert.Equal(texts[^1], finalMessage.Text);
-            Assert.Equal(texts[^1], string.Concat(result.Select(m => m.Text)));
-            Assert.Equal(string.Concat(texts), updateText);
+            Assert.Equal(expectedTotal, updateText);
+            Assert.Equal(UserInput + expectedTotal, string.Concat(result));
 
             static string Double(string s) => s + s;
         }
     }
 
     [Fact]
-    public async Task Test_SequentialWorkflowBuilder_NextAgentReceivesOnlyPreviousOutputAsync()
+    public async Task Test_SequentialWorkflowBuilder_DefaultNextAgentReceivesFullConversationAsync()
     {
         CapturingAgent first = new("agent1", "step-one");
         CapturingAgent second = new("agent2", "step-two");
 
         Workflow workflow = new SequentialWorkflowBuilder(first, second).Build();
+
+        _ = await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "start")]);
+
+        second.MessagesSeen.Should().NotBeNull();
+        second.MessagesSeen.Should().HaveCount(2);
+        second.MessagesSeen![0].Role.Should().Be(ChatRole.User);
+        second.MessagesSeen[0].Text.Should().Be("start");
+        second.MessagesSeen[1].Role.Should().Be(ChatRole.User);
+        second.MessagesSeen[1].Text.Should().Be("step-one");
+    }
+
+    [Fact]
+    public async Task Test_SequentialWorkflowBuilder_WithChainOnlyAgentResponses_NextAgentReceivesOnlyPreviousOutputAsync()
+    {
+        CapturingAgent first = new("agent1", "step-one");
+        CapturingAgent second = new("agent2", "step-two");
+
+        Workflow workflow = new SequentialWorkflowBuilder(first, second)
+            .WithChainOnlyAgentResponses()
+            .Build();
 
         _ = await OrchestrationTestHelpers.RunWorkflowAsync(workflow, [new ChatMessage(ChatRole.User, "start")]);
 


### PR DESCRIPTION
This pull request introduces a new configuration option for sequential agent workflows that allows each agent to receive only the previous agent's response instead of the full conversation history. This change adds flexibility for composing agent pipelines and is supported by updates to the builder API, implementation, and comprehensive unit tests.

### Sequential Workflow Enhancements

* Added a new `chainOnlyAgentResponses` parameter to the `AgentWorkflowBuilder.BuildSequential` methods, allowing workflows where each agent receives only the previous agent's output instead of the full conversation. Overloads and internal wiring were updated to support this option. [[1]](diffhunk://#diff-29f946017aacc71eef2f652ef2acd5c76df05523248fe0721444b3642e322607R15-R46) [[2]](diffhunk://#diff-29f946017aacc71eef2f652ef2acd5c76df05523248fe0721444b3642e322607L30-R62)
* Updated the `SequentialWorkflowBuilder` with a `WithChainOnlyAgentResponses` method and internal logic to store and use this configuration, affecting how messages are forwarded between agents. [[1]](diffhunk://#diff-4df1e2f4b79ea785d2ebffe09a064fb6851df32d1789432da7a50b10dd986aceR26) [[2]](diffhunk://#diff-4df1e2f4b79ea785d2ebffe09a064fb6851df32d1789432da7a50b10dd986aceR42-R56) [[3]](diffhunk://#diff-4df1e2f4b79ea785d2ebffe09a064fb6851df32d1789432da7a50b10dd986aceL52-R68)

### Sample and Test Coverage

* Updated the workflow sample (`Program.cs`) to expose the new `sequential-chain-only` workflow type, demonstrating the new behavior. [[1]](diffhunk://#diff-5725d9b3e627228d4f6d9137dda6a171450cec36c9b5f6b9f2f0e05d2b2e5984L30-R30) [[2]](diffhunk://#diff-5725d9b3e627228d4f6d9137dda6a171450cec36c9b5f6b9f2f0e05d2b2e5984R39-R46)
* Added and extended unit tests to cover both the default and chain-only behaviors, including new tests with a custom `CapturingAgent` to verify message passing semantics. [[1]](diffhunk://#diff-8740015954436f7f14b948299c702d45d6c9593949e92dd18da51fc47aa0f79bR53-R68) [[2]](diffhunk://#diff-4bc1216a035fd311aedb33a13716ded9ccc1ea34af828060502ffa3ce241c67aR74-R109) [[3]](diffhunk://#diff-4bc1216a035fd311aedb33a13716ded9ccc1ea34af828060502ffa3ce241c67aR181-R225) [[4]](diffhunk://#diff-4bc1216a035fd311aedb33a13716ded9ccc1ea34af828060502ffa3ce241c67aR6-R7)

These changes provide more granular control over agent workflow composition and ensure reliability through thorough testing.

Closes #1266 