### PR TITLE
Python: Fix Hyperlight CodeAct span parenting

### DIFF
--- a/python/packages/hyperlight/agent_framework_hyperlight/_execute_code_tool.py
+++ b/python/packages/hyperlight/agent_framework_hyperlight/_execute_code_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import mimetypes
 import os
 import shutil
@@ -162,7 +163,8 @@ class _SandboxWorker:
                 del exc
                 return False, (exc_type, exc_args)
 
-        ok, payload = self._executor.submit(_wrapped).result()
+        current_context = contextvars.copy_context()
+        ok, payload = self._executor.submit(lambda: current_context.run(_wrapped)).result()
         if ok:
             return cast(_T, payload)
         exc_type, exc_args = cast(tuple[type[BaseException], tuple[str, ...]], payload)
@@ -830,12 +832,13 @@ def _make_sandbox_callback(tool_obj: FunctionTool) -> Callable[..., Any]:
         # registered callbacks synchronously via FFI, so this must be a sync function.
         # We run the async call on a dedicated thread to avoid conflicts with any
         # event loop that may be running on the current thread.
+        current_context = contextvars.copy_context()
         result_box: list[Any] = [None]
         error_box: list[BaseException] = []
 
         def _run() -> None:
             try:
-                result_box[0] = asyncio.run(_invoke())
+                result_box[0] = current_context.run(lambda: asyncio.run(_invoke()))
             except BaseException as exc:
                 error_box.append(exc)
 

--- a/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
+++ b/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
@@ -14,7 +14,7 @@ import json
 import sys
 import threading
 import time
-from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Generator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -97,7 +97,7 @@ skip_if_hyperlight_integration_tests_disabled = pytest.mark.skipif(
 
 
 @fixture
-def span_exporter(monkeypatch) -> InMemorySpanExporter:
+def span_exporter(monkeypatch) -> Generator[InMemorySpanExporter]:
     env_vars = [
         "ENABLE_INSTRUMENTATION",
         "ENABLE_SENSITIVE_DATA",
@@ -139,7 +139,7 @@ def span_exporter(monkeypatch) -> InMemorySpanExporter:
         if not hasattr(current_tracer_provider, "add_span_processor"):
             raise RuntimeError("Tracer provider does not support adding span processors.")
 
-        current_tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+        cast(Any, current_tracer_provider).add_span_processor(SimpleSpanProcessor(exporter))
         yield exporter
         exporter.clear()
 

--- a/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
+++ b/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
@@ -135,7 +135,11 @@ def span_exporter(monkeypatch) -> InMemorySpanExporter:
         patch("agent_framework.observability.configure_otel_providers"),
     ):
         exporter = InMemorySpanExporter()
-        tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+        current_tracer_provider = trace.get_tracer_provider()
+        if not hasattr(current_tracer_provider, "add_span_processor"):
+            raise RuntimeError("Tracer provider does not support adding span processors.")
+
+        current_tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
         yield exporter
         exporter.clear()
 

--- a/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
+++ b/python/packages/hyperlight/tests/hyperlight/test_hyperlight_codeact.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import dataclasses
 import gc
+import importlib
 import importlib.metadata
 import importlib.util
 import inspect
@@ -18,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from agent_framework import (
@@ -32,6 +34,10 @@ from agent_framework import (
     ResponseStream,
     tool,
 )
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pytest import fixture
 
 from agent_framework_hyperlight import AllowedDomain, FileMount, HyperlightCodeActProvider, HyperlightExecuteCodeTool
 from agent_framework_hyperlight import _execute_code_tool as execute_code_module
@@ -88,6 +94,50 @@ skip_if_hyperlight_integration_tests_disabled = pytest.mark.skipif(
     (reason := _hyperlight_integration_static_skip_reason()) is not None,
     reason=reason or "Hyperlight integration tests are disabled.",
 )
+
+
+@fixture
+def span_exporter(monkeypatch) -> InMemorySpanExporter:
+    env_vars = [
+        "ENABLE_INSTRUMENTATION",
+        "ENABLE_SENSITIVE_DATA",
+        "ENABLE_CONSOLE_EXPORTERS",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        "OTEL_SERVICE_NAME",
+        "OTEL_SERVICE_VERSION",
+        "OTEL_RESOURCE_ATTRIBUTES",
+    ]
+
+    for key in env_vars:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ENABLE_INSTRUMENTATION", "True")
+    monkeypatch.setenv("ENABLE_SENSITIVE_DATA", "True")
+
+    import agent_framework.observability as observability
+    from opentelemetry import trace
+
+    importlib.reload(observability)
+    observability_settings = observability.ObservabilitySettings()
+    tracer_provider = TracerProvider(resource=observability.create_resource())
+    trace.set_tracer_provider(tracer_provider)
+    monkeypatch.setattr(observability, "OBSERVABILITY_SETTINGS", observability_settings, raising=False)
+
+    with (
+        patch("agent_framework.observability.OBSERVABILITY_SETTINGS", observability_settings),
+        patch("agent_framework.observability.configure_otel_providers"),
+    ):
+        exporter = InMemorySpanExporter()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+        yield exporter
+        exporter.clear()
 
 
 @pytest.fixture(scope="module")
@@ -377,6 +427,38 @@ def test_execute_code_tool_replaces_tools_with_the_same_name() -> None:
     assert len(tools) == 1
     assert tools[0] is replacement_compute
     assert execute_code.approval_mode == "always_require"
+
+
+async def test_execute_code_tool_parent_span_for_host_tools(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeSandbox.instances.clear()
+    monkeypatch.setattr(execute_code_module, "_load_sandbox_class", lambda: _FakeSandbox)
+
+    execute_code = HyperlightExecuteCodeTool(tools=[compute])
+
+    span_exporter.clear()
+    await execute_code.invoke(
+        arguments={"code": 'total = call_tool("compute", a=20, b=22)\nprint(total)'},
+        skip_parsing=True,
+    )
+
+    spans = span_exporter.get_finished_spans()
+    execute_code_spans = [span for span in spans if span.name == "execute_tool execute_code"]
+    compute_spans = [span for span in spans if span.name == "execute_tool compute"]
+
+    assert len(execute_code_spans) == 1
+    assert len(compute_spans) == 1
+
+    execute_code_span = execute_code_spans[0]
+    compute_span = compute_spans[0]
+
+    assert compute_span.context is not None
+    assert execute_code_span.context is not None
+    assert compute_span.context.trace_id == execute_code_span.context.trace_id
+    assert compute_span.parent is not None
+    assert compute_span.parent.span_id == execute_code_span.context.span_id
 
 
 def test_execute_code_tool_accepts_string_and_tuple_file_mounts_without_mode_flags(


### PR DESCRIPTION
### Motivation & Context

CodeAct host-tool calls made from inside `execute_code` were losing their parent span when Hyperlight hopped onto its worker thread. That made the execution flow look flattened in OTEL backends and hid the nested relationship between `execute_code` and the host tool call.

### Description & Review Guide

- **What are the major changes?** Preserve the active OpenTelemetry context across Hyperlight's worker-thread boundary before running the sandbox callback, and add a regression test that asserts the host-tool span is a child of `execute_code`.
- **What is the impact of these changes?** Hyperlight traces now reflect the real nested execution flow, which makes CodeAct runs easier to inspect and debug in observability tools.
- **What do you want reviewers to focus on?** The context handoff in the Hyperlight worker-thread path and the span-parenting assertion in the regression test.

### Related Issue

Fixes #6704

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] The PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
