### PR TITLE
.NET: Harden fan-in barrier checkpoint state and extend resume coverage

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeMap.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Agents.AI.Workflows.Checkpointing;
 
 namespace Microsoft.Agents.AI.Workflows.Execution;
 
@@ -120,13 +119,11 @@ internal sealed class EdgeMap
         return exportedStates;
     }
 
-    internal async ValueTask ImportStateAsync(Checkpoint checkpoint)
+    internal async ValueTask ImportStateAsync(Dictionary<EdgeId, PortableValue> edgeStateData)
     {
-        Dictionary<EdgeId, PortableValue> importedState = checkpoint.EdgeStateData;
-
-        foreach (EdgeId id in importedState.Keys)
+        foreach (EdgeId id in edgeStateData.Keys)
         {
-            PortableValue exportedState = importedState[id];
+            PortableValue exportedState = edgeStateData[id];
             await this._statefulRunners[id].ImportStateAsync(exportedState).ConfigureAwait(false);
         }
     }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeRunner.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeRunner.cs
@@ -97,14 +97,17 @@ internal sealed class FanInEdgeRunner(IRunnerContext runContext, FanInEdgeData e
 
     public ValueTask<PortableValue> ExportStateAsync()
     {
-        return new(new PortableValue(this._state));
+        return new(new PortableValue(this._state.Snapshot()));
     }
 
     public ValueTask ImportStateAsync(PortableValue state)
     {
         if (state.Is(out FanInEdgeState? importedState))
         {
-            this._state = importedState;
+            // Snapshot on the way in so subsequent ProcessMessage mutations cannot alias state
+            // that the checkpoint store may still be holding (e.g. an in-memory checkpoint that
+            // retains the live PortableValue reference).
+            this._state = importedState.Snapshot();
             return default;
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeState.cs
@@ -60,4 +60,18 @@ internal sealed class FanInEdgeState
             .Select(portable => portable.ToMessageEnvelope())
             .GroupBy(messageEnvelope => messageEnvelope.Source);
     }
+
+    // Snapshot mutable state under _syncLock so a checkpoint export cannot observe a partially
+    // updated buffer or be silently mutated afterwards (matters for in-memory checkpoint stores
+    // that retain the live PortableValue reference).
+    public FanInEdgeState Snapshot()
+    {
+        lock (this._syncLock)
+        {
+            return new FanInEdgeState(
+                this.SourceIds,
+                [.. this.Unseen],
+                [.. this.PendingMessages]);
+        }
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/FanInEdgeState.cs
@@ -69,7 +69,7 @@ internal sealed class FanInEdgeState
         lock (this._syncLock)
         {
             return new FanInEdgeState(
-                this.SourceIds,
+                [.. this.SourceIds],
                 [.. this.Unseen],
                 [.. this.PendingMessages]);
         }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunner.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunner.cs
@@ -418,7 +418,7 @@ internal sealed class InProcessRunner : ISuperStepRunner, ICheckpointingHandle
 
         Task executorNotifyTask = this.RunContext.NotifyCheckpointLoadedAsync(cancellationToken);
 
-        await this.RunContext.ImportEdgeStateAsync(checkpoint).ConfigureAwait(false);
+        await this.RunContext.ImportEdgeStateAsync(checkpoint.EdgeStateData).ConfigureAwait(false);
         await Task.WhenAll(executorNotifyTask,
                            restoreCheckpointIndexTask.AsTask()).ConfigureAwait(false);
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
@@ -418,11 +418,11 @@ internal sealed class InProcessRunnerContext : IRunnerContext
         return this._edgeMap.ExportStateAsync();
     }
 
-    internal ValueTask ImportEdgeStateAsync(Checkpoint checkpoint)
+    internal ValueTask ImportEdgeStateAsync(Dictionary<EdgeId, PortableValue> edgeStateData)
     {
         this.CheckEnded();
 
-        return this._edgeMap.ImportStateAsync(checkpoint);
+        return this._edgeMap.ImportStateAsync(edgeStateData);
     }
 
     internal async ValueTask RepublishUnservicedRequestsAsync(CancellationToken cancellationToken = default)

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/CheckpointResumeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/CheckpointResumeTests.cs
@@ -330,18 +330,58 @@ public class CheckpointResumeTests
     internal async Task Checkpoint_Resume_PreservesFanInBarrierBufferedMessagesAsync(ExecutionEnvironment environment)
     {
         // Arrange
+        Workflow workflow = CreateFanInBarrierWorkflow();
+        CheckpointManager checkpointManager = CheckpointManager.CreateInMemory();
+        InProcessExecutionEnvironment env = environment.ToWorkflowExecutionEnvironment();
+
+        ExternalRequest pendingRequest;
+        CheckpointInfo checkpoint;
+
+        await using (StreamingRun firstRun = await env.WithCheckpointing(checkpointManager)
+                                                      .RunStreamingAsync(workflow, "start"))
+        {
+            (pendingRequest, checkpoint) = await CapturePendingRequestAndCheckpointAsync(firstRun);
+        }
+
+        // Act + Assert
+        ExternalRequest replayedRequest = await ResumeAndAssertBarrierReleasesAsync(
+            env, checkpointManager, workflow, checkpoint, ["before", "after"]);
+
+        pendingRequest.RequestId.Should().Be(replayedRequest.RequestId,
+            "the replayed request should be the one from the checkpointed superstep");
+    }
+
+    /// <summary>
+    /// Verifies that fan-in barrier state is preserved across resume when more than two sources
+    /// participate, and multiple contributions are buffered before the checkpoint.
+    /// </summary>
+    [Theory]
+    [InlineData(ExecutionEnvironment.InProcess_OffThread)]
+    [InlineData(ExecutionEnvironment.InProcess_Lockstep)]
+    internal async Task Checkpoint_Resume_PreservesFanInBarrierBufferedMessages_MultiSourceAsync(ExecutionEnvironment environment)
+    {
+        // Arrange: a fan-out start broadcasts a trigger to two early barrier sources and to a
+        // request-port kickoff. Both early sources contribute pre-checkpoint and only the port
+        // response path is unseen at the checkpoint - the barrier must hold both buffered
+        // contributions across resume and only release once the third source contributes.
         const string RequestPortId = "Approval";
         const string SinkId = "Sink";
 
-        ExecutorBinding beforePause = new PreCheckpointBarrierSource("BeforePause", RequestPortId, SinkId);
+        ForwardMessageExecutor<string> start = new("Start");
+        ExecutorBinding earlyA = new BarrierContributor("EarlyA", SinkId, "before-1");
+        ExecutorBinding earlyB = new BarrierContributor("EarlyB", SinkId, "before-2");
+        ExecutorBinding kickoff = new RequestPortKickoff("Kickoff", RequestPortId);
         ExecutorBinding afterResume = new PostCheckpointBarrierSource("AfterResume", SinkId);
         ExecutorBinding sink = new BarrierSink(SinkId);
         RequestPort<ApprovalRequest, ApprovalReply> requestPort = RequestPort.Create<ApprovalRequest, ApprovalReply>(RequestPortId);
 
-        Workflow workflow = new WorkflowBuilder(beforePause)
-            .AddEdge(beforePause, requestPort)
+        Workflow workflow = new WorkflowBuilder(start)
+            .AddEdge(start, earlyA)
+            .AddEdge(start, earlyB)
+            .AddEdge(start, kickoff)
+            .AddEdge(kickoff, requestPort)
             .AddEdge(requestPort, afterResume)
-            .AddFanInBarrierEdge([beforePause, afterResume], sink)
+            .AddFanInBarrierEdge([earlyA, earlyB, afterResume], sink)
             .Build();
 
         CheckpointManager checkpointManager = CheckpointManager.CreateInMemory();
@@ -356,35 +396,95 @@ public class CheckpointResumeTests
             (pendingRequest, checkpoint) = await CapturePendingRequestAndCheckpointAsync(firstRun);
         }
 
-        // Act
-        await using StreamingRun resumed = await env.WithCheckpointing(checkpointManager)
-                                                    .ResumeStreamingAsync(workflow, checkpoint);
-
-        List<WorkflowEvent> resumedEvents = await ReadToHaltAsync(resumed);
-        ExternalRequest replayedRequest = resumedEvents.OfType<RequestInfoEvent>()
-                                                       .Select(evt => evt.Request)
-                                                       .Should()
-                                                       .ContainSingle("resume should replay the request captured after the first fan-in source")
-                                                       .Subject;
-
-        await resumed.SendResponseAsync(replayedRequest.CreateResponse(new ApprovalReply("yes")));
-
-        List<WorkflowEvent> completionEvents = await ReadToHaltAsync(resumed);
-
-        // Assert
-        completionEvents.OfType<WorkflowErrorEvent>().Should().BeEmpty(
-            "resuming across a partially satisfied fan-in barrier should not raise workflow errors");
-
-        string[] outputs = [.. completionEvents.OfType<BarrierReleasedEvent>().Select(evt => evt.Source)];
-        outputs.Should().BeEquivalentTo(["before", "after"],
-            "the barrier should release the contribution buffered before the checkpoint and the one produced after resume");
-
-        RunStatus status = await resumed.GetStatusAsync();
-        status.Should().Be(RunStatus.Idle,
-            "the fan-in target should run after the post-resume source contributes");
+        // Act + Assert
+        ExternalRequest replayedRequest = await ResumeAndAssertBarrierReleasesAsync(
+            env, checkpointManager, workflow, checkpoint, ["before-1", "before-2", "after"]);
 
         pendingRequest.RequestId.Should().Be(replayedRequest.RequestId,
-            "the replayed request should be the one from the checkpointed superstep");
+            "the replayed request should match the one captured at checkpoint time");
+    }
+
+    /// <summary>
+    /// Verifies that the same checkpoint can be resumed independently more than once - i.e. that
+    /// completing one resumed run does not mutate state inside the stored checkpoint.
+    /// </summary>
+    /// <remarks>
+    /// Without a snapshot at the export/import boundary, <c>FanInEdgeRunner</c> would hand the
+    /// in-memory <c>CheckpointManager</c> a live reference to the mutable <c>FanInEdgeState</c>.
+    /// The first resume would then reset the buffer back to "all unseen" while completing, and a
+    /// second resume from the same <see cref="CheckpointInfo"/> would deadlock waiting for the
+    /// pre-checkpoint contribution that no longer exists.
+    /// </remarks>
+    [Theory]
+    [InlineData(ExecutionEnvironment.InProcess_OffThread)]
+    [InlineData(ExecutionEnvironment.InProcess_Lockstep)]
+    internal async Task Checkpoint_Resume_FanInBarrierCheckpointCanBeResumedTwiceAsync(ExecutionEnvironment environment)
+    {
+        // Arrange
+        CheckpointManager checkpointManager = CheckpointManager.CreateInMemory();
+        InProcessExecutionEnvironment env = environment.ToWorkflowExecutionEnvironment();
+
+        CheckpointInfo checkpoint;
+
+        await using (StreamingRun firstRun = await env.WithCheckpointing(checkpointManager)
+                                                      .RunStreamingAsync(CreateFanInBarrierWorkflow(), "start"))
+        {
+            (_, checkpoint) = await CapturePendingRequestAndCheckpointAsync(firstRun);
+        }
+
+        // Act + Assert: each resume needs a fresh Workflow object because the previous run takes
+        // ownership of it. Resuming the same CheckpointInfo more than once must yield identical
+        // results - the first resume must not mutate state the checkpoint store is still holding.
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            await ResumeAndAssertBarrierReleasesAsync(
+                env, checkpointManager, CreateFanInBarrierWorkflow(), checkpoint, ["before", "after"]);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that fan-in barrier state buffered inside a subworkflow is preserved across a
+    /// checkpoint/resume cycle of the parent workflow.
+    /// </summary>
+    [Theory]
+    [InlineData(ExecutionEnvironment.InProcess_OffThread)]
+    [InlineData(ExecutionEnvironment.InProcess_Lockstep)]
+    internal async Task Checkpoint_Resume_PreservesFanInBarrierBufferedMessages_InSubworkflowAsync(ExecutionEnvironment environment)
+    {
+        // Arrange: the fan-in barrier lives inside a subworkflow; the fix has to apply to the
+        // subworkflow's runner context too.
+        const string InnerRequestPortId = "InnerApproval";
+        const string ForwardedRequestId = "ForwardedInnerApproval";
+
+        Workflow BuildOuter()
+        {
+            ExecutorBinding subworkflow = CreateFanInBarrierWorkflow(
+                    requestPortId: InnerRequestPortId, sinkId: "InnerSink")
+                .BindAsExecutor("InnerSubworkflow");
+
+            return new WorkflowBuilder(subworkflow)
+                .AddExternalRequest<ApprovalRequest, ApprovalReply>(subworkflow, id: ForwardedRequestId)
+                .Build();
+        }
+
+        CheckpointManager checkpointManager = CheckpointManager.CreateInMemory();
+        InProcessExecutionEnvironment env = environment.ToWorkflowExecutionEnvironment();
+
+        ExternalRequest pendingRequest;
+        CheckpointInfo checkpoint;
+
+        await using (StreamingRun firstRun = await env.WithCheckpointing(checkpointManager)
+                                                      .RunStreamingAsync(BuildOuter(), "start"))
+        {
+            (pendingRequest, checkpoint) = await CapturePendingRequestAndCheckpointAsync(firstRun);
+        }
+
+        // Act + Assert
+        ExternalRequest replayedRequest = await ResumeAndAssertBarrierReleasesAsync(
+            env, checkpointManager, BuildOuter(), checkpoint, ["before", "after"]);
+
+        pendingRequest.RequestId.Should().Be(replayedRequest.RequestId,
+            "the replayed subworkflow request should match the one captured at checkpoint time");
     }
 
     /// <summary>
@@ -551,6 +651,58 @@ public class CheckpointResumeTests
         return events;
     }
 
+    private static Workflow CreateFanInBarrierWorkflow(
+        string requestPortId = "Approval",
+        string sinkId = "Sink")
+    {
+        ExecutorBinding before = new PreCheckpointBarrierSource("BeforePause", requestPortId, sinkId);
+        ExecutorBinding after = new PostCheckpointBarrierSource("AfterResume", sinkId);
+        ExecutorBinding sink = new BarrierSink(sinkId);
+        RequestPort<ApprovalRequest, ApprovalReply> requestPort =
+            RequestPort.Create<ApprovalRequest, ApprovalReply>(requestPortId);
+
+        return new WorkflowBuilder(before)
+            .AddEdge(before, requestPort)
+            .AddEdge(requestPort, after)
+            .AddFanInBarrierEdge([before, after], sink)
+            .Build();
+    }
+
+    private static async ValueTask<ExternalRequest> ResumeAndAssertBarrierReleasesAsync(
+        InProcessExecutionEnvironment env,
+        CheckpointManager checkpointManager,
+        Workflow workflow,
+        CheckpointInfo checkpoint,
+        IEnumerable<string> expectedBarrierSources)
+    {
+        await using StreamingRun resumed = await env.WithCheckpointing(checkpointManager)
+                                                    .ResumeStreamingAsync(workflow, checkpoint);
+
+        List<WorkflowEvent> resumedEvents = await ReadToHaltAsync(resumed);
+        ExternalRequest replayedRequest = resumedEvents.OfType<RequestInfoEvent>()
+                                                       .Select(evt => evt.Request)
+                                                       .Should()
+                                                       .ContainSingle("resume should replay exactly one pending request")
+                                                       .Subject;
+
+        await resumed.SendResponseAsync(replayedRequest.CreateResponse(new ApprovalReply("yes")));
+
+        List<WorkflowEvent> completionEvents = await ReadToHaltAsync(resumed);
+
+        completionEvents.OfType<WorkflowErrorEvent>().Should().BeEmpty(
+            "resuming across a partially satisfied fan-in barrier should not raise workflow errors");
+
+        string[] outputs = [.. completionEvents.OfType<BarrierReleasedEvent>().Select(evt => evt.Source)];
+        outputs.Should().BeEquivalentTo(expectedBarrierSources,
+            "the barrier should release every expected contribution");
+
+        RunStatus status = await resumed.GetStatusAsync();
+        status.Should().Be(RunStatus.Idle,
+            "the resumed run should halt cleanly once every barrier source has contributed");
+
+        return replayedRequest;
+    }
+
     private sealed record BarrierContribution(string Source);
 
     private sealed record ApprovalRequest(string Prompt);
@@ -574,6 +726,26 @@ public class CheckpointResumeTests
             await ctx.SendMessageAsync(new BarrierContribution("before"), sinkId).ConfigureAwait(false);
             await ctx.SendMessageAsync(new ApprovalRequest("continue?"), requestPortId).ConfigureAwait(false);
         }
+    }
+
+    private sealed class BarrierContributor(string id, string sinkId, string label) : Executor(id)
+    {
+        protected override ProtocolBuilder ConfigureProtocol(ProtocolBuilder protocolBuilder)
+            => protocolBuilder.ConfigureRoutes(routeBuilder => routeBuilder.AddHandler<string>(this.HandleAsync))
+                              .SendsMessage<BarrierContribution>();
+
+        private ValueTask HandleAsync(string input, IWorkflowContext ctx)
+            => ctx.SendMessageAsync(new BarrierContribution(label), sinkId);
+    }
+
+    private sealed class RequestPortKickoff(string id, string requestPortId) : Executor(id)
+    {
+        protected override ProtocolBuilder ConfigureProtocol(ProtocolBuilder protocolBuilder)
+            => protocolBuilder.ConfigureRoutes(routeBuilder => routeBuilder.AddHandler<string>(this.HandleAsync))
+                              .SendsMessage<ApprovalRequest>();
+
+        private ValueTask HandleAsync(string input, IWorkflowContext ctx)
+            => ctx.SendMessageAsync(new ApprovalRequest("continue?"), requestPortId);
     }
 
     private sealed class PostCheckpointBarrierSource(string id, string sinkId) : Executor(id)


### PR DESCRIPTION
### Description & Review Guide

`FanInEdgeRunner` returned a `PortableValue` that held a live reference to the mutable `FanInEdgeState`. With `CheckpointManager.CreateInMemory` which stores Checkpoint references, any subsequent `ProcessMessage` mutated state inside the already-stored checkpoint. The first resume checkpoint aliased the same instance, so resuming the same `CheckpointInfo` a second time saw a fully reset barrier and would deadlock.

This fixes in-memory aliasing path that also manifested as checkpointed barrier silently drops buffered messages once you resume more than once. Workflows using an in-memory `checkpointManager` can now resume from the same checkpoint more than once without state corruption.

Fixes #6573 

### Contribution Checklist

- [X] The code builds clean without any errors or warnings
- [X] All unit tests pass, and I have added new tests where possible
- [X] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [X] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
