### PR TITLE
.NET: .NET Foundry: add CreateMcpTool projectConnectionId overload

### DIFF
--- a/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/Program.cs
@@ -33,11 +33,7 @@ var mcpTool = ResponseTool.CreateMcpTool(
 // Optional: authenticate the MCP server through a Foundry project connection.
 // The connection stores credentials, so the platform injects them at request time and no inline token is sent.
 // The public Microsoft Learn MCP server above needs no authentication, so this is shown for illustration only.
-//
-// Option A (native, on the raw McpTool used by the server-side definition below):
-//   mcpTool.ProjectConnectionId = "my-foundry-connection"; // from Azure.AI.Projects.Agents
-//
-// Option B (client-side AITool path), use the Foundry factory overload:
+// Use the FoundryAITool.CreateMcpTool overload that takes a projectConnectionId:
 //   AITool tool = FoundryAITool.CreateMcpTool(
 //       serverLabel: "github",
 //       serverUri: new Uri("https://api.githubcopilot.com/mcp"),

--- a/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/Program.cs
@@ -30,6 +30,20 @@ var mcpTool = ResponseTool.CreateMcpTool(
     serverUri: new Uri("https://learn.microsoft.com/api/mcp"),
     toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.NeverRequireApproval));
 
+// Optional: authenticate the MCP server through a Foundry project connection.
+// The connection stores credentials, so the platform injects them at request time and no inline token is sent.
+// The public Microsoft Learn MCP server above needs no authentication, so this is shown for illustration only.
+//
+// Option A (native, on the raw McpTool used by the server-side definition below):
+//   mcpTool.ProjectConnectionId = "my-foundry-connection"; // from Azure.AI.Projects.Agents
+//
+// Option B (client-side AITool path), use the Foundry factory overload:
+//   AITool tool = FoundryAITool.CreateMcpTool(
+//       serverLabel: "github",
+//       serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+//       projectConnectionId: "my-foundry-connection",
+//       toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+
 // Create a server side agent with the mcp tool, and expose it as an AIAgent.
 ProjectsAgentVersion agentVersion = await aiProjectClient.AgentAdministrationClient.CreateAgentVersionAsync(
     "MicrosoftLearnAgent",

--- a/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/README.md
+++ b/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/README.md
@@ -21,36 +21,17 @@ A hosted MCP server can authenticate through a Foundry **project connection** in
 authorization token or headers. The connection stores the credentials and the platform injects them
 at request time. This mirrors the Python `FoundryChatClient.get_mcp_tool(..., project_connection_id=...)`.
 
-Two equivalent ways to attach a connection in .NET:
+Use the `FoundryAITool.CreateMcpTool` overload that takes a `projectConnectionId`:
 
-- **Client AITool path** — use the Foundry factory overload, which packages the pass-through into one call:
+```csharp
+using Microsoft.Agents.AI.Foundry;
+using OpenAI.Responses;
 
-  ```csharp
-  using Microsoft.Agents.AI.Foundry;
-  using OpenAI.Responses;
+AITool tool = FoundryAITool.CreateMcpTool(
+    serverLabel: "github",
+    serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+    projectConnectionId: "my-foundry-connection",
+    toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+```
 
-  AITool tool = FoundryAITool.CreateMcpTool(
-      serverLabel: "github",
-      serverUri: new Uri("https://api.githubcopilot.com/mcp"),
-      projectConnectionId: "my-foundry-connection",
-      toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
-  ```
-
-- **Native McpTool path** — set `ProjectConnectionId` directly on the OpenAI `McpTool` (the extension
-  ships in `Azure.AI.Projects.Agents`). This is also the workaround that works today without the
-  overload, since `FoundryAITool.FromResponseTool` / `.AsAITool()` passes the tool through untouched:
-
-  ```csharp
-  using Azure.AI.Projects.Agents;
-  using OpenAI.Responses;
-
-  McpTool mcp = ResponseTool.CreateMcpTool(
-      serverLabel: "github",
-      serverUri: new Uri("https://api.githubcopilot.com/mcp"),
-      toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
-  mcp.ProjectConnectionId = "my-foundry-connection";
-
-  AITool tool = FoundryAITool.FromResponseTool(mcp);
-  ```
-
-Both emit `project_connection_id` on the MCP tool sent to Foundry.
+The resulting tool sends `project_connection_id` on the MCP tool to Foundry.

--- a/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/README.md
+++ b/dotnet/samples/02-agents/ModelContextProtocol/FoundryAgent_Hosted_MCP/README.md
@@ -14,3 +14,43 @@ Set the following environment variables:
 $env:FOUNDRY_PROJECT_ENDPOINT="https://your-foundry-service.services.ai.azure.com/api/projects/your-foundry-project" # Replace with your Microsoft Foundry resource endpoint
 $env:FOUNDRY_MODEL="gpt-5.4-mini"  # Optional, defaults to gpt-5.4-mini
 ```
+
+## Authenticating a hosted MCP server with a Foundry project connection
+
+A hosted MCP server can authenticate through a Foundry **project connection** instead of an inline
+authorization token or headers. The connection stores the credentials and the platform injects them
+at request time. This mirrors the Python `FoundryChatClient.get_mcp_tool(..., project_connection_id=...)`.
+
+Two equivalent ways to attach a connection in .NET:
+
+- **Client AITool path** — use the Foundry factory overload, which packages the pass-through into one call:
+
+  ```csharp
+  using Microsoft.Agents.AI.Foundry;
+  using OpenAI.Responses;
+
+  AITool tool = FoundryAITool.CreateMcpTool(
+      serverLabel: "github",
+      serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+      projectConnectionId: "my-foundry-connection",
+      toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+  ```
+
+- **Native McpTool path** — set `ProjectConnectionId` directly on the OpenAI `McpTool` (the extension
+  ships in `Azure.AI.Projects.Agents`). This is also the workaround that works today without the
+  overload, since `FoundryAITool.FromResponseTool` / `.AsAITool()` passes the tool through untouched:
+
+  ```csharp
+  using Azure.AI.Projects.Agents;
+  using OpenAI.Responses;
+
+  McpTool mcp = ResponseTool.CreateMcpTool(
+      serverLabel: "github",
+      serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+      toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+  mcp.ProjectConnectionId = "my-foundry-connection";
+
+  AITool tool = FoundryAITool.FromResponseTool(mcp);
+  ```
+
+Both emit `project_connection_id` on the MCP tool sent to Foundry.

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
@@ -194,6 +194,32 @@ public static class FoundryAITool
         => ResponseTool.CreateMcpTool(serverLabel, connectorId, authorizationToken, serverDescription, headers, allowedTools, toolCallApprovalPolicy).AsAITool();
 
     /// <summary>
+    /// Creates an <see cref="AITool"/> for a hosted MCP server that authenticates through a Foundry project connection.
+    /// </summary>
+    /// <remarks>
+    /// The project connection stores the authentication and connection details for the MCP server, so the platform
+    /// injects credentials at request time and no inline authorization token or headers are sent. This mirrors the
+    /// Python <c>FoundryChatClient.get_mcp_tool(..., project_connection_id=...)</c> factory.
+    /// </remarks>
+    /// <param name="serverLabel">The label for the MCP server.</param>
+    /// <param name="serverUri">The URI of the MCP server.</param>
+    /// <param name="projectConnectionId">The Foundry project connection ID that stores authentication for the MCP server.</param>
+    /// <param name="serverDescription">Optional server description.</param>
+    /// <param name="allowedTools">Optional filter for allowed tools.</param>
+    /// <param name="toolCallApprovalPolicy">Optional tool call approval policy.</param>
+    /// <returns>An <see cref="AITool"/> for MCP server tools backed by a Foundry project connection.</returns>
+    public static AITool CreateMcpTool(string serverLabel, Uri serverUri, string projectConnectionId, string? serverDescription = null, McpToolFilter? allowedTools = null, McpToolCallApprovalPolicy? toolCallApprovalPolicy = null)
+    {
+        McpTool tool = ResponseTool.CreateMcpTool(serverLabel, serverUri, authorizationToken: null, serverDescription, headers: null, allowedTools, toolCallApprovalPolicy);
+
+        // ProjectConnectionId is a Foundry extension (Azure.AI.Projects.Agents) that patches "project_connection_id"
+        // onto the MCP tool. The credentials live in the connection, so no inline token or headers are forwarded.
+        tool.ProjectConnectionId = projectConnectionId;
+
+        return tool.AsAITool();
+    }
+
+    /// <summary>
     /// Creates an <see cref="AITool"/> for code interpreter.
     /// </summary>
     /// <param name="container">The container configuration for the code interpreter.</param>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry/FoundryAITool.cs
@@ -175,9 +175,25 @@ public static class FoundryAITool
     /// <param name="headers">Optional custom headers.</param>
     /// <param name="allowedTools">Optional filter for allowed tools.</param>
     /// <param name="toolCallApprovalPolicy">Optional tool call approval policy.</param>
+    /// <param name="projectConnectionId">
+    /// Optional Foundry project connection ID that stores authentication and connection details for the MCP server.
+    /// When set, the platform injects the connection's credentials at request time. Mirrors the
+    /// Python <c>FoundryChatClient.get_mcp_tool(..., project_connection_id=...)</c> parameter.
+    /// </param>
     /// <returns>An <see cref="AITool"/> for MCP server tools.</returns>
-    public static AITool CreateMcpTool(string serverLabel, Uri serverUri, string? authorizationToken = null, string? serverDescription = null, IDictionary<string, string>? headers = null, McpToolFilter? allowedTools = null, McpToolCallApprovalPolicy? toolCallApprovalPolicy = null)
-        => ResponseTool.CreateMcpTool(serverLabel, serverUri, authorizationToken, serverDescription, headers, allowedTools, toolCallApprovalPolicy).AsAITool();
+    public static AITool CreateMcpTool(string serverLabel, Uri serverUri, string? authorizationToken = null, string? serverDescription = null, IDictionary<string, string>? headers = null, McpToolFilter? allowedTools = null, McpToolCallApprovalPolicy? toolCallApprovalPolicy = null, string? projectConnectionId = null)
+    {
+        McpTool tool = ResponseTool.CreateMcpTool(serverLabel, serverUri, authorizationToken, serverDescription, headers, allowedTools, toolCallApprovalPolicy);
+
+        if (projectConnectionId is not null)
+        {
+            // ProjectConnectionId is a Foundry extension (Azure.AI.Projects.Agents) that patches
+            // "project_connection_id" onto the MCP tool so the platform injects the connection's credentials.
+            tool.ProjectConnectionId = projectConnectionId;
+        }
+
+        return tool.AsAITool();
+    }
 
     /// <summary>
     /// Creates an <see cref="AITool"/> for MCP (Model Context Protocol) server tools using a connector ID.
@@ -192,32 +208,6 @@ public static class FoundryAITool
     /// <returns>An <see cref="AITool"/> for MCP server tools.</returns>
     public static AITool CreateMcpTool(string serverLabel, McpToolConnectorId connectorId, string? authorizationToken = null, string? serverDescription = null, IDictionary<string, string>? headers = null, McpToolFilter? allowedTools = null, McpToolCallApprovalPolicy? toolCallApprovalPolicy = null)
         => ResponseTool.CreateMcpTool(serverLabel, connectorId, authorizationToken, serverDescription, headers, allowedTools, toolCallApprovalPolicy).AsAITool();
-
-    /// <summary>
-    /// Creates an <see cref="AITool"/> for a hosted MCP server that authenticates through a Foundry project connection.
-    /// </summary>
-    /// <remarks>
-    /// The project connection stores the authentication and connection details for the MCP server, so the platform
-    /// injects credentials at request time and no inline authorization token or headers are sent. This mirrors the
-    /// Python <c>FoundryChatClient.get_mcp_tool(..., project_connection_id=...)</c> factory.
-    /// </remarks>
-    /// <param name="serverLabel">The label for the MCP server.</param>
-    /// <param name="serverUri">The URI of the MCP server.</param>
-    /// <param name="projectConnectionId">The Foundry project connection ID that stores authentication for the MCP server.</param>
-    /// <param name="serverDescription">Optional server description.</param>
-    /// <param name="allowedTools">Optional filter for allowed tools.</param>
-    /// <param name="toolCallApprovalPolicy">Optional tool call approval policy.</param>
-    /// <returns>An <see cref="AITool"/> for MCP server tools backed by a Foundry project connection.</returns>
-    public static AITool CreateMcpTool(string serverLabel, Uri serverUri, string projectConnectionId, string? serverDescription = null, McpToolFilter? allowedTools = null, McpToolCallApprovalPolicy? toolCallApprovalPolicy = null)
-    {
-        McpTool tool = ResponseTool.CreateMcpTool(serverLabel, serverUri, authorizationToken: null, serverDescription, headers: null, allowedTools, toolCallApprovalPolicy);
-
-        // ProjectConnectionId is a Foundry extension (Azure.AI.Projects.Agents) that patches "project_connection_id"
-        // onto the MCP tool. The credentials live in the connection, so no inline token or headers are forwarded.
-        tool.ProjectConnectionId = projectConnectionId;
-
-        return tool.AsAITool();
-    }
 
     /// <summary>
     /// Creates an <see cref="AITool"/> for code interpreter.

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAIToolTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAIToolTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using Azure.AI.Projects.Agents;
 using Microsoft.Extensions.AI;
 using OpenAI.Responses;
@@ -47,5 +48,46 @@ public class FoundryAIToolTests
         string json = ModelReaderWriter.Write(mcpTool, ModelReaderWriterOptions.Json).ToString();
         Assert.Contains("\"project_connection_id\":\"my-foundry-connection\"", json);
         Assert.Contains("\"server_url\":\"https://api.githubcopilot.com/mcp\"", json);
+    }
+
+    [Fact]
+    public void CreateMcpTool_WithoutProjectConnectionId_DoesNotEmitProjectConnectionId()
+    {
+        // Arrange & Act
+        AITool tool = FoundryAITool.CreateMcpTool(
+            serverLabel: "github",
+            serverUri: new Uri("https://api.githubcopilot.com/mcp"));
+
+        // Assert
+        var mcpTool = Assert.IsType<McpTool>(tool.GetService(typeof(McpTool)));
+        Assert.Null(mcpTool.ProjectConnectionId);
+        string json = ModelReaderWriter.Write(mcpTool, ModelReaderWriterOptions.Json).ToString();
+        Assert.DoesNotContain("project_connection_id", json);
+    }
+
+    [Fact]
+    public void CreateMcpTool_WithProjectConnectionIdAndOtherSettings_PreservesAllSettings()
+    {
+        // Arrange
+        const string ConnectionId = "my-foundry-connection";
+        const string Token = "my-token";
+
+        // Act
+        AITool tool = FoundryAITool.CreateMcpTool(
+            serverLabel: "github",
+            serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+            authorizationToken: Token,
+            serverDescription: "GitHub MCP",
+            headers: new Dictionary<string, string> { ["X-Custom"] = "value" },
+            allowedTools: new McpToolFilter { ToolNames = { "search_issues" } },
+            projectConnectionId: ConnectionId);
+
+        // Assert
+        var mcpTool = Assert.IsType<McpTool>(tool.GetService(typeof(McpTool)));
+        Assert.Equal(ConnectionId, mcpTool.ProjectConnectionId);
+        Assert.Equal(Token, mcpTool.AuthorizationToken);
+        Assert.Equal("GitHub MCP", mcpTool.ServerDescription);
+        Assert.Contains("X-Custom", mcpTool.Headers);
+        Assert.Contains("search_issues", mcpTool.AllowedTools.ToolNames);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAIToolTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/FoundryAIToolTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ClientModel.Primitives;
+using Azure.AI.Projects.Agents;
+using Microsoft.Extensions.AI;
+using OpenAI.Responses;
+
+#pragma warning disable OPENAI001
+
+namespace Microsoft.Agents.AI.Foundry.UnitTests;
+
+public class FoundryAIToolTests
+{
+    [Fact]
+    public void CreateMcpTool_WithProjectConnectionId_SetsProjectConnectionId()
+    {
+        // Arrange
+        const string ConnectionId = "my-foundry-connection";
+
+        // Act
+        AITool tool = FoundryAITool.CreateMcpTool(
+            serverLabel: "github",
+            serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+            projectConnectionId: ConnectionId,
+            toolCallApprovalPolicy: new McpToolCallApprovalPolicy(GlobalMcpToolCallApprovalPolicy.AlwaysRequireApproval));
+
+        // Assert
+        var mcpTool = Assert.IsType<McpTool>(tool.GetService(typeof(McpTool)));
+        Assert.Equal(ConnectionId, mcpTool.ProjectConnectionId);
+    }
+
+    [Fact]
+    public void CreateMcpTool_WithProjectConnectionId_SerializesProjectConnectionId()
+    {
+        // Arrange
+        const string ConnectionId = "my-foundry-connection";
+
+        // Act
+        AITool tool = FoundryAITool.CreateMcpTool(
+            serverLabel: "github",
+            serverUri: new Uri("https://api.githubcopilot.com/mcp"),
+            projectConnectionId: ConnectionId);
+
+        // Assert
+        var mcpTool = Assert.IsType<McpTool>(tool.GetService(typeof(McpTool)));
+        string json = ModelReaderWriter.Write(mcpTool, ModelReaderWriterOptions.Json).ToString();
+        Assert.Contains("\"project_connection_id\":\"my-foundry-connection\"", json);
+        Assert.Contains("\"server_url\":\"https://api.githubcopilot.com/mcp\"", json);
+    }
+}


### PR DESCRIPTION
### Motivation & Context

Python `FoundryChatClient.get_mcp_tool(..., project_connection_id=...)` can attach a Foundry project connection to a hosted MCP tool so the platform injects credentials at request time. The .NET `FoundryAITool.CreateMcpTool` had no equivalent, leaving a parity gap for callers who want connection based auth instead of an inline token or headers.

### Description & Review Guide

- **What are the major changes?**
  - New overload `FoundryAITool.CreateMcpTool(serverLabel, serverUri, projectConnectionId, serverDescription?, allowedTools?, toolCallApprovalPolicy?)`. It builds the OpenAI `McpTool`, sets `ProjectConnectionId`, and returns it as an `AITool`.
  - The connection id flows through the public `McpTool.ProjectConnectionId` extension that already ships in `Azure.AI.Projects.Agents` (it patches `project_connection_id`). The Foundry package already references that package, so there is no new dependency and no hand rolled JsonPatch.
  - Unit tests covering the round trip and the serialized `project_connection_id`.
  - Sample `Program.cs` and `README.md` updated with project connection guidance, including the workaround that works without the overload (set `mcp.ProjectConnectionId` then `FoundryAITool.FromResponseTool`).

- **What is the impact of these changes?**
  - Additive API only. Existing overloads are unchanged.
  - Note: the MEAI `HostedMcpServerTool` abstraction does not carry a connection id, so the OpenAI `McpTool` path used here is the supported route. This is captured in the linked issue.

### Related Issue

Fixes #6702

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
