### PR TITLE
Python: fix dependency maintenance cutoff

### DIFF
--- a/.github/workflows/python-dependency-maintenance.yml
+++ b/.github/workflows/python-dependency-maintenance.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set dependency release cutoff
         run: |
           cutoff="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
-          echo "UV_EXCLUDE_NEWER=${cutoff}" >> "$GITHUB_ENV"
+          echo "DEPENDENCY_RELEASE_CUTOFF=${cutoff}" >> "$GITHUB_ENV"
           echo "Using dependency release cutoff: ${cutoff}"
 
       - name: Repin dev dependency declarations

--- a/python/packages/hyperlight/agent_framework_hyperlight/_execute_code_tool.py
+++ b/python/packages/hyperlight/agent_framework_hyperlight/_execute_code_tool.py
@@ -90,6 +90,10 @@ class SandboxRuntime(Protocol):
     def execute(self, *, config: _RunConfig, code: str) -> list[Content]: ...
 
 
+class _NamedDirectory(Protocol):
+    name: str
+
+
 _T = TypeVar("_T")
 
 
@@ -725,7 +729,7 @@ def _collect_output_relative_paths(*, sandbox: Any, root: Path) -> set[str]:
 def _parse_output_files(
     *,
     sandbox: Any,
-    output_dir: TemporaryDirectory[str] | None,
+    output_dir: _NamedDirectory | None,
     expect_output_files: bool,
 ) -> list[Content]:
     if output_dir is None:

--- a/python/scripts/dependencies/_dependency_bounds_lower_impl.py
+++ b/python/scripts/dependencies/_dependency_bounds_lower_impl.py
@@ -388,7 +388,7 @@ class VersionCatalog:
 
 
 def _load_exclude_newer_from_env() -> datetime | None:
-    raw_value = os.environ.get("UV_EXCLUDE_NEWER")
+    raw_value = os.environ.get("DEPENDENCY_RELEASE_CUTOFF") or os.environ.get("UV_EXCLUDE_NEWER")
     if not raw_value:
         return None
     normalized = raw_value.removesuffix("Z")

--- a/python/scripts/dependencies/_dependency_bounds_upper_impl.py
+++ b/python/scripts/dependencies/_dependency_bounds_upper_impl.py
@@ -37,6 +37,8 @@ from scripts.task_runner import discover_projects, extract_poe_tasks, project_fi
 logger = logging.getLogger(__name__)
 
 CHECK_TASK_PRIORITY = ("check", "typing", "pyright", "mypy", "lint")
+AZURE_MONITOR_OPENTELEMETRY = "azure-monitor-opentelemetry"
+OPENTELEMETRY_SDK = "opentelemetry-sdk"
 REQ_PATTERN = r"^\s*([A-Za-z0-9_.-]+(?:\[[^\]]+\])?)\s*(.*?)\s*$"
 SECTION_HEADER_PATTERN = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 INLINE_ARRAY_ASSIGNMENT_PATTERN = re.compile(
@@ -238,6 +240,18 @@ def _select_latest_dev_version(versions: list[Version]) -> Version | None:
     return versions[-1]
 
 
+def _exact_pin_version(requirement: Requirement) -> Version | None:
+    """Return the exact pinned version from a requirement, if it has one."""
+    for specifier in requirement.specifier:
+        if specifier.operator not in {"==", "==="} or "*" in specifier.version:
+            continue
+        try:
+            return Version(specifier.version)
+        except InvalidVersion:
+            return None
+    return None
+
+
 @lru_cache(maxsize=8)
 def _load_workspace_package_versions(workspace_root: str) -> dict[str, Version]:
     workspace_path = Path(workspace_root)
@@ -283,6 +297,13 @@ def _collect_dev_pin_replacements(
         requirement for requirement in (dependency_groups.get("dev", []) or []) if isinstance(requirement, str)
     )
     logger.debug(f"Found {len(dev_requirements)} dev requirements in {pyproject_file}")
+    parsed_dev_requirements: dict[str, Requirement] = {}
+    for requirement in dev_requirements:
+        try:
+            parsed_requirement = Requirement(requirement)
+        except InvalidRequirement:
+            continue
+        parsed_dev_requirements[parsed_requirement.name.lower()] = parsed_requirement
 
     seen_requirements: set[str] = set()
     replacements: dict[str, str] = {}
@@ -308,6 +329,33 @@ def _collect_dev_pin_replacements(
             # back to lock data when PyPI cannot be reached or --version-source=lock is used.
             latest_version = _select_latest_dev_version(catalog.get(dependency_name))
         if latest_version is None:
+            continue
+        current_exact_version = _exact_pin_version(parsed_requirement)
+        if current_exact_version is None and not dependency_name.startswith("agent-framework"):
+            locked_version = _select_latest_dev_version(catalog.get_lock(dependency_name))
+            if locked_version is not None:
+                latest_version = locked_version
+        if current_exact_version is not None and latest_version < current_exact_version:
+            logger.info(
+                "Skipping %s in %s because selected version %s is older than current pin %s.",
+                dependency_name,
+                pyproject_file,
+                latest_version,
+                current_exact_version,
+            )
+            continue
+        if (
+            dependency_name == OPENTELEMETRY_SDK
+            and AZURE_MONITOR_OPENTELEMETRY in parsed_dev_requirements
+            and current_exact_version is not None
+            and latest_version != current_exact_version
+        ):
+            logger.info(
+                "Skipping %s in %s because %s currently pins the SDK version.",
+                dependency_name,
+                pyproject_file,
+                AZURE_MONITOR_OPENTELEMETRY,
+            )
             continue
 
         extras = f"[{','.join(sorted(parsed_requirement.extras))}]" if parsed_requirement.extras else ""
@@ -486,7 +534,7 @@ class VersionCatalog:
 
 
 def _load_exclude_newer_from_env() -> datetime | None:
-    raw_value = os.environ.get("UV_EXCLUDE_NEWER")
+    raw_value = os.environ.get("DEPENDENCY_RELEASE_CUTOFF") or os.environ.get("UV_EXCLUDE_NEWER")
     if not raw_value:
         return None
     normalized = raw_value.removesuffix("Z")


### PR DESCRIPTION
### Motivation & Context

The scheduled Python dependency maintenance workflow failed before it could create dependency updates because the release cutoff was exported as `UV_EXCLUDE_NEWER` for the entire job. That global uv setting made the already-pinned dev environment unsatisfiable whenever a current dependency pin, such as `prek==0.4.5`, was newer than the cutoff.

This keeps the workflow able to resolve the current workspace while still delaying automated dependency update candidates until they are older than the cutoff.

### Description & Review Guide

- **What are the major changes?** Replace the job-wide `UV_EXCLUDE_NEWER` export with `DEPENDENCY_RELEASE_CUTOFF`, have the dependency candidate catalog read that value, and make dev-pin refresh avoid downgrades when the cutoff excludes the current pin.
- **What is the impact of these changes?** Newly added or already-pinned dependencies can be resolved immediately, but maintenance updates still wait for the cutoff window. The dev-pin refresh also avoids known incompatible updates such as bumping `opentelemetry-sdk` while `azure-monitor-opentelemetry` pins it.
- **What do you want reviewers to focus on?** Whether the cutoff is now scoped correctly to update candidate selection rather than uv environment resolution.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No linked issue; this fixes a scheduled workflow failure observed in Python dependency maintenance.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
