### PR TITLE
docs: fix decision template links

### DIFF
--- a/docs/decisions/adr-short-template.md
+++ b/docs/decisions/adr-short-template.md
@@ -1,6 +1,6 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-madr-architecture-decisions.md)}
+status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-agent-run-response.md)}
 contact: {person proposing the ADR}
 date: {YYYY-MM-DD when the decision was last updated}
 deciders: {list everyone involved in the decision}

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,6 +1,6 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-madr-architecture-decisions.md)}
+status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-agent-run-response.md)}
 contact: {person proposing the ADR}
 date: {YYYY-MM-DD when the decision was last updated}
 deciders: {list everyone involved in the decision}

--- a/docs/specs/spec-template.md
+++ b/docs/specs/spec-template.md
@@ -1,6 +1,6 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by [SPEC-0001](0001-spec.md)}
+status: {proposed | rejected | accepted | deprecated | … | superseded by [SPEC-001](001-foundry-sdk-alignment.md)}
 contact: {person proposing the ADR}
 date: {YYYY-MM-DD when the decision was last updated}
 deciders: {list everyone involved in the decision}


### PR DESCRIPTION
## Summary

- Update the sample superseded-by links in the ADR and spec templates so they point at existing repository docs.
- Keep the examples concrete while avoiding broken relative Markdown links.

## Validation

- test -f docs/specs/001-foundry-sdk-alignment.md && test -f docs/decisions/0001-agent-run-response.md
- git diff --check

## Duplicate check

- Searched open PRs for spec-template, adr-template, 0001-madr-architecture-decisions, and 0001-spec; no duplicate PR found.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] This PR is linked to an issue and there is no other open PR for this issue. No issue is linked because this is a trivial docs link fix.
- [x] This is not a breaking change.
