### PR TITLE
Python: reject non-base64 data URIs in detect_media_type_from_base64

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -121,7 +121,12 @@ def detect_media_type_from_base64(
     if data_uri is not None:
         if data is not None:
             raise ValueError("Provide exactly one of data_bytes, data_str, or data_uri.")
-        # Remove data URI prefix if present
+        # Strip the data URI prefix. Only base64-encoded payloads are
+        # supported here, so a URI without ";base64," (e.g. a URL-encoded
+        # "data:image/svg+xml,<svg/>") gets the documented ValueError rather
+        # than an opaque IndexError from the split below.
+        if ";base64," not in data_uri:
+            raise ValueError("data_uri must be a base64-encoded data URI (e.g. 'data:image/png;base64,<data>').")
         data_str = data_uri.split(";base64,", 1)[1]
     if data_str is not None:
         if data is not None:

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -208,6 +208,19 @@ def test_data_content_detect_image_format_from_base64():
         detect_media_type_from_base64(data_str="data", data_uri="data:application/octet-stream;base64,AAA")
 
 
+def test_detect_media_type_rejects_non_base64_data_uri():
+    """A data URI without a ';base64,' segment must raise a clear ValueError.
+
+    Data URIs may carry URL-encoded (non-base64) payloads, e.g.
+    "data:image/svg+xml,<svg/>". detect_media_type_from_base64 only understands
+    base64 payloads, so such a URI should hit the documented ValueError instead
+    of leaking an IndexError out of the internal split.
+    """
+    for uri in ("data:image/svg+xml,<svg/>", "data:text/plain,Hello", "data:image/png,rawbytes"):
+        with pytest.raises(ValueError, match="base64"):
+            detect_media_type_from_base64(data_uri=uri)
+
+
 def test_data_content_create_data_uri_from_base64():
     """Test the create_data_uri_from_base64 class method."""
     # Test with PNG data


### PR DESCRIPTION
### Problem

`detect_media_type_from_base64` is part of the public API and its docstring documents that it raises `ValueError` on bad input. When given a data URI that has no `;base64,` segment, though, it raises a bare `IndexError` instead:

```python
from agent_framework import detect_media_type_from_base64

detect_media_type_from_base64(data_uri="data:image/svg+xml,<svg/>")
# IndexError: list index out of range
```

Per RFC 2397 a data URI can carry a URL-encoded (non-base64) payload, so `data:image/svg+xml,<svg/>`, `data:text/plain,Hello`, etc. are all valid URIs a caller can reasonably pass in. The function only understands base64 payloads, so the right outcome is the documented `ValueError`, not an opaque `IndexError` leaking from the internal `split(";base64,", 1)[1]`.

### Fix

Guard the split with the same check the rest of this module already uses. `_get_data_bytes_as_str` does `if ";base64," not in uri: raise ContentError(...)` before splitting, and `_validate_uri` checks for the comma before its split — this was the one spot that skipped the check. Now a URI without `;base64,` raises a clear `ValueError`.

### Test

Added `test_detect_media_type_rejects_non_base64_data_uri`, which asserts the three URIs above raise `ValueError`. It fails on `main` (the call raises `IndexError`, which the `pytest.raises(ValueError)` does not catch) and passes with this change. The existing `detect_media_type_from_base64` test still passes.
