### PR TITLE
Python: validate Redis history max messages

### DIFF
--- a/python/packages/redis/agent_framework_redis/_history_provider.py
+++ b/python/packages/redis/agent_framework_redis/_history_provider.py
@@ -70,6 +70,7 @@ class RedisHistoryProvider(HistoryProvider):
             ValueError: If neither redis_url nor credential_provider is provided.
             ValueError: If both redis_url and credential_provider are provided.
             ValueError: If credential_provider is used without host parameter.
+            ValueError: If max_messages is less than or equal to 0.
         """
         super().__init__(
             source_id,
@@ -86,6 +87,8 @@ class RedisHistoryProvider(HistoryProvider):
             raise ValueError("redis_url and credential_provider are mutually exclusive")
         if credential_provider is not None and host is None:
             raise ValueError("host is required when using credential_provider")
+        if max_messages is not None and max_messages <= 0:
+            raise ValueError("max_messages must be greater than 0")
 
         self.key_prefix = key_prefix
         self.max_messages = max_messages

--- a/python/packages/redis/tests/test_providers.py
+++ b/python/packages/redis/tests/test_providers.py
@@ -368,6 +368,27 @@ class TestRedisHistoryProviderInit:
         assert provider.store_outputs is False
         assert provider.store_inputs is False
 
+    @pytest.mark.parametrize("max_messages", [0, -1])
+    def test_invalid_max_messages_raises(self, max_messages: int):
+        with (
+            patch("agent_framework_redis._history_provider.redis.from_url") as mock_from_url,
+            pytest.raises(ValueError, match="max_messages must be greater than 0"),
+        ):
+            RedisHistoryProvider("mem", redis_url="redis://localhost:6379", max_messages=max_messages)
+
+        mock_from_url.assert_not_called()
+
+    @pytest.mark.parametrize("max_messages", [0, -1])
+    def test_invalid_max_messages_with_credential_provider_raises(self, max_messages: int):
+        mock_cred = MagicMock()
+        with (
+            patch("agent_framework_redis._history_provider.redis.Redis") as mock_redis,
+            pytest.raises(ValueError, match="max_messages must be greater than 0"),
+        ):
+            RedisHistoryProvider("mem", credential_provider=mock_cred, host="myhost", max_messages=max_messages)
+
+        mock_redis.assert_not_called()
+
     def test_no_redis_url_or_credential_raises(self):
         with pytest.raises(ValueError, match="Either redis_url or credential_provider must be provided"):
             RedisHistoryProvider("mem")


### PR DESCRIPTION
## Summary

- Reject RedisHistoryProvider max_messages values less than or equal to zero.
- Avoid ambiguous Redis LTRIM ranges for zero or negative retention counts.
- Add focused constructor validation tests for both redis_url and credential_provider construction paths, asserting Redis client construction is skipped for invalid values.

## Validation

- git diff --check upstream/main...HEAD
- uv run pytest packages/redis/tests/test_providers.py -q: 38 passed, with existing experimental warnings

## Duplicate check

- Searched open PRs for RedisHistoryProvider max_messages ltrim; no duplicate PR found.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] This PR is linked to an issue and there is no other open PR for this issue. No issue is linked because this is a narrow discovered validation gap.
- [x] This is not a breaking change.
