### PR TITLE
Python: Explicitly emit available_resources and available_scripts in skill content

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -675,9 +675,13 @@ def _build_skill_content(
 ) -> str:
     """Build XML-structured content for code-defined and class-based skills.
 
-    Produces an XML document containing name, description, instructions,
-    resources, and scripts elements.  Used by both :class:`InlineSkill`
-    and :class:`ClassSkill` to generate their ``content`` property.
+    Produces an XML document containing name, description, instructions, and
+    ``<available_resources>`` / ``<available_scripts>`` blocks.  The two blocks
+    are always emitted: when a category has no entries, a self-closing element
+    (e.g. ``<available_scripts />``) is emitted so the model knows none are
+    available and does not hallucinate their names.  Used by both
+    :class:`InlineSkill` and :class:`ClassSkill` to generate their ``content``
+    property.
 
     Args:
         name: The skill name.
@@ -698,13 +702,8 @@ def _build_skill_content(
         "</instructions>"
     )
 
-    if resources:
-        resource_lines = "\n".join(_create_resource_element(r) for r in resources)
-        result += f"\n\n<resources>\n{resource_lines}\n</resources>"
-
-    if scripts:
-        script_lines = "\n".join(_create_script_element(s) for s in scripts)
-        result += f"\n\n<scripts>\n{script_lines}\n</scripts>"
+    result += f"\n\n{_build_available_resources_block(resources)}"
+    result += f"\n\n{_build_available_scripts_block(scripts)}"
 
     return result
 
@@ -723,6 +722,50 @@ def _create_resource_element(resource: SkillResource) -> str:
     if resource.description:
         attrs += f' description="{xml_escape(resource.description, quote=True)}"'
     return f"  <resource {attrs}/>"
+
+
+def _build_available_resources_block(resources: Sequence[SkillResource] | None) -> str:
+    """Build an ``<available_resources>`` XML block for the given resources.
+
+    Each resource is emitted as a ``<resource name="…"/>`` element (with an
+    optional ``description`` attribute).  When there are no resources, a
+    self-closing ``<available_resources />`` element is returned so the model
+    knows none are available and does not hallucinate resource names.
+
+    Args:
+        resources: The resources to include in the block, if any.
+
+    Returns:
+        The ``<available_resources>`` XML block, or ``<available_resources />``
+        when *resources* is empty or ``None``.
+    """
+    if not resources:
+        return "<available_resources />"
+    resource_lines = "\n".join(_create_resource_element(r) for r in resources)
+    return f"<available_resources>\n{resource_lines}\n</available_resources>"
+
+
+def _build_available_scripts_block(scripts: Sequence[SkillScript] | None) -> str:
+    """Build an ``<available_scripts>`` XML block for the given scripts.
+
+    Each script is emitted as a ``<script name="…">`` element; when the script
+    has a parameter schema it is wrapped in a nested ``<parameters_schema>``
+    element, otherwise a self-closing ``<script …/>`` element is used.  When
+    there are no scripts, a self-closing ``<available_scripts />`` element is
+    returned so the model knows none are available and does not hallucinate
+    script names.
+
+    Args:
+        scripts: The scripts to include in the block, if any.
+
+    Returns:
+        The ``<available_scripts>`` XML block, or ``<available_scripts />``
+        when *scripts* is empty or ``None``.
+    """
+    if not scripts:
+        return "<available_scripts />"
+    script_lines = "\n".join(_create_script_element(s) for s in scripts)
+    return f"<available_scripts>\n{script_lines}\n</available_scripts>"
 
 
 @experimental(feature_id=ExperimentalFeature.SKILLS)
@@ -781,6 +824,10 @@ class InlineSkill(Skill):
 
     async def get_content(self) -> str:
         """Synthesized XML content with name, description, instructions, resources, and scripts.
+
+        The ``<available_resources>`` and ``<available_scripts>`` blocks are
+        always emitted; an empty category is rendered as a self-closing element
+        (e.g. ``<available_scripts />``) so the model knows none are available.
 
         The result is cached after the first access.  Adding resources or
         scripts after the first access will not be reflected.
@@ -1351,6 +1398,10 @@ class ClassSkill(Skill, ABC):
     async def get_content(self) -> str:
         """Synthesized XML content containing name, description, instructions, resources, and scripts.
 
+        The ``<available_resources>`` and ``<available_scripts>`` blocks are
+        always emitted; an empty category is rendered as a self-closing element
+        (e.g. ``<available_scripts />``) so the model knows none are available.
+
         The result is cached after the first access.
 
         Returns:
@@ -1437,25 +1488,27 @@ class FileSkill(Skill):
         return self._frontmatter
 
     async def get_content(self) -> str:
-        """The skill content with appended scripts block.
+        """The skill content with appended resource and script blocks.
 
-        When scripts are present, a ``<scripts>`` XML block is appended
-        to the raw SKILL.md content so that the LLM can discover each
-        script's ``<parameters_schema>``.
+        The raw SKILL.md content is followed by ``<available_resources>`` and
+        ``<available_scripts>`` blocks.  Both are always emitted: a category
+        with no entries is appended as a self-closing element (e.g.
+        ``<available_scripts />``) so the model knows none are available and
+        does not hallucinate their names.  When entries are present, scripts
+        include their ``<parameters_schema>`` so the LLM can discover the
+        argument format.
 
-        The result is cached after the first access.  Adding scripts
-        after the first access will not be reflected.
+        The result is cached after the first access.  Adding resources or
+        scripts after the first access will not be reflected.
 
         Returns:
             The skill content string.
         """
         if self._cached_content is not None:
             return self._cached_content
-        if not self._scripts:
-            self._cached_content = self._content
-        else:
-            script_lines = "\n".join(_create_script_element(s) for s in self._scripts)
-            self._cached_content = f"{self._content}\n\n<scripts>\n{script_lines}\n</scripts>"
+        resources_block = _build_available_resources_block(self._resources)
+        scripts_block = _build_available_scripts_block(self._scripts)
+        self._cached_content = f"{self._content}\n\n{resources_block}\n\n{scripts_block}"
         return self._cached_content
 
     async def get_resource(self, name: str) -> SkillResource | None:

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -1167,7 +1167,8 @@ class TestSkillsProviderCodeSkill:
         assert "<name>prog-skill</name>" in result
         assert "<description>A skill.</description>" in result
         assert "<instructions>\nCode-defined instructions.\n</instructions>" in result
-        assert "<resources>" not in result
+        assert "<available_resources />" in result
+        assert "<available_scripts />" in result
 
     async def test_load_skill_appends_resource_listing(self) -> None:
         skill = InlineSkill(
@@ -1184,7 +1185,7 @@ class TestSkillsProviderCodeSkill:
         assert "<name>prog-skill</name>" in result
         assert "<description>A skill.</description>" in result
         assert "Do things." in result
-        assert "<resources>" in result
+        assert "<available_resources>" in result
         assert '<resource name="ref-a" description="First resource"/>' in result
         assert '<resource name="ref-b"/>' in result
 
@@ -1196,7 +1197,7 @@ class TestSkillsProviderCodeSkill:
         await _init_provider(provider)
         result = await provider._load_skill(_raw_skills(provider), "prog-skill")
         assert "Body only." in result
-        assert "<resources>" not in result
+        assert "<available_resources />" in result
 
     async def test_read_static_resource(self) -> None:
         skill = InlineSkill(
@@ -3969,16 +3970,16 @@ class TestLoadSkillWithScripts:
         await _init_provider(provider)
         result = await provider._load_skill(_raw_skills(provider), "my-skill")
 
-        assert "<scripts>" in result
+        assert "<available_scripts>" in result
         assert 'name="analyze"' in result
         assert 'description="Run analysis"' in result
 
-    async def test_code_skill_no_scripts_element(self) -> None:
+    async def test_code_skill_emits_empty_scripts_element(self) -> None:
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
         provider = SkillsProvider([skill])
         await _init_provider(provider)
         result = await provider._load_skill(_raw_skills(provider), "my-skill")
-        assert "<scripts>" not in result
+        assert "<available_scripts />" in result
 
 
 # ---------------------------------------------------------------------------
@@ -4056,13 +4057,13 @@ class TestClassSkill:
         skill = _MinimalClassSkill()
         assert "Do minimal things." in (await skill.get_content())
 
-    async def test_minimal_skill_content_no_resources_element(self) -> None:
+    async def test_minimal_skill_content_emits_empty_resources_element(self) -> None:
         skill = _MinimalClassSkill()
-        assert "<resources>" not in (await skill.get_content())
+        assert "<available_resources />" in (await skill.get_content())
 
-    async def test_minimal_skill_content_no_scripts_element(self) -> None:
+    async def test_minimal_skill_content_emits_empty_scripts_element(self) -> None:
         skill = _MinimalClassSkill()
-        assert "<scripts>" not in (await skill.get_content())
+        assert "<available_scripts />" in (await skill.get_content())
 
     def test_full_skill_has_resources(self) -> None:
         skill = _FullClassSkill()
@@ -4076,12 +4077,12 @@ class TestClassSkill:
 
     async def test_full_skill_content_contains_resources(self) -> None:
         skill = _FullClassSkill()
-        assert "<resources>" in (await skill.get_content())
+        assert "<available_resources>" in (await skill.get_content())
         assert 'name="test-resource"' in (await skill.get_content())
 
     async def test_full_skill_content_contains_scripts(self) -> None:
         skill = _FullClassSkill()
-        assert "<scripts>" in (await skill.get_content())
+        assert "<available_scripts>" in (await skill.get_content())
         assert 'name="test-script"' in (await skill.get_content())
 
     async def test_content_is_cached(self) -> None:
@@ -4127,8 +4128,8 @@ class TestClassSkill:
 
         result = await provider._load_skill(_raw_skills(provider), "full-skill")
         assert "Use this skill for full tasks." in result
-        assert "<resources>" in result
-        assert "<scripts>" in result
+        assert "<available_resources>" in result
+        assert "<available_scripts>" in result
 
     async def test_in_memory_source_with_class_skill(self) -> None:
         skill = _MinimalClassSkill()
@@ -4345,12 +4346,12 @@ class TestClassSkillDecoratorDiscovery:
 
     async def test_content_includes_discovered_resources(self) -> None:
         skill = _DecoratorClassSkill()
-        assert "<resources>" in (await skill.get_content())
+        assert "<available_resources>" in (await skill.get_content())
         assert 'name="lookup-table"' in (await skill.get_content())
 
     async def test_content_includes_discovered_scripts(self) -> None:
         skill = _DecoratorClassSkill()
-        assert "<scripts>" in (await skill.get_content())
+        assert "<available_scripts>" in (await skill.get_content())
         assert 'name="convert"' in (await skill.get_content())
 
     def test_duplicate_resource_name_raises(self) -> None:
@@ -4748,7 +4749,7 @@ class _MixedPropertyMethodSkill(ClassSkill):
         await _init_provider(provider)
         result = await provider._load_skill(_raw_skills(provider), "my-skill")
 
-        assert "<scripts>" in result
+        assert "<available_scripts>" in result
         assert 'name="analyze"' in result
         assert "<parameters_schema>" in result
         assert '"query"' in result
@@ -5734,7 +5735,7 @@ class TestArrayStyleScriptArgs:
         assert "Failed to run" in result
 
     async def test_file_skill_content_includes_scripts_block(self) -> None:
-        """FileSkill.content appends a <scripts> block when scripts are present."""
+        """FileSkill.content appends an <available_scripts> block when scripts are present."""
         script = FileSkillScript(name="run.py", full_path=f"{_ABS}/test/run.py")
         skill = FileSkill(
             frontmatter=SkillFrontmatter(name="my-skill", description="test"),
@@ -5742,16 +5743,30 @@ class TestArrayStyleScriptArgs:
             path=f"{_ABS}/test",
             scripts=[script],
         )
-        assert "<scripts>" in (await skill.get_content())
+        assert "<available_scripts>" in (await skill.get_content())
         assert 'name="run.py"' in (await skill.get_content())
         assert "<parameters_schema>" in (await skill.get_content())
         assert '"type": "array"' in (await skill.get_content())
 
-    async def test_file_skill_content_no_scripts_no_block(self) -> None:
-        """FileSkill.content does not append a <scripts> block when no scripts."""
+    async def test_file_skill_content_no_scripts_emits_empty_block(self) -> None:
+        """FileSkill.content always emits self-closing resource and script blocks when empty."""
         skill = FileSkill(
             frontmatter=SkillFrontmatter(name="my-skill", description="test"),
             content="---\nname: my-skill\n---\nBody",
             path=f"{_ABS}/test",
         )
-        assert "<scripts>" not in (await skill.get_content())
+        content = await skill.get_content()
+        assert "<available_resources />" in content
+        assert "<available_scripts />" in content
+
+    async def test_file_skill_content_includes_resources_block(self) -> None:
+        """FileSkill.content appends an <available_resources> block when resources are present."""
+        skill = FileSkill(
+            frontmatter=SkillFrontmatter(name="my-skill", description="test"),
+            content="---\nname: my-skill\n---\nBody",
+            path=f"{_ABS}/test",
+            resources=[InlineSkillResource(name="ref-data", content="data")],
+        )
+        content = await skill.get_content()
+        assert "<available_resources>" in content
+        assert '<resource name="ref-data"/>' in content


### PR DESCRIPTION
### Motivation & Context

When a skill has no resources or scripts, the Python skill-content builders left those sections out of the generated content entirely. With nothing saying "there are none", a model can assume resources/scripts exist and hallucinate calls to names that aren't there. This ports .NET PR #6672 to Python so skill content always advertises an authoritative list (or explicit emptiness) for each category.

### Description & Review Guide

- **What are the major changes?** Skill content now always emits `<available_resources>` and `<available_scripts>` blocks — listing entries by name when present, or a self-closing element (`<available_resources />` / `<available_scripts />`) when empty. The blocks were renamed from `<resources>`/`<scripts>`. Two shared helpers (`_build_available_resources_block` / `_build_available_scripts_block`) centralize the logic, used by `InlineSkill`/`ClassSkill` (via `_build_skill_content`) and `FileSkill`. `FileSkill` now also emits its resources block, which it previously never did. Builder docstrings and unit tests were updated, with new tests for the empty-block and FileSkill-resources cases.
- **What is the impact of these changes?** The generated skill-content text changes (the two blocks are now always present and renamed). No public API is removed; the Skills feature remains experimental.
- **What do you want reviewers to focus on?** The renamed/always-emitted blocks and the new `FileSkill` resources emission.

### Related Issue

Closes #6348

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
