### PR TITLE
.NET: Migrate 01-get-started samples to Foundry as canonical default

### DIFF
--- a/dotnet/eng/verify-samples/GetStartedSamples.cs
+++ b/dotnet/eng/verify-samples/GetStartedSamples.cs
@@ -26,8 +26,8 @@ internal static class GetStartedSamples
         {
             Name = "01_hello_agent",
             ProjectPath = "samples/01-get-started/01_hello_agent",
-            RequiredEnvironmentVariables = ["AZURE_OPENAI_ENDPOINT"],
-            OptionalEnvironmentVariables = ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            RequiredEnvironmentVariables = ["FOUNDRY_PROJECT_ENDPOINT"],
+            OptionalEnvironmentVariables = ["FOUNDRY_MODEL"],
             ExpectedOutputDescription =
             [
                 "The output should contain a joke about a pirate.",
@@ -40,8 +40,8 @@ internal static class GetStartedSamples
         {
             Name = "02_add_tools",
             ProjectPath = "samples/01-get-started/02_add_tools",
-            RequiredEnvironmentVariables = ["AZURE_OPENAI_ENDPOINT"],
-            OptionalEnvironmentVariables = ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            RequiredEnvironmentVariables = ["FOUNDRY_PROJECT_ENDPOINT"],
+            OptionalEnvironmentVariables = ["FOUNDRY_MODEL"],
             MustContain = [],
             ExpectedOutputDescription =
             [
@@ -56,8 +56,8 @@ internal static class GetStartedSamples
         {
             Name = "03_multi_turn",
             ProjectPath = "samples/01-get-started/03_multi_turn",
-            RequiredEnvironmentVariables = ["AZURE_OPENAI_ENDPOINT"],
-            OptionalEnvironmentVariables = ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            RequiredEnvironmentVariables = ["FOUNDRY_PROJECT_ENDPOINT"],
+            OptionalEnvironmentVariables = ["FOUNDRY_MODEL"],
             ExpectedOutputDescription =
             [
                 "The output should contain a joke about a pirate.",
@@ -71,8 +71,8 @@ internal static class GetStartedSamples
         {
             Name = "04_memory",
             ProjectPath = "samples/01-get-started/04_memory",
-            RequiredEnvironmentVariables = ["AZURE_OPENAI_ENDPOINT"],
-            OptionalEnvironmentVariables = ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            RequiredEnvironmentVariables = ["FOUNDRY_PROJECT_ENDPOINT"],
+            OptionalEnvironmentVariables = ["FOUNDRY_MODEL"],
             MustContain =
             [
                 ">> Use session with blank memory",
@@ -97,8 +97,8 @@ internal static class GetStartedSamples
         {
             Name = "06_host_your_agent",
             ProjectPath = "samples/01-get-started/06_host_your_agent",
-            RequiredEnvironmentVariables = ["AZURE_OPENAI_ENDPOINT"],
-            OptionalEnvironmentVariables = ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            RequiredEnvironmentVariables = ["FOUNDRY_PROJECT_ENDPOINT"],
+            OptionalEnvironmentVariables = ["FOUNDRY_MODEL"],
             SkipReason = "Requires Azure Functions Core Tools runtime and starts a web server.",
         },
     ];

--- a/dotnet/samples/01-get-started/01_hello_agent/01_hello_agent.csproj
+++ b/dotnet/samples/01-get-started/01_hello_agent/01_hello_agent.csproj
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/01-get-started/01_hello_agent/Program.cs
+++ b/dotnet/samples/01-get-started/01_hello_agent/Program.cs
@@ -3,7 +3,6 @@
 // This sample shows how to create and use a simple AI agent with Microsoft Foundry as the backend.
 
 using Azure.Identity;
-using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");

--- a/dotnet/samples/01-get-started/01_hello_agent/Program.cs
+++ b/dotnet/samples/01-get-started/01_hello_agent/Program.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// This sample shows how to create and use a simple AI agent with Microsoft Foundry as the backend.
+// This sample shows how to create and use a simple AI agent with AIProjectClient as the backend.
 
+using Azure.AI.Projects;
 using Azure.Identity;
-using Microsoft.Agents.AI.Foundry;
+using Microsoft.Agents.AI;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
 var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
@@ -11,12 +12,8 @@ var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-FoundryAgent agent = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "You are good at telling jokes.",
-    name: "Joker");
+AIAgent agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
+    .AsAIAgent(model: model, instructions: "You are good at telling jokes.", name: "Joker");
 
 // Invoke the agent and output the text result.
 Console.WriteLine(await agent.RunAsync("Tell me a joke about a pirate."));

--- a/dotnet/samples/01-get-started/01_hello_agent/Program.cs
+++ b/dotnet/samples/01-get-started/01_hello_agent/Program.cs
@@ -1,23 +1,23 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// This sample shows how to create and use a simple AI agent with Azure OpenAI as the backend.
+// This sample shows how to create and use a simple AI agent with Microsoft Foundry as the backend.
 
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using OpenAI.Chat;
+using Microsoft.Agents.AI.Foundry;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
+FoundryAgent agent = new(
     new Uri(endpoint),
-    new DefaultAzureCredential())
-    .GetChatClient(deploymentName)
-    .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "You are good at telling jokes.",
+    name: "Joker");
 
 // Invoke the agent and output the text result.
 Console.WriteLine(await agent.RunAsync("Tell me a joke about a pirate."));

--- a/dotnet/samples/01-get-started/02_add_tools/02_add_tools.csproj
+++ b/dotnet/samples/01-get-started/02_add_tools/02_add_tools.csproj
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/01-get-started/02_add_tools/Program.cs
+++ b/dotnet/samples/01-get-started/02_add_tools/Program.cs
@@ -1,31 +1,31 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// This sample demonstrates how to use a ChatClientAgent with function tools.
-// It shows both non-streaming and streaming agent interactions using menu-related tools.
+// This sample demonstrates how to use a FoundryAgent with function tools.
+// It shows both non-streaming and streaming agent interactions using weather tools.
 
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
-using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 [Description("Get the weather for a given location.")]
 static string GetWeather([Description("The location to get the weather for.")] string location)
     => $"The weather in {location} is cloudy with a high of 15°C.";
 
-// Create the chat client and agent, and provide the function tool to the agent.
+// Create the agent and provide the function tool to the agent.
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
+FoundryAgent agent = new(
     new Uri(endpoint),
-    new DefaultAzureCredential())
-    .GetChatClient(deploymentName)
-    .AsAIAgent(instructions: "You are a helpful assistant", tools: [AIFunctionFactory.Create(GetWeather)]);
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "You are a helpful assistant",
+    tools: [AIFunctionFactory.Create(GetWeather)]);
 
 // Non-streaming agent interaction with function tools.
 Console.WriteLine(await agent.RunAsync("What is the weather like in Amsterdam?"));

--- a/dotnet/samples/01-get-started/02_add_tools/Program.cs
+++ b/dotnet/samples/01-get-started/02_add_tools/Program.cs
@@ -5,7 +5,6 @@
 
 using System.ComponentModel;
 using Azure.Identity;
-using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
 

--- a/dotnet/samples/01-get-started/02_add_tools/Program.cs
+++ b/dotnet/samples/01-get-started/02_add_tools/Program.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-// This sample demonstrates how to use a FoundryAgent with function tools.
+// This sample demonstrates how to use an AIProjectClient agent with function tools.
 // It shows both non-streaming and streaming agent interactions using weather tools.
 
 using System.ComponentModel;
+using Azure.AI.Projects;
 using Azure.Identity;
-using Microsoft.Agents.AI.Foundry;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
@@ -19,12 +20,8 @@ static string GetWeather([Description("The location to get the weather for.")] s
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-FoundryAgent agent = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "You are a helpful assistant",
-    tools: [AIFunctionFactory.Create(GetWeather)]);
+AIAgent agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
+    .AsAIAgent(model: model, instructions: "You are a helpful assistant", tools: [AIFunctionFactory.Create(GetWeather)]);
 
 // Non-streaming agent interaction with function tools.
 Console.WriteLine(await agent.RunAsync("What is the weather like in Amsterdam?"));

--- a/dotnet/samples/01-get-started/03_multi_turn/03_multi_turn.csproj
+++ b/dotnet/samples/01-get-started/03_multi_turn/03_multi_turn.csproj
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/01-get-started/03_multi_turn/Program.cs
+++ b/dotnet/samples/01-get-started/03_multi_turn/Program.cs
@@ -2,22 +2,22 @@
 
 // This sample shows how to create and use a simple AI agent with a multi-turn conversation.
 
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using OpenAI.Chat;
+using Microsoft.Agents.AI.Foundry;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
+FoundryAgent agent = new(
     new Uri(endpoint),
-    new DefaultAzureCredential())
-    .GetChatClient(deploymentName)
-    .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "You are good at telling jokes.",
+    name: "Joker");
 
 // Invoke the agent with a multi-turn conversation, where the context is preserved in the session object.
 AgentSession session = await agent.CreateSessionAsync();

--- a/dotnet/samples/01-get-started/03_multi_turn/Program.cs
+++ b/dotnet/samples/01-get-started/03_multi_turn/Program.cs
@@ -2,9 +2,9 @@
 
 // This sample shows how to create and use a simple AI agent with a multi-turn conversation.
 
+using Azure.AI.Projects;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Foundry;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
 var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
@@ -12,12 +12,8 @@ var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-FoundryAgent agent = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "You are good at telling jokes.",
-    name: "Joker");
+AIAgent agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
+    .AsAIAgent(model: model, instructions: "You are good at telling jokes.", name: "Joker");
 
 // Invoke the agent with a multi-turn conversation, where the context is preserved in the session object.
 AgentSession session = await agent.CreateSessionAsync();

--- a/dotnet/samples/01-get-started/04_memory/04_memory.csproj
+++ b/dotnet/samples/01-get-started/04_memory/04_memory.csproj
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/01-get-started/04_memory/Program.cs
+++ b/dotnet/samples/01-get-started/04_memory/Program.cs
@@ -8,9 +8,9 @@
 
 using System.Text;
 using System.Text.Json;
+using Azure.AI.Projects;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
 using SampleApp;
 
@@ -20,18 +20,14 @@ var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-FoundryAgent baseAgent = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "You are a friendly assistant.");
+var projectClient = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential());
 
 // Get the underlying IChatClient to use for the memory component.
-IChatClient? chatClient = baseAgent.GetService<IChatClient>();
-if (chatClient == null)
-{
-    throw new InvalidOperationException("Could not retrieve IChatClient from FoundryAgent.");
-}
+// The memory provider needs direct IChatClient access for structured extraction.
+IChatClient chatClient = projectClient
+    .AsAIAgent(new ChatClientAgentOptions { ChatOptions = new() { ModelId = model } })
+    .GetService<IChatClient>()
+    ?? throw new InvalidOperationException("Could not retrieve IChatClient from AIProjectClient agent.");
 
 // Create the agent and provide a factory to add our custom memory component to
 // all sessions created by the agent. Here each new memory component will have its own

--- a/dotnet/samples/01-get-started/04_memory/Program.cs
+++ b/dotnet/samples/01-get-started/04_memory/Program.cs
@@ -8,23 +8,30 @@
 
 using System.Text;
 using System.Text.Json;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
-using OpenAI.Chat;
 using SampleApp;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient chatClient = new AzureOpenAIClient(
+FoundryAgent baseAgent = new(
     new Uri(endpoint),
-    new DefaultAzureCredential())
-    .GetChatClient(deploymentName);
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "You are a friendly assistant.");
+
+// Get the underlying IChatClient to use for the memory component.
+IChatClient? chatClient = baseAgent.GetService<IChatClient>();
+if (chatClient == null)
+{
+    throw new InvalidOperationException("Could not retrieve IChatClient from FoundryAgent.");
+}
 
 // Create the agent and provide a factory to add our custom memory component to
 // all sessions created by the agent. Here each new memory component will have its own
@@ -36,7 +43,7 @@ ChatClient chatClient = new AzureOpenAIClient(
 AIAgent agent = chatClient.AsAIAgent(new ChatClientAgentOptions()
 {
     ChatOptions = new() { Instructions = "You are a friendly assistant. Always address the user by their name." },
-    AIContextProviders = [new UserInfoMemory(chatClient.AsIChatClient())]
+    AIContextProviders = [new UserInfoMemory(chatClient)]
 });
 
 // Create a new session for the conversation.

--- a/dotnet/samples/01-get-started/06_host_your_agent/06_host_your_agent.csproj
+++ b/dotnet/samples/01-get-started/06_host_your_agent/06_host_your_agent.csproj
@@ -21,11 +21,10 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Hosting.AzureFunctions\Microsoft.Agents.AI.Hosting.AzureFunctions.csproj" />
-    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
   </ItemGroup>
 </Project>

--- a/dotnet/samples/01-get-started/06_host_your_agent/Program.cs
+++ b/dotnet/samples/01-get-started/06_host_your_agent/Program.cs
@@ -4,36 +4,36 @@
 //
 // Prerequisites:
 //   - Azure Functions Core Tools
-//   - Azure OpenAI resource
+//   - Foundry project endpoint and credentials
 //
 // Environment variables:
-//   AZURE_OPENAI_ENDPOINT
-//   AZURE_OPENAI_DEPLOYMENT_NAME (defaults to "gpt-5.4-mini")
+//   FOUNDRY_PROJECT_ENDPOINT
+//   FOUNDRY_MODEL (defaults to "gpt-5.4-mini")
 //
 // Run with: func start
 // Then call: POST http://localhost:7071/api/agents/HostedAgent/run
 
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 using Microsoft.Agents.AI.Hosting.AzureFunctions;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Hosting;
-using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
-    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // Set up an AI agent following the standard Microsoft Agent Framework pattern.
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-    .GetChatClient(deploymentName)
-    .AsAIAgent(
-        instructions: "You are a helpful assistant hosted in Azure Functions.",
-        name: "HostedAgent");
+AIAgent agent = new FoundryAgent(
+    new Uri(endpoint),
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "You are a helpful assistant hosted in Azure Functions.",
+    name: "HostedAgent");
 
 // Configure the function app to host the AI agent.
 // This will automatically generate HTTP API endpoints for the agent.

--- a/dotnet/samples/01-get-started/06_host_your_agent/Program.cs
+++ b/dotnet/samples/01-get-started/06_host_your_agent/Program.cs
@@ -13,9 +13,9 @@
 // Run with: func start
 // Then call: POST http://localhost:7071/api/agents/HostedAgent/run
 
+using Azure.AI.Projects;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Foundry;
 using Microsoft.Agents.AI.Hosting.AzureFunctions;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Hosting;
@@ -28,12 +28,8 @@ var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new FoundryAgent(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "You are a helpful assistant hosted in Azure Functions.",
-    name: "HostedAgent");
+AIAgent agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
+    .AsAIAgent(model: model, instructions: "You are a helpful assistant hosted in Azure Functions.", name: "HostedAgent");
 
 // Configure the function app to host the AI agent.
 // This will automatically generate HTTP API endpoints for the agent.

--- a/dotnet/samples/AGENTS.md
+++ b/dotnet/samples/AGENTS.md
@@ -80,32 +80,35 @@ dotnet/samples/
 
 ## Default provider
 
-All canonical samples (01-get-started) use **Azure OpenAI** via `AzureOpenAIClient`
-with `DefaultAzureCredential`:
+All canonical samples (01-get-started) use **Microsoft Foundry** with the Foundry Responses API via `FoundryAgent` or `AIProjectClient.AsAIAgent()` with `DefaultAzureCredential`:
 
 ```csharp
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
-    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
+var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-    .GetChatClient(deploymentName)
-    .AsAIAgent(instructions: "...", name: "...");
+FoundryAgent agent = new(
+    new Uri(endpoint),
+    new DefaultAzureCredential(),
+    model: model,
+    instructions: "...",
+    name: "...");
 ```
 
 Environment variables:
-- `AZURE_OPENAI_ENDPOINT` — Your Azure OpenAI endpoint
-- `AZURE_OPENAI_DEPLOYMENT_NAME` — Model deployment name (defaults to `gpt-5.4-mini`)
+- `FOUNDRY_PROJECT_ENDPOINT` — Your Foundry project endpoint
+- `FOUNDRY_MODEL` — Model name (defaults to `gpt-5.4-mini`)
 
 For authentication, run `az login` before running samples.
+
+**Note:** For samples demonstrating other providers (Azure OpenAI, OpenAI, Anthropic, etc.), see `02-agents/AgentProviders/`.
+
 
 ## Snippet tags for docs integration
 

--- a/dotnet/samples/AGENTS.md
+++ b/dotnet/samples/AGENTS.md
@@ -85,6 +85,7 @@ All canonical samples (01-get-started) use **Microsoft Foundry** with the Foundr
 ```csharp
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
@@ -137,5 +138,4 @@ dotnet run
 - Prefer `client.GetChatClient(deployment).AsAIAgent(...)` extension method pattern
 - Azure Functions hosting uses `ConfigureDurableAgents(options => options.AddAIAgent(agent))`
 - Workflows use `WorkflowBuilder` with `Executor<TIn, TOut>` and edge connections
-
 

--- a/dotnet/samples/AGENTS.md
+++ b/dotnet/samples/AGENTS.md
@@ -80,12 +80,12 @@ dotnet/samples/
 
 ## Default provider
 
-All canonical samples (01-get-started) use **Microsoft Foundry** with the Foundry Responses API via `FoundryAgent` or `AIProjectClient.AsAIAgent()` with `DefaultAzureCredential`:
+All canonical samples (01-get-started) use **Microsoft Foundry** via `AIProjectClient.AsAIAgent()` with `DefaultAzureCredential`:
 
 ```csharp
+using Azure.AI.Projects;
 using Azure.Identity;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Foundry;
 
 var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT is not set.");
@@ -94,12 +94,8 @@ var model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-FoundryAgent agent = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential(),
-    model: model,
-    instructions: "...",
-    name: "...");
+AIAgent agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
+    .AsAIAgent(model: model, instructions: "...", name: "...");
 ```
 
 Environment variables:
@@ -107,6 +103,8 @@ Environment variables:
 - `FOUNDRY_MODEL` — Model name (defaults to `gpt-5.4-mini`)
 
 For authentication, run `az login` before running samples.
+
+**Note:** Use `FoundryAgent` only when demonstrating Foundry-managed (prompt) agents specifically — see `02-agents/AgentsWithFoundry/`. For all other samples, use `AIProjectClient.AsAIAgent()`.
 
 **Note:** For samples demonstrating other providers (Azure OpenAI, OpenAI, Anthropic, etc.), see `02-agents/AgentProviders/`.
 


### PR DESCRIPTION
This pull request updates the canonical "01-get-started" .NET samples to use Microsoft Foundry as the default AI provider instead of Azure OpenAI. It replaces all references to Azure OpenAI with Microsoft Foundry, updates environment variables, and adjusts project dependencies accordingly. The documentation is also revised to reflect these changes.

**Provider migration and environment variables:**
* All samples in `01-get-started` now use `FoundryAgent` from `Microsoft.Agents.AI.Foundry` instead of `AzureOpenAIClient` from `Microsoft.Agents.AI.OpenAI`. [[1]](diffhunk://#diff-e318a0a83d3169c7171936c4338cdb62c5168b2b8204ee420e723a2378e67aadL3-R19) [[2]](diffhunk://#diff-3f73fdc9ec6501972d341a2a978be9254789c65bbe912cf81438b9822781eb90L3-R27) [[3]](diffhunk://#diff-901d51a271309261062df78ca1e0a889616365ce613efa61d0e515a94fb1862eL5-R20) [[4]](diffhunk://#diff-0470f77ef385b9472ab6e73bcc19dbd96aeb773a98c883a973406ab93dcde7c8L11-R34) [[5]](diffhunk://#diff-75441cf25c07a12b8342067f4065bdf6ec81c14ec39dc77f1cc9558ccd601335L7-R34)
* Environment variables have been updated from `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT_NAME` to `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL` throughout code, sample verification, and documentation. [[1]](diffhunk://#diff-47fed3497c1a4ba5a2e04546698a0feba77a7a841606274282a6f48901e0c401L29-R30) [[2]](diffhunk://#diff-47fed3497c1a4ba5a2e04546698a0feba77a7a841606274282a6f48901e0c401L43-R44) [[3]](diffhunk://#diff-47fed3497c1a4ba5a2e04546698a0feba77a7a841606274282a6f48901e0c401L59-R60) [[4]](diffhunk://#diff-47fed3497c1a4ba5a2e04546698a0feba77a7a841606274282a6f48901e0c401L74-R75) [[5]](diffhunk://#diff-47fed3497c1a4ba5a2e04546698a0feba77a7a841606274282a6f48901e0c401L100-R101) [[6]](diffhunk://#diff-c81b60e455a4bd5791b9c0481b2b8ec57d30ff9019562eb7c89ad789ba469638L83-R113)

**Project and package dependency updates:**
* All sample `.csproj` files now reference `Microsoft.Agents.AI.Foundry` and `Microsoft.Extensions.AI.Abstractions` instead of OpenAI-specific packages. [[1]](diffhunk://#diff-6abfcef8c0a661050084a1f4a2032dd39ff98eede9836ff5bce5cab4f8f149b9L12-R17) [[2]](diffhunk://#diff-c10dbdfdbb6fd689c39f030c2badf7253edb64e29d67fba39db2f503ca2e1678L24-R28)

**Sample code and logic changes:**
* Sample logic is updated to instantiate and use `FoundryAgent`, including for advanced scenarios like memory and Azure Functions hosting. [[1]](diffhunk://#diff-0470f77ef385b9472ab6e73bcc19dbd96aeb773a98c883a973406ab93dcde7c8L11-R34) [[2]](diffhunk://#diff-0470f77ef385b9472ab6e73bcc19dbd96aeb773a98c883a973406ab93dcde7c8L39-R46) [[3]](diffhunk://#diff-75441cf25c07a12b8342067f4065bdf6ec81c14ec39dc77f1cc9558ccd601335L7-R34)
* Sample descriptions and comments are revised to reference Foundry and the new environment variables. [[1]](diffhunk://#diff-e318a0a83d3169c7171936c4338cdb62c5168b2b8204ee420e723a2378e67aadL3-R19) [[2]](diffhunk://#diff-3f73fdc9ec6501972d341a2a978be9254789c65bbe912cf81438b9822781eb90L3-R27) [[3]](diffhunk://#diff-75441cf25c07a12b8342067f4065bdf6ec81c14ec39dc77f1cc9558ccd601335L7-R34)

**Documentation updates:**
* `AGENTS.md` is updated to show Foundry as the default provider, including code snippets and environment variable descriptions. [[1]](diffhunk://#diff-c81b60e455a4bd5791b9c0481b2b8ec57d30ff9019562eb7c89ad789ba469638L83-R113) [[2]](diffhunk://#diff-c81b60e455a4bd5791b9c0481b2b8ec57d30ff9019562eb7c89ad789ba469638L138)
