### PR TITLE
.NET: fix(hosting): emit url_citation annotation events from streamed AI Search responses

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -394,8 +394,8 @@ internal static class OutputConverter
             {
                 yield return new UrlCitationBody(
                     citation.Url,
-                    (long)region.StartIndex!.Value,
-                    (long)region.EndIndex!.Value,
+                    region.StartIndex!.Value,
+                    region.EndIndex!.Value,
                     citation.Title ?? string.Empty);
             }
         }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
@@ -45,6 +46,7 @@ internal static class OutputConverter
         OutputItemMessageBuilder? currentMessageBuilder = null;
         TextContentBuilder? currentTextBuilder = null;
         StringBuilder? accumulatedText = null;
+        List<Annotation>? accumulatedAnnotations = null;
         string? previousMessageId = null;
         bool hasTerminalEvent = false;
         var executorItemIds = new Dictionary<string, string>();
@@ -60,7 +62,7 @@ internal static class OutputConverter
             if (update.RawRepresentation is WorkflowEvent workflowEvent && update.Contents.Count == 0)
             {
                 // Close any open message builder before emitting workflow items
-                foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                 {
                     yield return evt;
                 }
@@ -68,6 +70,7 @@ internal static class OutputConverter
                 currentTextBuilder = null;
                 currentMessageBuilder = null;
                 accumulatedText = null;
+                accumulatedAnnotations = null;
                 previousMessageId = null;
 
                 foreach (var evt in EmitWorkflowEvent(stream, workflowEvent, executorItemIds))
@@ -86,7 +89,7 @@ internal static class OutputConverter
                     {
                         if (!IsSameMessage(update.MessageId, previousMessageId) && currentMessageBuilder is not null)
                         {
-                            foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                            foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                             {
                                 yield return evt;
                             }
@@ -94,6 +97,7 @@ internal static class OutputConverter
                             currentTextBuilder = null;
                             currentMessageBuilder = null;
                             accumulatedText = null;
+                            accumulatedAnnotations = null;
                         }
 
                         previousMessageId = update.MessageId;
@@ -115,6 +119,14 @@ internal static class OutputConverter
                             yield return currentTextBuilder!.EmitDelta(textContent.Text);
                         }
 
+                        if (textContent.Annotations is { Count: > 0 })
+                        {
+                            foreach (var sdkAnnotation in ConvertToSdkAnnotations(textContent.Annotations))
+                            {
+                                (accumulatedAnnotations ??= []).Add(sdkAnnotation);
+                            }
+                        }
+
                         break;
                     }
 
@@ -125,7 +137,7 @@ internal static class OutputConverter
                             break;
                         }
 
-                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                         {
                             yield return evt;
                         }
@@ -133,6 +145,7 @@ internal static class OutputConverter
                         currentTextBuilder = null;
                         currentMessageBuilder = null;
                         accumulatedText = null;
+                        accumulatedAnnotations = null;
                         previousMessageId = null;
 
                         var arguments = functionCall.Arguments is not null
@@ -149,7 +162,7 @@ internal static class OutputConverter
 
                     case TextReasoningContent reasoningContent:
                     {
-                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                         {
                             yield return evt;
                         }
@@ -157,6 +170,7 @@ internal static class OutputConverter
                         currentTextBuilder = null;
                         currentMessageBuilder = null;
                         accumulatedText = null;
+                        accumulatedAnnotations = null;
                         previousMessageId = null;
 
                         var reasoningBuilder = stream.AddOutputItemReasoningItem();
@@ -176,7 +190,7 @@ internal static class OutputConverter
 
                     case ToolApprovalRequestContent approvalRequest when approvalRequest.ToolCall is FunctionCallContent approvalFunctionCall:
                     {
-                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                         {
                             yield return evt;
                         }
@@ -184,6 +198,7 @@ internal static class OutputConverter
                         currentTextBuilder = null;
                         currentMessageBuilder = null;
                         accumulatedText = null;
+                        accumulatedAnnotations = null;
                         previousMessageId = null;
 
                         // The Responses API only standardizes the MCP-flavored approval primitive.
@@ -237,7 +252,7 @@ internal static class OutputConverter
 
                     case ErrorContent errorContent:
                     {
-                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                         {
                             yield return evt;
                         }
@@ -245,6 +260,7 @@ internal static class OutputConverter
                         currentTextBuilder = null;
                         currentMessageBuilder = null;
                         accumulatedText = null;
+                        accumulatedAnnotations = null;
                         previousMessageId = null;
                         hasTerminalEvent = true;
 
@@ -269,7 +285,7 @@ internal static class OutputConverter
                             break;
                         }
 
-                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+                        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
                         {
                             yield return evt;
                         }
@@ -277,6 +293,7 @@ internal static class OutputConverter
                         currentTextBuilder = null;
                         currentMessageBuilder = null;
                         accumulatedText = null;
+                        accumulatedAnnotations = null;
                         previousMessageId = null;
 
                         var outputText = EncodeFunctionResultAsJsonStringPayload(functionResult.Result);
@@ -304,7 +321,7 @@ internal static class OutputConverter
         }
 
         // Close any remaining open message
-        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText))
+        foreach (var evt in CloseCurrentMessage(currentMessageBuilder, currentTextBuilder, accumulatedText, accumulatedAnnotations))
         {
             yield return evt;
         }
@@ -318,7 +335,8 @@ internal static class OutputConverter
     private static IEnumerable<ResponseStreamEvent> CloseCurrentMessage(
         OutputItemMessageBuilder? messageBuilder,
         TextContentBuilder? textBuilder,
-        StringBuilder? accumulatedText)
+        StringBuilder? accumulatedText,
+        List<Annotation>? annotations = null)
     {
         if (messageBuilder is null)
         {
@@ -329,6 +347,16 @@ internal static class OutputConverter
         {
             var finalText = accumulatedText?.ToString() ?? string.Empty;
             yield return textBuilder.EmitTextDone(finalText);
+
+            // Annotations must be emitted after EmitTextDone and before EmitDone.
+            if (annotations is not null)
+            {
+                foreach (var annotation in annotations)
+                {
+                    yield return textBuilder.EmitAnnotationAdded(annotation);
+                }
+            }
+
             yield return textBuilder.EmitDone();
         }
 
@@ -337,6 +365,41 @@ internal static class OutputConverter
 
     private static bool IsSameMessage(string? currentId, string? previousId) =>
         currentId is not { Length: > 0 } || previousId is not { Length: > 0 } || currentId == previousId;
+
+    /// <summary>
+    /// Converts MEAI <see cref="AIAnnotation"/> instances to Responses SDK <see cref="Annotation"/> objects.
+    /// Only <see cref="CitationAnnotation"/> with a URL and at least one <see cref="TextSpanAnnotatedRegion"/>
+    /// with explicit start/end indices is converted; all other shapes are skipped.
+    /// </summary>
+    private static IEnumerable<Annotation> ConvertToSdkAnnotations(IList<AIAnnotation> annotations)
+    {
+        foreach (var ann in annotations)
+        {
+            if (ann is not CitationAnnotation citation || citation.Url is null)
+            {
+                continue;
+            }
+
+            var regions = citation.AnnotatedRegions?
+                .OfType<TextSpanAnnotatedRegion>()
+                .Where(r => r.StartIndex is not null && r.EndIndex is not null)
+                .ToList();
+
+            if (regions is not { Count: > 0 })
+            {
+                continue;
+            }
+
+            foreach (var region in regions)
+            {
+                yield return new UrlCitationBody(
+                    citation.Url,
+                    (long)region.StartIndex!.Value,
+                    (long)region.EndIndex!.Value,
+                    citation.Title ?? string.Empty);
+            }
+        }
+    }
 
     private static ResponseUsage ConvertUsage(UsageDetails details, ResponseUsage? existing)
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -1373,6 +1373,218 @@ public class OutputConverterTests
         Assert.Contains(events, e => e is ResponseFailedEvent);
     }
 
+    // === url_citation annotation coverage (N series) ===
+
+    // N-01: A TextContent with a url_citation annotation emits ResponseOutputTextAnnotationAddedEvent.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_TextWithUrlCitationAnnotation_EmitsAnnotationEventAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var annotation = new CitationAnnotation
+        {
+            Url = new Uri("https://example.com/doc"),
+            Title = "Example Document",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 0, EndIndex = 5 }]
+        };
+        var textContent = new MeaiTextContent("Hello") { Annotations = [annotation] };
+        var update = new AgentResponseUpdate { MessageId = "msg_1", Contents = [textContent] };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var annotationEvent = Assert.Single(events.OfType<ResponseOutputTextAnnotationAddedEvent>());
+        var urlCitation = Assert.IsType<UrlCitationBody>(annotationEvent.Annotation);
+        Assert.Equal(new Uri("https://example.com/doc"), urlCitation.Url);
+        Assert.Equal("Example Document", urlCitation.Title);
+        Assert.Equal(0L, urlCitation.StartIndex);
+        Assert.Equal(5L, urlCitation.EndIndex);
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // N-02: Annotation event must appear after the last text delta and before output_item.done.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_TextWithAnnotation_AnnotationOrderedAfterDeltaBeforeMessageDoneAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var annotation = new CitationAnnotation
+        {
+            Url = new Uri("https://example.com/src"),
+            Title = "Source",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 10, EndIndex = 20 }]
+        };
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("text with citation") { Annotations = [annotation] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var lastDeltaIdx = events.FindLastIndex(e => e is ResponseTextDeltaEvent);
+        var annotationIdx = events.FindIndex(e => e is ResponseOutputTextAnnotationAddedEvent);
+        var messageDoneIdx = events.FindIndex(e => e is ResponseOutputItemDoneEvent);
+
+        Assert.True(annotationIdx >= 0, "Expected ResponseOutputTextAnnotationAddedEvent");
+        Assert.True(messageDoneIdx >= 0, "Expected ResponseOutputItemDoneEvent");
+        Assert.True(lastDeltaIdx < annotationIdx, "Annotation must come after last text delta");
+        Assert.True(annotationIdx < messageDoneIdx, "Annotation must come before output_item.done");
+    }
+
+    // N-03: Multiple annotations on one TextContent all emit events, in order.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_TextWithMultipleAnnotations_EmitsAllAnnotationsAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var ann1 = new CitationAnnotation
+        {
+            Url = new Uri("https://a.example.com"),
+            Title = "A",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 0, EndIndex = 10 }]
+        };
+        var ann2 = new CitationAnnotation
+        {
+            Url = new Uri("https://b.example.com"),
+            Title = "B",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 20, EndIndex = 30 }]
+        };
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("text") { Annotations = [ann1, ann2] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        var annotationEvents = events.OfType<ResponseOutputTextAnnotationAddedEvent>().ToList();
+        Assert.Equal(2, annotationEvents.Count);
+        var first = Assert.IsType<UrlCitationBody>(annotationEvents[0].Annotation);
+        Assert.Equal("A", first.Title);
+        var second = Assert.IsType<UrlCitationBody>(annotationEvents[1].Annotation);
+        Assert.Equal("B", second.Title);
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // N-04: Annotations on a TextContent across multiple streaming updates are all accumulated.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_AnnotationsAcrossMultipleUpdates_AccumulatesAllAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var ann1 = new CitationAnnotation
+        {
+            Url = new Uri("https://first.example.com"),
+            Title = "First",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 0, EndIndex = 5 }]
+        };
+        var ann2 = new CitationAnnotation
+        {
+            Url = new Uri("https://second.example.com"),
+            Title = "Second",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 6, EndIndex = 11 }]
+        };
+        var updates = new[]
+        {
+            new AgentResponseUpdate { MessageId = "msg_1", Contents = [new MeaiTextContent("Hello") { Annotations = [ann1] }] },
+            new AgentResponseUpdate { MessageId = "msg_1", Contents = [new MeaiTextContent(" world") { Annotations = [ann2] }] },
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(updates), stream))
+        {
+            events.Add(evt);
+        }
+
+        var annotationEvents = events.OfType<ResponseOutputTextAnnotationAddedEvent>().ToList();
+        Assert.Equal(2, annotationEvents.Count);
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // N-05: A CitationAnnotation without a URL is skipped (no annotation event emitted).
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_CitationAnnotationWithoutUrl_IsSkippedAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var annotation = new CitationAnnotation
+        {
+            Url = null,
+            Title = "No URL",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 0, EndIndex = 5 }]
+        };
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("text") { Annotations = [annotation] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Empty(events.OfType<ResponseOutputTextAnnotationAddedEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // N-06: A CitationAnnotation without TextSpanAnnotatedRegion is skipped.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_CitationAnnotationWithoutRegions_IsSkippedAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var annotation = new CitationAnnotation
+        {
+            Url = new Uri("https://example.com"),
+            Title = "No Regions",
+            AnnotatedRegions = null
+        };
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("text") { Annotations = [annotation] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Empty(events.OfType<ResponseOutputTextAnnotationAddedEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
+    // N-07: A non-CitationAnnotation in Annotations is silently skipped.
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_NonCitationAnnotation_IsSkippedAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var rawAnnotation = new AIAnnotation(); // base type, not a CitationAnnotation
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("text") { Annotations = [rawAnnotation] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Empty(events.OfType<ResponseOutputTextAnnotationAddedEvent>());
+        Assert.IsType<ResponseCompletedEvent>(events[^1]);
+    }
+
     private sealed class RawToolCallContent : ToolCallContent
     {
         public RawToolCallContent(string callId) : base(callId) { }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -1373,9 +1373,9 @@ public class OutputConverterTests
         Assert.Contains(events, e => e is ResponseFailedEvent);
     }
 
-    // === url_citation annotation coverage (N series) ===
+    #region url_citation annotation coverage
 
-    // N-01: A TextContent with a url_citation annotation emits ResponseOutputTextAnnotationAddedEvent.
+    /// <summary>A <see cref="MeaiTextContent"/> with a url_citation annotation emits a <see cref="ResponseOutputTextAnnotationAddedEvent"/>.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_TextWithUrlCitationAnnotation_EmitsAnnotationEventAsync()
     {
@@ -1404,7 +1404,7 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // N-02: Annotation event must appear after the last text delta and before output_item.done.
+    /// <summary>The annotation event must appear after the last text delta and before output_item.done.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_TextWithAnnotation_AnnotationOrderedAfterDeltaBeforeMessageDoneAsync()
     {
@@ -1437,7 +1437,7 @@ public class OutputConverterTests
         Assert.True(annotationIdx < messageDoneIdx, "Annotation must come before output_item.done");
     }
 
-    // N-03: Multiple annotations on one TextContent all emit events, in order.
+    /// <summary>Multiple annotations on one <see cref="MeaiTextContent"/> all emit events, in order.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_TextWithMultipleAnnotations_EmitsAllAnnotationsAsync()
     {
@@ -1475,7 +1475,7 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // N-04: Annotations on a TextContent across multiple streaming updates are all accumulated.
+    /// <summary>Annotations on a <see cref="MeaiTextContent"/> across multiple streaming updates are all accumulated.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_AnnotationsAcrossMultipleUpdates_AccumulatesAllAsync()
     {
@@ -1509,7 +1509,7 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // N-05: A CitationAnnotation without a URL is skipped (no annotation event emitted).
+    /// <summary>A <see cref="CitationAnnotation"/> without a URL is skipped (no annotation event emitted).</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_CitationAnnotationWithoutUrl_IsSkippedAsync()
     {
@@ -1536,7 +1536,7 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // N-06: A CitationAnnotation without TextSpanAnnotatedRegion is skipped.
+    /// <summary>A <see cref="CitationAnnotation"/> without a <see cref="TextSpanAnnotatedRegion"/> is skipped.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_CitationAnnotationWithoutRegions_IsSkippedAsync()
     {
@@ -1563,7 +1563,7 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
-    // N-07: A non-CitationAnnotation in Annotations is silently skipped.
+    /// <summary>A non-<see cref="CitationAnnotation"/> in Annotations is silently skipped.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_NonCitationAnnotation_IsSkippedAsync()
     {
@@ -1584,6 +1584,8 @@ public class OutputConverterTests
         Assert.Empty(events.OfType<ResponseOutputTextAnnotationAddedEvent>());
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
+
+    #endregion
 
     private sealed class RawToolCallContent : ToolCallContent
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -1404,6 +1404,45 @@ public class OutputConverterTests
         Assert.IsType<ResponseCompletedEvent>(events[^1]);
     }
 
+    /// <summary>The content_part.done and output_item.done payloads carry the url_citation metadata, guarding against the empty-annotations regression where only the annotation.added event fires.</summary>
+    [Fact]
+    public async Task ConvertUpdatesToEventsAsync_TextWithUrlCitationAnnotation_DoneEventsCarryAnnotationMetadataAsync()
+    {
+        var (stream, _) = CreateTestStream();
+        var annotation = new CitationAnnotation
+        {
+            Url = new Uri("https://example.com/doc"),
+            Title = "Example Document",
+            AnnotatedRegions = [new TextSpanAnnotatedRegion { StartIndex = 0, EndIndex = 5 }]
+        };
+        var update = new AgentResponseUpdate
+        {
+            MessageId = "msg_1",
+            Contents = [new MeaiTextContent("Hello") { Annotations = [annotation] }]
+        };
+
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(new[] { update }), stream))
+        {
+            events.Add(evt);
+        }
+
+        // content_part.done must serialize the annotation, not an empty array.
+        var contentPartDone = Assert.Single(events.OfType<ResponseContentPartDoneEvent>());
+        var donePart = Assert.IsType<OutputContentOutputTextContent>(contentPartDone.Part);
+        var donePartCitation = Assert.IsType<UrlCitationBody>(Assert.Single(donePart.Annotations));
+        Assert.Equal(new Uri("https://example.com/doc"), donePartCitation.Url);
+        Assert.Equal("Example Document", donePartCitation.Title);
+
+        // output_item.done message content must also carry the annotation.
+        var outputItemDone = Assert.Single(events.OfType<ResponseOutputItemDoneEvent>());
+        var doneMessage = Assert.IsType<OutputItemMessage>(outputItemDone.Item);
+        var doneText = Assert.IsType<MessageContentOutputTextContent>(Assert.Single(doneMessage.Content));
+        var doneTextCitation = Assert.IsType<UrlCitationBody>(Assert.Single(doneText.Annotations));
+        Assert.Equal(new Uri("https://example.com/doc"), doneTextCitation.Url);
+        Assert.Equal("Example Document", doneTextCitation.Title);
+    }
+
     /// <summary>The annotation event must appear after the last text delta and before output_item.done.</summary>
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_TextWithAnnotation_AnnotationOrderedAfterDeltaBeforeMessageDoneAsync()


### PR DESCRIPTION
## Problem

When using `FoundryAITool.CreateAzureAISearchTool()` with a hosted agent via `MapFoundryResponses`, the SSE stream produced citation markers in text (e.g. `【5:0†source】`) but:

- `response.output_text.annotation.added` events were never emitted
- `annotations` arrays in `response.content_part.done` and `response.output_item.done` were always empty

## Root Cause

`OutputConverter.ConvertUpdatesToEventsAsync` processes `TextContent` from `AgentResponseUpdate.Contents` but only extracts `.Text` — it ignores `TextContent.Annotations`, which is where the agent framework surfaces `CitationAnnotation` (url_citation) metadata from Azure AI Search grounding.

## Fix

- Accumulate `CitationAnnotation` instances from each `TextContent` update across the full message (parallel to how text is accumulated in `StringBuilder`)
- Convert them to `UrlCitationBody` SDK objects via a new `ConvertToSdkAnnotations` helper, matching the approach already used by the OpenAI ChatCompletions path in `AgentResponseExtensions.ToChoiceMessageAnnotations`
- Emit them via `TextContentBuilder.EmitAnnotationAdded` in `CloseCurrentMessage`, after `EmitTextDone` and before `EmitDone` (required by the SDK builder lifecycle)
- Non-`CitationAnnotation` types and citations without explicit `TextSpanAnnotatedRegion` start/end indices are silently skipped

## Tests

7 new unit tests (N-01–N-07) in `OutputConverterTests`:

| Test | Covers |
|---|---|
| N-01 | Basic url_citation emission: URL, title, start/end indices |
| N-02 | Ordering: annotation after last text delta, before output_item.done |
| N-03 | Multiple annotations on one TextContent all emitted in order |
| N-04 | Annotations accumulated across multiple streaming updates for the same message |
| N-05 | `CitationAnnotation` with null URL is skipped |
| N-06 | `CitationAnnotation` with no `TextSpanAnnotatedRegion` is skipped |
| N-07 | Non-`CitationAnnotation` `AIAnnotation` is skipped |

- Fixes #6641

<!-- oss-radar:idempotency=auto-20260620-201514.w3.microsoft_agent-framework.6641 -->