### PR TITLE
.NET: Forward AG-UI forwarded properties from chat options

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.AGUI/AGUIChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI.AGUI/AGUIChatClient.cs
@@ -214,6 +214,7 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 RunId = runId,
                 Messages = messagesList.AsAGUIMessages(this._jsonSerializerOptions),
                 State = state,
+                ForwardedProperties = ExtractForwardedPropertiesFromOptions(options),
             };
 
             // Add tools if provided
@@ -286,6 +287,18 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 return null;
             }
             return threadId;
+        }
+
+        private static JsonElement ExtractForwardedPropertiesFromOptions(ChatOptions? options)
+        {
+            if (options?.AdditionalProperties is null ||
+              !options.AdditionalProperties.TryGetValue("ag_ui_forwarded_properties", out object? forwardedProperties) ||
+              forwardedProperties is not JsonElement jsonElement)
+            {
+                return default;
+            }
+
+            return jsonElement;
         }
 
         // Extract the session id from the second last message's function call content additional properties

--- a/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/AGUIChatClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/AGUIChatClientTests.cs
@@ -1396,6 +1396,44 @@ public sealed class AGUIAgentTests
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_ForwardsAdditionalPropertiesInRunInputAsync()
+    {
+        // Arrange
+        var forwardedProperties = new { tenant = "contoso", conversation = "abc123" };
+
+        var captureHandler = new StateCapturingTestDelegatingHandler();
+        captureHandler.AddResponse(
+        [
+            new RunStartedEvent { ThreadId = "thread1", RunId = "run1" },
+            new RunFinishedEvent { ThreadId = "thread1", RunId = "run1" }
+        ]);
+        using HttpClient httpClient = new(captureHandler);
+
+        var chatClient = new AGUIChatClient(httpClient, "http://localhost/agent", null, AGUIJsonSerializerContext.Default.Options);
+        var options = new ChatOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["ag_ui_forwarded_properties"] = JsonSerializer.SerializeToElement(forwardedProperties)
+            }
+        };
+        List<ChatMessage> messages = [new ChatMessage(ChatRole.User, "Hello")];
+
+        // Act
+        await foreach (var _ in chatClient.GetStreamingResponseAsync(messages, options))
+        {
+            // Just consume the stream
+        }
+
+        // Assert
+        Assert.True(captureHandler.RequestWasMade);
+        Assert.NotNull(captureHandler.CapturedForwardedProperties);
+        Assert.Equal(JsonValueKind.Object, captureHandler.CapturedForwardedProperties.Value.ValueKind);
+        Assert.Equal("contoso", captureHandler.CapturedForwardedProperties.Value.GetProperty("tenant").GetString());
+        Assert.Equal("abc123", captureHandler.CapturedForwardedProperties.Value.GetProperty("conversation").GetString());
+    }
+
+    [Fact]
     public async Task GetStreamingResponseAsync_WithMalformedStateJson_ThrowsInvalidOperationExceptionAsync()
     {
         // Arrange
@@ -1730,6 +1768,7 @@ internal sealed class StateCapturingTestDelegatingHandler : DelegatingHandler
 
     public bool RequestWasMade { get; private set; }
     public JsonElement? CapturedState { get; private set; }
+    public JsonElement? CapturedForwardedProperties { get; private set; }
     public int CapturedMessageCount { get; private set; }
     public IReadOnlyList<int> CapturedMessageCounts => this._capturedMessageCounts;
 
@@ -1754,6 +1793,10 @@ internal sealed class StateCapturingTestDelegatingHandler : DelegatingHandler
             if (input.State.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null)
             {
                 this.CapturedState = input.State;
+            }
+            if (input.ForwardedProperties.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null)
+            {
+                this.CapturedForwardedProperties = input.ForwardedProperties;
             }
             this.CapturedMessageCount = input.Messages.Count();
             this._capturedMessageCounts.Add(this.CapturedMessageCount);


### PR DESCRIPTION
### Motivation & Context

`AGUIChatClient` currently builds `RunAgentInput` without copying AG-UI forwarded properties from `ChatOptions.AdditionalProperties["ag_ui_forwarded_properties"]`, so client callers cannot populate the `forwardedProps` field in the request body.

This fixes #6600.

### Description & Review Guide

- **What are the major changes?**
  - Populate `RunAgentInput.ForwardedProperties` from `ChatOptions.AdditionalProperties["ag_ui_forwarded_properties"]` when the value is a `JsonElement`.
  - Add a regression test that verifies the serialized AG-UI run input includes the forwarded properties.

- **What is the impact of these changes?**
  - AG-UI client requests now preserve the forwarded properties already supported by the server-side hosting path.
  - The change is limited to request construction and does not change public API shape.

- **What do you want reviewers to focus on?**
  - Whether the client should only forward `JsonElement` values here, matching the existing `RunAgentInput.ForwardedProperties` shape.

Verification:

```text
dotnet run --project dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/Microsoft.Agents.AI.AGUI.UnitTests.csproj -f net10.0 -- --filter-method Microsoft.Agents.AI.AGUI.UnitTests.AGUIAgentTests.GetStreamingResponseAsync_ForwardsAdditionalPropertiesInRunInputAsync --output Normal --no-progress
dotnet run --project dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/Microsoft.Agents.AI.AGUI.UnitTests.csproj -f net10.0 -- --output Normal --no-progress
dotnet build dotnet/src/Microsoft.Agents.AI.AGUI/Microsoft.Agents.AI.AGUI.csproj -f net10.0 -v minimal
dotnet build dotnet/tests/Microsoft.Agents.AI.AGUI.UnitTests/Microsoft.Agents.AI.AGUI.UnitTests.csproj -f net10.0 -v minimal
git diff --check
```

### Related Issue

Fixes #6600

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.
