### PR TITLE
Python: Fix 3 bugs — snapshot ID, null args, pydantic validation (#6266, #5934, #6366)

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -718,8 +718,16 @@ def _build_messages_snapshot(
 
     # Add assistant message with tool calls only (no content)
     if flow.pending_tool_calls:
+        # Tool-call assistant messages are not streamed via TEXT_MESSAGE_START,
+        # so they must not reuse flow.message_id when accumulated_text exists
+        # (which belongs to the streamed text message). Fixes #6266.
+        tool_call_message_id = (
+            generate_event_id()
+            if flow.accumulated_text
+            else (flow.message_id or generate_event_id())
+        )
         tool_call_message = {
-            "id": flow.message_id or generate_event_id(),
+            "id": tool_call_message_id,
             "role": "assistant",
             "tool_calls": flow.pending_tool_calls.copy(),
         }
@@ -732,10 +740,9 @@ def _build_messages_snapshot(
     # This is a separate message from the tool calls message to maintain
     # the expected AG-UI protocol format (see issue #3619)
     if flow.accumulated_text:
-        # Use a new ID for the content message if we had tool calls (separate message)
-        content_message_id = (
-            generate_event_id() if flow.pending_tool_calls else (flow.message_id or generate_event_id())
-        )
+        # Always preserve the streamed text id so the client can reconcile.
+        # Fixes #6266 — the text message must keep flow.message_id.
+        content_message_id = flow.message_id or generate_event_id()
         all_messages.append(
             {
                 "id": content_message_id,

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -650,8 +650,10 @@ class FunctionTool(SerializationMixin):
                 if isinstance(arguments, Mapping):
                     parsed_arguments = dict(arguments)
                     if self.input_model is not None and not self._schema_supplied:
+                        # Use exclude_unset instead of exclude_none to preserve
+                        # explicitly null arguments from the model. Fixes #5934.
                         parsed_arguments = self.input_model.model_validate(parsed_arguments).model_dump(
-                            exclude_none=True
+                            exclude_unset=True
                         )
                 elif isinstance(arguments, BaseModel):
                     if (
@@ -660,7 +662,7 @@ class FunctionTool(SerializationMixin):
                         and not isinstance(arguments, self.input_model)
                     ):
                         raise TypeError(f"Expected {self.input_model.__name__}, got {type(arguments).__name__}")
-                    parsed_arguments = arguments.model_dump(exclude_none=True)
+                    parsed_arguments = arguments.model_dump(exclude_unset=True)
                 else:
                     raise TypeError(
                         f"Expected mapping-like arguments for tool '{self.name}', got {type(arguments).__name__}"
@@ -1508,7 +1510,9 @@ async def _auto_invoke_function(
         runtime_kwargs["session"] = invocation_session
     try:
         if not cast(bool, getattr(tool, "_schema_supplied", False)) and tool.input_model is not None:
-            args = tool.input_model.model_validate(parsed_args).model_dump(exclude_none=True)
+            # Use exclude_unset instead of exclude_none to preserve
+            # explicitly null arguments from the model. Fixes #5934.
+            args = tool.input_model.model_validate(parsed_args).model_dump(exclude_unset=True)
         else:
             args = dict(parsed_args)
         args = _validate_arguments_against_schema(

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -2397,7 +2397,12 @@ class ChatResponse(SerializationMixin, Generic[ResponseModelT]):
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            # Use only the last message's text for structured output parsing,
+            # not self.text which concatenates ALL messages. In multi-turn
+            # scenarios (e.g., with tool calls), intermediate messages would
+            # corrupt the JSON payload. Fixes #6366.
+            last_text = self.messages[-1].text if self.messages else self.text
+            self._value = cast(ResponseModelT, _parse_structured_response_value(last_text, self._response_format))
             self._value_parsed = True
         return self._value
 
@@ -2661,7 +2666,10 @@ class AgentResponse(SerializationMixin, Generic[ResponseModelT]):
         if self._value_parsed:
             return self._value
         if self._response_format is not None:
-            self._value = cast(ResponseModelT, _parse_structured_response_value(self.text, self._response_format))
+            # Use only the last message's text for structured output parsing,
+            # not self.text which concatenates ALL messages. Fixes #6366.
+            last_text = self.messages[-1].text if self.messages else self.text
+            self._value = cast(ResponseModelT, _parse_structured_response_value(last_text, self._response_format))
             self._value_parsed = True
         return self._value
 


### PR DESCRIPTION
## Fixes

This PR fixes **3 Python bugs** that are all reproduced and assigned to @moonbox3:

---

### Fix #6266: `MessagesSnapshotEvent` reassigns streamed text message ID

**Root cause:** In `_build_messages_snapshot`, `flow.message_id` (the streamed text ID) was assigned to the tool-call message, and the text message got a fresh ID. This broke client reconciliation (e.g., CopilotKit frontends).

**Fix:** When both tool calls and text exist, the tool-call message gets a fresh `generate_event_id()` and the text message keeps `flow.message_id`.

| Turn shape | Tool-call msg id | Text msg id |
|---|---|---|
| Text only | n/a | `flow.message_id` |
| Tool calls only | `flow.message_id` or new | n/a |
| Tool calls **and** text | fresh `generate_event_id()` | `flow.message_id` |

**File:** `packages/ag-ui/agent_framework_ag_ui/_agent_run.py`

---

### Fix #5934: Auto function calling removes null arguments

**Root cause:** `model_dump(exclude_none=True)` strips null arguments before invoking tools. When the model generates `{"location": "Seattle", "unit": null}`, the `unit` key is removed entirely, causing required-but-nullable parameters to fail with "Argument parsing failed."

**Fix:** Replace `exclude_none=True` with `exclude_unset=True`. This preserves explicitly-set None values from the model while still excluding fields the model didn't mention.

**File:** `packages/core/agent_framework/_tools.py` (3 locations)

---

### Fix #6366: `AgentResponse.value` throws pydantic ValidationError

**Root cause:** `self.text` concatenates ALL messages in the response history. In multi-turn agent loops with tool calls, this produces invalid JSON like:
```
{ "skill_name": "building-permit-compliance" }{ "compliant": true }
```

**Fix:** `ChatResponse.value` and `AgentResponse.value` now use only the **last message's** text for structured output parsing, since that's where the final JSON payload lives.

**File:** `packages/core/agent_framework/_types.py` (2 locations)

---

## Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] Is this a breaking change? **No** — all fixes are behavioral corrections
- [x] All 3 bugs are labeled "reproduced" by maintainers

cc @moonbox3
