### PR TITLE
.NET: Fix hosted agent crash after tool call by rooting session store under $HOME (#6231)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
@@ -26,11 +26,15 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// Foundry's data model.
 /// </para>
 /// <para>
-/// When running in a Foundry hosted environment, sessions are stored under the well-known
-/// <c>/.checkpoints</c> path; locally, they fall under <c>{cwd}/.checkpoints</c>. The session
-/// JSON produced when the agent serializes the session already contains the workflow's
-/// in-memory checkpoint manager state, so a single file per (agent, conversation) pair is
-/// sufficient to resume long-running workflows across process restarts.
+/// When running in a Foundry hosted environment, sessions are stored under
+/// <c>{$HOME}/.checkpoints</c> (the platform sets <c>HOME</c> to <c>/home/session</c> by
+/// default). This is the only container directory that is writable and durably preserved
+/// across requests for the lifetime of the session; the container's root filesystem is
+/// read-only and paths outside <c>$HOME</c> may be cleared between requests. Locally,
+/// sessions fall under <c>{cwd}/.checkpoints</c>. The session JSON produced when the agent
+/// serializes the session already contains the workflow's in-memory checkpoint manager
+/// state, so a single file per (agent, conversation) pair is sufficient to resume
+/// long-running workflows across process restarts.
 /// </para>
 /// <para>
 /// Files are written atomically via a temp-file + <see cref="File.Move(string, string, bool)"/>
@@ -41,12 +45,22 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 public sealed class FileSystemAgentSessionStore : AgentSessionStore
 {
     /// <summary>
-    /// The well-known absolute path used when running inside a Foundry hosted environment.
+    /// The name of the environment variable whose value is the writable, durable session-data
+    /// directory in a Foundry hosted container. The platform injects it (default
+    /// <see cref="DefaultHostedSessionDataDirectory"/>).
     /// </summary>
-    public const string HostedCheckpointDirectory = "/.checkpoints";
+    public const string SessionDataDirectoryEnvironmentVariable = "HOME";
 
     /// <summary>
-    /// The directory name used under the current working directory when running locally.
+    /// The default value of <see cref="SessionDataDirectoryEnvironmentVariable"/> used when the
+    /// platform has not injected <c>HOME</c>. This is the only writable, durable location in a
+    /// Foundry hosted container; the container's root filesystem is read-only.
+    /// </summary>
+    public const string DefaultHostedSessionDataDirectory = "/home/session";
+
+    /// <summary>
+    /// The directory name used for checkpoint files, appended under the hosted session-data
+    /// directory (<c>$HOME</c>) or, locally, under the current working directory.
     /// </summary>
     public const string LocalCheckpointDirectoryName = ".checkpoints";
 
@@ -71,16 +85,39 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
 
     /// <summary>
     /// Creates a <see cref="FileSystemAgentSessionStore"/> rooted at the default location:
-    /// <see cref="HostedCheckpointDirectory"/> when running in a Foundry hosted environment,
-    /// otherwise <see cref="LocalCheckpointDirectoryName"/> under the current working directory.
+    /// <c>{$HOME}/.checkpoints</c> when running in a Foundry hosted environment (the platform
+    /// sets <c>HOME</c> to <see cref="DefaultHostedSessionDataDirectory"/> by default), otherwise
+    /// <see cref="LocalCheckpointDirectoryName"/> under the current working directory.
     /// </summary>
     /// <returns>A new <see cref="FileSystemAgentSessionStore"/> instance.</returns>
     public static FileSystemAgentSessionStore CreateDefault()
+        => new(ResolveDefaultRootDirectory(
+            FoundryEnvironment.IsHosted,
+            Environment.GetEnvironmentVariable(SessionDataDirectoryEnvironmentVariable),
+            Environment.CurrentDirectory));
+
+    /// <summary>
+    /// Resolves the default root directory for <see cref="CreateDefault"/>. Factored out so the
+    /// hosted-vs-local path selection can be unit-tested without depending on the process-wide,
+    /// statically-cached <c>FoundryEnvironment.IsHosted</c> value.
+    /// </summary>
+    /// <param name="isHosted">Whether the process is running in a Foundry hosted environment.</param>
+    /// <param name="homeDirectory">The value of the <c>HOME</c> environment variable, if any.</param>
+    /// <param name="currentDirectory">The current working directory, used for the local fallback.</param>
+    /// <returns>The root directory under which session files are written.</returns>
+    internal static string ResolveDefaultRootDirectory(bool isHosted, string? homeDirectory, string currentDirectory)
     {
-        string root = FoundryEnvironment.IsHosted
-            ? HostedCheckpointDirectory
-            : Path.Combine(Environment.CurrentDirectory, LocalCheckpointDirectoryName);
-        return new FileSystemAgentSessionStore(root);
+        if (isHosted)
+        {
+            // In a Foundry hosted container only the session-state directory ($HOME, default
+            // /home/session) is writable and durably preserved across requests. Writing under the
+            // filesystem root (the previous "/.checkpoints" default) fails because the root
+            // filesystem is read-only — see issue #6231.
+            string home = string.IsNullOrWhiteSpace(homeDirectory) ? DefaultHostedSessionDataDirectory : homeDirectory!;
+            return Path.Combine(home, LocalCheckpointDirectoryName);
+        }
+
+        return Path.Combine(currentDirectory, LocalCheckpointDirectoryName);
     }
 
     /// <inheritdoc/>
@@ -92,14 +129,7 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
 
         JsonElement serialized = await agent.SerializeSessionAsync(session, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        Directory.CreateDirectory(this.RootDirectory);
-
         string path = this.GetSessionPath(agent, conversationId);
-        string? parentDir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(parentDir))
-        {
-            Directory.CreateDirectory(parentDir);
-        }
 
         // Each save writes to its own temp file before atomically renaming over the
         // destination. Last writer wins for the final file, but no reader can observe
@@ -108,6 +138,14 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
 
         try
         {
+            Directory.CreateDirectory(this.RootDirectory);
+
+            string? parentDir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
             using (FileStream stream = new(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
             using (Utf8JsonWriter writer = new(stream))
             {
@@ -116,12 +154,32 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
 
             File.Move(tempPath, path, overwrite: true);
         }
-        catch
+        catch (Exception ex)
         {
             try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+
+            // A non-writable session directory is fatal: the caller asked to persist the session
+            // and we could not. Replace the opaque raw error (e.g. "Read-only file system :
+            // '/.checkpoints'") with an actionable message — in a Foundry hosted container only
+            // $HOME (default /home/session) is writable and durable. See issue #6231.
+            if (ex is IOException or UnauthorizedAccessException)
+            {
+                throw new IOException(this.BuildNotWritableMessage(path), ex);
+            }
+
             throw;
         }
     }
+
+    private string BuildNotWritableMessage(string sessionFilePath) =>
+        $"Failed to persist the agent session to '{sessionFilePath}'. The session store directory " +
+        $"'{this.RootDirectory}' could not be created or written to. In a Foundry hosted container only the " +
+        $"session-state directory referenced by the '{SessionDataDirectoryEnvironmentVariable}' environment " +
+        $"variable (default '{DefaultHostedSessionDataDirectory}') is writable and durably preserved across " +
+        "requests; the container's root filesystem is read-only and paths outside it may be cleared between " +
+        $"requests. Use {nameof(FileSystemAgentSessionStore)}.{nameof(CreateDefault)}() (which targets that " +
+        $"directory), construct the store with a path under it, or register a different {nameof(AgentSessionStore)} " +
+        $"(for example {nameof(InMemoryAgentSessionStore)}) via AddFoundryResponses(agent, agentSessionStore).";
 
     /// <inheritdoc/>
     public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, CancellationToken cancellationToken = default)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
@@ -112,12 +112,38 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
             // In a Foundry hosted container only the session-state directory ($HOME, default
             // /home/session) is writable and durably preserved across requests. Writing under the
             // filesystem root (the previous "/.checkpoints" default) fails because the root
-            // filesystem is read-only — see issue #6231.
-            string home = string.IsNullOrWhiteSpace(homeDirectory) ? DefaultHostedSessionDataDirectory : homeDirectory!;
+            // filesystem is read-only — see issue #6231. HOME is settable on the agent definition,
+            // so fall back to the default when it is missing, blank, a filesystem root (e.g. "/"),
+            // or otherwise unusable, to guarantee the store never lands directly under the root.
+            string home = IsUsableHostedHomeDirectory(homeDirectory) ? homeDirectory! : DefaultHostedSessionDataDirectory;
             return Path.Combine(home, LocalCheckpointDirectoryName);
         }
 
         return Path.Combine(currentDirectory, LocalCheckpointDirectoryName);
+    }
+
+    /// <summary>
+    /// Determines whether a hosted <c>HOME</c> value can safely root the session store. Rejects
+    /// null/blank values, a filesystem root (e.g. <c>"/"</c> or a drive root, which would put the
+    /// store back under the read-only container root and reintroduce issue #6231), and paths that
+    /// cannot be normalized.
+    /// </summary>
+    private static bool IsUsableHostedHomeDirectory(string? homeDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(homeDirectory))
+        {
+            return false;
+        }
+
+        try
+        {
+            string full = Path.GetFullPath(homeDirectory);
+            return !string.Equals(full, Path.GetPathRoot(full), StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc/>

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/ToolCallingHostedAgentTests.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/ToolCallingHostedAgentTests.cs
@@ -17,7 +17,7 @@ public sealed class ToolCallingHostedAgentTests(ToolCallingHostedAgentFixture fi
 {
     private readonly ToolCallingHostedAgentFixture _fixture = fixture;
 
-    [Fact(Skip = "Pending TestContainer build and end to end smoke (step 5).")]
+    [Fact]
     public async Task ServerSideTool_IsInvokedWhenPromptedAsync()
     {
         // Arrange
@@ -32,7 +32,7 @@ public sealed class ToolCallingHostedAgentTests(ToolCallingHostedAgentFixture fi
             "Expected at least one FunctionCallContent in the response messages.");
     }
 
-    [Fact(Skip = "Pending TestContainer build and end to end smoke (step 5).")]
+    [Fact]
     public async Task ServerSideTool_NotInvokedWhenNotNeededAsync()
     {
         // Arrange
@@ -47,7 +47,7 @@ public sealed class ToolCallingHostedAgentTests(ToolCallingHostedAgentFixture fi
         Assert.Equal(0, toolCallCount);
     }
 
-    [Fact(Skip = "Pending TestContainer build and end to end smoke (step 5).")]
+    [Fact]
     public async Task ServerSideTool_MultiTurn_RemembersPriorToolResultAsync()
     {
         // Arrange
@@ -64,7 +64,7 @@ public sealed class ToolCallingHostedAgentTests(ToolCallingHostedAgentFixture fi
         Assert.Contains("42", second.Text);
     }
 
-    [Fact(Skip = "Pending TestContainer build and end to end smoke (step 5).")]
+    [Fact]
     public async Task ServerSideTool_WithArguments_ReturnsExpectedResultAsync()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
@@ -300,6 +300,28 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
             root);
     }
 
+    [Theory]
+    [InlineData("/")]
+    public void ResolveDefaultRootDirectory_HostedWithFilesystemRootHome_FallsBackToDefault(string home)
+    {
+        // Arrange / Act: a filesystem-root HOME (e.g. "/") must NOT root the store at
+        // "/.checkpoints", which is read-only in the container and caused issue #6231.
+        var root = FileSystemAgentSessionStore.ResolveDefaultRootDirectory(
+            isHosted: true,
+            homeDirectory: home,
+            currentDirectory: "/some/cwd");
+
+        // Assert: falls back to the default session-data directory, never the filesystem root.
+        Assert.Equal(
+            Path.Combine(
+                FileSystemAgentSessionStore.DefaultHostedSessionDataDirectory,
+                FileSystemAgentSessionStore.LocalCheckpointDirectoryName),
+            root);
+        Assert.NotEqual(
+            Path.Combine(Path.GetPathRoot(Path.GetFullPath(home))!, FileSystemAgentSessionStore.LocalCheckpointDirectoryName),
+            root);
+    }
+
     [Fact]
     public async Task SaveSessionAsync_NonWritableDirectory_ThrowsClearActionableIOExceptionAsync()
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
@@ -249,6 +249,83 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         Assert.False(Directory.Exists(this._root), "Read miss must not create the root directory.");
     }
 
+    [Fact]
+    public void ResolveDefaultRootDirectory_Hosted_RootsUnderHome()
+    {
+        // Arrange / Act
+        var root = FileSystemAgentSessionStore.ResolveDefaultRootDirectory(
+            isHosted: true,
+            homeDirectory: "/home/session",
+            currentDirectory: "/some/cwd");
+
+        // Assert
+        Assert.Equal(
+            Path.Combine("/home/session", FileSystemAgentSessionStore.LocalCheckpointDirectoryName),
+            root);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveDefaultRootDirectory_HostedWithoutHome_UsesDefaultSessionDataDirectory(string? home)
+    {
+        // Arrange / Act
+        var root = FileSystemAgentSessionStore.ResolveDefaultRootDirectory(
+            isHosted: true,
+            homeDirectory: home,
+            currentDirectory: "/some/cwd");
+
+        // Assert: falls back to the spec default ("/home/session"), never the filesystem root.
+        Assert.Equal(
+            Path.Combine(
+                FileSystemAgentSessionStore.DefaultHostedSessionDataDirectory,
+                FileSystemAgentSessionStore.LocalCheckpointDirectoryName),
+            root);
+        Assert.NotEqual("/.checkpoints", root);
+    }
+
+    [Fact]
+    public void ResolveDefaultRootDirectory_NotHosted_UsesCurrentDirectory()
+    {
+        // Arrange / Act
+        var root = FileSystemAgentSessionStore.ResolveDefaultRootDirectory(
+            isHosted: false,
+            homeDirectory: "/home/session",
+            currentDirectory: "/some/cwd");
+
+        // Assert
+        Assert.Equal(
+            Path.Combine("/some/cwd", FileSystemAgentSessionStore.LocalCheckpointDirectoryName),
+            root);
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_NonWritableDirectory_ThrowsClearActionableIOExceptionAsync()
+    {
+        // Arrange: place a file where the store's root directory needs to be created. Creating
+        // a directory under an existing file fails with IOException on every OS, standing in for
+        // the read-only root filesystem of a Foundry hosted container (issue #6231).
+        Directory.CreateDirectory(this._root);
+        var blockingFile = Path.Combine(this._root, "blocking-file");
+        File.WriteAllText(blockingFile, "x");
+
+        var store = new FileSystemAgentSessionStore(Path.Combine(blockingFile, ".checkpoints"));
+        var agent = new TestAgent();
+
+        // Act
+        var ex = await Assert.ThrowsAsync<IOException>(
+            async () => await store.SaveSessionAsync(agent, "conv-fatal", NewSession()));
+
+        // Assert: failure stays fatal but the message is clear and actionable, and the original
+        // IO error is preserved as the inner exception.
+        Assert.Contains("could not be created or written to", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(FileSystemAgentSessionStore.SessionDataDirectoryEnvironmentVariable, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(FileSystemAgentSessionStore.DefaultHostedSessionDataDirectory, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(store.RootDirectory, ex.Message, StringComparison.Ordinal);
+        Assert.NotNull(ex.InnerException);
+    }
+
     private static TestSession NewSession() => new();
 
     private sealed class TestSession : AgentSession


### PR DESCRIPTION
### Motivation & Context

After upgrading a .NET hosted Foundry agent to `Microsoft.Agents.AI.Foundry.Hosting` 1.8.0, the container starts but crashes right after the agent invokes a local `AIFunctionFactory.Create(...)` tool, with the platform log `mount: /app: mount failed: No such file or directory.`.

Root cause: PR #5589 (first shipped in 1.8.0) made `FileSystemAgentSessionStore` the default session store in `AddFoundryResponses`. When hosted, `CreateDefault()` rooted the store at the absolute path `/.checkpoints` (the filesystem root). `AgentFrameworkResponseHandler` persists the session in a `finally` after the response stream, so the first tool-call turn writes under `/.checkpoints`. In a Foundry hosted container the root filesystem is read-only, so `Directory.CreateDirectory("/.checkpoints")` throws `IOException: Read-only file system`, which tears down the request and the container. The `mount: /app` message is the platform's downstream symptom. 1.3.0 had no file-backed default, which is why the upgrade introduced the failure.

Per `container-image-spec.md` section 5, the only writable and durable location in a hosted container is `$HOME` (default `/home/session`); the root filesystem is read-only and paths outside `$HOME` may be cleared between requests.

### Description & Review Guide

- **What are the major changes?**
  - `FileSystemAgentSessionStore.CreateDefault()` now roots the hosted store at `{$HOME}/.checkpoints` (env `HOME`, default `/home/session`) instead of `/.checkpoints`. Local (non-hosted) behavior is unchanged (`{cwd}/.checkpoints`).
  - Path selection is factored into an internal `ResolveDefaultRootDirectory(isHosted, home, cwd)` so it can be unit tested without the process-wide cached `FoundryEnvironment.IsHosted`.
  - Persistence failures stay **fatal** (the store complements Foundry storage; a silent loss would be worse), but `SaveSessionAsync` now wraps `IOException`/`UnauthorizedAccessException` in a clear, actionable `IOException` that names the path and the `$HOME` requirement, preserving the raw error as `InnerException`.
  - The public constant `HostedCheckpointDirectory` (`"/.checkpoints"`) is replaced by `SessionDataDirectoryEnvironmentVariable` (`"HOME"`) and `DefaultHostedSessionDataDirectory` (`"/home/session"`) on the `[Experimental]` `FileSystemAgentSessionStore` type.
  - Added 6 unit tests (hosted/local path resolution, including an assertion that the hosted root is never the filesystem root, plus the clear fatal error).
  - Enabled the four `ToolCallingHostedAgentTests` (previously skipped pending end to end smoke), which exercise server-side tool invocation and multi-turn session persistence in a real hosted container.

- **What is the impact of these changes?**
  - Hosted agents that use local function tools no longer crash after a tool call. Sessions now persist to the platform's durable `$HOME` volume so they survive across requests and restarts.
  - Non-hosted/local usage is unchanged.

### Verification

- Build: `--warnaserror` clean (0 warnings) on the changed projects.
- Format: CI-parity `dotnet format --verify-no-changes` (Docker `mcr.microsoft.com/dotnet/sdk:10.0`) clean on all three changed projects.
- Unit: all 21 `FileSystemAgentSessionStoreTests` pass.
- Repro plus Docker: a standalone repro reproduces the original `IOException: Read-only file system : '/.checkpoints'` under a read-only root container, and confirms the fix succeeds when `$HOME` is writable and emits the clear fatal error when it is not.
- Live: the four `ToolCalling` Foundry Hosted Agents integration tests pass end to end against a live Foundry project, including the multi-turn session-persistence test, confirming the platform mounts `$HOME` writable and the fix resolves the issue.

### Related Issue

Fixes #6231

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
