### PR TITLE
.NET: Fix SearchDirectoriesForSkills to stop recursing after finding SKILL.md

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/File/AgentFileSkillsSource.cs
@@ -162,7 +162,10 @@ internal sealed partial class AgentFileSkillsSource : AgentSkillsSource
         string skillFilePath = Path.Combine(directory, SkillFileName);
         if (File.Exists(skillFilePath))
         {
+            // Once a SKILL.md is found, this directory is the skill root.
+            // Subdirectories are part of this skill and should not be treated as independent skill roots.
             results.Add(Path.GetFullPath(directory));
+            return;
         }
 
         if (currentDepth >= MaxSkillDirectorySearchDepth)

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
@@ -1199,4 +1199,26 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
         Assert.Equal("references/legit.md", skill.GetTestResources()![0].Name);
     }
 #endif
+
+    [Fact]
+    public async Task GetSkillsAsync_NestedSkillMd_DoesNotTreatSubdirectoryAsIndependentSkillAsync()
+    {
+        // Arrange — parent has SKILL.md; subdirectory also has SKILL.md.
+        // Only the parent should be discovered as a skill root.
+        string parentSkillDir = this.CreateSkillDirectory("parent-skill", "Parent skill", "Parent body.");
+        string childDir = Path.Combine(parentSkillDir, "child");
+        Directory.CreateDirectory(childDir);
+        File.WriteAllText(
+            Path.Combine(childDir, "SKILL.md"),
+            "---\nname: child-skill\ndescription: Child skill\n---\nChild body.");
+
+        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
+
+        // Act
+        var skills = await source.GetSkillsAsync();
+
+        // Assert — only the parent skill is discovered; the nested child is not an independent skill
+        Assert.Single(skills);
+        Assert.Equal("parent-skill", skills[0].Frontmatter.Name);
+    }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/FileAgentSkillLoaderTests.cs
@@ -1203,14 +1203,15 @@ public sealed class FileAgentSkillLoaderTests : IDisposable
     [Fact]
     public async Task GetSkillsAsync_NestedSkillMd_DoesNotTreatSubdirectoryAsIndependentSkillAsync()
     {
-        // Arrange — parent has SKILL.md; subdirectory also has SKILL.md.
+        // Arrange — parent has SKILL.md; subdirectory also has SKILL.md with a name
+        // matching its directory so it would pass validation if discovered.
         // Only the parent should be discovered as a skill root.
         string parentSkillDir = this.CreateSkillDirectory("parent-skill", "Parent skill", "Parent body.");
         string childDir = Path.Combine(parentSkillDir, "child");
         Directory.CreateDirectory(childDir);
         File.WriteAllText(
             Path.Combine(childDir, "SKILL.md"),
-            "---\nname: child-skill\ndescription: Child skill\n---\nChild body.");
+            "---\nname: child\ndescription: Child skill\n---\nChild body.");
 
         var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
 


### PR DESCRIPTION
### Motivation & Context

`SearchDirectoriesForSkills` finds a `SKILL.md` in a directory and adds it as a skill, but then keeps recursing into subdirectories. This causes subdirectories beneath a skill to be incorrectly treated as independent skill roots.

### Description & Review Guide

- **What are the major changes?** One-line fix: add a `return` after `results.Add(...)` so recursion stops once a `SKILL.md` is found.
- **What is the impact of these changes?** Subdirectories of a skill are no longer discovered as separate skills. The standard flat layout is unaffected (the root directory has no `SKILL.md`). Script/resource scanning is unaffected — those use their own separate recursion.
- **What do you want reviewers to focus on?** Whether there's a legitimate use case for nested independent skills within a parent skill boundary.

### Related Issue

Fixes microsoft/agent-framework#6683

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**