### PR TITLE
Python: support knowledge_source_params in AzureAISearchContextProvider

### DIFF
--- a/python/packages/azure-ai-search/README.md
+++ b/python/packages/azure-ai-search/README.md
@@ -19,5 +19,6 @@ See the [Azure AI Search context provider examples](../../samples/02-agents/cont
 
 - Semantic search with hybrid (vector + keyword) queries
 - Agentic mode with Knowledge Bases for complex multi-hop reasoning
+- Per-source retrieval parameters (e.g. OData filters) in agentic mode
 - Environment variable configuration with Settings class
 - API key and managed identity authentication

--- a/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
+++ b/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
         KnowledgeBaseRetrievalResponse,
         KnowledgeRetrievalIntent,
         KnowledgeRetrievalSemanticIntent,
+        KnowledgeSourceParams,
     )
     from azure.search.documents.knowledgebases.models import (
         KnowledgeRetrievalLowReasoningEffort as KBRetrievalLowReasoningEffort,
@@ -239,6 +240,7 @@ class AzureAISearchContextProvider(ContextProvider):
         azure_openai_api_key: str | None = None,
         knowledge_base_output_mode: KnowledgeBaseOutputModeLiteral = "extractive_data",
         retrieval_reasoning_effort: RetrievalReasoningEffortLiteral = "minimal",
+        knowledge_source_params: list[KnowledgeSourceParams] | None = None,
         agentic_message_history_count: int = _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
@@ -264,6 +266,8 @@ class AzureAISearchContextProvider(ContextProvider):
             azure_openai_api_key: Optional Azure OpenAI API key for Knowledge Base creation.
             knowledge_base_output_mode: Output mode for Knowledge Base retrieval.
             retrieval_reasoning_effort: Reasoning effort for query planning.
+            knowledge_source_params: Optional per-source retrieval parameters (for example an
+                OData ``filter_add_on``) forwarded to the agentic retrieval request.
             agentic_message_history_count: Number of recent messages included in retrieval.
             env_file_path: Optional ``.env`` file checked before process environment variables.
             env_file_encoding: Encoding for the ``.env`` file.
@@ -292,6 +296,7 @@ class AzureAISearchContextProvider(ContextProvider):
         azure_openai_api_key: str | None = None,
         knowledge_base_output_mode: KnowledgeBaseOutputModeLiteral = "extractive_data",
         retrieval_reasoning_effort: RetrievalReasoningEffortLiteral = "minimal",
+        knowledge_source_params: list[KnowledgeSourceParams] | None = None,
         agentic_message_history_count: int = _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
@@ -317,6 +322,8 @@ class AzureAISearchContextProvider(ContextProvider):
             azure_openai_api_key: Unused when connecting to an existing Knowledge Base.
             knowledge_base_output_mode: Output mode for Knowledge Base retrieval.
             retrieval_reasoning_effort: Reasoning effort for query planning.
+            knowledge_source_params: Optional per-source retrieval parameters (for example an
+                OData ``filter_add_on``) forwarded to the agentic retrieval request.
             agentic_message_history_count: Number of recent messages included in retrieval.
             env_file_path: Optional ``.env`` file checked before process environment variables.
             env_file_encoding: Encoding for the ``.env`` file.
@@ -345,6 +352,7 @@ class AzureAISearchContextProvider(ContextProvider):
         azure_openai_api_key: str | None = None,
         knowledge_base_output_mode: KnowledgeBaseOutputModeLiteral = "extractive_data",
         retrieval_reasoning_effort: RetrievalReasoningEffortLiteral = "minimal",
+        knowledge_source_params: list[KnowledgeSourceParams] | None = None,
         agentic_message_history_count: int = _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
@@ -374,6 +382,8 @@ class AzureAISearchContextProvider(ContextProvider):
             azure_openai_api_key: Optional Azure OpenAI API key for Knowledge Base creation.
             knowledge_base_output_mode: Output mode for Knowledge Base retrieval.
             retrieval_reasoning_effort: Reasoning effort for query planning.
+            knowledge_source_params: Optional per-source retrieval parameters (for example an
+                OData ``filter_add_on``) forwarded to the agentic retrieval request.
             agentic_message_history_count: Number of recent messages included in retrieval.
             env_file_path: Optional ``.env`` file checked before process environment variables.
             env_file_encoding: Encoding for the ``.env`` file.
@@ -401,6 +411,7 @@ class AzureAISearchContextProvider(ContextProvider):
         azure_openai_api_key: str | None = None,
         knowledge_base_output_mode: KnowledgeBaseOutputModeLiteral = "extractive_data",
         retrieval_reasoning_effort: RetrievalReasoningEffortLiteral = "minimal",
+        knowledge_source_params: list[KnowledgeSourceParams] | None = None,
         agentic_message_history_count: int = _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
@@ -429,6 +440,8 @@ class AzureAISearchContextProvider(ContextProvider):
             azure_openai_api_key: Azure OpenAI API key.
             knowledge_base_output_mode: Output mode for Knowledge Base retrieval.
             retrieval_reasoning_effort: Reasoning effort for Knowledge Base query planning.
+            knowledge_source_params: Optional per-source retrieval parameters (for example an
+                OData ``filter_add_on``) forwarded to the agentic retrieval request.
             agentic_message_history_count: Number of recent messages for agentic mode.
             env_file_path: Path to environment file for loading settings.
             env_file_encoding: Encoding of the environment file.
@@ -474,6 +487,9 @@ class AzureAISearchContextProvider(ContextProvider):
         if mode == "agentic" and settings.get("index_name") and not model:
             raise ValueError("model is required for agentic mode when creating Knowledge Base from index.")
 
+        if knowledge_source_params is not None and mode != "agentic":
+            raise ValueError("knowledge_source_params is only supported in agentic mode.")
+
         resolved_credential: AzureKeyCredential | AsyncTokenCredential
         if credential:
             resolved_credential = credential  # type: ignore[assignment]
@@ -505,6 +521,7 @@ class AzureAISearchContextProvider(ContextProvider):
         self.knowledge_base_output_mode = knowledge_base_output_mode
         self.retrieval_reasoning_effort = retrieval_reasoning_effort
         self.agentic_message_history_count = agentic_message_history_count
+        self._knowledge_source_params = knowledge_source_params
 
         self._use_existing_knowledge_base = False
         if mode == "agentic":
@@ -830,6 +847,7 @@ class AzureAISearchContextProvider(ContextProvider):
                 retrieval_reasoning_effort=reasoning_effort,
                 output_mode=output_mode,
                 include_activity=True,
+                knowledge_source_params=self._knowledge_source_params,
             )
         else:
             kb_messages = self._prepare_messages_for_kb_search(messages)
@@ -838,6 +856,7 @@ class AzureAISearchContextProvider(ContextProvider):
                 retrieval_reasoning_effort=reasoning_effort,
                 output_mode=output_mode,
                 include_activity=True,
+                knowledge_source_params=self._knowledge_source_params,
             )
 
         if not self._retrieval_client:

--- a/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
+++ b/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
@@ -11,6 +11,7 @@ from agent_framework import Content, Message
 from agent_framework._sessions import AgentSession, SessionContext
 from agent_framework.exceptions import SettingNotFoundError
 from azure.core.credentials import AzureKeyCredential
+from azure.search.documents.knowledgebases.models import SearchIndexKnowledgeSourceParams
 
 from agent_framework_azure_ai_search._context_provider import AzureAISearchContextProvider
 
@@ -314,6 +315,17 @@ class TestInitAgenticValidation:
         assert provider.index_name == "idx"
         assert provider.knowledge_base_name == "idx-kb"
         assert provider._use_existing_knowledge_base is False
+
+    def test_knowledge_source_params_in_semantic_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="agentic mode"):
+            cast(Any, AzureAISearchContextProvider)(
+                source_id="s",
+                endpoint="https://test.search.windows.net",
+                index_name="idx",
+                api_key="key",
+                mode="semantic",
+                knowledge_source_params=[SearchIndexKnowledgeSourceParams(knowledge_source_name="src")],
+            )
 
 
 # -- __aenter__ / __aexit__ ---------------------------------------------------
@@ -1334,6 +1346,45 @@ class TestAgenticSearch:
         results = await provider._agentic_search([Message(role="user", contents=["query"])])
         assert len(results) == 1
         assert results[0].text == "No results found from Knowledge Base."
+
+    @pytest.mark.parametrize("effort", ["minimal", "medium"])
+    async def test_knowledge_source_params_reach_request(self, effort: str) -> None:
+        provider = _make_provider()
+        provider._knowledge_base_initialized = True
+        provider.knowledge_base_name = "kb"
+        provider.retrieval_reasoning_effort = effort
+        params = [SearchIndexKnowledgeSourceParams(knowledge_source_name="src", filter_add_on="category eq 'public'")]
+        provider._knowledge_source_params = params
+
+        mock_result = Mock()
+        mock_result.response = []
+        mock_result.references = None
+        mock_retrieval = AsyncMock()
+        mock_retrieval.retrieve = AsyncMock(return_value=mock_result)
+        provider._retrieval_client = mock_retrieval
+
+        await provider._agentic_search([Message(role="user", contents=["q"])])
+
+        request = mock_retrieval.retrieve.call_args.kwargs["retrieval_request"]
+        assert request.knowledge_source_params is params
+
+    async def test_default_sends_no_knowledge_source_params(self) -> None:
+        provider = _make_provider()
+        provider._knowledge_base_initialized = True
+        provider.knowledge_base_name = "kb"
+        provider.retrieval_reasoning_effort = "minimal"
+
+        mock_result = Mock()
+        mock_result.response = []
+        mock_result.references = None
+        mock_retrieval = AsyncMock()
+        mock_retrieval.retrieve = AsyncMock(return_value=mock_result)
+        provider._retrieval_client = mock_retrieval
+
+        await provider._agentic_search([Message(role="user", contents=["q"])])
+
+        request = mock_retrieval.retrieve.call_args.kwargs["retrieval_request"]
+        assert request.knowledge_source_params is None
 
 
 # -- before_run: agentic mode --------------------------------------------------

--- a/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
+++ b/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
@@ -3,7 +3,7 @@
 
 import os
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -11,7 +11,7 @@ from agent_framework import Content, Message
 from agent_framework._sessions import AgentSession, SessionContext
 from agent_framework.exceptions import SettingNotFoundError
 from azure.core.credentials import AzureKeyCredential
-from azure.search.documents.knowledgebases.models import SearchIndexKnowledgeSourceParams
+from azure.search.documents.knowledgebases.models import KnowledgeSourceParams, SearchIndexKnowledgeSourceParams
 
 from agent_framework_azure_ai_search._context_provider import AzureAISearchContextProvider
 
@@ -1348,12 +1348,14 @@ class TestAgenticSearch:
         assert results[0].text == "No results found from Knowledge Base."
 
     @pytest.mark.parametrize("effort", ["minimal", "medium"])
-    async def test_knowledge_source_params_reach_request(self, effort: str) -> None:
+    async def test_knowledge_source_params_reach_request(self, effort: Literal["minimal", "medium"]) -> None:
         provider = _make_provider()
         provider._knowledge_base_initialized = True
         provider.knowledge_base_name = "kb"
         provider.retrieval_reasoning_effort = effort
-        params = [SearchIndexKnowledgeSourceParams(knowledge_source_name="src", filter_add_on="category eq 'public'")]
+        params: list[KnowledgeSourceParams] = [
+            SearchIndexKnowledgeSourceParams(knowledge_source_name="src", filter_add_on="category eq 'public'")
+        ]
         provider._knowledge_source_params = params
 
         mock_result = Mock()

--- a/python/samples/02-agents/context_providers/azure_ai_search/search_context_agentic.py
+++ b/python/samples/02-agents/context_providers/azure_ai_search/search_context_agentic.py
@@ -85,6 +85,13 @@ async def main() -> None:
             # Optional: Configure retrieval behavior
             knowledge_base_output_mode="extractive_data",  # or "answer_synthesis"
             retrieval_reasoning_effort="minimal",  # or "medium", "low"
+            # Optional: per-source params, e.g. an OData filter for multi-tenant isolation
+            # (import SearchIndexKnowledgeSourceParams from azure.search.documents.knowledgebases.models):
+            # knowledge_source_params=[
+            #     SearchIndexKnowledgeSourceParams(
+            #         knowledge_source_name="my-source", filter_add_on="category eq 'public'"
+            #     )
+            # ],
         )
     else:
         # Auto-create Knowledge Base from index


### PR DESCRIPTION
## Summary

Adds an optional keyword-only `knowledge_source_params: list[KnowledgeSourceParams] | None = None`
to `AzureAISearchContextProvider`, forwarded verbatim into both
`KnowledgeBaseRetrievalRequest` constructions in `_agentic_search`.

This lets callers set per-source agentic retrieval options — most importantly
`filter_add_on` (server-side OData filtering), and also
`include_reference_source_data` and the other `KnowledgeSourceParams` fields —
without subclassing the provider or reaching into private methods.

## Behavior

- **Back-compatible:** default `None` means retrieval requests are built exactly as before.
- **Agentic-only:** the parameter is omitted from the semantic overload, so passing it
  in semantic mode is a type error; a runtime `ValueError` also guards untyped callers.

## Relationship to existing work

Superset of #5095 / #5100 (which hardcodes `include_reference_source_data`): this exposes
the full `KnowledgeSourceParams` surface generically.

## Tests

- `knowledge_source_params` reaches the request in both the minimal (intents) and
  non-minimal (messages) agentic branches.
- Default path sends `None` (back-compat).
- Passing the parameter in semantic mode raises.

`uv run poe test -P azure-ai-search` (121 passed, 97% coverage), `uv run poe syntax -P azure-ai-search`,
and `uv run poe pyright -P azure-ai-search` all pass.

Closes #5560
