### PR TITLE
.NET: Remove unnecessary declarative logging

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeFunctionToolExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/InvokeFunctionToolExecutor.cs
@@ -14,7 +14,6 @@ using Microsoft.Agents.AI.Workflows.Declarative.Kit;
 using Microsoft.Agents.AI.Workflows.Declarative.PowerFx;
 using Microsoft.Agents.ObjectModel;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Workflows.Declarative.ObjectModel;
@@ -168,9 +167,6 @@ internal sealed class InvokeFunctionToolExecutor(
             {
                 if (!this._approvalSnapshots.ContainsKey(approval.RequestId))
                 {
-                    this.Logger.LogWarning(
-                        "Approval response '{RequestId}' did not match any pending invocation on '{ActionId}'.",
-                        approval.RequestId, this.Id);
                     await this.AssignErrorAsync(context, "No pending approval matched the response.").ConfigureAwait(false);
                 }
                 else if (!approval.Approved)
@@ -184,9 +180,6 @@ internal sealed class InvokeFunctionToolExecutor(
                 }
                 else
                 {
-                    this.Logger.LogWarning(
-                        "Approval response '{RequestId}' had no remaining pending snapshot on '{ActionId}'.",
-                        approval.RequestId, this.Id);
                     await this.AssignErrorAsync(context, "No pending approval matched the response.").ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
### Motivation & Context

Remove unnecessary declarative logging that's breaking publishing build because they did not match the repo convention.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
