### PR TITLE
Python: surface Gemini cached and thinking token counts in usage details

### DIFF
--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -1051,6 +1051,10 @@ class RawGeminiChatClient(
             details["output_token_count"] = v
         if (v := usage.total_token_count) is not None:
             details["total_token_count"] = v
+        if (v := usage.cached_content_token_count) is not None:
+            details["cache_read_input_token_count"] = v
+        if (v := usage.thoughts_token_count) is not None:
+            details["reasoning_output_token_count"] = v
         return details or None
 
     def _map_finish_reason(self, reason: str | None) -> FinishReasonLiteral | None:

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -93,6 +93,8 @@ def _make_response(
     prompt_tokens: int | None = 10,
     output_tokens: int | None = 5,
     total_tokens: int | None = 15,
+    cached_tokens: int | None = None,
+    thoughts_tokens: int | None = None,
 ) -> MagicMock:
     """Build a mock types.GenerateContentResponse."""
     response = MagicMock()
@@ -113,6 +115,8 @@ def _make_response(
         usage.prompt_token_count = prompt_tokens
         usage.candidates_token_count = output_tokens
         usage.total_token_count = total_tokens
+        usage.cached_content_token_count = cached_tokens
+        usage.thoughts_token_count = thoughts_tokens
         response.usage_metadata = usage
     else:
         response.usage_metadata = None
@@ -372,6 +376,27 @@ async def test_get_response_usage_details() -> None:
     assert response.usage_details["input_token_count"] == 20
     assert response.usage_details["output_token_count"] == 8
     assert response.usage_details["total_token_count"] == 28
+
+
+async def test_get_response_usage_details_includes_cached_and_reasoning_tokens() -> None:
+    """Surfaces Gemini cached-content and thinking token counts into the canonical usage fields."""
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(
+        return_value=_make_response(
+            [_make_part(text="Hi")],
+            prompt_tokens=20,
+            output_tokens=8,
+            total_tokens=28,
+            cached_tokens=12,
+            thoughts_tokens=6,
+        )
+    )
+
+    response = await client.get_response(messages=[Message(role="user", contents=[Content.from_text("Hi")])])
+
+    assert response.usage_details is not None
+    assert response.usage_details["cache_read_input_token_count"] == 12
+    assert response.usage_details["reasoning_output_token_count"] == 6
 
 
 async def test_get_response_no_usage_when_metadata_absent() -> None:


### PR DESCRIPTION
### Motivation & Context

The Gemini chat client only surfaces input, output, and total token counts in `usage_details`. Gemini's `GenerateContentResponseUsageMetadata` also reports `cached_content_token_count` (tokens served from context cache) and `thoughts_token_count` (tokens spent thinking by reasoning models), and `_parse_usage` drops both. For cached prompts and thinking models, cache and reasoning usage silently read as zero, which throws off cost and token accounting.

`UsageDetails` already defines canonical fields for these (`cache_read_input_token_count`, `reasoning_output_token_count`), and the OpenAI and Anthropic connectors already populate them, so Gemini was the odd one out.

### Description & Review Guide

- **What are the major changes?** `RawGeminiChatClient._parse_usage` now maps `cached_content_token_count` to `cache_read_input_token_count` and `thoughts_token_count` to `reasoning_output_token_count`, following the same `is not None` guard pattern as the existing three fields.
- **What is the impact of these changes?** Cache-read and reasoning token counts are now reported for Gemini, consistent with the OpenAI and Anthropic connectors. Responses that omit these fields are unchanged (the values stay unset).
- **What do you want reviewers to focus on?** That the source field names match `google-genai`'s usage metadata and the target keys match the `UsageDetails` contract.

Added `test_get_response_usage_details_includes_cached_and_reasoning_tokens` and extended the `_make_response` test helper with the two fields. The full `test_gemini_client.py` suite passes locally (113 passed, 8 integration skipped).

### Related Issue

Fixes #6637

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] This PR is linked to an issue and there is no other open PR for this issue.
- [x] **This is not a breaking change.**
