### PR TITLE
Python: Fix Foundry aiohttp dependency

### DIFF
--- a/python/packages/foundry/pyproject.toml
+++ b/python/packages/foundry/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "agent-framework-core>=1.8.1,<2",
     "agent-framework-openai>=1.8.1,<2",
+    "aiohttp>=3.9,<4",
     "azure-ai-inference>=1.0.0b9,<1.0.0b10",
     "azure-ai-projects>=2.2.0,<3.0",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -534,6 +534,7 @@ source = { editable = "packages/foundry" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-ai-inference", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-ai-projects", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -542,6 +543,7 @@ dependencies = [
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
     { name = "agent-framework-openai", editable = "packages/openai" },
+    { name = "aiohttp", specifier = ">=3.9,<4" },
     { name = "azure-ai-inference", specifier = ">=1.0.0b9,<1.0.0b10" },
     { name = "azure-ai-projects", specifier = ">=2.2.0,<3.0" },
 ]


### PR DESCRIPTION
### Motivation & Context

Installing only `agent-framework-foundry` leaves out `aiohttp`, but the Foundry package constructs async Azure AI Projects clients through `azure.ai.projects.aio.AIProjectClient`. In a minimal install, constructing `FoundryChatClient` fails with `ModuleNotFoundError: No module named 'aiohttp'`.

The root cause is that `azure-ai-projects` depends on plain `azure-core`; `aiohttp` is only exposed through Azure Core's optional `aio` extra. An upstream Azure SDK issue was opened at Azure/azure-sdk-for-python#47539, but `agent-framework-foundry` should still declare the runtime dependency needed by its own async client surface.

### Description & Review Guide

- **What are the major changes?** Add `aiohttp>=3.9,<4` to `agent-framework-foundry` and update `uv.lock` package metadata.
- **What is the impact of these changes?** Minimal `agent-framework-foundry` installs now include the async Azure Core transport dependency needed to construct Foundry clients.
- **What do you want reviewers to focus on?** Whether declaring `aiohttp` directly on `agent-framework-foundry` is the right defensive package metadata fix while the Azure SDK upstream issue is pending.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #6566

No other open PR was found for this issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
