### PR TITLE
Python: stabilize dependency maintenance final checks

### DIFF
--- a/.github/workflows/python-dependency-maintenance.yml
+++ b/.github/workflows/python-dependency-maintenance.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./python
 
       - name: Refresh lockfile after dev pin updates
-        run: uv lock --upgrade
+        run: uv lock
         working-directory: ./python
 
       - name: Save dev dependency changes
@@ -285,7 +285,7 @@ jobs:
 
       - name: Refresh lockfile after dependency range updates
         if: steps.validate_bounds_test.outcome == 'success' && steps.validate_ranges.outcome == 'success'
-        run: uv lock --upgrade
+        run: uv lock
         working-directory: ./python
 
       - name: Install final dependency set

--- a/python/scripts/dependencies/_dependency_bounds_upper_impl.py
+++ b/python/scripts/dependencies/_dependency_bounds_upper_impl.py
@@ -17,7 +17,6 @@ import tempfile
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -39,6 +38,7 @@ logger = logging.getLogger(__name__)
 CHECK_TASK_PRIORITY = ("check", "typing", "pyright", "mypy", "lint")
 AZURE_MONITOR_OPENTELEMETRY = "azure-monitor-opentelemetry"
 OPENTELEMETRY_SDK = "opentelemetry-sdk"
+VALIDATION_TOOL_DEV_PINS = frozenset({"mypy", "pyrefly", "pyright", "ruff", "ty", "zuban"})
 REQ_PATTERN = r"^\s*([A-Za-z0-9_.-]+(?:\[[^\]]+\])?)\s*(.*?)\s*$"
 SECTION_HEADER_PATTERN = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 INLINE_ARRAY_ASSIGNMENT_PATTERN = re.compile(
@@ -252,25 +252,6 @@ def _exact_pin_version(requirement: Requirement) -> Version | None:
     return None
 
 
-@lru_cache(maxsize=8)
-def _load_workspace_package_versions(workspace_root: str) -> dict[str, Version]:
-    workspace_path = Path(workspace_root)
-    versions: dict[str, Version] = {}
-    for package_pyproject in sorted((workspace_path / "packages").glob("*/pyproject.toml")):
-        with package_pyproject.open("rb") as f:
-            package_data = tomli.load(f)
-        project_section = package_data.get("project", {}) or {}
-        package_name = str(project_section.get("name", "")).strip().lower()
-        package_version = project_section.get("version")
-        if not package_name or not package_version:
-            continue
-        try:
-            versions[package_name] = Version(str(package_version))
-        except InvalidVersion:
-            continue
-    return versions
-
-
 def _collect_dev_pin_replacements(
     pyproject_file: Path,
     *,
@@ -287,8 +268,6 @@ def _collect_dev_pin_replacements(
         optional_dependencies.keys(),
         dependency_groups.keys(),
     )
-    workspace_versions = _load_workspace_package_versions(str(pyproject_file.parent.parent.parent.resolve()))
-
     dev_requirements: list[str] = []
     dev_requirements.extend(
         requirement for requirement in (optional_dependencies.get("dev", []) or []) if isinstance(requirement, str)
@@ -322,16 +301,27 @@ def _collect_dev_pin_replacements(
             continue
         dependency_name = parsed_requirement.name.lower()
         if dependency_name.startswith("agent-framework"):
-            latest_version = workspace_versions.get(dependency_name)
-        else:
-            # Dev-tool refreshes should follow the selected version source (PyPI by default)
-            # instead of being pinned by the current lockfile. VersionCatalog already falls
-            # back to lock data when PyPI cannot be reached or --version-source=lock is used.
-            latest_version = _select_latest_dev_version(catalog.get(dependency_name))
+            logger.info(
+                "Skipping %s in %s because internal package pins are maintained by package versioning.",
+                dependency_name,
+                pyproject_file,
+            )
+            continue
+        # Dev-tool refreshes should follow the selected version source (PyPI by default)
+        # instead of being pinned by the current lockfile. VersionCatalog already falls
+        # back to lock data when PyPI cannot be reached or --version-source=lock is used.
+        latest_version = _select_latest_dev_version(catalog.get(dependency_name))
         if latest_version is None:
             continue
         current_exact_version = _exact_pin_version(parsed_requirement)
-        if current_exact_version is None and not dependency_name.startswith("agent-framework"):
+        if current_exact_version is not None and dependency_name in VALIDATION_TOOL_DEV_PINS:
+            logger.info(
+                "Skipping %s in %s because validation tool upgrades should be handled separately.",
+                dependency_name,
+                pyproject_file,
+            )
+            continue
+        if current_exact_version is None:
             locked_version = _select_latest_dev_version(catalog.get_lock(dependency_name))
             if locked_version is not None:
                 latest_version = locked_version


### PR DESCRIPTION
### Motivation & Context

The Python dependency maintenance workflow now gets past the release-cutoff bootstrap issue, but the manual run still failed during final validation. The generated update set was broadening beyond the script-selected dependency candidates: `uv lock --upgrade` refreshed unrelated lockfile entries, and auto-updating validation tooling/internal Agent Framework pins introduced failures unrelated to the intended dependency maintenance PR.

This keeps the workflow focused on dependencies selected by the maintenance scripts so final checks validate the generated PR instead of opportunistic toolchain or unrelated lockfile churn.

### Description & Review Guide

- **What are the major changes?** Refresh the lockfile with `uv lock` instead of broad `uv lock --upgrade`, skip exact dev pins for validation tools (`ruff`, `mypy`, `pyright`, `pyrefly`, `ty`, `zuban`), and skip internal `agent-framework-*` dev pins in the automated dev-pin refresh.
- **What is the impact of these changes?** Dependency maintenance still updates selected external dev pins and package dependency ranges, but avoids self-inflicted final-check failures from new validator diagnostics, internal package versioning drift, and unrelated lockfile upgrades.
- **What do you want reviewers to focus on?** Whether the workflow now scopes automated updates narrowly enough: candidate selection happens in the scripts, while lockfile refresh only materializes those selected changes.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No linked issue; this fixes a scheduled/manual Python dependency maintenance workflow failure observed after #6658.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
