### PR TITLE
.NET/Python: Purview: prefer token principal for user identity

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Purview/PurviewClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Purview/PurviewClient.cs
@@ -265,7 +265,7 @@ internal sealed class PurviewClient : IPurviewClient
         var token = await this._tokenCredential.GetTokenAsync(new TokenRequestContext(this._scopes), cancellationToken).ConfigureAwait(false);
         string userId = request.UserId;
 
-        string uri = $"{this._graphUri}/{userId}/dataSecurityAndGovernance/activities/contentActivities";
+        string uri = $"{this._graphUri}/users/{userId}/dataSecurityAndGovernance/activities/contentActivities";
 
         using (HttpRequestMessage message = new(HttpMethod.Post, new Uri(uri)))
         {

--- a/dotnet/src/Microsoft.Agents.AI.Purview/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.Purview/README.md
@@ -82,7 +82,7 @@ The plugin requires the following Graph permissions:
 - Content.Process.All : [processContent](https://learn.microsoft.com/en-us/graph/api/userdatasecurityandgovernance-processcontent)
 - ContentActivity.Write : [contentActivity](https://learn.microsoft.com/en-us/graph/api/activitiescontainer-post-contentactivities)
 
-Authentication with user tokens is preferred. If authenticating with app tokens, the agent-framework caller will need to provide an entra user id for each `ChatMessage` send to the agent/client. This user id can be set using the `SetUserId` extension method, or by setting the `"userId"` field of the `AdditionalProperties` dictionary.
+Authentication with user tokens is preferred. When the configured credential resolves to a user token, that token's user id is used for Purview policy evaluation. If authenticating with app tokens, the token does not contain an end-user principal, so the agent-framework caller will need to provide an entra user id for each `ChatMessage` sent to the agent/client. This user id can be set using the `SetUserId` extension method, or by setting the `"userId"` field of the `AdditionalProperties` dictionary.
 
 ``` csharp
 // Manually

--- a/dotnet/src/Microsoft.Agents.AI.Purview/ScopedContentProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Purview/ScopedContentProcessor.cs
@@ -106,8 +106,8 @@ internal sealed class ScopedContentProcessor : IScopedContentProcessor
         List<ProcessContentRequest> pcRequests = [];
         TokenInfo? tokenInfo = await this._purviewClient.GetUserInfoFromTokenAsync(cancellationToken, settings.TenantId).ConfigureAwait(false);
         string tenantId = tokenInfo?.TenantId ?? settings.TenantId ?? throw new PurviewRequestException("No tenant id provided or inferred for Purview request. Please provide a tenant id in PurviewSettings or configure the TokenCredential to authenticate to a tenant.");
-        string? resolvedUserId = tokenInfo?.UserId ?? userId;
-        if (resolvedUserId == null && TryGetUserIdFromPayload(messages, out string? payloadUserId))
+        string? resolvedUserId = !string.IsNullOrEmpty(tokenInfo?.UserId) ? tokenInfo.UserId : userId;
+        if (string.IsNullOrEmpty(resolvedUserId) && TryGetUserIdFromPayload(messages, out string? payloadUserId))
         {
             resolvedUserId = payloadUserId;
         }

--- a/dotnet/src/Microsoft.Agents.AI.Purview/ScopedContentProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Purview/ScopedContentProcessor.cs
@@ -75,9 +75,10 @@ internal sealed class ScopedContentProcessor : IScopedContentProcessor
         foreach (ChatMessage message in messages)
         {
             if (message.AdditionalProperties != null &&
-                message.AdditionalProperties.TryGetValue(Constants.UserId, out userId) &&
-                !string.IsNullOrEmpty(userId))
+                message.AdditionalProperties.TryGetValue(Constants.UserId, out string? potentialUserId) &&
+                Guid.TryParse(potentialUserId, out Guid _))
             {
+                userId = potentialUserId;
                 return true;
             }
             else if (Guid.TryParse(message.AuthorName, out Guid _))
@@ -103,20 +104,13 @@ internal sealed class ScopedContentProcessor : IScopedContentProcessor
     private async Task<List<ProcessContentRequest>> MapMessageToPCRequestsAsync(IEnumerable<ChatMessage> messages, string? sessionId, Activity activity, PurviewSettings settings, string? userId, CancellationToken cancellationToken)
     {
         List<ProcessContentRequest> pcRequests = [];
-        TokenInfo? tokenInfo = null;
-
-        bool needUserId = userId == null && TryGetUserIdFromPayload(messages, out userId);
-
-        // Only get user info if the tenant id is null or if there's no location.
-        // If location is missing, we will create a new location using the client id.
-        if (settings.TenantId == null ||
-            settings.PurviewAppLocation == null ||
-            needUserId)
+        TokenInfo? tokenInfo = await this._purviewClient.GetUserInfoFromTokenAsync(cancellationToken, settings.TenantId).ConfigureAwait(false);
+        string tenantId = tokenInfo?.TenantId ?? settings.TenantId ?? throw new PurviewRequestException("No tenant id provided or inferred for Purview request. Please provide a tenant id in PurviewSettings or configure the TokenCredential to authenticate to a tenant.");
+        string? resolvedUserId = tokenInfo?.UserId ?? userId;
+        if (resolvedUserId == null && TryGetUserIdFromPayload(messages, out string? payloadUserId))
         {
-            tokenInfo = await this._purviewClient.GetUserInfoFromTokenAsync(cancellationToken, settings.TenantId).ConfigureAwait(false);
+            resolvedUserId = payloadUserId;
         }
-
-        string tenantId = settings.TenantId ?? tokenInfo?.TenantId ?? throw new PurviewRequestException("No tenant id provided or inferred for Purview request. Please provide a tenant id in PurviewSettings or configure the TokenCredential to authenticate to a tenant.");
 
         foreach (ChatMessage message in messages)
         {
@@ -166,18 +160,12 @@ internal sealed class ScopedContentProcessor : IScopedContentProcessor
             };
             ContentToProcess contentToProcess = new([conversationMetadata], activityMetadata, deviceMetadata, integratedAppMetadata, protectedAppMetadata);
 
-            if (userId == null &&
-                tokenInfo?.UserId != null)
+            if (string.IsNullOrEmpty(resolvedUserId))
             {
-                userId = tokenInfo.UserId;
+                throw new PurviewRequestException("No user id provided or inferred for Purview request. Please provide an Entra user id in each message, pass a user id to the processor, or configure the TokenCredential to authenticate to an Entra user.");
             }
 
-            if (string.IsNullOrEmpty(userId))
-            {
-                throw new PurviewRequestException("No user id provided or inferred for Purview request. Please provide an Entra user id in each message's AuthorName, set a default Entra user id in PurviewSettings, or configure the TokenCredential to authenticate to an Entra user.");
-            }
-
-            ProcessContentRequest pcRequest = new(contentToProcess, userId, tenantId);
+            ProcessContentRequest pcRequest = new(contentToProcess, resolvedUserId, tenantId);
             pcRequests.Add(pcRequest);
         }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/PurviewClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/PurviewClientTests.cs
@@ -376,8 +376,8 @@ public sealed class PurviewClientTests : IDisposable
         Assert.NotNull(result);
         Assert.Null(result.Error);
 
-        // Verify request - note the endpoint is different from ProcessContent
-        Assert.Equal("https://graph.microsoft.com/v1.0/test-user-id/dataSecurityAndGovernance/activities/contentActivities", this._handler.RequestUri?.ToString());
+        // Verify request
+        Assert.Equal("https://graph.microsoft.com/v1.0/users/test-user-id/dataSecurityAndGovernance/activities/contentActivities", this._handler.RequestUri?.ToString());
         Assert.Equal(HttpMethod.Post, this._handler.RequestMethod);
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/ScopedContentProcessorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/ScopedContentProcessorTests.cs
@@ -447,6 +447,56 @@ public sealed class ScopedContentProcessorTests
     }
 
     [Fact]
+    public async Task ProcessMessagesAsync_MatchesAnyLocationInScope_WhenMatchingLocationFirstAsync()
+    {
+        // Arrange
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test message")
+        };
+        var settings = CreateValidPurviewSettings();
+
+        var psResponse = new ProtectionScopesResponse
+        {
+            Scopes =
+            [
+                new()
+                {
+                    Activities = ProtectionScopeActivities.UploadText,
+                    Locations =
+                    [
+                        new("microsoft.graph.policyLocationApplication", "app-123"),
+                        new("microsoft.graph.policyLocationApplication", "other-app-456")
+                    ],
+                    ExecutionMode = ExecutionMode.EvaluateInline,
+                    PolicyActions =
+                    [
+                        new() { Action = DlpAction.BlockAccess }
+                    ]
+                }
+            ]
+        };
+
+        this._mockCacheProvider.Setup(x => x.GetAsync<ProtectionScopesCacheKey, ProtectionScopesResponse>(
+            It.IsAny<ProtectionScopesCacheKey>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(psResponse);
+
+        this._mockPurviewClient.Setup(x => x.ProcessContentAsync(
+            It.IsAny<ProcessContentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessContentResponse { PolicyActions = [] });
+
+        // Act
+        var result = await this._processor.ProcessMessagesAsync(
+            messages, "session-123", Activity.UploadText, settings, "user-123", CancellationToken.None);
+
+        // Assert
+        Assert.True(result.shouldBlock);
+        this._mockPurviewClient.Verify(x => x.ProcessContentAsync(
+            It.IsAny<ProcessContentRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        this._mockChannelHandler.Verify(x => x.QueueJob(It.IsAny<ContentActivityJob>()), Times.Never);
+    }
+
+    [Fact]
     public async Task ProcessMessagesAsync_WithNoTenantId_ThrowsPurviewExceptionAsync()
     {
         // Arrange
@@ -492,13 +542,14 @@ public sealed class ScopedContentProcessorTests
     public async Task ProcessMessagesAsync_ExtractsUserIdFromMessageAdditionalProperties_Async()
     {
         // Arrange
+        string userId = Guid.NewGuid().ToString();
         var messages = new List<ChatMessage>
         {
             new (ChatRole.User, "Test message")
             {
                 AdditionalProperties = new AdditionalPropertiesDictionary
                 {
-                    { "userId", "user-from-props" }
+                    { "userId", userId }
                 }
             }
         };
@@ -518,7 +569,119 @@ public sealed class ScopedContentProcessorTests
             messages, "session-123", Activity.UploadText, settings, null, CancellationToken.None);
 
         // Assert
-        Assert.Equal("user-from-props", result.userId);
+        Assert.Equal(userId, result.userId);
+    }
+
+    [Fact]
+    public async Task ProcessMessagesAsync_IgnoresInvalidAdditionalPropertiesUserId_Async()
+    {
+        // Arrange
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test message")
+            {
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    { "userId", "not-a-guid" }
+                }
+            }
+        };
+        var settings = CreateValidPurviewSettings();
+        var tokenInfo = new TokenInfo { TenantId = "tenant-123", ClientId = "client-123" };
+
+        this._mockPurviewClient.Setup(x => x.GetUserInfoFromTokenAsync(It.IsAny<CancellationToken>(), settings.TenantId))
+            .ReturnsAsync(tokenInfo);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<PurviewRequestException>(() =>
+            this._processor.ProcessMessagesAsync(messages, "session-123", Activity.UploadText, settings, null, CancellationToken.None));
+
+        Assert.Contains("No user id provided or inferred", exception.Message);
+    }
+
+    [Fact]
+    public async Task ProcessMessagesAsync_UsesTokenUserIdBeforeMessageAdditionalProperties_Async()
+    {
+        // Arrange
+        string tokenUserId = Guid.NewGuid().ToString();
+        string messageUserId = Guid.NewGuid().ToString();
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test message")
+            {
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    { "userId", messageUserId }
+                }
+            }
+        };
+        var settings = CreateValidPurviewSettings();
+        var tokenInfo = new TokenInfo { TenantId = "tenant-123", UserId = tokenUserId, ClientId = "client-123" };
+
+        this._mockPurviewClient.Setup(x => x.GetUserInfoFromTokenAsync(It.IsAny<CancellationToken>(), settings.TenantId))
+            .ReturnsAsync(tokenInfo);
+
+        this._mockCacheProvider.Setup(x => x.GetAsync<ProtectionScopesCacheKey, ProtectionScopesResponse>(
+            It.IsAny<ProtectionScopesCacheKey>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProtectionScopesResponse?)null);
+
+        this._mockPurviewClient.Setup(x => x.GetProtectionScopesAsync(
+            It.IsAny<ProtectionScopesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProtectionScopesResponse { Scopes = [] });
+        this._mockPurviewClient.Setup(x => x.ProcessContentAsync(
+            It.IsAny<ProcessContentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessContentResponse { PolicyActions = [] });
+
+        // Act
+        var result = await this._processor.ProcessMessagesAsync(
+            messages, "session-123", Activity.UploadText, settings, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(tokenUserId, result.userId);
+        this._mockPurviewClient.Verify(x => x.ProcessContentAsync(
+            It.Is<ProcessContentRequest>(request => request.UserId == tokenUserId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessagesAsync_UsesTokenUserIdBeforeAuthorName_Async()
+    {
+        // Arrange
+        string tokenUserId = Guid.NewGuid().ToString();
+        string authorUserId = Guid.NewGuid().ToString();
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test message")
+            {
+                AuthorName = authorUserId
+            }
+        };
+        var settings = CreateValidPurviewSettings();
+        var tokenInfo = new TokenInfo { TenantId = "tenant-123", UserId = tokenUserId, ClientId = "client-123" };
+
+        this._mockPurviewClient.Setup(x => x.GetUserInfoFromTokenAsync(It.IsAny<CancellationToken>(), settings.TenantId))
+            .ReturnsAsync(tokenInfo);
+
+        this._mockCacheProvider.Setup(x => x.GetAsync<ProtectionScopesCacheKey, ProtectionScopesResponse>(
+            It.IsAny<ProtectionScopesCacheKey>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProtectionScopesResponse?)null);
+
+        this._mockPurviewClient.Setup(x => x.GetProtectionScopesAsync(
+            It.IsAny<ProtectionScopesRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProtectionScopesResponse { Scopes = [] });
+        this._mockPurviewClient.Setup(x => x.ProcessContentAsync(
+            It.IsAny<ProcessContentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessContentResponse { PolicyActions = [] });
+
+        // Act
+        var result = await this._processor.ProcessMessagesAsync(
+            messages, "session-123", Activity.UploadText, settings, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(tokenUserId, result.userId);
+        this._mockPurviewClient.Verify(x => x.ProcessContentAsync(
+            It.Is<ProcessContentRequest>(request => request.UserId == tokenUserId),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/ScopedContentProcessorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Purview.UnitTests/ScopedContentProcessorTests.cs
@@ -685,6 +685,40 @@ public sealed class ScopedContentProcessorTests
     }
 
     [Fact]
+    public async Task ProcessMessagesAsync_UsesProvidedUserId_WhenTokenUserIdIsEmptyAsync()
+    {
+        // Arrange
+        string providedUserId = Guid.NewGuid().ToString();
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "Test message")
+        };
+        var settings = CreateValidPurviewSettings();
+        var tokenInfo = new TokenInfo { TenantId = "tenant-123", UserId = string.Empty, ClientId = "client-123" };
+
+        this._mockPurviewClient.Setup(x => x.GetUserInfoFromTokenAsync(It.IsAny<CancellationToken>(), settings.TenantId))
+            .ReturnsAsync(tokenInfo);
+
+        this._mockCacheProvider.Setup(x => x.GetAsync<ProtectionScopesCacheKey, ProtectionScopesResponse>(
+            It.IsAny<ProtectionScopesCacheKey>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProtectionScopesResponse?)null);
+
+        this._mockPurviewClient.Setup(x => x.ProcessContentAsync(
+            It.IsAny<ProcessContentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessContentResponse { PolicyActions = [] });
+
+        // Act
+        var result = await this._processor.ProcessMessagesAsync(
+            messages, "session-123", Activity.UploadText, settings, providedUserId, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(providedUserId, result.userId);
+        this._mockPurviewClient.Verify(x => x.ProcessContentAsync(
+            It.Is<ProcessContentRequest>(request => request.UserId == providedUserId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task ProcessMessagesAsync_ExtractsUserIdFromMessageAuthorName_WhenValidGuidAsync()
     {
         // Arrange

--- a/python/packages/purview/README.md
+++ b/python/packages/purview/README.md
@@ -315,7 +315,7 @@ except (PurviewAuthenticationError, PurviewRateLimitError, PurviewRequestError, 
 ---
 
 ## Notes
-- **User Identification**: Provide a `user_id` per request (e.g. in `Message(..., additional_properties={"user_id": "<guid>"})`) for per-user policy scoping. If no user_id is provided, policy evaluation is skipped entirely.
+- **User Identification**: When the configured credential resolves to a user token, that token's `user_id` is used for per-user policy scoping. For app-token credentials, provide a `user_id` per request (e.g. in `Message(..., additional_properties={"user_id": "<guid>"})`). If no user_id is provided or inferred, policy evaluation is skipped.
 - **Blocking Messages**: Can be customized via `blocked_prompt_message` and `blocked_response_message` in `PurviewSettings`. By default, they are "Prompt blocked by policy" and "Response blocked by policy" respectively.
 - **Streaming Responses**: Post-response policy evaluation presently applies only to non-streaming chat responses.
 - **Error Handling**: Use `ignore_exceptions` and `ignore_payment_required` settings for graceful degradation. When enabled, errors are logged but don't fail the request.

--- a/python/packages/purview/agent_framework_purview/_processor.py
+++ b/python/packages/purview/agent_framework_purview/_processor.py
@@ -117,10 +117,7 @@ class ScopedContentProcessor:
             A tuple of (requests, resolved_user_id)
         """
         results: list[ProcessContentRequest] = []
-        token_info = None
-
-        if not (self._settings.get("tenant_id") and self._settings.get("purview_app_location")):
-            token_info = await self._client.get_user_info_from_token(tenant_id=self._settings.get("tenant_id"))
+        token_info = await self._client.get_user_info_from_token(tenant_id=self._settings.get("tenant_id"))
 
         tenant_id = (token_info or {}).get("tenant_id") or self._settings.get("tenant_id")
         if not tenant_id or not _is_valid_guid(tenant_id):
@@ -128,6 +125,9 @@ class ScopedContentProcessor:
 
         resolved_user_id = (token_info or {}).get("user_id")
         resolved_author_name = None
+        if not resolved_user_id:
+            resolved_user_id = provided_user_id if provided_user_id and _is_valid_guid(provided_user_id) else None
+
         if not resolved_user_id:
             for m in messages:
                 if m.additional_properties:
@@ -140,9 +140,6 @@ class ScopedContentProcessor:
 
         if not resolved_user_id and resolved_author_name:
             resolved_user_id = resolved_author_name
-
-        if not resolved_user_id:
-            resolved_user_id = provided_user_id if provided_user_id and _is_valid_guid(provided_user_id) else None
 
         # Return empty results if user_id is empty
         if not resolved_user_id or not _is_valid_guid(resolved_user_id):

--- a/python/packages/purview/tests/purview/test_processor.py
+++ b/python/packages/purview/tests/purview/test_processor.py
@@ -471,6 +471,10 @@ class TestScopedContentProcessor:
             ),
         )
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [
             Message(
@@ -496,6 +500,10 @@ class TestScopedContentProcessor:
             ),
         )
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [Message(role="user", contents=["Test message"])]
 
@@ -517,6 +525,10 @@ class TestScopedContentProcessor:
             ),
         )
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [Message(role="user", contents=["Test message"])]
 
@@ -632,10 +644,10 @@ class TestUserIdResolution:
         mock_client.get_user_info_from_token.assert_called_once()
         assert user_id == "11111111-1111-1111-1111-111111111111"
 
-    async def test_user_id_from_additional_properties_takes_priority(
+    async def test_user_id_from_token_takes_priority_over_additional_properties(
         self, mock_client: AsyncMock, settings: PurviewSettings
     ) -> None:
-        """Test user_id from additional_properties takes priority over token."""
+        """Test token user_id takes priority over message additional_properties."""
         processor = ScopedContentProcessor(mock_client, settings)
 
         messages = [
@@ -648,15 +660,19 @@ class TestUserIdResolution:
 
         requests, user_id = await processor._map_messages(messages, Activity.UPLOAD_TEXT)
 
-        # Token info should not be called since we have user_id in message
-        mock_client.get_user_info_from_token.assert_not_called()
-        assert user_id == "22222222-2222-2222-2222-222222222222"
+        mock_client.get_user_info_from_token.assert_called_once()
+        assert user_id == "11111111-1111-1111-1111-111111111111"
+        assert all(req.user_id == "11111111-1111-1111-1111-111111111111" for req in requests)
 
     async def test_user_id_from_author_name_as_fallback(
         self, mock_client: AsyncMock, settings: PurviewSettings
     ) -> None:
         """Test user_id is extracted from author_name when it's a valid GUID."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [
             Message(
@@ -675,6 +691,10 @@ class TestUserIdResolution:
     ) -> None:
         """Test author_name is ignored if it's not a valid GUID."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [
             Message(
@@ -695,6 +715,10 @@ class TestUserIdResolution:
     ) -> None:
         """Test provided_user_id parameter is used as last resort."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [Message(role="user", contents=["Test"])]
 
@@ -707,6 +731,10 @@ class TestUserIdResolution:
     async def test_invalid_provided_user_id_ignored(self, mock_client: AsyncMock, settings: PurviewSettings) -> None:
         """Test invalid provided_user_id is ignored."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [Message(role="user", contents=["Test"])]
 
@@ -718,6 +746,10 @@ class TestUserIdResolution:
     async def test_multiple_messages_same_user_id(self, mock_client: AsyncMock, settings: PurviewSettings) -> None:
         """Test that all messages use the same resolved user_id."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [
             Message(
@@ -740,6 +772,10 @@ class TestUserIdResolution:
     ) -> None:
         """Test that the first valid user_id found in messages is used for all."""
         processor = ScopedContentProcessor(mock_client, settings)
+        mock_client.get_user_info_from_token.return_value = {
+            "tenant_id": "12345678-1234-1234-1234-123456789012",
+            "client_id": "12345678-1234-1234-1234-123456789012",
+        }
 
         messages = [
             Message(role="user", contents=["First"], author_name="Not a GUID"),


### PR DESCRIPTION
### Motivation & Context

Purview middleware needs consistent identity resolution across .NET and Python. User-token credentials should evaluate policy for the authenticated token principal, while app-token flows should continue to support supplied end-user IDs for policy scoping.

This also aligns the content activities route with the other Purview Graph user routes.

### Description & Review Guide

- **What are the major changes?**
  - Resolve Purview user identity by inspecting token info first in both .NET and Python middleware.
  - Use supplied/message fallback user IDs only when the token has no user principal.
  - Require .NET message `userId` fallback values to parse as GUIDs, matching Python validation.
  - Fix .NET content activities URL to use `/users/{userId}/...`.
  - Add/update regression tests for token precedence, invalid fallback IDs, scope location matching, and content activity route construction.

- **What is the impact of these changes?**
  - User-token flows consistently bind policy evaluation to the authenticated user.
  - App-token flows remain supported through validated supplied/message user IDs.
  - Content activity audit requests use the documented user route.

- **What do you want reviewers to focus on?**
  - Identity precedence in `ScopedContentProcessor` / `_processor.py`.
  - App-token fallback behavior remains supported.
  - Route assertion in `PurviewClientTests`.

### Related Issue

No public issue. Security hardening and parity fix for Purview middleware.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
