### PR TITLE
.NET: (Durable): Scope workflow status/respond endpoints to route workflow name

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
@@ -20,6 +20,8 @@ internal static class BuiltInFunctions
 {
     internal const string HttpPrefix = "http-";
     internal const string McpToolPrefix = "mcptool-";
+    internal const string StatusFunctionSuffix = "-status";
+    internal const string RespondFunctionSuffix = "-respond";
 
     private const string WaitForResponseHeaderName = "x-ms-wait-for-response";
 
@@ -90,7 +92,7 @@ internal static class BuiltInFunctions
         }
 
         OrchestrationMetadata? metadata = await client.GetInstanceAsync(runId, getInputsAndOutputs: true);
-        if (metadata is null)
+        if (metadata is null || !IsOrchestrationOwnedByWorkflow(metadata.Name, context.FunctionDefinition.Name, StatusFunctionSuffix))
         {
             return await CreateErrorResponseAsync(req, context, HttpStatusCode.NotFound, $"Workflow run '{runId}' not found.");
         }
@@ -146,7 +148,7 @@ internal static class BuiltInFunctions
 
         // Verify the orchestration exists and is in a valid state
         OrchestrationMetadata? metadata = await client.GetInstanceAsync(runId, getInputsAndOutputs: true);
-        if (metadata is null)
+        if (metadata is null || !IsOrchestrationOwnedByWorkflow(metadata.Name, context.FunctionDefinition.Name, RespondFunctionSuffix))
         {
             return await CreateErrorResponseAsync(req, context, HttpStatusCode.NotFound, $"Workflow run '{runId}' not found.");
         }
@@ -653,6 +655,37 @@ internal static class BuiltInFunctions
 
         // Remove the HttpPrefix from the function name to get the agent name.
         return functionName[HttpPrefix.Length..];
+    }
+
+    /// <summary>
+    /// Extracts the workflow name from the function definition name by stripping the
+    /// <see cref="HttpPrefix"/> and the given suffix (e.g., "-status" or "-respond").
+    /// </summary>
+    /// <summary>
+    /// Extracts the workflow name from the function definition name by stripping the
+    /// <see cref="HttpPrefix"/> and the given suffix (e.g., "-status" or "-respond").
+    /// </summary>
+    internal static string GetWorkflowName(string functionName, string suffix)
+    {
+        if (!functionName.StartsWith(HttpPrefix, StringComparison.Ordinal) ||
+            !functionName.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Built-in HTTP trigger function name '{functionName}' does not match the expected pattern '{HttpPrefix}<workflowName>{suffix}'.");
+        }
+
+        return functionName[HttpPrefix.Length..^suffix.Length];
+    }
+
+    /// <summary>
+    /// Returns true if the orchestration name matches the expected orchestration for the
+    /// workflow derived from the given function name and suffix.
+    /// </summary>
+    internal static bool IsOrchestrationOwnedByWorkflow(string orchestrationName, string functionName, string suffix)
+    {
+        string workflowName = GetWorkflowName(functionName, suffix);
+        string expectedOrchestrationName = WorkflowNamingHelper.ToOrchestrationFunctionName(workflowName);
+        return string.Equals(orchestrationName, expectedOrchestrationName, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
@@ -661,10 +661,6 @@ internal static class BuiltInFunctions
     /// Extracts the workflow name from the function definition name by stripping the
     /// <see cref="HttpPrefix"/> and the given suffix (e.g., "-status" or "-respond").
     /// </summary>
-    /// <summary>
-    /// Extracts the workflow name from the function definition name by stripping the
-    /// <see cref="HttpPrefix"/> and the given suffix (e.g., "-status" or "-respond").
-    /// </summary>
     internal static string GetWorkflowName(string functionName, string suffix)
     {
         if (!functionName.StartsWith(HttpPrefix, StringComparison.Ordinal) ||
@@ -683,6 +679,12 @@ internal static class BuiltInFunctions
     /// </summary>
     internal static bool IsOrchestrationOwnedByWorkflow(string orchestrationName, string functionName, string suffix)
     {
+        if (!functionName.StartsWith(HttpPrefix, StringComparison.Ordinal) ||
+            !functionName.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         string workflowName = GetWorkflowName(functionName, suffix);
         string expectedOrchestrationName = WorkflowNamingHelper.ToOrchestrationFunctionName(workflowName);
         return string.Equals(orchestrationName, expectedOrchestrationName, StringComparison.OrdinalIgnoreCase);

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Scope workflow status/respond endpoints to the route workflow name ([#6608](https://github.com/microsoft/agent-framework/pull/6608))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Support returning workflow results from HTTP trigger endpoint ([#5321](https://github.com/microsoft/agent-framework/pull/5321))
 - Added MCP tool trigger support for durable workflows ([#4768](https://github.com/microsoft/agent-framework/pull/4768))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
@@ -89,7 +89,7 @@ internal sealed class DurableWorkflowsFunctionMetadataTransformer : IFunctionMet
             // Register a status endpoint if opted in via AddWorkflow(exposeStatusEndpoint: true).
             if (this._options.IsStatusEndpointEnabled(workflow.Key))
             {
-                string statusFunctionName = $"{BuiltInFunctions.HttpPrefix}{workflow.Key}-status";
+                string statusFunctionName = $"{BuiltInFunctions.HttpPrefix}{workflow.Key}{BuiltInFunctions.StatusFunctionSuffix}";
                 if (registeredFunctions.Add(statusFunctionName))
                 {
                     this._logger.LogRegisteringWorkflowTrigger(workflow.Key, statusFunctionName, "http-status");
@@ -105,7 +105,7 @@ internal sealed class DurableWorkflowsFunctionMetadataTransformer : IFunctionMet
             bool hasRequestPorts = workflow.Value.ReflectExecutors().Values.Any(b => b is RequestPortBinding);
             if (hasRequestPorts)
             {
-                string respondFunctionName = $"{BuiltInFunctions.HttpPrefix}{workflow.Key}-respond";
+                string respondFunctionName = $"{BuiltInFunctions.HttpPrefix}{workflow.Key}{BuiltInFunctions.RespondFunctionSuffix}";
                 if (registeredFunctions.Add(respondFunctionName))
                 {
                     this._logger.LogRegisteringWorkflowTrigger(workflow.Key, respondFunctionName, "http-respond");

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsWorkflowRoutingTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsWorkflowRoutingTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests;
+
+public sealed class BuiltInFunctionsWorkflowRoutingTests
+{
+    [Theory]
+    [InlineData("http-MyWorkflow-status", "-status", "MyWorkflow")]
+    [InlineData("http-OrderProcessor-status", "-status", "OrderProcessor")]
+    [InlineData("http-MyWorkflow-respond", "-respond", "MyWorkflow")]
+    [InlineData("http-Multi-Dash-Name-status", "-status", "Multi-Dash-Name")]
+    public void GetWorkflowName_ReturnsCorrectNameAsync(string functionName, string suffix, string expectedWorkflowName)
+    {
+        // Act
+        string result = BuiltInFunctions.GetWorkflowName(functionName, suffix);
+
+        // Assert
+        Assert.Equal(expectedWorkflowName, result);
+    }
+
+    [Theory]
+    [InlineData("invalid-name", "-status")]
+    [InlineData("http-MyWorkflow-respond", "-status")] // wrong suffix
+    [InlineData("mcptool-MyWorkflow-status", "-status")] // wrong prefix
+    public void GetWorkflowName_ThrowsForInvalidPattern(string functionName, string suffix)
+    {
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+            BuiltInFunctions.GetWorkflowName(functionName, suffix));
+    }
+
+    [Theory]
+    [InlineData("dafx-MyWorkflow", "http-MyWorkflow-status", "-status", true)]
+    [InlineData("dafx-MyWorkflow", "http-MyWorkflow-respond", "-respond", true)]
+    [InlineData("dafx-myworkflow", "http-MyWorkflow-status", "-status", true)] // case-insensitive
+    [InlineData("dafx-MYWORKFLOW", "http-MyWorkflow-respond", "-respond", true)] // case-insensitive
+    [InlineData("dafx-OtherWorkflow", "http-MyWorkflow-status", "-status", false)] // cross-workflow
+    [InlineData("dafx-PrivilegedWorkflow", "http-PublicWorkflow-status", "-status", false)] // attack scenario
+    [InlineData("dafx-PrivilegedWorkflow", "http-PublicWorkflow-respond", "-respond", false)] // attack scenario
+    public void IsOrchestrationOwnedByWorkflow_ValidatesCorrectly(
+        string orchestrationName,
+        string functionName,
+        string suffix,
+        bool expectedResult)
+    {
+        // Act
+        bool result = BuiltInFunctions.IsOrchestrationOwnedByWorkflow(orchestrationName, functionName, suffix);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsWorkflowRoutingTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsWorkflowRoutingTests.cs
@@ -9,7 +9,7 @@ public sealed class BuiltInFunctionsWorkflowRoutingTests
     [InlineData("http-OrderProcessor-status", "-status", "OrderProcessor")]
     [InlineData("http-MyWorkflow-respond", "-respond", "MyWorkflow")]
     [InlineData("http-Multi-Dash-Name-status", "-status", "Multi-Dash-Name")]
-    public void GetWorkflowName_ReturnsCorrectNameAsync(string functionName, string suffix, string expectedWorkflowName)
+    public void GetWorkflowName_ReturnsCorrectName(string functionName, string suffix, string expectedWorkflowName)
     {
         // Act
         string result = BuiltInFunctions.GetWorkflowName(functionName, suffix);


### PR DESCRIPTION
### Motivation & Context

 The workflow status and respond HTTP endpoints include the workflow name in the route path (e.g., `workflows/PublicWorkflow/status/{runId}`) which implies per-workflow scoping. However, the handlers performed a global durable  task lookup by `runId` without verifying the orchestration instance belongs to the workflow named in the route.

 This meant a caller with access to one workflow's endpoint could read status (including pending HITL request details) or send events to a different workflow in the same Function App by supplying that workflow's `runId`.

 ### Description & Review Guide

 - **What are the major changes?**
   - `GetWorkflowStatusAsync` and `RespondToWorkflowAsync` now validate that `metadata.Name` matches the expected orchestration function name derived from the route. Mismatches return 404.
   - Extracted `GetWorkflowName` and `IsOrchestrationOwnedByWorkflow` as `internal static` helpers for testability and reuse.
   - Added `StatusFunctionSuffix` / `RespondFunctionSuffix` constants shared between `BuiltInFunctions` and `DurableWorkflowsFunctionMetadataTransformer`.
   - Added 14 unit tests covering valid parsing, invalid patterns, case-insensitive matching, and cross-workflow scenarios.

 - **What is the impact of these changes?**
   - A `runId` belonging to a different workflow now returns 404 instead of leaking state or accepting events.
   - No impact on legitimate usage — a valid `runId` for the correct workflow continues to work as before.

 - **What do you want reviewers to focus on?**
   - The ownership validation logic and whether the 404 response is appropriate for the mismatch case.

 ### Related Issue

 Fixes #

 ### Contribution Checklist

 - [x] The code builds clean without any errors or warnings
 - [x] All unit tests pass, and I have added new tests where possible
 - [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
 - [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
 - [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title  prefix in sync automatically