### PR TITLE
.NET: Explicitly emit available_resources and available_scripts in skill content

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkill.cs
@@ -48,16 +48,19 @@ public sealed class AgentFileSkill : AgentSkill
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Returns the raw SKILL.md content. When the skill has scripts, a
-    /// <c>&lt;available_scripts&gt;</c> block is appended describing the argument format.
-    /// The result is cached after the first access.
+    /// Returns the raw SKILL.md content with an <c>&lt;available_resources&gt;</c> and an
+    /// <c>&lt;available_scripts&gt;</c> block appended, so the model gets an authoritative list for each
+    /// category. A category with no entries is appended as a self-closing element (e.g.
+    /// <c>&lt;available_scripts /&gt;</c>) so the model knows none are available and does not hallucinate
+    /// their names. The result is cached after the first access.
     /// </remarks>
     public override ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
     {
-        var content = this._content ??= this._scripts is { Count: > 0 }
-            ? this._originalContent + AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(this._scripts)
-            : this._originalContent;
-        return new(content);
+        this._content ??=
+            this._originalContent
+            + "\n" + AgentInlineSkillContentBuilder.BuildAvailableResourcesBlock(this._resources)
+            + "\n" + AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(this._scripts);
+        return new(this._content);
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkill.cs
@@ -49,13 +49,13 @@ public sealed class AgentFileSkill : AgentSkill
     /// <inheritdoc/>
     /// <remarks>
     /// Returns the raw SKILL.md content. When the skill has scripts, a
-    /// <c>&lt;script_schemas&gt;</c> block is appended describing the argument format.
+    /// <c>&lt;available_scripts&gt;</c> block is appended describing the argument format.
     /// The result is cached after the first access.
     /// </remarks>
     public override ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
     {
         var content = this._content ??= this._scripts is { Count: > 0 }
-            ? this._originalContent + AgentInlineSkillContentBuilder.BuildScriptSchemasBlock(this._scripts)
+            ? this._originalContent + AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(this._scripts)
             : this._originalContent;
         return new(content);
     }

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -206,7 +206,8 @@ public abstract class AgentClassSkill<
     /// </summary>
     /// <remarks>
     /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the LLM
-    /// knows it can be accessed; an empty block prevents hallucinated resource calls.
+    /// knows it can be accessed. When no resources are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="value">The static resource value.</param>
@@ -220,7 +221,8 @@ public abstract class AgentClassSkill<
     /// </summary>
     /// <remarks>
     /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the LLM
-    /// knows it can be accessed; an empty block prevents hallucinated resource calls.
+    /// knows it can be accessed. When no resources are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="method">A method that produces the resource value when requested.</param>
@@ -238,7 +240,8 @@ public abstract class AgentClassSkill<
     /// </summary>
     /// <remarks>
     /// The script is listed in the <c>&lt;available_scripts&gt;</c> block of the skill body so the LLM
-    /// knows it can be called; an empty block prevents hallucinated script calls.
+    /// knows it can be called. When no scripts are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated script calls.
     /// </remarks>
     /// <param name="name">The script name.</param>
     /// <param name="method">A method to execute when the script is invoked.</param>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentClassSkill.cs
@@ -120,6 +120,7 @@ public abstract class AgentClassSkill<
             this.Frontmatter.Name,
             this.Frontmatter.Description,
             this.Instructions,
+            this.Resources,
             this.Scripts));
     }
 
@@ -160,8 +161,9 @@ public abstract class AgentClassSkill<
     /// Override this property in derived classes to provide skill-specific resources.
     /// </para>
     /// <para>
-    /// Resources are not automatically included in the skill body.
-    /// To enable discovery, reference resources by name in the skill's instructions or in other resources.
+    /// Resources are listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the LLM
+    /// knows which ones can be accessed. When empty, a self-closing element is emitted to prevent
+    /// hallucinated resource calls.
     /// </para>
     /// </remarks>
     public virtual IReadOnlyList<AgentSkillResource>? Resources => this._resources.Value;
@@ -178,8 +180,9 @@ public abstract class AgentClassSkill<
     /// Override this property in derived classes to provide skill-specific scripts.
     /// </para>
     /// <para>
-    /// Only script parameter schemas are included in the skill body (as a <c>&lt;script_schemas&gt;</c> block).
-    /// To enable discovery, reference scripts by name in the skill's instructions or in a resource.
+    /// Scripts are listed in the <c>&lt;available_scripts&gt;</c> block of the skill body so the LLM
+    /// knows which ones can be called. When empty, a self-closing element is emitted to prevent
+    /// hallucinated script calls.
     /// </para>
     /// </remarks>
     public virtual IReadOnlyList<AgentSkillScript>? Scripts => this._scripts.Value;
@@ -202,8 +205,8 @@ public abstract class AgentClassSkill<
     /// Creates a skill resource backed by a static value.
     /// </summary>
     /// <remarks>
-    /// Resources are not automatically included in the skill body.
-    /// To enable discovery, reference the resource by name in the skill's instructions or in another resource.
+    /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the LLM
+    /// knows it can be accessed; an empty block prevents hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="value">The static resource value.</param>
@@ -216,8 +219,8 @@ public abstract class AgentClassSkill<
     /// Creates a skill resource backed by a delegate that produces a dynamic value.
     /// </summary>
     /// <remarks>
-    /// Resources are not automatically included in the skill body.
-    /// To enable discovery, reference the resource by name in the skill's instructions or in another resource.
+    /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the LLM
+    /// knows it can be accessed; an empty block prevents hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="method">A method that produces the resource value when requested.</param>
@@ -234,8 +237,8 @@ public abstract class AgentClassSkill<
     /// Creates a skill script backed by a delegate.
     /// </summary>
     /// <remarks>
-    /// Only the script's parameter schema is included in the skill body (as a <c>&lt;script_schemas&gt;</c> block).
-    /// To enable discovery, reference the script by name in the skill's instructions or in a resource.
+    /// The script is listed in the <c>&lt;available_scripts&gt;</c> block of the skill body so the LLM
+    /// knows it can be called; an empty block prevents hallucinated script calls.
     /// </remarks>
     /// <param name="name">The script name.</param>
     /// <param name="method">A method to execute when the script is invoked.</param>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkill.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkill.cs
@@ -107,7 +107,7 @@ public sealed class AgentInlineSkill : AgentSkill
     /// <inheritdoc/>
     public override ValueTask<string> GetContentAsync(CancellationToken cancellationToken = default)
     {
-        return new(this._cachedContent ??= AgentInlineSkillContentBuilder.Build(this.Frontmatter.Name, this.Frontmatter.Description, this._instructions, this._scripts));
+        return new(this._cachedContent ??= AgentInlineSkillContentBuilder.Build(this.Frontmatter.Name, this.Frontmatter.Description, this._instructions, this._resources, this._scripts));
     }
 
     /// <inheritdoc/>
@@ -128,8 +128,9 @@ public sealed class AgentInlineSkill : AgentSkill
     /// Registers a static resource with this skill.
     /// </summary>
     /// <remarks>
-    /// Resources are not automatically included in the skill body.
-    /// To enable discovery, reference the resource by name in the skill's instructions or in another resource.
+    /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the
+    /// LLM knows it can be accessed. When no resources are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="value">The static resource value.</param>
@@ -146,8 +147,9 @@ public sealed class AgentInlineSkill : AgentSkill
     /// The delegate's parameters and return type are automatically marshaled via <c>AIFunctionFactory</c>.
     /// </summary>
     /// <remarks>
-    /// Resources are not automatically included in the skill body.
-    /// To enable discovery, reference the resource by name in the skill's instructions or in another resource.
+    /// The resource is listed in the <c>&lt;available_resources&gt;</c> block of the skill body so the
+    /// LLM knows it can be accessed. When no resources are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated resource calls.
     /// </remarks>
     /// <param name="name">The resource name.</param>
     /// <param name="method">A method that produces the resource value when requested.</param>
@@ -168,8 +170,9 @@ public sealed class AgentInlineSkill : AgentSkill
     /// The delegate's parameters and return type are automatically marshaled via <c>AIFunctionFactory</c>.
     /// </summary>
     /// <remarks>
-    /// Only the script's parameter schema is included in the skill body (as a <c>&lt;script_schemas&gt;</c> block).
-    /// To enable discovery, reference the script by name in the skill's instructions or in a resource.
+    /// The script is listed in the <c>&lt;available_scripts&gt;</c> block of the skill body so the
+    /// LLM knows it can be called. When no scripts are registered, the block is emitted as a
+    /// self-closing element to signal that none exist, preventing hallucinated script calls.
     /// </remarks>
     /// <param name="name">The script name.</param>
     /// <param name="method">A method to execute when the script is invoked.</param>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
@@ -39,32 +39,43 @@ internal static class AgentInlineSkillContentBuilder
         .Append(EscapeXmlString(instructions))
         .Append("\n</instructions>");
 
-        if (resources is { Count: > 0 })
-        {
-            sb.Append("\n\n<available_resources>\n");
-            foreach (var resource in resources)
-            {
-                sb.Append($"  <resource name=\"{EscapeXmlString(resource.Name)}\"/>\n");
-            }
+        sb.Append('\n');
+        sb.Append(BuildAvailableResourcesBlock(resources ?? []));
+        sb.Append('\n');
+        sb.Append(BuildAvailableScriptsBlock(scripts ?? []));
 
-            sb.Append("</available_resources>");
-        }
-        else
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds an <c>&lt;available_resources&gt;...&lt;/available_resources&gt;</c> XML block for the given resources.
+    /// Each resource is emitted as a self-closing <c>&lt;resource name="..."/&gt;</c> element. When the list is empty,
+    /// a self-closing <c>&lt;available_resources /&gt;</c> element is returned. This block lets the model know which
+    /// resources can be read (or that there are none) so it does not hallucinate resource names.
+    /// </summary>
+    /// <param name="resources">The resources to include in the block.</param>
+    /// <returns>
+    /// An XML string starting with <c>\n&lt;available_resources&gt;</c>, or <c>\n&lt;available_resources /&gt;</c> if the list is empty.
+    /// </returns>
+    public static string BuildAvailableResourcesBlock(IReadOnlyList<AgentSkillResource> resources)
+    {
+        _ = Throw.IfNull(resources);
+
+        if (resources.Count == 0)
         {
             // Emit an empty element so the model knows no resources are available and does not hallucinate resource names.
-            sb.Append("\n\n<available_resources />");
+            return "\n<available_resources />";
         }
 
-        if (scripts is { Count: > 0 })
+        var sb = new StringBuilder();
+        sb.Append("\n<available_resources>\n");
+
+        foreach (var resource in resources)
         {
-            sb.Append('\n');
-            sb.Append(BuildAvailableScriptsBlock(scripts));
+            sb.Append($"  <resource name=\"{EscapeXmlString(resource.Name)}\"/>\n");
         }
-        else
-        {
-            // Emit an empty element so the model knows no scripts are available and does not hallucinate script names.
-            sb.Append("\n\n<available_scripts />");
-        }
+
+        sb.Append("</available_resources>");
 
         return sb.ToString();
     }
@@ -73,18 +84,22 @@ internal static class AgentInlineSkillContentBuilder
     /// Builds an <c>&lt;available_scripts&gt;...&lt;/available_scripts&gt;</c> XML block for the given scripts.
     /// Each script is emitted as a <c>&lt;script name="..."&gt;</c> element; when the script has a
     /// parameter schema it is wrapped in a nested <c>&lt;parameters_schema&gt;</c> element, otherwise a
-    /// self-closing <c>&lt;script&gt;</c> element is used. This block lets the model know which scripts
-    /// can be called and how to format their arguments.
+    /// self-closing <c>&lt;script&gt;</c> element is used. When the list is empty, a self-closing
+    /// <c>&lt;available_scripts /&gt;</c> element is returned. This block lets the model know which scripts
+    /// can be called and how to format their arguments (or that there are none) so it does not hallucinate script names.
     /// </summary>
     /// <param name="scripts">The scripts to include in the block.</param>
-    /// <returns>An XML string starting with <c>\n&lt;available_scripts&gt;</c>, or an empty string if the list is empty.</returns>
+    /// <returns>
+    /// An XML string starting with <c>\n&lt;available_scripts&gt;</c>, or <c>\n&lt;available_scripts /&gt;</c> if the list is empty.
+    /// </returns>
     public static string BuildAvailableScriptsBlock(IReadOnlyList<AgentSkillScript> scripts)
     {
         _ = Throw.IfNull(scripts);
 
         if (scripts.Count == 0)
         {
-            return string.Empty;
+            // Emit an empty element so the model knows no scripts are available and does not hallucinate script names.
+            return "\n<available_scripts />";
         }
 
         var sb = new StringBuilder();

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillContentBuilder.cs
@@ -12,17 +12,19 @@ namespace Microsoft.Agents.AI;
 internal static class AgentInlineSkillContentBuilder
 {
     /// <summary>
-    /// Builds the complete skill content containing name, description, instructions, and script parameter schemas.
+    /// Builds the complete skill content containing name, description, instructions, resources, and script parameter schemas.
     /// </summary>
     /// <param name="name">The skill name.</param>
     /// <param name="description">The skill description.</param>
     /// <param name="instructions">The raw instructions text.</param>
+    /// <param name="resources">Optional resources associated with the skill.</param>
     /// <param name="scripts">Optional scripts associated with the skill.</param>
     /// <returns>An XML-structured content string.</returns>
     public static string Build(
         string name,
         string description,
         string instructions,
+        IReadOnlyList<AgentSkillResource>? resources,
         IReadOnlyList<AgentSkillScript>? scripts)
     {
         _ = Throw.IfNullOrWhitespace(name);
@@ -37,24 +39,46 @@ internal static class AgentInlineSkillContentBuilder
         .Append(EscapeXmlString(instructions))
         .Append("\n</instructions>");
 
+        if (resources is { Count: > 0 })
+        {
+            sb.Append("\n\n<available_resources>\n");
+            foreach (var resource in resources)
+            {
+                sb.Append($"  <resource name=\"{EscapeXmlString(resource.Name)}\"/>\n");
+            }
+
+            sb.Append("</available_resources>");
+        }
+        else
+        {
+            // Emit an empty element so the model knows no resources are available and does not hallucinate resource names.
+            sb.Append("\n\n<available_resources />");
+        }
+
         if (scripts is { Count: > 0 })
         {
             sb.Append('\n');
-            sb.Append(BuildScriptSchemasBlock(scripts));
+            sb.Append(BuildAvailableScriptsBlock(scripts));
+        }
+        else
+        {
+            // Emit an empty element so the model knows no scripts are available and does not hallucinate script names.
+            sb.Append("\n\n<available_scripts />");
         }
 
         return sb.ToString();
     }
 
     /// <summary>
-    /// Builds a <c>&lt;script_schemas&gt;...&lt;/script_schemas&gt;</c> XML block for the given scripts.
-    /// Each script is emitted as a <c>&lt;schema script="..."&gt;</c> element containing only
-    /// the parameter schema. This block serves as a reference for the model to know how to
-    /// format arguments when calling scripts, not as a discovery mechanism.
+    /// Builds an <c>&lt;available_scripts&gt;...&lt;/available_scripts&gt;</c> XML block for the given scripts.
+    /// Each script is emitted as a <c>&lt;script name="..."&gt;</c> element; when the script has a
+    /// parameter schema it is wrapped in a nested <c>&lt;parameters_schema&gt;</c> element, otherwise a
+    /// self-closing <c>&lt;script&gt;</c> element is used. This block lets the model know which scripts
+    /// can be called and how to format their arguments.
     /// </summary>
     /// <param name="scripts">The scripts to include in the block.</param>
-    /// <returns>An XML string starting with <c>\n&lt;script_schemas&gt;</c>, or an empty string if the list is empty.</returns>
-    public static string BuildScriptSchemasBlock(IReadOnlyList<AgentSkillScript> scripts)
+    /// <returns>An XML string starting with <c>\n&lt;available_scripts&gt;</c>, or an empty string if the list is empty.</returns>
+    public static string BuildAvailableScriptsBlock(IReadOnlyList<AgentSkillScript> scripts)
     {
         _ = Throw.IfNull(scripts);
 
@@ -64,7 +88,7 @@ internal static class AgentInlineSkillContentBuilder
         }
 
         var sb = new StringBuilder();
-        sb.Append("\n<script_schemas>\n");
+        sb.Append("\n<available_scripts>\n");
 
         foreach (var script in scripts)
         {
@@ -72,15 +96,17 @@ internal static class AgentInlineSkillContentBuilder
 
             if (parametersSchema is null)
             {
-                sb.Append($"  <schema script=\"{EscapeXmlString(script.Name)}\"/>\n");
+                sb.Append($"  <script name=\"{EscapeXmlString(script.Name)}\"/>\n");
             }
             else
             {
-                sb.Append($"  <schema script=\"{EscapeXmlString(script.Name)}\">{EscapeXmlString(parametersSchema.Value.GetRawText(), preserveQuotes: true)}</schema>\n");
+                sb.Append($"  <script name=\"{EscapeXmlString(script.Name)}\">\n");
+                sb.Append($"    <parameters_schema>{EscapeXmlString(parametersSchema.Value.GetRawText(), preserveQuotes: true)}</parameters_schema>\n");
+                sb.Append("  </script>\n");
             }
         }
 
-        sb.Append("</script_schemas>");
+        sb.Append("</available_scripts>");
 
         return sb.ToString();
     }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentClassSkillTests.cs
@@ -382,9 +382,10 @@ public sealed class AgentClassSkillTests
         // Arrange
         var skill = new AttributedFullSkill();
 
-        // Act & Assert — Content no longer includes resources in body; scripts are in script_schemas
-        Assert.DoesNotContain("<resources>", await skill.GetContentAsync());
-        Assert.Contains("<script_schemas>", await skill.GetContentAsync());
+        // Act & Assert — Content includes resources in body; scripts are in available_scripts
+        Assert.Contains("<available_resources>", await skill.GetContentAsync());
+        Assert.Contains("conversion-table", await skill.GetContentAsync());
+        Assert.Contains("<available_scripts>", await skill.GetContentAsync());
         Assert.Contains("convert", await skill.GetContentAsync());
 
         // Act & Assert — discovered members are cached
@@ -502,7 +503,7 @@ public sealed class AgentClassSkillTests
     }
 
     [Fact]
-    public async Task Content_DoesNotRenderResources_InBodyAsync()
+    public async Task Content_RendersResources_InBodyAsync()
     {
         // Arrange
         var skill = new AttributedResourcePropertiesSkill();
@@ -510,8 +511,10 @@ public sealed class AgentClassSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — resources are no longer rendered in body content
-        Assert.DoesNotContain("<resources>", content);
+        // Assert — resources are rendered in body content by name; descriptions are not emitted
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("ref-data", content);
+        Assert.DoesNotContain("Some important data.", content);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentFileSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentFileSkillScriptTests.cs
@@ -122,10 +122,10 @@ public sealed class AgentFileSkillScriptTests
 
         // Assert — content starts with original and appends per-script entries
         Assert.StartsWith("Original content", content);
-        Assert.Contains("<script_schemas>", content);
-        Assert.Contains("<schema script=\"build\">", content);
-        Assert.Contains("<schema script=\"deploy\">", content);
-        Assert.Contains("</script_schemas>", content);
+        Assert.Contains("<available_scripts>", content);
+        Assert.Contains("<script name=\"build\">", content);
+        Assert.Contains("<script name=\"deploy\">", content);
+        Assert.Contains("</available_scripts>", content);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentFileSkillScriptTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentFileSkillScriptTests.cs
@@ -126,10 +126,13 @@ public sealed class AgentFileSkillScriptTests
         Assert.Contains("<script name=\"build\">", content);
         Assert.Contains("<script name=\"deploy\">", content);
         Assert.Contains("</available_scripts>", content);
+
+        // A scripts-only skill still emits an empty resources peer so the model knows none are available
+        Assert.Contains("<available_resources />", content);
     }
 
     [Fact]
-    public async Task Content_WithoutScripts_ReturnsOriginalContentAsync()
+    public async Task Content_WithoutResourcesOrScripts_EmitsSelfClosingPeersAsync()
     {
         // Arrange
         var fileSkill = new AgentFileSkill(
@@ -140,8 +143,56 @@ public sealed class AgentFileSkillScriptTests
         // Act
         var content = await fileSkill.GetContentAsync();
 
-        // Assert
-        Assert.Equal("Original content only", content);
+        // Assert — both blocks are always emitted as self-closing elements so the model knows none are available
+        Assert.StartsWith("Original content only", content);
+        Assert.Contains("<available_resources />", content);
+        Assert.Contains("<available_scripts />", content);
+    }
+
+    [Fact]
+    public async Task Content_WithResources_AppendsResourceEntriesAsync()
+    {
+        // Arrange
+        var fileSkill = new AgentFileSkill(
+            new AgentSkillFrontmatter("my-skill", "A skill"),
+            "Original content",
+            "/skills/my-skill",
+            resources: [new AgentInlineSkillResource("reference", "value"), new AgentInlineSkillResource("table", "value")]);
+
+        // Act
+        var content = await fileSkill.GetContentAsync();
+
+        // Assert — content starts with original and appends per-resource entries so the model knows what is callable
+        Assert.StartsWith("Original content", content);
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("<resource name=\"reference\"/>", content);
+        Assert.Contains("<resource name=\"table\"/>", content);
+        Assert.Contains("</available_resources>", content);
+
+        // A resources-only skill still emits an empty scripts peer so the model knows none are available
+        Assert.Contains("<available_scripts />", content);
+    }
+
+    [Fact]
+    public async Task Content_WithResourcesAndScripts_AppendsResourcesBeforeScriptsAsync()
+    {
+        // Arrange
+        static Task<object?> RunnerAsync(AgentFileSkill s, AgentFileSkillScript sc, JsonElement? a, IServiceProvider? sp, CancellationToken ct) => Task.FromResult<object?>(null);
+        var fileSkill = new AgentFileSkill(
+            new AgentSkillFrontmatter("my-skill", "A skill"),
+            "Original content",
+            "/skills/my-skill",
+            resources: [new AgentInlineSkillResource("reference", "value")],
+            scripts: [CreateScript("build", "/scripts/build.sh", RunnerAsync)]);
+
+        // Act
+        var content = await fileSkill.GetContentAsync();
+
+        // Assert — resources block precedes scripts block
+        var resourcesIndex = content.IndexOf("<available_resources>", StringComparison.Ordinal);
+        var scriptsIndex = content.IndexOf("<available_scripts>", StringComparison.Ordinal);
+        Assert.True(resourcesIndex >= 0 && scriptsIndex >= 0);
+        Assert.True(resourcesIndex < scriptsIndex);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillContentBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillContentBuilderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -116,13 +115,61 @@ public sealed class AgentInlineSkillContentBuilderTests
     }
 
     [Fact]
-    public void BuildAvailableScriptsBlock_EmptyList_ReturnsEmptyString()
+    public void BuildAvailableResourcesBlock_EmptyList_ReturnsSelfClosingElement()
+    {
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableResourcesBlock(Array.Empty<AgentSkillResource>());
+
+        // Assert — empty list yields a self-closing element so the model knows none are available
+        Assert.Equal("\n<available_resources />", block);
+    }
+
+    [Fact]
+    public void BuildAvailableResourcesBlock_WithResources_EmitsSelfClosingResourceEntries()
+    {
+        // Arrange
+        var resources = new AgentSkillResource[]
+        {
+            new AgentInlineSkillResource("config", "value", "A described resource."),
+            new AgentInlineSkillResource("table", "value"),
+        };
+
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableResourcesBlock(resources);
+
+        // Assert — resources are listed by name only (no description)
+        Assert.Contains("<available_resources>", block);
+        Assert.Contains("<resource name=\"config\"/>", block);
+        Assert.Contains("<resource name=\"table\"/>", block);
+        Assert.Contains("</available_resources>", block);
+        Assert.DoesNotContain("A described resource.", block);
+    }
+
+    [Fact]
+    public void BuildAvailableResourcesBlock_ResourceNameWithSpecialCharacters_IsXmlEscaped()
+    {
+        // Arrange
+        var resources = new AgentSkillResource[] { new AgentInlineSkillResource("a<b>&\"c", "v") };
+
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableResourcesBlock(resources);
+
+        // Assert
+        Assert.Contains("<resource name=\"a&lt;b&gt;&amp;&quot;c\"/>", block);
+    }
+
+    [Fact]
+    public void BuildAvailableResourcesBlock_NullResources_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => AgentInlineSkillContentBuilder.BuildAvailableResourcesBlock(null!));
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_EmptyList_ReturnsSelfClosingElement()
     {
         // Act
         var block = AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(Array.Empty<AgentSkillScript>());
 
-        // Assert
-        Assert.Equal(string.Empty, block);
+        // Assert — empty list yields a self-closing element so the model knows none are available
+        Assert.Equal("\n<available_scripts />", block);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillContentBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillContentBuilderTests.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
+
+/// <summary>
+/// Unit tests for <see cref="AgentInlineSkillContentBuilder"/>, focusing on the structure of the
+/// emitted <c>&lt;available_resources&gt;</c> and <c>&lt;available_scripts&gt;</c> blocks.
+/// </summary>
+public sealed class AgentInlineSkillContentBuilderTests
+{
+    [Fact]
+    public void Build_NullResourcesAndScripts_EmitsSelfClosingTags()
+    {
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build("my-skill", "A skill.", "Instructions.", resources: null, scripts: null);
+
+        // Assert — explicit empty elements signal "none available" so the model does not hallucinate names
+        Assert.Contains("<available_resources />", content);
+        Assert.Contains("<available_scripts />", content);
+        Assert.DoesNotContain("<available_resources>", content);
+        Assert.DoesNotContain("<available_scripts>", content);
+    }
+
+    [Fact]
+    public void Build_EmptyResourcesAndScripts_EmitsSelfClosingTags()
+    {
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build(
+            "my-skill",
+            "A skill.",
+            "Instructions.",
+            resources: Array.Empty<AgentSkillResource>(),
+            scripts: Array.Empty<AgentSkillScript>());
+
+        // Assert
+        Assert.Contains("<available_resources />", content);
+        Assert.Contains("<available_scripts />", content);
+    }
+
+    [Fact]
+    public void Build_ResourcesOnly_EmitsResourceEntriesAndSelfClosingScripts()
+    {
+        // Arrange
+        var resources = new AgentSkillResource[]
+        {
+            new AgentInlineSkillResource("config", "value", "A described resource."),
+            new AgentInlineSkillResource("table", "value"),
+        };
+
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build("my-skill", "A skill.", "Instructions.", resources, scripts: null);
+
+        // Assert — resources are listed by name (no description), scripts are an empty element
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("<resource name=\"config\"/>", content);
+        Assert.Contains("<resource name=\"table\"/>", content);
+        Assert.Contains("</available_resources>", content);
+        Assert.DoesNotContain("A described resource.", content);
+        Assert.Contains("<available_scripts />", content);
+    }
+
+    [Fact]
+    public void Build_ScriptsOnly_EmitsSelfClosingResourcesAndScriptsBlock()
+    {
+        // Arrange
+        var scripts = new AgentSkillScript[] { new FakeScript("run", ParseSchema("{\"type\":\"object\"}")) };
+
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build("my-skill", "A skill.", "Instructions.", resources: null, scripts);
+
+        // Assert
+        Assert.Contains("<available_resources />", content);
+        Assert.Contains("<available_scripts>", content);
+        Assert.Contains("<script name=\"run\">", content);
+        Assert.Contains("</available_scripts>", content);
+    }
+
+    [Fact]
+    public void Build_MultipleResources_RendersAllInRegistrationOrder()
+    {
+        // Arrange
+        var resources = new AgentSkillResource[]
+        {
+            new AgentInlineSkillResource("first", "v"),
+            new AgentInlineSkillResource("second", "v"),
+            new AgentInlineSkillResource("third", "v"),
+        };
+
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build("my-skill", "A skill.", "Instructions.", resources, scripts: null);
+
+        // Assert — order is preserved
+        var firstIndex = content.IndexOf("first", StringComparison.Ordinal);
+        var secondIndex = content.IndexOf("second", StringComparison.Ordinal);
+        var thirdIndex = content.IndexOf("third", StringComparison.Ordinal);
+        Assert.True(firstIndex < secondIndex && secondIndex < thirdIndex);
+    }
+
+    [Fact]
+    public void Build_ResourceNameWithSpecialCharacters_IsXmlEscaped()
+    {
+        // Arrange
+        var resources = new AgentSkillResource[] { new AgentInlineSkillResource("a<b>&\"c", "v") };
+
+        // Act
+        var content = AgentInlineSkillContentBuilder.Build("my-skill", "A skill.", "Instructions.", resources, scripts: null);
+
+        // Assert — XML special characters in the name are escaped
+        Assert.Contains("<resource name=\"a&lt;b&gt;&amp;&quot;c\"/>", content);
+    }
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_EmptyList_ReturnsEmptyString()
+    {
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(Array.Empty<AgentSkillScript>());
+
+        // Assert
+        Assert.Equal(string.Empty, block);
+    }
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_ScriptWithoutSchema_UsesSelfClosingScript()
+    {
+        // Arrange — a script whose ParametersSchema is null
+        var scripts = new AgentSkillScript[] { new FakeScript("no-params", parametersSchema: null) };
+
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(scripts);
+
+        // Assert — self-closing <script> element with no nested parameters_schema
+        Assert.Contains("<script name=\"no-params\"/>", block);
+        Assert.DoesNotContain("<parameters_schema>", block);
+    }
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_ScriptWithSchema_WrapsSchemaInParametersSchemaElement()
+    {
+        // Arrange
+        var scripts = new AgentSkillScript[] { new FakeScript("search", ParseSchema("{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}}}")) };
+
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(scripts);
+
+        // Assert — schema is wrapped in <parameters_schema> with preserved quotes (no CDATA)
+        Assert.Contains("<script name=\"search\">", block);
+        Assert.Contains("<parameters_schema>", block);
+        Assert.Contains("\"query\"", block);
+        Assert.Contains("</parameters_schema>", block);
+        Assert.Contains("</script>", block);
+        Assert.DoesNotContain("<![CDATA[", block);
+    }
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_ScriptNameWithSpecialCharacters_IsXmlEscaped()
+    {
+        // Arrange
+        var scripts = new AgentSkillScript[] { new FakeScript("a<b>&\"c", parametersSchema: null) };
+
+        // Act
+        var block = AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(scripts);
+
+        // Assert
+        Assert.Contains("<script name=\"a&lt;b&gt;&amp;&quot;c\"/>", block);
+    }
+
+    [Fact]
+    public void BuildAvailableScriptsBlock_NullScripts_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => AgentInlineSkillContentBuilder.BuildAvailableScriptsBlock(null!));
+
+    private static JsonElement ParseSchema(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private sealed class FakeScript : AgentSkillScript
+    {
+        private readonly JsonElement? _parametersSchema;
+
+        public FakeScript(string name, JsonElement? parametersSchema)
+            : base(name)
+        {
+            this._parametersSchema = parametersSchema;
+        }
+
+        public override JsonElement? ParametersSchema => this._parametersSchema;
+
+        public override Task<object?> RunAsync(AgentSkill skill, JsonElement? arguments, IServiceProvider? serviceProvider, CancellationToken cancellationToken = default) =>
+            Task.FromResult<object?>(null);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
@@ -149,7 +149,7 @@ public sealed class AgentInlineSkillTests
     }
 
     [Fact]
-    public async Task Content_DoesNotIncludeResourcesInBodyAsync()
+    public async Task Content_IncludesResourcesInBodyAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("my-skill", "A valid skill.", "Instructions.");
@@ -158,12 +158,14 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — resources are no longer rendered in the body; they're accessed via GetResourceAsync
-        Assert.DoesNotContain("<resources>", content);
+        // Assert — resources are rendered in the body so the model can discover them
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("config", content);
+        Assert.DoesNotContain("A config resource.", content);
     }
 
     [Fact]
-    public async Task Content_DoesNotIncludeDelegateResourcesInBodyAsync()
+    public async Task Content_IncludesDelegateResourcesInBodyAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("my-skill", "A valid skill.", "Instructions.");
@@ -172,8 +174,9 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — resources are no longer rendered in the body
-        Assert.DoesNotContain("<resources>", content);
+        // Assert — resources are rendered in the body
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("dynamic", content);
     }
 
     [Fact]
@@ -187,7 +190,7 @@ public sealed class AgentInlineSkillTests
         var content = await skill.GetContentAsync();
 
         // Assert
-        Assert.Contains("<script_schemas>", content);
+        Assert.Contains("<available_scripts>", content);
         Assert.Contains("run", content);
     }
 
@@ -218,8 +221,9 @@ public sealed class AgentInlineSkillTests
         var content = await skill.GetContentAsync();
 
         // Assert
-        Assert.DoesNotContain("<resources>", content);
-        Assert.Contains("<script_schemas>", content);
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("r1", content);
+        Assert.Contains("<available_scripts>", content);
         Assert.Contains("s1", content);
     }
 
@@ -233,8 +237,9 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — JSON schema should be present inside <schema> element (no extra wrapper) with preserved quotes
-        Assert.Contains("<schema script=\"search\">", content);
+        // Assert — JSON schema should be present inside <parameters_schema> element with preserved quotes
+        Assert.Contains("<script name=\"search\">", content);
+        Assert.Contains("<parameters_schema>", content);
         Assert.Contains("\"query\"", content);
         Assert.DoesNotContain("<![CDATA[", content);
     }
@@ -417,7 +422,7 @@ public sealed class AgentInlineSkillTests
     }
 
     [Fact]
-    public async Task Content_NoResourcesOrScripts_DoesNotContainResourcesOrScriptsTagsAsync()
+    public async Task Content_NoResourcesOrScripts_EmitsSelfClosingTagsAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("my-skill", "A valid skill.", "Instructions.");
@@ -425,9 +430,9 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert
-        Assert.DoesNotContain("<resources>", content);
-        Assert.DoesNotContain("<script_schemas>", content);
+        // Assert — empty self-closing elements are emitted when no resources or scripts exist
+        Assert.Contains("<available_resources />", content);
+        Assert.Contains("<available_scripts />", content);
     }
 
     [Fact]
@@ -470,9 +475,8 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — description is no longer emitted in the script_schemas block;
-        // the block only contains parameter schemas for calling scripts.
-        Assert.Contains("<schema script=\"my-script\"", content);
+        // Assert — only the script name is emitted; the description is not rendered as an attribute
+        Assert.Contains("<script name=\"my-script\"", content);
         Assert.DoesNotContain("description=\"Runs something.\"", content);
     }
 
@@ -492,7 +496,7 @@ public sealed class AgentInlineSkillTests
     }
 
     [Fact]
-    public async Task Content_ResourceWithDescription_NotRenderedInBodyAsync()
+    public async Task Content_ResourceWithDescription_RenderedInBodyWithoutDescriptionAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("my-skill", "A valid skill.", "Instructions.");
@@ -502,10 +506,11 @@ public sealed class AgentInlineSkillTests
         // Act
         var content = await skill.GetContentAsync();
 
-        // Assert — resources are no longer rendered in the body
-        Assert.DoesNotContain("<resources>", content);
-        Assert.DoesNotContain("with-desc", content);
-        Assert.DoesNotContain("no-desc", content);
+        // Assert — resources are rendered by name in the body; descriptions are not emitted
+        Assert.Contains("<available_resources>", content);
+        Assert.Contains("<resource name=\"with-desc\"/>", content);
+        Assert.Contains("<resource name=\"no-desc\"/>", content);
+        Assert.DoesNotContain("A described resource.", content);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentInlineSkillTests.cs
@@ -160,7 +160,7 @@ public sealed class AgentInlineSkillTests
 
         // Assert — resources are rendered in the body so the model can discover them
         Assert.Contains("<available_resources>", content);
-        Assert.Contains("config", content);
+        Assert.Contains("<resource name=\"config\"/>", content);
         Assert.DoesNotContain("A config resource.", content);
     }
 
@@ -176,7 +176,7 @@ public sealed class AgentInlineSkillTests
 
         // Assert — resources are rendered in the body
         Assert.Contains("<available_resources>", content);
-        Assert.Contains("dynamic", content);
+        Assert.Contains("<resource name=\"dynamic\"/>", content);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public sealed class AgentInlineSkillTests
 
         // Assert
         Assert.Contains("<available_scripts>", content);
-        Assert.Contains("run", content);
+        Assert.Contains("<script name=\"run\"", content);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation & Context

When a skill has no resources or scripts, `AgentInlineSkillContentBuilder` left those sections out of the generated content entirely. With nothing saying "there are none", models can assume resources/scripts exist and hallucinate calls to names that aren't there.

### Description & Review Guide

- **What are the major changes?** `AgentInlineSkillContentBuilder.Build` now always emits `<available_resources>` and `<available_scripts>` - listing entries by name when present, or self-closing (`<available_resources />` / `<available_scripts />`) when empty. Script schemas are wrapped in a nested `<parameters_schema>` element. Added builder unit tests and updated public XML docs.
- **What is the impact of these changes?** The generated skill content text changes (the two blocks are now always present). No public API is removed.

### Related Issue

Closes: #6371

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.
