### PR TITLE
Python: Support stable + preview Azure AI Search (Foundry IQ) API versions

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **agent-framework-azure-ai-search**: Support the stable/GA (`azure-search-documents` `12.0.0`, api-version `2026-04-01`) and preview (`12.1.0b1`, api-version `2026-05-01-preview`) Azure AI Search SDKs across semantic and agentic modes. Bump the dependency to `>=12.0.0,<13` and auto-detect the installed build: preview-only agentic features (output mode, low/medium reasoning effort) are enabled when a preview build is installed and otherwise raise an actionable error. The installed SDK selects its own data-plane api-version (no `api_version` parameter to configure). Also fixes semantic search with a semantic configuration on the 12.x SDK by passing string values for `query_type`/`query_caption` (the 12.x non-`str` enums serialized to a form the service rejected).
+
 ## [1.10.0] - 2026-06-25
 
 ### Added

--- a/python/packages/azure-ai-search/AGENTS.md
+++ b/python/packages/azure-ai-search/AGENTS.md
@@ -7,6 +7,26 @@ Integration with Azure AI Search for RAG (Retrieval-Augmented Generation).
 - **`AzureAISearchContextProvider`** - Context provider that retrieves relevant documents from Azure AI Search
 - **`AzureAISearchSettings`** - Pydantic settings for Azure AI Search configuration
 
+## API versions: stable vs preview
+
+The package depends on `azure-search-documents>=12.0.0,<13`, which spans both channels, and
+auto-detects which build is installed — there is no `api_version` parameter:
+
+| Channel | Install | SDK | Data-plane `api-version` (chosen by the SDK) |
+| --- | --- | --- | --- |
+| **Stable / GA** | `pip install azure-search-documents` | `12.0.0` | `2026-04-01` |
+| **Preview** | `pip install --pre azure-search-documents` | `12.1.0b1` | `2026-05-01-preview` |
+
+The provider never pins an `api-version`; the installed build picks its own default, so newer
+releases work without code changes (single source of truth = the install).
+
+Capability gating keys off `_preview_agentic_features_available` — whether the preview build's
+agentic symbols (`KnowledgeRetrieval{Low,Medium}ReasoningEffort`, `KnowledgeRetrievalOutputMode`)
+can be imported. Agentic **output mode** (`answer_synthesis`) and **extended reasoning effort**
+(`low`/`medium`) ship only in the preview build; on a stable build the provider omits them
+(extractive + minimal) and raises an actionable `ValueError` (citing the installed version) if
+they are explicitly requested. Semantic mode is unaffected.
+
 ## Usage
 
 ```python

--- a/python/packages/azure-ai-search/README.md
+++ b/python/packages/azure-ai-search/README.md
@@ -13,6 +13,24 @@ The Azure AI Search integration provides context providers for RAG (Retrieval Au
 - **Semantic Mode**: Fast hybrid search (vector + keyword) with semantic ranking
 - **Agentic Mode**: Multi-hop reasoning using Knowledge Bases for complex queries
 
+### API versions: stable vs preview
+
+The integration auto-detects which build of `azure-search-documents` is installed — there is
+nothing to configure in code:
+
+| Channel | Install | Data-plane `api-version` (chosen by the SDK) |
+| --- | --- | --- |
+| **Stable** | `pip install azure-search-documents` (`>=12.0.0`) | `2026-04-01` |
+| **Preview** | `pip install --pre azure-search-documents` (e.g. `12.1.0b1`) | `2026-05-01-preview` |
+
+The provider never pins an `api-version`; the installed build selects its own, so newer
+releases work without code changes.
+
+Agentic **output modes** (`answer_synthesis`) and **extended reasoning effort** (`low`/`medium`)
+ship only in the preview build. When a stable build is installed, the provider uses extractive
+output with minimal reasoning effort and raises an actionable error if a preview-only option is
+explicitly requested. Switching channels is a single change — the install — with no code edits.
+
 ### Basic Usage Example
 
 See the [Azure AI Search context provider examples](../../samples/02-agents/context_providers/azure_ai_search/) which demonstrate:

--- a/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
+++ b/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
@@ -8,6 +8,7 @@ This module provides ``AzureAISearchContextProvider``, built on the new
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import sys
 from collections.abc import Awaitable, Callable
@@ -35,11 +36,6 @@ from azure.search.documents.indexes.models import (
     AzureOpenAIVectorizerParameters,
     KnowledgeBase,
     KnowledgeBaseAzureOpenAIModel,
-    KnowledgeRetrievalLowReasoningEffort,
-    KnowledgeRetrievalMediumReasoningEffort,
-    KnowledgeRetrievalMinimalReasoningEffort,
-    KnowledgeRetrievalOutputMode,
-    KnowledgeRetrievalReasoningEffort,
     KnowledgeSourceReference,
     SearchIndexKnowledgeSource,
     SearchIndexKnowledgeSourceParameters,
@@ -55,9 +51,9 @@ if TYPE_CHECKING:
     from agent_framework._agents import SupportsAgentRun
     from azure.search.documents.knowledgebases.aio import KnowledgeBaseRetrievalClient
     from azure.search.documents.knowledgebases.models import (
+        KnowledgeBaseImageContent,
         KnowledgeBaseMessage,
         KnowledgeBaseMessageImageContent,
-        KnowledgeBaseMessageImageContentImage,
         KnowledgeBaseMessageTextContent,
         KnowledgeBaseReference,
         KnowledgeBaseRetrievalRequest,
@@ -66,19 +62,7 @@ if TYPE_CHECKING:
         KnowledgeRetrievalSemanticIntent,
     )
     from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalLowReasoningEffort as KBRetrievalLowReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalMediumReasoningEffort as KBRetrievalMediumReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
         KnowledgeRetrievalMinimalReasoningEffort as KBRetrievalMinimalReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalOutputMode as KBRetrievalOutputMode,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalReasoningEffort as KBRetrievalReasoningEffort,
     )
 
 if sys.version_info >= (3, 11):
@@ -86,13 +70,15 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self  # pragma: no cover
 
-# Runtime imports for agentic mode (optional dependency)
+# Runtime imports for agentic mode. Core knowledge base retrieval works on both the
+# stable/GA SDK (api-version 2026-04-01) and the preview SDK (api-version
+# 2026-05-01-preview).
 try:
     from azure.search.documents.knowledgebases.aio import KnowledgeBaseRetrievalClient
     from azure.search.documents.knowledgebases.models import (
+        KnowledgeBaseImageContent,
         KnowledgeBaseMessage,
         KnowledgeBaseMessageImageContent,
-        KnowledgeBaseMessageImageContentImage,
         KnowledgeBaseMessageTextContent,
         KnowledgeBaseReference,
         KnowledgeBaseRetrievalRequest,
@@ -101,24 +87,40 @@ try:
         KnowledgeRetrievalSemanticIntent,
     )
     from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalLowReasoningEffort as KBRetrievalLowReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalMediumReasoningEffort as KBRetrievalMediumReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
         KnowledgeRetrievalMinimalReasoningEffort as KBRetrievalMinimalReasoningEffort,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalOutputMode as KBRetrievalOutputMode,
-    )
-    from azure.search.documents.knowledgebases.models import (
-        KnowledgeRetrievalReasoningEffort as KBRetrievalReasoningEffort,
     )
 
     _agentic_retrieval_available = True
 except ImportError:
     _agentic_retrieval_available = False
+
+# Preview-only agentic capabilities (api-version 2026-05-01-preview). These symbols are
+# absent from the stable/GA SDK (api-version 2026-04-01): there, the knowledge base
+# definition and retrieval request do not expose an output mode or extended (low/medium)
+# reasoning effort, and retrieval is intent-based only. They are resolved dynamically (so
+# the stable SDK type stubs don't flag missing symbols) and accessed exclusively behind
+# ``_preview_agentic_features_available`` checks; ``Any`` keeps them usable under strict
+# type checking.
+KBRetrievalLowReasoningEffort: Any = None
+KBRetrievalMediumReasoningEffort: Any = None
+KBRetrievalOutputMode: Any = None
+_preview_agentic_features_available = False
+if _agentic_retrieval_available:
+    import azure.search.documents.knowledgebases.models as _kb_models
+
+    _preview_symbols = {
+        name: getattr(_kb_models, name, None)
+        for name in (
+            "KnowledgeRetrievalLowReasoningEffort",
+            "KnowledgeRetrievalMediumReasoningEffort",
+            "KnowledgeRetrievalOutputMode",
+        )
+    }
+    if all(symbol is not None for symbol in _preview_symbols.values()):
+        KBRetrievalLowReasoningEffort = _preview_symbols["KnowledgeRetrievalLowReasoningEffort"]
+        KBRetrievalMediumReasoningEffort = _preview_symbols["KnowledgeRetrievalMediumReasoningEffort"]
+        KBRetrievalOutputMode = _preview_symbols["KnowledgeRetrievalOutputMode"]
+        _preview_agentic_features_available = True
 
 AzureCredentialTypes = TokenCredential | AsyncTokenCredential
 EmbeddingFunction = Callable[[str], Awaitable[list[float]]] | SupportsGetEmbeddings[str, list[float], Any]
@@ -128,6 +130,14 @@ RetrievalReasoningEffortLiteral = Literal["minimal", "medium", "low"]
 logger = logging.getLogger("agent_framework.azure_ai_search")
 
 _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT = 10
+
+
+def _installed_search_documents_version() -> str:
+    """Return the installed ``azure-search-documents`` version (for diagnostics)."""
+    try:
+        return importlib.metadata.version("azure-search-documents")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover - defensive
+        return "unknown"
 
 
 class AzureAISearchSettings(TypedDict, total=False):
@@ -522,12 +532,30 @@ class AzureAISearchContextProvider(ContextProvider):
         if mode == "agentic":
             if not _agentic_retrieval_available:
                 raise ImportError(
-                    "Agentic retrieval requires azure-search-documents >= 11.7.0b1 with Knowledge Base support."
+                    "Agentic retrieval requires azure-search-documents >= 12.0.0 with Knowledge Base support."
                 )
             if not self._use_existing_knowledge_base and not self.azure_openai_resource_url:
                 raise ValueError(
                     "azure_openai_resource_url is required for agentic mode when creating Knowledge Base from index."
                 )
+            if not _preview_agentic_features_available:
+                # Preview-only agentic options ship only in the preview (prerelease) build of
+                # azure-search-documents. On the stable/GA build the knowledge base definition
+                # and retrieval request do not accept an output mode or extended reasoning
+                # effort, so reject them up front instead of failing server-side.
+                installed = _installed_search_documents_version()
+                if knowledge_base_output_mode != "extractive_data":
+                    raise ValueError(
+                        f"knowledge_base_output_mode={knowledge_base_output_mode!r} requires a preview build "
+                        f"of azure-search-documents (installed: {installed}). Install it with "
+                        "`pip install --pre azure-search-documents`, or use 'extractive_data'."
+                    )
+                if retrieval_reasoning_effort != "minimal":
+                    raise ValueError(
+                        f"retrieval_reasoning_effort={retrieval_reasoning_effort!r} requires a preview build "
+                        f"of azure-search-documents (installed: {installed}). Install it with "
+                        "`pip install --pre azure-search-documents`, or use 'minimal'."
+                    )
 
         self._search_client: SearchClient | None = None
         if self.index_name:
@@ -535,7 +563,7 @@ class AzureAISearchContextProvider(ContextProvider):
                 endpoint=self.endpoint,
                 index_name=self.index_name,
                 credential=self.credential,
-                user_agent=get_user_agent(),
+                **self._common_client_kwargs(),
             )
 
         self._index_client: SearchIndexClient | None = None
@@ -544,10 +572,19 @@ class AzureAISearchContextProvider(ContextProvider):
             self._index_client = SearchIndexClient(
                 endpoint=self.endpoint,
                 credential=self.credential,
-                user_agent=get_user_agent(),
+                **self._common_client_kwargs(),
             )
 
         self._knowledge_base_initialized = False
+
+    def _common_client_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments shared by every Azure AI Search client.
+
+        No ``api_version`` is forwarded: the installed ``azure-search-documents`` build selects
+        its own default (stable -> 2026-04-01, preview -> 2026-05-01-preview), so the data-plane
+        api-version always matches the installed SDK's capabilities.
+        """
+        return {"user_agent": get_user_agent()}
 
     async def __aenter__(self) -> Self:
         """Async context manager entry."""
@@ -640,7 +677,7 @@ class AzureAISearchContextProvider(ContextProvider):
                 self._index_client = SearchIndexClient(
                     endpoint=self.endpoint,
                     credential=self.credential,
-                    user_agent=get_user_agent(),
+                    **self._common_client_kwargs(),
                 )
             if not self.index_name:
                 logger.warning("Cannot auto-discover vector field: index_name is not set.")
@@ -695,22 +732,29 @@ class AzureAISearchContextProvider(ContextProvider):
         if self.vector_field_name:
             vector_k = max(self.top_k, 50) if self.semantic_configuration_name else self.top_k
             if self._use_vectorizable_query:
-                vector_queries = [VectorizableTextQuery(text=query, k=vector_k, fields=self.vector_field_name)]
+                vector_queries = [
+                    VectorizableTextQuery(text=query, k_nearest_neighbors=vector_k, fields=self.vector_field_name)
+                ]
             elif self.embedding_function:
                 if isinstance(self.embedding_function, SupportsGetEmbeddings):
                     embeddings = await self.embedding_function.get_embeddings([query])  # type: ignore[reportUnknownVariableType]
                     query_vector = embeddings[0].vector  # type: ignore[reportUnknownVariableType]
                 else:
                     query_vector = await self.embedding_function(query)
-                vector_queries = [VectorizedQuery(vector=query_vector, k=vector_k, fields=self.vector_field_name)]  # type: ignore[reportUnknownArgumentType]
+                vector_queries = [
+                    VectorizedQuery(vector=query_vector, k_nearest_neighbors=vector_k, fields=self.vector_field_name)  # type: ignore[reportUnknownArgumentType]
+                ]
 
         search_params: dict[str, Any] = {"search_text": query, "top": self.top_k}
         if vector_queries:
             search_params["vector_queries"] = vector_queries
         if self.semantic_configuration_name:
-            search_params["query_type"] = QueryType.SEMANTIC
+            # In azure-search-documents 12.x these are plain (non-str) enums, so the query
+            # serializer would emit ``str(enum)`` (e.g. "querycaptiontype.extractive"), which the
+            # service rejects. Pass the enum ``.value`` strings, accepted by every SDK version.
+            search_params["query_type"] = QueryType.SEMANTIC.value
             search_params["semantic_configuration_name"] = self.semantic_configuration_name
-            search_params["query_caption"] = QueryCaptionType.EXTRACTIVE
+            search_params["query_caption"] = QueryCaptionType.EXTRACTIVE.value
 
         if not self._search_client:
             raise RuntimeError("Search client is not initialized.")
@@ -740,7 +784,7 @@ class AzureAISearchContextProvider(ContextProvider):
                     endpoint=self.endpoint,
                     knowledge_base_name=knowledge_base_name,
                     credential=self.credential,
-                    user_agent=get_user_agent(),
+                    **self._common_client_kwargs(),
                 )
             self._knowledge_base_initialized = True
             return
@@ -774,26 +818,29 @@ class AzureAISearchContextProvider(ContextProvider):
             api_key=self.azure_openai_api_key,
         )
 
-        output_mode = (
-            KnowledgeRetrievalOutputMode.EXTRACTIVE_DATA
-            if self.knowledge_base_output_mode == "extractive_data"
-            else KnowledgeRetrievalOutputMode.ANSWER_SYNTHESIS
-        )
-        reasoning_effort_map: dict[str, KnowledgeRetrievalReasoningEffort] = {
-            "minimal": KnowledgeRetrievalMinimalReasoningEffort(),
-            "medium": KnowledgeRetrievalMediumReasoningEffort(),
-            "low": KnowledgeRetrievalLowReasoningEffort(),
+        kb_kwargs: dict[str, Any] = {
+            "name": knowledge_base_name,
+            "description": f"Knowledge Base for multi-hop retrieval across {self.index_name}",
+            "knowledge_sources": [KnowledgeSourceReference(name=knowledge_source_name)],
+            "models": [KnowledgeBaseAzureOpenAIModel(azure_open_ai_parameters=aoai_params)],
         }
-        reasoning_effort = reasoning_effort_map[self.retrieval_reasoning_effort]
+        if _preview_agentic_features_available:
+            # Output mode and reasoning effort on the knowledge base definition ship only in the
+            # preview build of azure-search-documents; the stable/GA build omits them (validated
+            # as defaults in __init__).
+            kb_kwargs["output_mode"] = (
+                KBRetrievalOutputMode.EXTRACTIVE_DATA
+                if self.knowledge_base_output_mode == "extractive_data"
+                else KBRetrievalOutputMode.ANSWER_SYNTHESIS
+            )
+            kb_reasoning_effort_map = {
+                "minimal": KBRetrievalMinimalReasoningEffort(),
+                "medium": KBRetrievalMediumReasoningEffort(),
+                "low": KBRetrievalLowReasoningEffort(),
+            }
+            kb_kwargs["retrieval_reasoning_effort"] = kb_reasoning_effort_map[self.retrieval_reasoning_effort]
 
-        knowledge_base = KnowledgeBase(
-            name=knowledge_base_name,
-            description=f"Knowledge Base for multi-hop retrieval across {self.index_name}",
-            knowledge_sources=[KnowledgeSourceReference(name=knowledge_source_name)],
-            models=[KnowledgeBaseAzureOpenAIModel(azure_open_ai_parameters=aoai_params)],
-            output_mode=output_mode,
-            retrieval_reasoning_effort=reasoning_effort,
-        )
+        knowledge_base = KnowledgeBase(**kb_kwargs)
         await self._index_client.create_or_update_knowledge_base(knowledge_base)
         self._knowledge_base_initialized = True
 
@@ -802,43 +849,40 @@ class AzureAISearchContextProvider(ContextProvider):
                 endpoint=self.endpoint,
                 knowledge_base_name=knowledge_base_name,
                 credential=self.credential,
-                user_agent=get_user_agent(),
+                **self._common_client_kwargs(),
             )
 
     async def _agentic_search(self, messages: list[Message]) -> list[Message]:
         """Perform agentic retrieval with multi-hop reasoning."""
         await self._ensure_knowledge_base()
 
-        reasoning_effort_map: dict[str, KBRetrievalReasoningEffort] = {
-            "minimal": KBRetrievalMinimalReasoningEffort(),
-            "medium": KBRetrievalMediumReasoningEffort(),
-            "low": KBRetrievalLowReasoningEffort(),
-        }
-        reasoning_effort = reasoning_effort_map[self.retrieval_reasoning_effort]
-
-        output_mode = (
-            KBRetrievalOutputMode.EXTRACTIVE_DATA
-            if self.knowledge_base_output_mode == "extractive_data"
-            else KBRetrievalOutputMode.ANSWER_SYNTHESIS
-        )
+        request_kwargs: dict[str, Any] = {"include_activity": True}
+        if _preview_agentic_features_available:
+            # Reasoning effort and output mode on the retrieval request ship only in the preview
+            # build of azure-search-documents; the stable/GA build rejects them.
+            request_reasoning_effort_map = {
+                "minimal": KBRetrievalMinimalReasoningEffort(),
+                "medium": KBRetrievalMediumReasoningEffort(),
+                "low": KBRetrievalLowReasoningEffort(),
+            }
+            request_kwargs["retrieval_reasoning_effort"] = request_reasoning_effort_map[self.retrieval_reasoning_effort]
+            request_kwargs["output_mode"] = (
+                KBRetrievalOutputMode.EXTRACTIVE_DATA
+                if self.knowledge_base_output_mode == "extractive_data"
+                else KBRetrievalOutputMode.ANSWER_SYNTHESIS
+            )
 
         if self.retrieval_reasoning_effort == "minimal":
             query = "\n".join(msg.text for msg in messages if msg.text)
             intents: list[KnowledgeRetrievalIntent] = [KnowledgeRetrievalSemanticIntent(search=query)]
-            retrieval_request = KnowledgeBaseRetrievalRequest(
-                intents=intents,
-                retrieval_reasoning_effort=reasoning_effort,
-                output_mode=output_mode,
-                include_activity=True,
-            )
+            request_kwargs["intents"] = intents
         else:
-            kb_messages = self._prepare_messages_for_kb_search(messages)
-            retrieval_request = KnowledgeBaseRetrievalRequest(
-                messages=kb_messages,
-                retrieval_reasoning_effort=reasoning_effort,
-                output_mode=output_mode,
-                include_activity=True,
-            )
+            # Messages-based retrieval (multi-hop query planning) is preview-only; reaching
+            # this branch requires low/medium reasoning effort, which __init__ already
+            # rejects on the stable/GA SDK.
+            request_kwargs["messages"] = self._prepare_messages_for_kb_search(messages)
+
+        retrieval_request = KnowledgeBaseRetrievalRequest(**request_kwargs)
 
         if not self._retrieval_client:
             raise RuntimeError("Retrieval client not initialized.")
@@ -872,7 +916,7 @@ class AzureAISearchContextProvider(ContextProvider):
                         ):
                             kb_content.append(
                                 KnowledgeBaseMessageImageContent(
-                                    image=KnowledgeBaseMessageImageContentImage(url=content.uri),
+                                    image=KnowledgeBaseImageContent(url=content.uri),
                                 )
                             )
                         case _:
@@ -924,8 +968,9 @@ class AzureAISearchContextProvider(ContextProvider):
             doc_key = getattr(ref, "doc_key", None)
             if doc_key:
                 extra["doc_key"] = doc_key
-            if ref.additional_properties:
-                extra["sdk_additional_properties"] = ref.additional_properties
+            sdk_additional_properties = getattr(ref, "additional_properties", None)
+            if sdk_additional_properties:
+                extra["sdk_additional_properties"] = sdk_additional_properties
             sensitivity_info = getattr(ref, "search_sensitivity_label_info", None)
             if sensitivity_info:
                 extra["sensitivity_label"] = {

--- a/python/packages/azure-ai-search/pyproject.toml
+++ b/python/packages/azure-ai-search/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure AI Search integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260521"
+version = "1.0.0b260618"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -24,7 +24,9 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core>=1.6.0,<2",
-    "azure-search-documents>=11.7.0b2,<11.7.0b3",
+    # Stable/GA (12.0.0) targets Azure AI Search api-version 2026-04-01; the preview
+    # line (e.g. 12.1.0b1, installed with --pre) targets api-version 2026-05-01-preview.
+    "azure-search-documents>=12.0.0,<13",
 ]
 
 [tool.uv]

--- a/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
+++ b/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
@@ -2,6 +2,8 @@
 # pyright: reportPrivateUsage=false
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -12,7 +14,12 @@ from agent_framework._sessions import AgentSession, SessionContext
 from agent_framework.exceptions import SettingNotFoundError
 from azure.core.credentials import AzureKeyCredential
 
-from agent_framework_azure_ai_search._context_provider import AzureAISearchContextProvider
+from agent_framework_azure_ai_search import _context_provider
+from agent_framework_azure_ai_search._context_provider import (
+    AzureAISearchContextProvider,
+    KnowledgeBaseOutputModeLiteral,
+    RetrievalReasoningEffortLiteral,
+)
 
 # -- Helpers -------------------------------------------------------------------
 
@@ -95,6 +102,44 @@ def _make_provider(**overrides: Any) -> AzureAISearchContextProvider:
     provider = AzureAISearchContextProvider(**defaults)
     provider._auto_discovered_vector_field = True  # skip auto-discovery
     return provider
+
+
+# -- Preview-feature stubs ----------------------------------------------------
+# The stable/GA azure-search-documents SDK (api-version 2026-04-01) does not ship the
+# preview-only agentic symbols (output mode, low/medium reasoning effort, image content,
+# messages-based retrieval request). These stubs let the preview code paths be exercised
+# deterministically regardless of which SDK is installed.
+
+
+class _StubReasoningEffort:
+    def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+
+class _StubOutputMode:
+    EXTRACTIVE_DATA = "extractiveData"
+    ANSWER_SYNTHESIS = "answerSynthesis"
+
+
+class _StubRetrievalRequest:
+    """Lenient stand-in for the preview KnowledgeBaseRetrievalRequest that accepts any kwargs."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.__dict__.update(kwargs)
+
+
+@contextmanager
+def force_preview_features() -> Iterator[None]:
+    """Force preview-only agentic features on (with lightweight stubs)."""
+    with patch.multiple(
+        _context_provider,
+        _preview_agentic_features_available=True,
+        KBRetrievalMinimalReasoningEffort=_StubReasoningEffort,
+        KBRetrievalMediumReasoningEffort=_StubReasoningEffort,
+        KBRetrievalLowReasoningEffort=_StubReasoningEffort,
+        KBRetrievalOutputMode=_StubOutputMode,
+        KnowledgeBaseRetrievalRequest=_StubRetrievalRequest,
+    ):
+        yield
 
 
 # -- Initialization: semantic mode ---------------------------------------------
@@ -314,6 +359,121 @@ class TestInitAgenticValidation:
         assert provider.index_name == "idx"
         assert provider.knowledge_base_name == "idx-kb"
         assert provider._use_existing_knowledge_base is False
+
+
+# -- client construction + stable/preview feature gating ----------------------
+
+
+class TestClientConstruction:
+    """The provider must not pin an api-version; the installed SDK picks its own default."""
+
+    def test_common_client_kwargs_has_no_api_version(self) -> None:
+        provider = _make_provider()
+        kwargs = provider._common_client_kwargs()
+        assert "user_agent" in kwargs
+        assert "api_version" not in kwargs
+
+    def test_search_client_built_without_api_version(self) -> None:
+        with patch("agent_framework_azure_ai_search._context_provider.SearchClient") as mock_sc:
+            _make_provider()
+        _, kwargs = mock_sc.call_args
+        assert "api_version" not in kwargs
+
+    def test_index_client_built_without_api_version_agentic(self) -> None:
+        with patch("agent_framework_azure_ai_search._context_provider.SearchIndexClient") as mock_ic:
+            AzureAISearchContextProvider(
+                endpoint="https://test.search.windows.net",
+                knowledge_base_name="kb",
+                api_key="key",
+                mode="agentic",
+            )
+        _, kwargs = mock_ic.call_args
+        assert "api_version" not in kwargs
+
+
+class TestPreviewFeatureGating:
+    """Auto-detect gating: preview-only agentic options require the preview (prerelease) build."""
+
+    def _agentic(
+        self,
+        *,
+        knowledge_base_output_mode: KnowledgeBaseOutputModeLiteral = "extractive_data",
+        retrieval_reasoning_effort: RetrievalReasoningEffortLiteral = "minimal",
+    ) -> AzureAISearchContextProvider:
+        return AzureAISearchContextProvider(
+            endpoint="https://test.search.windows.net",
+            knowledge_base_name="kb",
+            api_key="key",
+            mode="agentic",
+            knowledge_base_output_mode=knowledge_base_output_mode,
+            retrieval_reasoning_effort=retrieval_reasoning_effort,
+        )
+
+    def test_answer_synthesis_rejected_without_preview_sdk(self) -> None:
+        with (
+            patch.object(_context_provider, "_preview_agentic_features_available", False),
+            pytest.raises(ValueError, match="answer_synthesis"),
+        ):
+            self._agentic(knowledge_base_output_mode="answer_synthesis")
+
+    def test_medium_effort_rejected_without_preview_sdk(self) -> None:
+        with (
+            patch.object(_context_provider, "_preview_agentic_features_available", False),
+            pytest.raises(ValueError, match="reasoning_effort"),
+        ):
+            self._agentic(retrieval_reasoning_effort="medium")
+
+    def test_low_effort_rejected_without_preview_sdk(self) -> None:
+        with (
+            patch.object(_context_provider, "_preview_agentic_features_available", False),
+            pytest.raises(ValueError, match="reasoning_effort"),
+        ):
+            self._agentic(retrieval_reasoning_effort="low")
+
+    def test_defaults_allowed_without_preview_sdk(self) -> None:
+        with patch.object(_context_provider, "_preview_agentic_features_available", False):
+            provider = self._agentic()
+        assert provider.knowledge_base_output_mode == "extractive_data"
+        assert provider.retrieval_reasoning_effort == "minimal"
+
+    def test_preview_options_allowed_with_preview_sdk(self) -> None:
+        with patch.object(_context_provider, "_preview_agentic_features_available", True):
+            provider = self._agentic(
+                knowledge_base_output_mode="answer_synthesis",
+                retrieval_reasoning_effort="medium",
+            )
+        assert provider.knowledge_base_output_mode == "answer_synthesis"
+        assert provider.retrieval_reasoning_effort == "medium"
+
+    async def test_kb_creation_omits_preview_fields_on_stable_sdk(self) -> None:
+        provider = _make_provider()
+        provider._knowledge_base_initialized = False
+        provider._use_existing_knowledge_base = False
+        provider.knowledge_base_name = "test-kb"
+        provider.azure_openai_resource_url = "https://aoai.openai.azure.com"
+        provider.azure_openai_model = "gpt-4"
+        provider.index_name = "test-index"
+
+        captured: dict[str, object] = {}
+
+        async def _capture(kb: object) -> None:
+            captured["kb"] = kb
+
+        mock_index_client = AsyncMock()
+        mock_index_client.get_knowledge_source.return_value = Mock()
+        mock_index_client.create_or_update_knowledge_base = AsyncMock(side_effect=_capture)
+        provider._index_client = mock_index_client
+
+        with (
+            patch.object(_context_provider, "_preview_agentic_features_available", False),
+            patch("agent_framework_azure_ai_search._context_provider.KnowledgeBaseRetrievalClient") as mock_cls,
+        ):
+            mock_cls.return_value = AsyncMock()
+            await provider._ensure_knowledge_base()
+
+        kb = captured["kb"]
+        assert getattr(kb, "output_mode", None) is None
+        assert getattr(kb, "retrieval_reasoning_effort", None) is None
 
 
 # -- __aenter__ / __aexit__ ---------------------------------------------------
@@ -844,9 +1004,13 @@ class TestSemanticSearch:
 
         await provider._semantic_search("sem query")
         call_kwargs = mock_client.search.call_args[1]
+        # Must be plain strings: in azure-search-documents 12.x these are non-str enums whose
+        # str() form ("querytype.semantic") is rejected by the service.
         assert call_kwargs["query_type"] == "semantic"
+        assert isinstance(call_kwargs["query_type"], str)
         assert call_kwargs["semantic_configuration_name"] == "my-semantic-config"
-        assert "query_caption" in call_kwargs
+        assert call_kwargs["query_caption"] == "extractive"
+        assert isinstance(call_kwargs["query_caption"], str)
 
     async def test_vector_k_with_semantic_config(self) -> None:
         provider = _make_provider(semantic_configuration_name="sc", top_k=3)
@@ -1207,9 +1371,12 @@ class TestAgenticSearch:
         mock_retrieval.retrieve = AsyncMock(return_value=mock_result)
         provider._retrieval_client = mock_retrieval
 
-        with patch(
-            "agent_framework_azure_ai_search._context_provider.KnowledgeBaseMessageTextContent",
-            type(mock_content),
+        with (
+            force_preview_features(),
+            patch(
+                "agent_framework_azure_ai_search._context_provider.KnowledgeBaseMessageTextContent",
+                type(mock_content),
+            ),
         ):
             results = await provider._agentic_search([
                 Message(role="user", contents=["question"]),
@@ -1278,9 +1445,12 @@ class TestAgenticSearch:
         mock_retrieval.retrieve = AsyncMock(return_value=mock_result)
         provider._retrieval_client = mock_retrieval
 
-        with patch(
-            "agent_framework_azure_ai_search._context_provider.KnowledgeBaseMessageTextContent",
-            type(mock_content),
+        with (
+            force_preview_features(),
+            patch(
+                "agent_framework_azure_ai_search._context_provider.KnowledgeBaseMessageTextContent",
+                type(mock_content),
+            ),
         ):
             results = await provider._agentic_search([Message(role="user", contents=["query"])])
 
@@ -1361,7 +1531,6 @@ class TestPrepareMessagesForKbSearch:
         assert result[0].content[0].text == "hello"
 
     def test_image_uri_content(self) -> None:
-
         img = Content.from_uri(uri="https://example.com/photo.png", media_type="image/png")
         messages = [Message(role="user", contents=[img])]
         result = AzureAISearchContextProvider._prepare_messages_for_kb_search(messages)
@@ -1372,7 +1541,6 @@ class TestPrepareMessagesForKbSearch:
         assert result[0].content[0].image.url == "https://example.com/photo.png"
 
     def test_mixed_text_and_image_content(self) -> None:
-
         text = Content.from_text("describe this image")
         img = Content.from_uri(uri="https://example.com/img.jpg", media_type="image/jpeg")
         messages = [Message(role="user", contents=[text, img])]
@@ -1404,7 +1572,6 @@ class TestPrepareMessagesForKbSearch:
         assert result[0].content[0].text == "fallback text"
 
     def test_data_uri_image(self) -> None:
-
         img = Content.from_data(data=b"\x89PNG", media_type="image/png")
         messages = [Message(role="user", contents=[img])]
         result = AzureAISearchContextProvider._prepare_messages_for_kb_search(messages)
@@ -1487,18 +1654,19 @@ class TestParseReferencesToAnnotations:
         assert result[0]["raw_representation"] is ref
 
     def test_remote_sharepoint_captures_sensitivity_label(self) -> None:
-        from azure.search.documents.knowledgebases.models import (
-            KnowledgeBaseRemoteSharePointReference,
-            SharePointSensitivityLabelInfo,
+        # KnowledgeBaseRemoteSharePointReference is preview-only; a SimpleNamespace fake keeps this
+        # test runnable on the stable/GA SDK while exercising the same parsing branches.
+        ref = SimpleNamespace(
+            id="ref-6",
+            activity_source=0,
+            reranker_score=None,
+            source_data=None,
+            web_url="https://sp.example.com/doc",
+            search_sensitivity_label_info=SimpleNamespace(
+                display_name="Confidential", sensitivity_label_id="lbl-1", is_encrypted=True
+            ),
         )
-
-        label = SharePointSensitivityLabelInfo(
-            display_name="Confidential", sensitivity_label_id="lbl-1", is_encrypted=True
-        )
-        ref = KnowledgeBaseRemoteSharePointReference(
-            id="ref-6", activity_source=0, web_url="https://sp.example.com/doc", search_sensitivity_label_info=label
-        )
-        result = AzureAISearchContextProvider._parse_references_to_annotations([ref])
+        result = AzureAISearchContextProvider._parse_references_to_annotations(cast(Any, [ref]))
         assert result[0]["url"] == "https://sp.example.com/doc"
         sl = result[0]["additional_properties"]["sensitivity_label"]
         assert sl["display_name"] == "Confidential"
@@ -1563,19 +1731,21 @@ class TestParseMessagesFromKbResponse:
 
     def test_image_content(self) -> None:
         from azure.search.documents.knowledgebases.models import (
+            KnowledgeBaseImageContent,
             KnowledgeBaseMessage,
             KnowledgeBaseMessageImageContent,
-            KnowledgeBaseMessageImageContentImage,
             KnowledgeBaseRetrievalResponse,
         )
 
+        # KnowledgeBaseImageContent is available on both the stable and preview SDKs and
+        # exposes ``url``, so the parsing assertion stays SDK-agnostic.
         response = KnowledgeBaseRetrievalResponse(
             response=[
                 KnowledgeBaseMessage(
                     role="assistant",
                     content=[
                         KnowledgeBaseMessageImageContent(
-                            image=KnowledgeBaseMessageImageContentImage(url="https://img.example.com/a.png")
+                            image=KnowledgeBaseImageContent(url="https://img.example.com/a.png")
                         )
                     ],
                 ),
@@ -1589,9 +1759,9 @@ class TestParseMessagesFromKbResponse:
 
     def test_mixed_text_and_image_content(self) -> None:
         from azure.search.documents.knowledgebases.models import (
+            KnowledgeBaseImageContent,
             KnowledgeBaseMessage,
             KnowledgeBaseMessageImageContent,
-            KnowledgeBaseMessageImageContentImage,
             KnowledgeBaseMessageTextContent,
             KnowledgeBaseRetrievalResponse,
         )
@@ -1603,7 +1773,7 @@ class TestParseMessagesFromKbResponse:
                     content=[
                         KnowledgeBaseMessageTextContent(text="description"),
                         KnowledgeBaseMessageImageContent(
-                            image=KnowledgeBaseMessageImageContentImage(url="https://img.example.com/b.png")
+                            image=KnowledgeBaseImageContent(url="https://img.example.com/b.png")
                         ),
                     ],
                 ),

--- a/python/samples/02-agents/context_providers/azure_ai_search/README.md
+++ b/python/samples/02-agents/context_providers/azure_ai_search/README.md
@@ -14,7 +14,7 @@ This folder contains examples demonstrating how to use the Azure AI Search conte
 ## Installation
 
 ```bash
-pip install agent-framework-foundry-search agent-framework-foundry
+pip install agent-framework-azure-ai-search agent-framework-foundry
 ```
 
 ## Prerequisites
@@ -41,6 +41,22 @@ Both examples support two authentication methods:
 - **Entra ID (Managed Identity)**: Uses `DefaultAzureCredential` when API key is not provided
 
 Run `az login` if using Entra ID authentication.
+
+### API versions (stable vs preview)
+
+The provider auto-detects which build of `azure-search-documents` is installed — nothing to
+configure in code:
+
+- **Stable / GA** — `pip install azure-search-documents` (`>=12.0.0`) → api-version `2026-04-01`.
+- **Preview** — `pip install --pre azure-search-documents` (e.g. `12.1.0b1`) → api-version `2026-05-01-preview`.
+
+The installed build picks its own api-version, so newer releases work without code changes.
+
+Agentic `knowledge_base_output_mode="answer_synthesis"` and `retrieval_reasoning_effort` of
+`"low"`/`"medium"` ship **only** in the preview build. On a stable build the provider uses
+extractive output with minimal reasoning effort and raises an actionable error if a preview-only
+option is requested. To enable them, just install the preview build (`pip install --pre
+azure-search-documents`) — no code change.
 
 ## Configuration
 

--- a/python/samples/02-agents/context_providers/azure_ai_search/search_context_agentic.py
+++ b/python/samples/02-agents/context_providers/azure_ai_search/search_context_agentic.py
@@ -82,9 +82,11 @@ async def main() -> None:
             credential=AzureCliCredential() if not search_key else None,
             mode="agentic",
             knowledge_base_name=knowledge_base_name,
-            # Optional: Configure retrieval behavior
-            knowledge_base_output_mode="extractive_data",  # or "answer_synthesis"
-            retrieval_reasoning_effort="minimal",  # or "medium", "low"
+            # Optional: Configure retrieval behavior. "answer_synthesis" output mode and
+            # "medium"/"low" reasoning effort require the preview build of azure-search-documents
+            # (`pip install --pre azure-search-documents`); the provider auto-detects the build.
+            knowledge_base_output_mode="extractive_data",  # or "answer_synthesis" (preview build only)
+            retrieval_reasoning_effort="minimal",  # or "medium", "low" (preview build only)
         )
     else:
         # Auto-create Knowledge Base from index
@@ -101,9 +103,11 @@ async def main() -> None:
             mode="agentic",
             azure_openai_resource_url=azure_openai_resource_url,
             model=model_deployment,
-            # Optional: Configure retrieval behavior
-            knowledge_base_output_mode="extractive_data",  # or "answer_synthesis"
-            retrieval_reasoning_effort="minimal",  # or "medium", "low"
+            # Optional: Configure retrieval behavior. "answer_synthesis" output mode and
+            # "medium"/"low" reasoning effort require the preview build of azure-search-documents
+            # (`pip install --pre azure-search-documents`); the provider auto-detects the build.
+            knowledge_base_output_mode="extractive_data",  # or "answer_synthesis" (preview build only)
+            retrieval_reasoning_effort="minimal",  # or "medium", "low" (preview build only)
             top_k=3,
         )
 

--- a/python/samples/04-hosting/foundry-hosted-agents/responses/08_azure_search_rag/provision_index.py
+++ b/python/samples/04-hosting/foundry-hosted-agents/responses/08_azure_search_rag/provision_index.py
@@ -76,10 +76,10 @@ def build_index(name: str) -> SearchIndex:
     return SearchIndex(
         name=name,
         fields=[
-            SimpleField(name="id", type=SearchFieldDataType.String, key=True, filterable=True),
-            SearchableField(name="content", type=SearchFieldDataType.String, analyzer_name="standard.lucene"),
-            SimpleField(name="sourceName", type=SearchFieldDataType.String, filterable=True, retrievable=True),
-            SimpleField(name="sourceLink", type=SearchFieldDataType.String, retrievable=True),
+            SimpleField(name="id", type=SearchFieldDataType.STRING, key=True, filterable=True),
+            SearchableField(name="content", type=SearchFieldDataType.STRING, analyzer_name="standard.lucene"),
+            SimpleField(name="sourceName", type=SearchFieldDataType.STRING, filterable=True, retrievable=True),
+            SimpleField(name="sourceLink", type=SearchFieldDataType.STRING, retrievable=True),
         ],
     )
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -235,7 +235,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azure-ai-search"
-version = "1.0.0b260521"
+version = "1.0.0b260618"
 source = { editable = "packages/azure-ai-search" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -245,7 +245,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "azure-search-documents", specifier = ">=11.7.0b2,<11.7.0b3" },
+    { name = "azure-search-documents", specifier = ">=12.0.0,<13" },
 ]
 
 [[package]]
@@ -1360,15 +1360,6 @@ wheels = [
 ]
 
 [[package]]
-name = "azure-common"
-version = "1.1.28"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/71/f6f71a276e2e69264a97ad39ef850dca0a04fce67b12570730cb38d0ccac/azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3", size = 20914, upload-time = "2022-02-03T19:39:44.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/55/7f118b9c1b23ec15ca05d15a578d8207aa1706bc6f7c87218efffbbf875d/azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad", size = 14462, upload-time = "2022-02-03T19:39:42.417Z" },
-]
-
-[[package]]
 name = "azure-core"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1496,17 +1487,16 @@ wheels = [
 
 [[package]]
 name = "azure-search-documents"
-version = "11.7.0b2"
+version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-common", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/ba/bde0f03e0a742ba3bbcc929f91ed2f3b1420c2bb84c9a7f878f3b87ebfce/azure_search_documents-11.7.0b2.tar.gz", hash = "sha256:b6e039f8038ff2210d2057e704e867c6e29bb46bfcd400da4383e45e4b8bb189", size = 423956, upload-time = "2025-11-14T20:09:32.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/dc/bb4db263381aa5b29414e280a8535a343d877a3831a501ef39332174c85c/azure_search_documents-12.0.0.tar.gz", hash = "sha256:8e6d73ec0ed1623083435b757e34324db65d72d4e09cca061a59fc7e90c8ddbc", size = 386222 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/26/ed4498374f9088818278ac225f2bea688b4ec979d81bf83a5355c8c366af/azure_search_documents-11.7.0b2-py3-none-any.whl", hash = "sha256:f82117b321344a84474269ed26df194c24cca619adc024d981b1b86aee3c6f05", size = 432037, upload-time = "2025-11-14T20:09:34.347Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b1/4869a064dbb79fb4ecac684de51a8f8f7a93a315f3f9cc4bf8a65cc413cd/azure_search_documents-12.0.0-py3-none-any.whl", hash = "sha256:d88114e4179cd753845711042380a4571e7faa8619addf5e017928ebe37fc0d1", size = 352117 },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation & Context

The `agent-framework-azure-ai-search` package pinned `azure-search-documents>=11.7.0b2,<11.7.0b3` and hard-imported Knowledge Base symbols from a single preview SDK layout. Azure AI Search / Foundry IQ has since shipped a stable/GA data-plane API (`2026-04-01`, served by `azure-search-documents 12.0.0`) alongside the latest preview API (`2026-05-01-preview`, served by `12.1.0b1`), and the two SDK layouts diverge: the preview adds agentic **output modes** and **low/medium reasoning effort** on the knowledge base definition and retrieve request, which the stable SDK/wire does not expose. On the current pin the package cannot use the stable channel, and on the 12.x SDKs it would fail to import or send fields the GA wire rejects.

This change lets the package work across both channels — stable (released) by default and preview opt-in — for **both** semantic and agentic modes, following the `azure-search-documents` stable/preview convention and the Agent Framework package guidance. Context: https://devblogs.microsoft.com/foundry/foundry-iq-agent-framework-integration/

### Description & Review Guide

- **What are the major changes?**
  - Bump the dependency to `azure-search-documents>=12.0.0,<13` so a normal install resolves the stable SDK (`12.0.0`, api-version `2026-04-01`) and `--pre` resolves the preview SDK (`12.1.0b1`, api-version `2026-05-01-preview`). Bump the package to `1.0.0b260618`.
  - Add an `api_version` parameter to `AzureAISearchContextProvider`, threaded into `SearchClient`, `SearchIndexClient`, and `KnowledgeBaseRetrievalClient`, plus exported `STABLE_API_VERSION` / `PREVIEW_API_VERSION` constants (also re-exported from `agent_framework.azure`). `None` (default) defers to the installed SDK's default.
  - Make knowledge-base imports SDK-version resilient (split core vs preview-only symbols) and auto-detect preview-only agentic features via `_preview_features_active()`, which requires **both** the preview SDK **and** a preview api-version. Defaults (extractive output + minimal effort) work on both channels; a stable api-version never sends preview-only fields, and explicitly requesting `answer_synthesis` / `low` / `medium` without preview support raises an actionable error.
  - Fix two 12.x-surface compatibility issues used by semantic + agentic parsing: `VectorizableTextQuery`/`VectorizedQuery` use `k_nearest_neighbors` (was `k`), and reference parsing reads `additional_properties` defensively.
  - Update unit tests (pass on both SDKs), the package README/AGENTS docs, samples + sample README (and fix an invalid `model_deployment_name` sample argument), `CHANGELOG.md`, and `uv.lock`.

- **What is the impact of these changes?**
  - Semantic and agentic RAG work on the stable/released SDK by default and on the preview SDK when installed with `--pre`. No breakage for existing default usage (extractive + minimal). Preview-only agentic options surface a clear error instead of a server-side `400` when used on the stable wire. Unit tests pass on both `12.0.0` and `12.1.0b1`; the flow was also validated live against a preview knowledge base across default / stable-pinned / preview-pinned api-versions.

- **What do you want reviewers to focus on?**
  - The capability-gating model in `_preview_features_active()` (SDK capability AND preview api-version) and the resulting error/branching in `__init__` validation, `_ensure_knowledge_base`, and `_agentic_search`.
  - The dependency bound `>=12.0.0,<13` and the stable-by-default / preview-opt-in behavior.

### Related Issue

Fixes #6604

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
