### PR TITLE
.NET: Bugfix Emit execute_tool spans when Auto Wiring via Agent UseOpenTelemetry

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
@@ -94,6 +94,12 @@ public static class ChatClientExtensions
             chatBuilder.Use(innerClient => new PerServiceCallChatHistoryPersistingChatClient(innerClient));
         }
 
+        // DeferredOpenTelemetryChatClient is registered last so it sits as the innermost decorator, directly
+        // above the leaf client and below FunctionInvokingChatClient. It is inert until an OpenTelemetryAgent
+        // activates it. Placing OpenTelemetry below FICC ensures the chat span closes before tools are invoked,
+        // so FICC emits execute_tool spans on the agent source.
+        chatBuilder.Use(innerClient => new DeferredOpenTelemetryChatClient(innerClient));
+
         var agentChatClient = chatBuilder.Build(services);
 
         if (options?.ChatOptions?.Tools is { Count: > 0 })

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/DeferredOpenTelemetryChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/DeferredOpenTelemetryChatClient.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// A delegating chat client that reserves a position for OpenTelemetry instrumentation directly above
+/// the leaf <see cref="IChatClient"/> and below the <see cref="FunctionInvokingChatClient"/> in a
+/// <see cref="ChatClientAgent"/> pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The slot is inert until <see cref="Activate"/> is called: it simply forwards to its inner client.
+/// When the agent is wrapped by an <see cref="OpenTelemetryAgent"/>, that agent activates the slot with
+/// the resolved source name, at which point the slot routes calls through an
+/// <see cref="OpenTelemetryChatClient"/> so chat spans are emitted below the
+/// <see cref="FunctionInvokingChatClient"/>.
+/// </para>
+/// <para>
+/// Positioning OpenTelemetry below FICC is required for tool telemetry: the chat span then closes before
+/// FICC invokes tools, so <see cref="System.Diagnostics.Activity.Current"/> is the invoke_agent span and
+/// FICC emits execute_tool spans on the agent source.
+/// </para>
+/// </remarks>
+internal sealed class DeferredOpenTelemetryChatClient : DelegatingChatClient
+{
+    private readonly object _activationLock = new();
+    private volatile IChatClient _target;
+    private OpenTelemetryChatClient? _activatedClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeferredOpenTelemetryChatClient"/> class in its inert state.
+    /// </summary>
+    /// <param name="innerClient">The underlying chat client to forward to until the slot is activated.</param>
+    public DeferredOpenTelemetryChatClient(IChatClient innerClient)
+        : base(innerClient)
+    {
+        this._target = innerClient;
+    }
+
+    /// <summary>Gets a value indicating whether the slot has been activated.</summary>
+    public bool IsActive => !ReferenceEquals(this._target, this.InnerClient);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the activated <see cref="OpenTelemetryChatClient"/> should
+    /// include potentially sensitive information (such as message content) in telemetry. Reading or writing
+    /// this property is a no-op while the slot is inert; the owning <see cref="OpenTelemetryAgent"/> applies
+    /// and propagates the value once the slot is activated.
+    /// </summary>
+    public bool EnableSensitiveData
+    {
+        get => this._activatedClient?.EnableSensitiveData ?? false;
+        set
+        {
+            if (this._activatedClient is { } activatedClient)
+            {
+                activatedClient.EnableSensitiveData = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Activates the slot so that calls are routed through an <see cref="OpenTelemetryChatClient"/> wrapping
+    /// the inner client under the specified <paramref name="sourceName"/>. Idempotent and thread-safe; a
+    /// second call (or a call after another thread activated the slot) is a no-op.
+    /// </summary>
+    /// <param name="sourceName">The telemetry source name to emit chat spans under.</param>
+    public void Activate(string sourceName)
+    {
+        if (this.IsActive)
+        {
+            return;
+        }
+
+        lock (this._activationLock)
+        {
+            if (this.IsActive)
+            {
+                return;
+            }
+
+            var activatedTarget = this.InnerClient.AsBuilder().UseOpenTelemetry(sourceName: sourceName).Build();
+
+            // Capture the OpenTelemetryChatClient so the owning agent can propagate EnableSensitiveData to it
+            // (the agent's value may be set after construction, e.g. via the UseOpenTelemetry configure callback).
+            this._activatedClient = activatedTarget.GetService(typeof(OpenTelemetryChatClient)) as OpenTelemetryChatClient;
+            this._target = activatedTarget;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+        this._target.GetResponseAsync(messages, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public override IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+        this._target.GetStreamingResponseAsync(messages, options, cancellationToken);
+
+    /// <inheritdoc/>
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+
+        // Return this slot for its own type and base contracts; otherwise forward to the current target so
+        // that, once activated, queries such as OpenTelemetryChatClient and ActivitySource resolve to the
+        // activated instrumentation rather than the bare leaf.
+        return serviceKey is null && serviceType.IsInstanceOfType(this)
+            ? this
+            : this._target.GetService(serviceType, serviceKey);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !ReferenceEquals(this._target, this.InnerClient))
+        {
+            // When activated, _target is an OpenTelemetryChatClient wrapping the inner client; dispose it so its
+            // own telemetry resources are released. It also disposes the inner client, which is idempotent with the
+            // base.Dispose call below.
+            this._target.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
@@ -42,6 +42,12 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
     /// </summary>
     private readonly bool _autoWireChatClient;
 
+    /// <summary>
+    /// The auto-wired below-FICC telemetry slot, when one was activated. Cached so that updates to
+    /// <see cref="EnableSensitiveData"/> made after construction can be propagated to it.
+    /// </summary>
+    private DeferredOpenTelemetryChatClient? _innerTelemetrySlot;
+
     /// <summary>Initializes a new instance of the <see cref="OpenTelemetryAgent"/> class.</summary>
     /// <param name="innerAgent">The underlying <see cref="AIAgent"/> to be augmented with telemetry capabilities.</param>
     /// <param name="sourceName">
@@ -91,6 +97,8 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
         this._otelClient = new OpenTelemetryChatClient(
             new ForwardingChatClient(this),
             sourceName: this._sourceName);
+
+        this.TryActivateInnerChatClientTelemetry();
     }
 
     /// <inheritdoc/>
@@ -120,7 +128,16 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
     public bool EnableSensitiveData
     {
         get => this._otelClient.EnableSensitiveData;
-        set => this._otelClient.EnableSensitiveData = value;
+        set
+        {
+            this._otelClient.EnableSensitiveData = value;
+
+            // Keep the auto-wired below-FICC slot in sync so its chat span captures message content too.
+            if (this._innerTelemetrySlot is { } slot)
+            {
+                slot.EnableSensitiveData = value;
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -204,84 +221,52 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
     }
 
     /// <summary>
-    /// If auto-wiring is enabled and the inner agent is a <see cref="ChatClientAgent"/> whose underlying
-    /// <see cref="IChatClient"/> is not already instrumented with <see cref="OpenTelemetryChatClient"/>, returns a
-    /// new <see cref="ChatClientAgentRunOptions"/> with a <see cref="ChatClientAgentRunOptions.ChatClientFactory"/>
-    /// that wraps the chat client with <see cref="OpenTelemetryChatClient"/>. When <paramref name="options"/> is a
-    /// plain <see cref="AgentRunOptions"/> (the base type, not <see cref="ChatClientAgentRunOptions"/>), the base
-    /// properties are copied onto the new <see cref="ChatClientAgentRunOptions"/> so high-level callers that pass
-    /// the abstract <see cref="AgentRunOptions"/> still benefit from auto-wiring and propagate their settings to
-    /// the inner agent. Otherwise, returns <paramref name="options"/> unchanged.
+    /// When auto-wiring is enabled and the inner agent is a <see cref="ChatClientAgent"/> whose underlying
+    /// <see cref="IChatClient"/> is not already instrumented, activates the in-place
+    /// <see cref="DeferredOpenTelemetryChatClient"/> slot so that chat spans are emitted below the
+    /// <see cref="FunctionInvokingChatClient"/> under this agent's source name. Positioning OpenTelemetry below FICC
+    /// is what allows FICC to emit execute_tool spans on the agent source. Respects
+    /// <see cref="ChatClientAgentOptions.UseProvidedChatClientAsIs"/> and is a no-op when no slot is reachable.
     /// </summary>
-    private AgentRunOptions? GetRunOptionsWithChatClientWiring(AgentRunOptions? options)
+    private void TryActivateInnerChatClientTelemetry()
     {
         if (!this._autoWireChatClient)
         {
-            return options;
+            return;
         }
 
-        // The auto-wiring only applies when a ChatClientAgent is reachable from the inner agent. Otherwise, no-op.
+        // Auto-wiring only applies when a ChatClientAgent is reachable from the inner agent. Otherwise, no-op.
         // Use GetService rather than a type check so wrapping agents that expose a nested ChatClientAgent are supported.
         var chatClientAgent = this.InnerAgent.GetService<ChatClientAgent>();
         if (chatClientAgent is null)
         {
-            return options;
+            return;
         }
 
         // Respect ChatClientAgentOptions.UseProvidedChatClientAsIs: don't decorate the chat client when the user opted out.
         if (chatClientAgent.GetService<ChatClientAgentOptions>()?.UseProvidedChatClientAsIs is true)
         {
-            return options;
+            return;
         }
 
-        // Capture the underlying IChatClient and check whether it is already instrumented.
+        // Don't activate when the chat client is already instrumented (e.g. the caller added their own
+        // OpenTelemetryChatClient), to avoid emitting duplicate chat spans.
         var chatClient = chatClientAgent.GetService<IChatClient>();
         if (chatClient is null || chatClient.GetService(typeof(OpenTelemetryChatClient)) is not null)
         {
-            return options;
+            return;
         }
 
-        string sourceName = this._sourceName;
-        bool enableSensitiveData = this.EnableSensitiveData;
-        static IChatClient WrapIfNeeded(IChatClient cc, string sourceName, bool enableSensitiveData) =>
-            cc.GetService(typeof(OpenTelemetryChatClient)) is not null
-                ? cc
-                : cc.AsBuilder().UseOpenTelemetry(sourceName: sourceName, configure: o => o.EnableSensitiveData = enableSensitiveData).Build();
-
-        if (options is ChatClientAgentRunOptions ccOptions)
+        // Activate the pre-placed slot in-place (below FICC) rather than wrapping a new OpenTelemetryChatClient
+        // around the whole pipeline on each run. Cache it and seed its EnableSensitiveData from the current
+        // value so a later change to this agent's EnableSensitiveData can be propagated to the inner chat span.
+        if (chatClient.GetService(typeof(DeferredOpenTelemetryChatClient)) is DeferredOpenTelemetryChatClient slot)
         {
-            // Don't mutate the caller's options; clone and chain any caller-provided factory.
-            // If the user factory already returns an OpenTelemetry-instrumented client, don't double-wrap.
-            var clone = (ChatClientAgentRunOptions)ccOptions.Clone();
-            var userFactory = clone.ChatClientFactory;
-            clone.ChatClientFactory = cc => WrapIfNeeded(userFactory is null ? cc : userFactory(cc), sourceName, enableSensitiveData);
-            return clone;
+            slot.Activate(this._sourceName);
+            slot.EnableSensitiveData = this.EnableSensitiveData;
+            this._innerTelemetrySlot = slot;
         }
-
-        // For a plain AgentRunOptions (or null), create a ChatClientAgentRunOptions and preserve
-        // any base AgentRunOptions properties from the caller so they reach the inner agent.
-        var newOptions = new ChatClientAgentRunOptions
-        {
-            ChatClientFactory = cc => WrapIfNeeded(cc, sourceName, enableSensitiveData),
-        };
-
-        if (options is not null)
-        {
-            CopyBaseAgentRunOptions(options, newOptions);
-        }
-
-        return newOptions;
     }
-
-#pragma warning disable MEAI001 // ContinuationToken is experimental; copy it through to preserve caller-provided value.
-    private static void CopyBaseAgentRunOptions(AgentRunOptions source, AgentRunOptions target)
-    {
-        target.ContinuationToken = source.ContinuationToken;
-        target.AllowBackgroundResponses = source.AllowBackgroundResponses;
-        target.AdditionalProperties = source.AdditionalProperties?.Clone();
-        target.ResponseFormat = source.ResponseFormat;
-    }
-#pragma warning restore MEAI001
 
     /// <summary>The stub <see cref="IChatClient"/> used to delegate from the <see cref="OpenTelemetryChatClient"/> into the inner <see cref="AIAgent"/>.</summary>
     /// <param name="parentAgent"></param>
@@ -295,11 +280,9 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
             // Update the current activity to reflect the agent invocation.
             parentAgent.UpdateCurrentActivity(fo?.CurrentActivity);
 
-            // If enabled, wire the underlying chat client with OpenTelemetryChatClient via ChatClientFactory.
-            var runOptions = parentAgent.GetRunOptionsWithChatClientWiring(fo?.Options);
-
-            // Invoke the inner agent.
-            var response = await parentAgent.InnerAgent.RunAsync(messages, fo?.Session, runOptions, cancellationToken).ConfigureAwait(false);
+            // Invoke the inner agent. Chat-level telemetry is emitted by the in-place DeferredOpenTelemetryChatClient
+            // slot (below FICC), activated once at construction; no per-run chat-client wiring is needed here.
+            var response = await parentAgent.InnerAgent.RunAsync(messages, fo?.Session, fo?.Options, cancellationToken).ConfigureAwait(false);
 
             // Wrap the response in a ChatResponse so we can pass it back through OpenTelemetryChatClient.
             return response.AsChatResponse();
@@ -313,11 +296,9 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
             // Update the current activity to reflect the agent invocation.
             parentAgent.UpdateCurrentActivity(fo?.CurrentActivity);
 
-            // If enabled, wire the underlying chat client with OpenTelemetryChatClient via ChatClientFactory.
-            var runOptions = parentAgent.GetRunOptionsWithChatClientWiring(fo?.Options);
-
-            // Invoke the inner agent.
-            await foreach (var update in parentAgent.InnerAgent.RunStreamingAsync(messages, fo?.Session, runOptions, cancellationToken).ConfigureAwait(false))
+            // Invoke the inner agent. Chat-level telemetry is emitted by the in-place DeferredOpenTelemetryChatClient
+            // slot (below FICC), activated once at construction; no per-run chat-client wiring is needed here.
+            await foreach (var update in parentAgent.InnerAgent.RunStreamingAsync(messages, fo?.Session, fo?.Options, cancellationToken).ConfigureAwait(false))
             {
                 // Wrap the response updates in ChatResponseUpdates so we can pass them back through OpenTelemetryChatClient.
                 yield return update.AsChatResponseUpdate();

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
@@ -795,9 +795,9 @@ public class OpenTelemetryAgentTests
     [Fact]
     public async Task AutoWireChatClient_PlainAgentRunOptions_PreservesBaseProperties_Async()
     {
-        // Auto-wiring converts a plain AgentRunOptions into a ChatClientAgentRunOptions. The base
-        // properties (ContinuationToken, AllowBackgroundResponses, AdditionalProperties, ResponseFormat)
-        // must be preserved so they reach the inner agent.
+        // The auto-wire no longer rewrites the caller's options (the slot below FICC is activated once at
+        // construction), so a plain AgentRunOptions reaches the inner agent unchanged with all base
+        // properties (AllowBackgroundResponses, AdditionalProperties, ResponseFormat) intact.
         AgentRunOptions? observedOptions = null;
         var fakeChatClient = new AutoWireTestChatClient();
         var innerChatClientAgent = new ChatClientAgent(fakeChatClient);
@@ -827,17 +827,27 @@ public class OpenTelemetryAgentTests
 
         _ = await agent.RunAsync("hi", options: inputOptions);
 
+        // Options flow through unchanged (same instance, no conversion to ChatClientAgentRunOptions).
         Assert.NotNull(observedOptions);
-        Assert.IsType<ChatClientAgentRunOptions>(observedOptions);
-        Assert.Equal(true, observedOptions!.AllowBackgroundResponses);
+        Assert.Same(inputOptions, observedOptions);
+        Assert.Equal(true, observedOptions.AllowBackgroundResponses);
         Assert.Same(ChatResponseFormat.Json, observedOptions.ResponseFormat);
         Assert.NotNull(observedOptions.AdditionalProperties);
         Assert.Equal("customValue", observedOptions.AdditionalProperties!["customKey"]);
     }
 
     [Fact]
-    public async Task AutoWireChatClient_UserFactoryReturnsInstrumentedClient_DoesNotDoubleWrap_Async()
+    public async Task AutoWireChatClient_UserFactoryAddsOwnOTel_CoexistsWithBelowFiccSlot_Async()
     {
+        // This is NOT a single model call counted twice. One model call is observed by two independent
+        // OpenTelemetry layers, so each layer emits its own "chat" span:
+        //   - the framework's slot, always activated below FICC by OpenTelemetryAgent. This below-FICC layer
+        //     is what lets FICC emit execute_tool spans, so it must remain even when the caller adds their own
+        //     instrumentation. Dropping it to avoid the second span would reintroduce the missing-tool-span bug.
+        //   - the caller's per-run ChatClientFactory, which wraps the pipeline above FICC with its own
+        //     OpenTelemetryChatClient.
+        // The two chat spans nest and measure different scopes (the above-FICC span covers the whole tool loop,
+        // the below-FICC span covers each individual model call), so both coexisting is the intended result.
         var sourceName = Guid.NewGuid().ToString();
         var activities = new List<Activity>();
         using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
@@ -849,7 +859,7 @@ public class OpenTelemetryAgentTests
         var inner = new ChatClientAgent(fakeChatClient);
         using var agent = new OpenTelemetryAgent(inner, sourceName);
 
-        // User factory wraps the chat client with OpenTelemetryChatClient itself.
+        // User factory wraps the chat client with OpenTelemetryChatClient itself (above FICC).
         var runOptions = new ChatClientAgentRunOptions
         {
             ChatClientFactory = cc => cc.AsBuilder().UseOpenTelemetry(sourceName: sourceName).Build(),
@@ -857,8 +867,10 @@ public class OpenTelemetryAgentTests
 
         _ = await agent.RunAsync("hi", options: runOptions);
 
-        // Expect 2 activities (invoke_agent + a single chat span). If we double-wrapped, we would see 3.
-        Assert.Equal(2, activities.Count);
+        // invoke_agent + two chat spans: one from the caller's above-FICC OTel and one from the slot below FICC.
+        Assert.Equal(3, activities.Count);
+        Assert.Contains(activities, a => a.DisplayName.StartsWith("invoke_agent", StringComparison.Ordinal));
+        Assert.Equal(2, activities.Count(a => string.Equals(a.GetTagItem("gen_ai.operation.name") as string, "chat", StringComparison.Ordinal)));
     }
 
     [Theory]
@@ -893,8 +905,8 @@ public class OpenTelemetryAgentTests
     [Fact]
     public async Task AutoWireChatClient_PlainAgentRunOptions_PreservesContinuationToken_Async()
     {
-        // ContinuationToken is the fourth base AgentRunOptions property copied by CopyBaseAgentRunOptions
-        // and is not exercised by AutoWireChatClient_PlainAgentRunOptions_PreservesBaseProperties_Async.
+        // ContinuationToken on a plain AgentRunOptions must reach the inner agent unchanged now that the
+        // auto-wire passes the caller's options straight through (no conversion to ChatClientAgentRunOptions).
         AgentRunOptions? observedOptions = null;
         var fakeChatClient = new AutoWireTestChatClient();
         var innerChatClientAgent = new ChatClientAgent(fakeChatClient);
@@ -921,8 +933,8 @@ public class OpenTelemetryAgentTests
         _ = await agent.RunAsync("hi", options: inputOptions);
 
         Assert.NotNull(observedOptions);
-        Assert.IsType<ChatClientAgentRunOptions>(observedOptions);
-        Assert.Same(token, observedOptions!.ContinuationToken);
+        Assert.Same(inputOptions, observedOptions);
+        Assert.Same(token, observedOptions.ContinuationToken);
     }
 #pragma warning restore MEAI001
 
@@ -1061,11 +1073,10 @@ public class OpenTelemetryAgentTests
     [InlineData(true, true)]
     public async Task AutoWireChatClient_EnableSensitiveData_PropagatedToInnerChatClient_Async(bool enableSensitiveData, bool streaming)
     {
-        // Regression test for: when EnableSensitiveData is set on OpenTelemetryAgent, the auto-wired
-        // inner OpenTelemetryChatClient must also have EnableSensitiveData propagated to it. Previously,
-        // GetRunOptionsWithChatClientWiring created the inner client without passing EnableSensitiveData,
-        // so the inner chat span would never emit gen_ai.input.messages / gen_ai.output.messages even
-        // when the caller explicitly set EnableSensitiveData = true.
+        // Regression test (issue #5873): when EnableSensitiveData is set on OpenTelemetryAgent, the auto-wired
+        // inner OpenTelemetryChatClient (the below-FICC slot) must also have EnableSensitiveData propagated to it,
+        // so the inner chat span captures gen_ai.input.messages / gen_ai.output.messages. The agent sets the value
+        // on the slot after construction, since EnableSensitiveData is typically set via the UseOpenTelemetry callback.
         var sourceName = Guid.NewGuid().ToString();
         var activities = new List<Activity>();
         using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
@@ -1109,6 +1120,71 @@ public class OpenTelemetryAgentTests
         }
     }
 
+    [Fact]
+    public async Task AutoWireChatClient_EmitsExecuteToolSpans_Async()
+    {
+        // The core of the OTel-below-FICC fix: with the slot active below FICC, the inner chat span closes
+        // before FICC invokes tools, so Activity.Current is the invoke_agent span and FICC emits an
+        // execute_tool span on the agent source, parented under invoke_agent.
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        var tool = AIFunctionFactory.Create(() => "sunny", "get_weather");
+        var fakeChatClient = new ToolCallingTestChatClient();
+        var inner = new ChatClientAgent(fakeChatClient, new ChatClientAgentOptions
+        {
+            ChatOptions = new ChatOptions { Tools = [tool] },
+        });
+        using var agent = new OpenTelemetryAgent(inner, sourceName);
+
+        _ = await agent.RunAsync("weather?");
+
+        var invokeAgent = Assert.Single(activities, a => a.DisplayName.StartsWith("invoke_agent", StringComparison.Ordinal));
+        var executeTool = Assert.Single(activities, a => a.DisplayName.StartsWith("execute_tool", StringComparison.Ordinal));
+        Assert.Equal(sourceName, executeTool.Source.Name);
+        Assert.Equal(invokeAgent.SpanId, executeTool.ParentSpanId);
+        Assert.Contains(activities, a => string.Equals(a.GetTagItem("gen_ai.operation.name") as string, "chat", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DeferredOpenTelemetryChatClient_InertUntilActivated_Async()
+    {
+        var sourceName = Guid.NewGuid().ToString();
+        var activities = new List<Activity>();
+        using var tracerProvider = OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .AddInMemoryExporter(activities)
+            .Build();
+
+        var leaf = new AutoWireTestChatClient();
+        using var slot = new DeferredOpenTelemetryChatClient(leaf);
+
+        // Inert: resolves itself for its own type and forwards other lookups to the inner client. The bare
+        // leaf is not instrumented, so the OpenTelemetryChatClient lookup is null and no span is emitted.
+        Assert.False(slot.IsActive);
+        Assert.Same(slot, slot.GetService(typeof(DeferredOpenTelemetryChatClient)));
+        Assert.Null(slot.GetService(typeof(OpenTelemetryChatClient)));
+        _ = await slot.GetResponseAsync("hi");
+        Assert.Empty(activities);
+
+        // Active: routes through an OpenTelemetryChatClient that emits a chat span on the source.
+        slot.Activate(sourceName);
+        Assert.True(slot.IsActive);
+        Assert.NotNull(slot.GetService(typeof(OpenTelemetryChatClient)));
+        _ = await slot.GetResponseAsync("hi");
+        var chat = Assert.Single(activities);
+        Assert.Equal("chat", chat.GetTagItem("gen_ai.operation.name") as string);
+
+        // Idempotent: a second activation does not replace the existing wrapper.
+        var target = slot.GetService(typeof(OpenTelemetryChatClient));
+        slot.Activate(sourceName);
+        Assert.Same(target, slot.GetService(typeof(OpenTelemetryChatClient)));
+    }
+
     private sealed class AutoWireTestChatClient : IChatClient
     {
         public Action<IEnumerable<ChatMessage>, ChatOptions?>? OnGetResponseAsync { get; set; }
@@ -1124,6 +1200,41 @@ public class OpenTelemetryAgentTests
             this.OnGetResponseAsync?.Invoke(messages, options);
             await Task.Yield();
             yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType?.IsInstanceOfType(this) == true ? this : null;
+
+        public void Dispose() { }
+    }
+
+    private sealed class ToolCallingTestChatClient : IChatClient
+    {
+        private int _callCount;
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            // First call returns a tool call so FICC invokes the tool; the second call returns the final text.
+            if (Interlocked.Increment(ref this._callCount) == 1)
+            {
+                var call = new FunctionCallContent("call_1", "get_weather", new Dictionary<string, object?>());
+                return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, [call])));
+            }
+
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref this._callCount) == 1)
+            {
+                yield return new ChatResponseUpdate(ChatRole.Assistant, [new FunctionCallContent("call_1", "get_weather", new Dictionary<string, object?>())]);
+                await Task.Yield();
+                yield break;
+            }
+
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "done");
         }
 
         public object? GetService(Type serviceType, object? serviceKey = null) =>


### PR DESCRIPTION
### Motivation & Context

When an agent is instrumented with `UseOpenTelemetry()` and invokes in-proc tools, no `execute_tool <name>` span was emitted. The auto-wire placed `OpenTelemetryChatClient` **above** `FunctionInvokingChatClient` (FICC), producing `OTel(FICC(leaf))`. With OpenTelemetry above FICC, the `chat` span stays open during the tool loop, so FICC sees no `invoke_agent` source and skips the tool span. Tool calls only showed up inside `gen_ai.output.messages`, never as their own span, breaking parity with the GenAI semantic conventions and with Python.

This repositions OpenTelemetry **below** FICC, producing `FICC(OTel(leaf))`, so the tool span is emitted on the agent source.

### Description & Review Guide

- **What are the major changes?**
  - New internal `DeferredOpenTelemetryChatClient`: an inert `DelegatingChatClient` slot whose `Activate(sourceName)` swaps its target to `inner.AsBuilder().UseOpenTelemetry(sourceName).Build()`. Idempotent and lock guarded.
  - `WithDefaultAgentMiddleware` always registers this slot as the innermost decorator, so it lands directly below FICC.
  - `OpenTelemetryAgent` activates the slot once at construction (same guards as before: auto wire enabled, inner `ChatClientAgent` reachable, not `UseProvidedChatClientAsIs`, not already instrumented) and forwards run options straight through. The previous per-run `ChatClientFactory` outer wrap was removed.
  - Unit tests updated and added, including a proof that `execute_tool` is emitted on the agent source, parented under `invoke_agent`, plus a focused test for the inert/active slot.

- **What is the impact of these changes?**
  - `execute_tool <name>` spans now appear for tool-calling agents that use `UseOpenTelemetry()`.
  - The emitted telemetry now matches a hand-wired `FICC(OpenTelemetry(leaf))` pipeline (verified across placements: auto wire, bring your own OpenTelemetry chat client, and hand-wired agent all produce `invoke_agent` over `chat` + `execute_tool` with no doubled spans).
  - Behavioral note: the inner `chat` span now fires per model call rather than once per run. Bringing your own OpenTelemetry chat client does not double the chat span; the slot stays inert when an `OpenTelemetryChatClient` is already present.

- **Why below FICC?** FICC resolves the tool span source per call as `invokeAgentActivity?.Source ?? _activitySource`. With OpenTelemetry below FICC the `chat` span closes before the tool loop, so `Activity.Current` is the `invoke_agent` span and its source drives `execute_tool`.

### Related Issue

Fixes #6666

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**

