### PR TITLE
Python: enforce dependency-bounds validator in CI

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -141,3 +141,44 @@ jobs:
           UV_CACHE_DIR: /tmp/.uv-cache
       - name: Run tests/samples type checkers (mypy, pyrefly, ty)
         run: uv run python scripts/workspace_poe_tasks.py ci-test-typing
+
+  dependency-bounds:
+    name: Dependency Bounds Validation
+    if: "!cancelled()"
+    runs-on: ubuntu-latest
+    # Match the Python dependency maintenance workflow so PR results line up with the
+    # nightly/dispatch sweep. Reevaluate if package installability starts differing
+    # across supported Python versions.
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: ./python
+    env:
+      UV_PYTHON: "3.13"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # The upper-bound resolver builds the internal workspace graph, so fetch full
+          # history to mirror the dependency maintenance workflow.
+          fetch-depth: 0
+      - name: Set up python and install the project
+        id: python-setup
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+        env:
+          UV_CACHE_DIR: /tmp/.uv-cache
+      # Smoke both ends of every package's allowed dependency range (lowest-direct and
+      # highest) and run each package's pyright pass in an isolated environment. This
+      # catches floor-too-low, missing-optional-dependency, and isolated-env typing
+      # regressions that the full-workspace test and typing jobs do not.
+      - name: Validate dependency bounds (lower + upper)
+        run: uv run poe validate-dependency-bounds-test --package "*"
+      - name: Upload dependency bounds report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dependency-bounds-test-results
+          path: python/scripts/dependencies/dependency-bounds-test-results.json
+          if-no-files-found: warn

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -169,6 +169,14 @@ jobs:
           os: ${{ runner.os }}
         env:
           UV_CACHE_DIR: /tmp/.uv-cache
+      # Pin the dependency release cutoff to the same 7-day window the dependency
+      # maintenance workflow uses, so this PR check resolves the same upstream
+      # releases as the weekly sweep instead of pulling in newer ones and diverging.
+      - name: Set dependency release cutoff
+        run: |
+          cutoff="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          echo "UV_EXCLUDE_NEWER=${cutoff}" >> "$GITHUB_ENV"
+          echo "Using dependency release cutoff: ${cutoff}"
       # Smoke both ends of every package's allowed dependency range (lowest-direct and
       # highest) and run each package's pyright pass in an isolated environment. This
       # catches floor-too-low, missing-optional-dependency, and isolated-env typing


### PR DESCRIPTION
Fixes #6582.

### Motivation & Context

The dependency-bounds validator (`uv run poe validate-dependency-bounds-test`) is
only run by the weekly `python-dependency-maintenance.yml` workflow, where it is
`continue-on-error: true` and merely opens an issue on failure. It is not a required
PR check, so dependency-floor, missing-optional-dependency, and isolated-env typing
regressions can land on `main` and ship in a release before anyone notices — as
happened at the `python-1.8.1` tag, which was released while the validator was red
for `packages/core` at `lowest-direct` resolution.

### Description & Review Guide

Adds a blocking **Dependency Bounds Validation** job to `python-code-quality.yml`,
which already runs on `pull_request` → `main`, `merge_group`, and `workflow_dispatch`.
The job runs `validate-dependency-bounds-test --package "*"`, which smoke-tests both
ends of every package's allowed dependency range (`lowest-direct` and `highest`) and
runs each package's pyright pass in an isolated environment.

- **No `continue-on-error`**, so it can gate PRs and the merge queue — the gap this
  issue is about.
- Mirrors the dependency maintenance workflow's environment (Python 3.13, full git
  history for the internal workspace graph) so PR results line up with the nightly sweep.
- Uploads the JSON report as an artifact for triage on failure.
- `timeout-minutes: 60` guards against a hung resolver.

The underlying floor/packaging issues this validator caught (the telemetry
`find_spec` `except` clause, the `agent-framework-tools` dev dependency on core, and
the shell-tool test `skipif` guards) were already fixed in the 1.9.0 version bump, so
the validator is green on `main` and this job can be required immediately.

### Cost / scoping note

A full lower+upper sweep across all packages is somewhat slow. If per-PR cost becomes
a concern, follow-up options are to scope the run to changed packages on standard PRs,
or to run the full sweep nightly plus required-on-merge-queue. This PR wires up the
full required check first as the minimal correct fix; scoping can be layered on later.
