### PR TITLE
Python: Add WebSearchDisplayObserver to harness console

### DIFF
--- a/python/samples/02-agents/harness/console/observers/__init__.py
+++ b/python/samples/02-agents/harness/console/observers/__init__.py
@@ -19,6 +19,7 @@ from .text_output import TextOutputObserver
 from .tool_approval import ToolApprovalObserver
 from .tool_call_display import ToolCallDisplayObserver
 from .usage_display import UsageDisplayObserver
+from .web_search_display import WebSearchDisplayObserver
 
 if TYPE_CHECKING:
     from agent_framework import Agent
@@ -45,6 +46,7 @@ def build_default_observers() -> list[ConsoleObserver]:
     return [
         TextOutputObserver(),
         ToolCallDisplayObserver(),
+        WebSearchDisplayObserver(),
         ErrorDisplayObserver(),
         UsageDisplayObserver(),
         ReasoningDisplayObserver(),
@@ -95,6 +97,7 @@ def build_observers_with_planning(
 
     return [
         ToolCallDisplayObserver(),
+        WebSearchDisplayObserver(),
         ToolApprovalObserver(),
         ErrorDisplayObserver(),
         ReasoningDisplayObserver(),
@@ -117,6 +120,7 @@ __all__ = [
     "ToolApprovalObserver",
     "ToolCallDisplayObserver",
     "UsageDisplayObserver",
+    "WebSearchDisplayObserver",
     "build_default_observers",
     "build_observers_with_planning",
 ]

--- a/python/samples/02-agents/harness/console/observers/web_search_display.py
+++ b/python/samples/02-agents/harness/console/observers/web_search_display.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from rich.markup import escape
+
 from .base import ConsoleObserver
 
 if TYPE_CHECKING:
@@ -97,7 +99,7 @@ class WebSearchDisplayObserver(ConsoleObserver):
         lines = ["🌐 Web Search: search"]
         for i, query in enumerate(queries):
             connector = "├─" if (i < len(queries) - 1 or has_sources) else "└─"
-            query_text = _truncate(str(query), _MAX_QUERY_DISPLAY_LENGTH)
+            query_text = escape(_truncate(str(query), _MAX_QUERY_DISPLAY_LENGTH))
             lines.append(f'\n   {connector} "{query_text}"')
 
         if has_sources:
@@ -111,7 +113,7 @@ class WebSearchDisplayObserver(ConsoleObserver):
 
     def _display_open_page_action(self, ux: IUXStateDriver, action: dict) -> None:
         """Display an open page action."""
-        url = action.get("url") or "(unknown)"
+        url = escape(str(action.get("url") or "(unknown)"))
         ux.append_info_line(
             f"🌐 Web Search: open page\n   └─ {url}",
             "cyan",
@@ -119,10 +121,10 @@ class WebSearchDisplayObserver(ConsoleObserver):
 
     def _display_find_in_page_action(self, ux: IUXStateDriver, action: dict) -> None:
         """Display a find-in-page action."""
-        url = action.get("url") or "(unknown)"
-        pattern = action.get("pattern") or "(unknown)"
+        url = escape(str(action.get("url") or "(unknown)"))
+        pattern = escape(_truncate(str(action.get("pattern") or "(unknown)"), _MAX_QUERY_DISPLAY_LENGTH))
         ux.append_info_line(
-            f'🌐 Web Search: find in page\n   ├─ "{_truncate(pattern, _MAX_QUERY_DISPLAY_LENGTH)}"\n   └─ {url}',
+            f'🌐 Web Search: find in page\n   ├─ "{pattern}"\n   └─ {url}',
             "cyan",
         )
 
@@ -135,9 +137,9 @@ def _truncate(text: str, max_length: int) -> str:
 def _format_source(source: Any) -> str:
     """Format a source entry for display."""
     if isinstance(source, dict):
-        url = source.get("url") or source.get("uri") or "(unknown)"
+        url = escape(str(source.get("url") or source.get("uri") or "(unknown)"))
         title = source.get("title")
         if title:
-            return f"{_truncate(title, _MAX_QUERY_DISPLAY_LENGTH)} — {url}"
-        return str(url)
-    return str(source)
+            return f"{escape(_truncate(str(title), _MAX_QUERY_DISPLAY_LENGTH))} — {url}"
+        return url
+    return escape(str(source))

--- a/python/samples/02-agents/harness/console/observers/web_search_display.py
+++ b/python/samples/02-agents/harness/console/observers/web_search_display.py
@@ -1,0 +1,143 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Web search display observer for showing search activity in the console.
+
+Displays web search activity as it streams in from the API, showing search
+queries, page opens, and find-in-page actions with 🌐 prefix.
+
+The actual details (queries, URLs, sources) come from the ``search_tool_result``
+content emitted when the search completes (``response.output_item.done``).
+The initial ``search_tool_call`` is emitted when the item is first added and
+typically has an empty or incomplete action.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .base import ConsoleObserver
+
+if TYPE_CHECKING:
+    from agent_framework import Agent, Content
+
+    from ..state_driver import IUXStateDriver
+
+_MAX_QUERY_DISPLAY_LENGTH = 120
+
+
+class WebSearchDisplayObserver(ConsoleObserver):
+    """Displays web search activity in the scroll area.
+
+    Shows search queries, page opens, and find-in-page actions. Details are
+    extracted from ``search_tool_result`` content (the completed action), which
+    contains the full action type, queries, URLs, and sources.
+    """
+
+    async def on_content(
+        self,
+        ux: IUXStateDriver,
+        content: Content,
+        agent: Agent,
+        session: Any,
+    ) -> None:
+        """Display web search activity from search content items.
+
+        Args:
+            ux: The UX state driver for UI updates.
+            content: The content item to check for search activity.
+            agent: The AI agent.
+            session: The agent session.
+        """
+        if content.type == "search_tool_result":
+            self._display_search_result(ux, content)
+
+    def _display_search_result(self, ux: IUXStateDriver, content: Content) -> None:
+        """Display a completed search tool result with action details."""
+        tool_name = getattr(content, "tool_name", None) or "web_search"
+        if tool_name != "web_search":
+            return
+
+        result = getattr(content, "result", None)
+        if not isinstance(result, dict):
+            ux.append_info_line("🌐 Web Search", "cyan")
+            return
+
+        action = result.get("action")
+        if not isinstance(action, dict):
+            ux.append_info_line("🌐 Web Search", "cyan")
+            return
+
+        action_type = action.get("type")
+
+        if action_type == "search":
+            self._display_search_action(ux, action)
+        elif action_type == "open_page":
+            self._display_open_page_action(ux, action)
+        elif action_type == "find_in_page":
+            self._display_find_in_page_action(ux, action)
+        else:
+            ux.append_info_line("🌐 Web Search", "cyan")
+
+    def _display_search_action(self, ux: IUXStateDriver, action: dict) -> None:
+        """Display a search action with queries and optional sources."""
+        queries = action.get("queries") or []
+        if not queries:
+            # Fall back to the single "query" field
+            query = action.get("query")
+            if query:
+                queries = [query]
+
+        if not queries:
+            ux.append_info_line("🌐 Web Search: search", "cyan")
+            return
+
+        sources = action.get("sources") or []
+        has_sources = len(sources) > 0
+
+        lines = ["🌐 Web Search: search"]
+        for i, query in enumerate(queries):
+            connector = "├─" if (i < len(queries) - 1 or has_sources) else "└─"
+            query_text = _truncate(str(query), _MAX_QUERY_DISPLAY_LENGTH)
+            lines.append(f'\n   {connector} "{query_text}"')
+
+        if has_sources:
+            lines.append("\n   │")
+            for i, source in enumerate(sources):
+                connector = "├─" if i < len(sources) - 1 else "└─"
+                line = _format_source(source)
+                lines.append(f"\n   {connector} {line}")
+
+        ux.append_info_line("".join(lines), "cyan")
+
+    def _display_open_page_action(self, ux: IUXStateDriver, action: dict) -> None:
+        """Display an open page action."""
+        url = action.get("url") or "(unknown)"
+        ux.append_info_line(
+            f"🌐 Web Search: open page\n   └─ {url}",
+            "cyan",
+        )
+
+    def _display_find_in_page_action(self, ux: IUXStateDriver, action: dict) -> None:
+        """Display a find-in-page action."""
+        url = action.get("url") or "(unknown)"
+        pattern = action.get("pattern") or "(unknown)"
+        ux.append_info_line(
+            f'🌐 Web Search: find in page\n   ├─ "{_truncate(pattern, _MAX_QUERY_DISPLAY_LENGTH)}"\n   └─ {url}',
+            "cyan",
+        )
+
+
+def _truncate(text: str, max_length: int) -> str:
+    """Truncate text to max length with ellipsis."""
+    return text if len(text) <= max_length else text[: max_length - 1] + "…"
+
+
+def _format_source(source: Any) -> str:
+    """Format a source entry for display."""
+    if isinstance(source, dict):
+        url = source.get("url") or source.get("uri") or "(unknown)"
+        title = source.get("title")
+        if title:
+            return f"{_truncate(title, _MAX_QUERY_DISPLAY_LENGTH)} — {url}"
+        return str(url)
+    return str(source)


### PR DESCRIPTION
### Motivation & Context

The Python harness console did not display web search activity (search queries, page opens, find-in-page actions) when using models with web search tools. The .NET harness console already has a `WebSearchDisplayObserver` that shows this activity, but the Python port was missing this observer. Users running the `harness_research.py` sample saw no indication of web search tool calls in the output stream.

### Description & Review Guide

- **What are the major changes?**
  - Added `WebSearchDisplayObserver` in `python/samples/02-agents/harness/console/observers/web_search_display.py`
  - Registered the observer in both `build_default_observers()` and `build_observers_with_planning()` in `__init__.py`

- **What is the impact of these changes?**
  - Web search activity now displays in the harness console with a 🌐 prefix, showing:
    - **Search actions**: queries and sources in a tree-view format
    - **Open page actions**: the URL being opened
    - **Find-in-page actions**: the search pattern and URL
  - The observer reads from `search_tool_result` content (emitted on `response.output_item.done`) rather than `search_tool_call` (emitted on `response.output_item.added`), because the action details are only fully populated when the search completes.

- **What do you want reviewers to focus on?**
  - Whether the action dict field access (`result["action"]["type"]`, `action["queries"]`, etc.) correctly matches the serialized OpenAI SDK `ActionSearch` / `ActionOpenPage` / `ActionFind` models.
  - Whether the observer should also handle `search_tool_call` for an early "searching..." indicator.

### Related Issue

No linked issue — this is a feature addition to the Python harness console port (related to PR #6312).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.