### PR TITLE
.NET: Add IncludeDetailedErrors option for skill script execution

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -322,7 +322,7 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         catch (Exception ex)
         {
             LogResourceReadError(this._logger, skillName, resourceName, ex);
-            return $"Error: Failed to read resource '{resourceName}' from skill '{skillName}'.";
+            throw;
         }
     }
 
@@ -357,7 +357,7 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         catch (Exception ex)
         {
             LogScriptExecutionError(this._logger, skillName, scriptName, ex);
-            return $"Error: Failed to execute script '{scriptName}' from skill '{skillName}'.";
+            throw;
         }
     }
 

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -357,6 +357,12 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         catch (Exception ex)
         {
             LogScriptExecutionError(this._logger, skillName, scriptName, ex);
+
+            if (this._options?.IncludeDetailedErrors == true)
+            {
+                return $"Error: Failed to execute script '{scriptName}' from skill '{skillName}'. Exception: {ex.Message}";
+            }
+
             throw;
         }
     }

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
@@ -28,6 +28,20 @@ public sealed class AgentSkillsProviderOptions
     public bool ScriptApproval { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether detailed exception information is included
+    /// in the error message returned to the model when a script execution fails.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="false"/> (the default), exceptions propagate to the caller, allowing
+    /// <see cref="Extensions.AI.FunctionInvokingChatClient"/> to apply its own
+    /// <c>IncludeDetailedErrors</c> policy — which achieves the same effect without requiring
+    /// this property to be set. When <see langword="true"/>, the exception message is appended
+    /// to the error string returned directly to the model, enabling it to retry with different
+    /// arguments. However, this may disclose raw exception details to the model.
+    /// </remarks>
+    public bool IncludeDetailedErrors { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether caching of tools and instructions is disabled.
     /// When <see langword="false"/> (the default), the provider caches the tools and instructions
     /// after the first build and returns the cached instance on subsequent calls.

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
@@ -37,7 +37,11 @@ public sealed class AgentSkillsProviderOptions
     /// <c>IncludeDetailedErrors</c> policy — which achieves the same effect without requiring
     /// this property to be set. When <see langword="true"/>, the exception message is appended
     /// to the error string returned directly to the model, enabling it to retry with different
-    /// arguments. However, this may disclose raw exception details to the model.
+    /// arguments. However, this may disclose raw exception details to the model. Exercise
+    /// particular caution when enabling this for skills whose scripts originate from untrusted
+    /// or third-party sources: a maliciously crafted script could throw an exception whose
+    /// message embeds a prompt-injection payload, which would then be fed back to the model.
+    /// Only enable this when the skills and their scripts come from a trusted source.
     /// </remarks>
     public bool IncludeDetailedErrors { get; set; }
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -626,6 +626,31 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadSkillResource_ResourceThrows_PropagatesExceptionAsync()
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("res-skill", "Has resources", "Body.");
+        Func<object> failing = () => throw new InvalidOperationException("boom-resource");
+        skill.AddResource("config", failing);
+        var provider = new AgentSkillsProvider(skill);
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+        var readTool = result.Tools!.First(t => t.Name == "read_skill_resource") as AIFunction;
+
+        // Act & Assert — the exception is not swallowed but propagates to the caller.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await readTool!.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["skillName"] = "res-skill",
+                ["resourceName"] = "config",
+            })
+            {
+                Services = new TestServiceProvider(),
+            }));
+        Assert.Equal("boom-resource", ex.Message);
+    }
+
+    [Fact]
     public async Task RunSkillScript_EmptySkillName_ReturnsErrorAsync()
     {
         // Arrange
@@ -719,6 +744,31 @@ public sealed class AgentSkillsProviderTests : IDisposable
 
         // Assert
         Assert.Equal("Error: Script 'scripts/missing.py' not found in skill 'err-script4-skill'.", content!.ToString());
+    }
+
+    [Fact]
+    public async Task RunSkillScript_ScriptThrows_PropagatesExceptionAsync()
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("script-skill", "Has scripts", "Body.");
+        Func<object> failing = () => throw new InvalidOperationException("boom-script");
+        skill.AddScript("explode", failing);
+        var provider = new AgentSkillsProvider(skill);
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+        var runScriptTool = result.Tools!.First(t => t.Name == "run_skill_script") as AIFunction;
+
+        // Act & Assert — the exception is not swallowed but propagates to the caller.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await runScriptTool!.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+            {
+                ["skillName"] = "script-skill",
+                ["scriptName"] = "explode",
+            })
+            {
+                Services = new TestServiceProvider(),
+            }));
+        Assert.Equal("boom-script", ex.Message);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -747,7 +747,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task RunSkillScript_ScriptThrows_PropagatesExceptionAsync()
+    public async Task RunSkillScript_ScriptThrows_PropagatesExceptionByDefaultAsync()
     {
         // Arrange
         var skill = new AgentInlineSkill("script-skill", "Has scripts", "Body.");
@@ -758,7 +758,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
         var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
         var runScriptTool = result.Tools!.First(t => t.Name == "run_skill_script") as AIFunction;
 
-        // Act & Assert — the exception is not swallowed but propagates to the caller.
+        // Act & Assert — exception propagates when IncludeDetailedErrors is not set
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await runScriptTool!.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
             {
@@ -769,6 +769,33 @@ public sealed class AgentSkillsProviderTests : IDisposable
                 Services = new TestServiceProvider(),
             }));
         Assert.Equal("boom-script", ex.Message);
+    }
+
+    [Fact]
+    public async Task RunSkillScript_ScriptThrows_IncludesDetailsWhenEnabledAsync()
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("script-skill", "Has scripts", "Body.");
+        Func<object> failing = () => throw new InvalidOperationException("boom-script");
+        skill.AddScript("explode", failing);
+        var options = new AgentSkillsProviderOptions { IncludeDetailedErrors = true };
+        var provider = new AgentSkillsProvider(new[] { skill }, options);
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+        var runScriptTool = result.Tools!.First(t => t.Name == "run_skill_script") as AIFunction;
+
+        // Act
+        var content = await runScriptTool!.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object?>
+        {
+            ["skillName"] = "script-skill",
+            ["scriptName"] = "explode",
+        })
+        {
+            Services = new TestServiceProvider(),
+        });
+
+        // Assert — includes exception message
+        Assert.Equal("Error: Failed to execute script 'explode' from skill 'script-skill'. Exception: boom-script", content!.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation & Context

`AgentSkillsProvider.RunSkillScriptAsync` swallows exceptions and returns a generic error string. The model never learns *why* a script failed, so it cannot self-correct by retrying with different arguments.

### Description & Review Guide

- **What are the major changes?**
  - Added `IncludeDetailedErrors` property to `AgentSkillsProviderOptions`. When `true`, the script catch block returns an error string with `Exception: {ex.Message}` appended. When `false` (default), the exception is logged and rethrown — delegating error handling to `FunctionInvokingChatClient`.
  - `ReadSkillResourceAsync` now logs and rethrows the exception instead of returning a generic error string. Resources take no arguments, so a swallowed generic error is not actionable by the model; rethrowing lets the underlying chat client decide how to surface it.

### Related Issue

Fixes #6304

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue
- [x] **This is not a breaking change.**