### PR TITLE
.NET: Harden archive extraction guard so path containment is statically recognized

### DIFF
--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/Program.cs
@@ -168,9 +168,11 @@ static void SafeExtractZip(ZipArchive archive, string destinationDir)
 
     foreach (ZipArchiveEntry entry in archive.Entries)
     {
+        // Resolve the entry against the destination, then require the result to stay within the
+        // destination subtree. A single StartsWith containment check is the only gate to extraction,
+        // so any entry that escapes (for example via '..') is rejected.
         string entryPath = Path.GetFullPath(Path.Combine(destRoot, entry.FullName));
-        if (!entryPath.StartsWith(destRootWithSep, comparison)
-            && !string.Equals(entryPath, destRoot, comparison))
+        if (!entryPath.StartsWith(destRootWithSep, comparison))
         {
             throw new InvalidOperationException(
                 $"Refusing to extract unsafe path '{entry.FullName}' outside of '{destRoot}'.");

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/HostedAgentSkillsPatternTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/HostedAgentSkillsPatternTests.cs
@@ -98,6 +98,24 @@ public sealed class HostedAgentSkillsPatternTests : IDisposable
         Assert.True(Directory.Exists(Path.Combine(destDir, "subdir")));
     }
 
+    [Fact]
+    public void SafeExtractZip_NestedFileWithinDestination_Extracts()
+    {
+        // Arrange — a legitimate nested entry must still pass the single containment gate
+        string destDir = Path.Combine(this._testRoot, "nested-extract");
+        Directory.CreateDirectory(destDir);
+        byte[] zip = CreateZipWithEntry("docs/SKILL.md", "nested body");
+
+        // Act
+        using var archive = new ZipArchive(new MemoryStream(zip), ZipArchiveMode.Read);
+        SafeExtractZip(archive, destDir);
+
+        // Assert
+        string extracted = Path.Combine(destDir, "docs", "SKILL.md");
+        Assert.True(File.Exists(extracted));
+        Assert.Equal("nested body", File.ReadAllText(extracted));
+    }
+
     // ── Skill name validation tests ──────────────────────────────────────────
 
     [Theory]
@@ -273,9 +291,11 @@ public sealed class HostedAgentSkillsPatternTests : IDisposable
 
         foreach (ZipArchiveEntry entry in archive.Entries)
         {
+            // Resolve the entry against the destination, then require the result to stay within the
+            // destination subtree. A single StartsWith containment check is the only gate to
+            // extraction, so any entry that escapes (for example via '..') is rejected.
             string entryPath = Path.GetFullPath(Path.Combine(destRoot, entry.FullName));
-            if (!entryPath.StartsWith(destRootWithSep, comparison)
-                && !string.Equals(entryPath, destRoot, comparison))
+            if (!entryPath.StartsWith(destRootWithSep, comparison))
             {
                 throw new InvalidOperationException(
                     $"Refusing to extract unsafe path '{entry.FullName}' outside of '{destRoot}'.");


### PR DESCRIPTION
## Summary

Closes #6564.

The Hosted-AgentSkills Foundry sample and its mirrored unit-test helper extract a downloaded ZIP archive with a `SafeExtractZip` guard meant to keep every entry inside the destination directory. The guard accepted an entry when **either** the resolved path started with the destination root **or** it equaled the destination root exactly. That second `string.Equals(...)` branch left an acceptance path not covered by the `StartsWith` containment check, so static analysis (CodeQL `cs/zipslip`, CWE-22) could not prove the extraction sink always stays within the destination and flagged it.

This makes the single resolved-path `StartsWith(destinationRootWithSeparator)` check the only gate to extraction, which is both the statically recognized containment pattern and a hardening to one deterministic acceptance path.

## Changes

- `dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/Program.cs` — `SafeExtractZip` now gates extraction solely on the containment check.
- `dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/HostedAgentSkillsPatternTests.cs` — same change to the mirrored helper, plus a nested-entry regression test.

## Behavior

Named files and `subdir/` directory entries still extract; entries that resolve outside the destination are rejected. The only difference is that a degenerate entry resolving exactly to the destination root is now rejected, which is the safe outcome. The Python port (`python/.../09_foundry_skills/main.py` `_safe_extract_zip`) already uses a `Path.resolve()` parent-containment check and is unaffected.

## Validation

- Sample and unit-test projects build clean with `--warnaserror`.
- `HostedAgentSkillsPatternTests` 15/15 pass, including the existing traversal and sibling-prefix rejection tests and the new nested-entry test.
- `dotnet format --verify-no-changes` clean for both projects (CI-parity, SDK 10.0 container).