### PR TITLE
.NET: Change A2A default session store to NoopAgentSessionStore

### DIFF
--- a/dotnet/samples/05-end-to-end/A2AClientServer/A2AServer/Program.cs
+++ b/dotnet/samples/05-end-to-end/A2AClientServer/A2AServer/Program.cs
@@ -101,9 +101,14 @@ else
     throw new ArgumentException("Either A2AServer:ApiKey or A2AServer:ConnectionString & agentName must be provided");
 }
 
-// When running in production, make sure to use an SessionIsolationKeyProvider, e.g. ClaimsIdentity-based
-// if using Claims-based Identity for Authentication/Authorization
+// IMPORTANT: In production, register a SessionIsolationKeyProvider to isolate sessions by authenticated caller.
+// Without this, contextId alone is the session key — any caller who knows a contextId can access that session.
+// Example using claims-based identity:
 // builder.Services.UseClaimsBasedSessionIsolation(new() { ClaimType = ClaimTypes.NameIdentifier });
+
+// By default, NoopAgentSessionStore is used — sessions are not persisted across requests.
+// To enable multi-turn conversations, register a session store explicitly, e.g.:
+// builder.Services.AddKeyedSingleton<AgentSessionStore>(hostA2AAgent.Name, new InMemoryAgentSessionStore());
 
 builder.AddA2AServer(hostA2AAgent);
 

--- a/dotnet/samples/05-end-to-end/AgentWebChat/AgentWebChat.AgentHost/Program.cs
+++ b/dotnet/samples/05-end-to-end/AgentWebChat/AgentWebChat.AgentHost/Program.cs
@@ -28,9 +28,14 @@ builder.AddDevUI();
 builder.AddOpenAIChatCompletions();
 builder.AddOpenAIResponses();
 
-// When running in production, make sure to use an SessionIsolationKeyProvider, e.g. ClaimsIdentity-based
-// if using Claims-based Identity for Authentication/Authorization
+// IMPORTANT: In production, register a SessionIsolationKeyProvider to isolate sessions by authenticated caller.
+// Without this, contextId alone is the session key — any caller who knows a contextId can access that session.
+// Example using claims-based identity:
 // builder.Services.UseClaimsBasedSessionIsolation(new() { ClaimType = ClaimTypes.NameIdentifier });
+
+// By default, NoopAgentSessionStore is used — sessions are not persisted across requests.
+// To enable multi-turn conversations, register a session store explicitly, e.g.:
+// agentBuilder.WithInMemorySessionStore();
 
 var pirateAgentBuilder = builder.AddAIAgent(
     "pirate",
@@ -152,8 +157,9 @@ builder.Services.AddKeyedSingleton<AIAgent>("my-di-matchingname-agent", (sp, nam
 pirateAgentBuilder.AddA2AServer();
 knightsKnavesAgentBuilder.AddA2AServer();
 
-// When running in production, make sure to use an SessionIsolationKeyProvider, e.g. ClaimsIdentity-based
-// if using Claims-based Identity for Authentication/Authorization
+// IMPORTANT: In production, register a SessionIsolationKeyProvider to isolate sessions by authenticated caller.
+// Without this, contextId alone is the session key — any caller who knows a contextId can access that session.
+// Example using claims-based identity:
 // builder.Services.UseClaimsBasedSessionIsolation(new() { ClaimType = ClaimTypes.NameIdentifier });
 
 var app = builder.Build();

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerServiceCollectionExtensions.cs
@@ -189,7 +189,7 @@ public static class A2AServerServiceCollectionExtensions
             var isolationKeyProvider = serviceProvider.GetService<SessionIsolationKeyProvider>();
             if (agentSessionStore?.GetService<IsolationKeyScopedAgentSessionStore>() is null)
             {
-                agentSessionStore ??= new InMemoryAgentSessionStore();
+                agentSessionStore ??= new NoopAgentSessionStore();
                 agentSessionStore = new IsolationKeyScopedAgentSessionStore(agentSessionStore, isolationKeyProvider, new() { Strict = isolationKeyProvider != null });
             }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
@@ -62,10 +62,10 @@ public sealed class A2AServerServiceCollectionExtensionsTests
 
     /// <summary>
     /// Verifies that when no ITaskStore or AgentSessionStore are registered,
-    /// AddA2AServer falls back to in-memory defaults and resolves successfully.
+    /// AddA2AServer falls back to noop defaults and resolves successfully.
     /// </summary>
     [Fact]
-    public async Task AddA2AServer_WithNoCustomStores_FallsBackToInMemoryDefaultsAsync()
+    public async Task AddA2AServer_WithNoCustomStores_FallsBackToNoopDefaultsAsync()
     {
         // Arrange
         const string AgentName = "default-stores-agent";
@@ -382,7 +382,7 @@ public sealed class A2AServerServiceCollectionExtensionsTests
 
     /// <summary>
     /// Verifies that when no custom stores or handlers are registered, the server uses
-    /// the default in-memory stores and processes requests successfully end-to-end.
+    /// the default noop session store and processes requests successfully end-to-end.
     /// </summary>
     [Fact]
     public async Task AddA2AServer_WithNoCustomStores_DefaultStoresProcessRequestSuccessfullyAsync()
@@ -400,7 +400,7 @@ public sealed class A2AServerServiceCollectionExtensionsTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var response = await server.SendMessageAsync(CreateTestSendMessageRequest(), cts.Token);
 
-        // Assert - request was processed successfully with default in-memory stores
+        // Assert - request was processed successfully with default noop session store
         Assert.NotNull(response);
         Assert.Equal(SendMessageResponseCase.Message, response.PayloadCase);
         Assert.NotNull(response.Message);

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
@@ -62,10 +62,10 @@ public sealed class A2AServerServiceCollectionExtensionsTests
 
     /// <summary>
     /// Verifies that when no ITaskStore or AgentSessionStore are registered,
-    /// AddA2AServer falls back to noop defaults and resolves successfully.
+    /// AddA2AServer falls back to noop session store default and resolves successfully.
     /// </summary>
     [Fact]
-    public async Task AddA2AServer_WithNoCustomStores_FallsBackToNoopDefaultsAsync()
+    public async Task AddA2AServer_WithNoCustomStores_FallsBackToNoopSessionStoreDefaultAsync()
     {
         // Arrange
         const string AgentName = "default-stores-agent";


### PR DESCRIPTION
Align the A2A hosting layer default session store with the AG-UI sibling by using \NoopAgentSessionStore\, making persistence an explicit opt-in choice.

Update samples to document how to register a persistent session store for multi-turn conversations.