### PR TITLE
Migrate to using issue type bug instead of label bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE/dotnet-issue.yml
+++ b/.github/ISSUE_TEMPLATE/dotnet-issue.yml
@@ -1,7 +1,7 @@
 name: .NET Bug Report
 description: Report a bug in the Agent Framework .NET SDK
 title: ".NET: [Bug]: "
-labels: ["bug", ".NET"]
+labels: [".NET"]
 type: bug
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/python-issue.yml
+++ b/.github/ISSUE_TEMPLATE/python-issue.yml
@@ -1,7 +1,7 @@
 name: Python Bug Report
 description: Report a bug in the Agent Framework Python SDK
 title: "Python: [Bug]: "
-labels: ["bug", "Python"]
+labels: ["Python"]
 type: bug
 body:
   - type: textarea

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -90,9 +90,7 @@ jobs:
             // Check for issue type from issue form dropdown
             const issueTypeField = getFormFieldValue(body, 'Type of Issue')
             if (issueTypeField) {
-              if (issueTypeField === 'Bug') {
-                labels.push("bug")
-              } else if (issueTypeField === 'Feature Request') {
+              if (issueTypeField === 'Feature Request') {
                 labels.push("enhancement")
               } else if (issueTypeField === 'Question') {
                 labels.push("question")


### PR DESCRIPTION
### Motivation & Context

Given the current edits and consolidation to the labels we're making, we're moving away from the single `bug` label and using the issue `Type` as `Bug`. 

After this, we can make sure no other current issues are referencing the `bug` label and can move any to the `Type: Bug`.

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
