### PR TITLE
.NET: [BREAKING] Align Foundry.Hosting experimental flags to MAAI001 for MAF-specific APIs

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// with agent-framework <see cref="AIAgent"/> instances, enabling agent-framework agents and workflows
 /// to be hosted as Azure Foundry Hosted Agents.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public class AgentFrameworkResponseHandler : ResponseHandler
 {
     private readonly IServiceProvider _serviceProvider;

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentSessionStore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// allowing conversations to be resumed across HTTP requests, application restarts,
 /// or different service instances in hosted scenarios.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public abstract class AgentSessionStore
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// rename so a partially-written file cannot be observed by a concurrent reader.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FileSystemAgentSessionStore : AgentSessionStore
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryAIToolExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryAIToolExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// Extension methods for <see cref="FoundryAITool"/> that require Azure.AI.Projects 2.1.0-beta.1+
 /// types (e.g. <see cref="ToolboxRecord"/>, <see cref="ToolboxVersion"/>).
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class FoundryAIToolExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <summary>
 /// Options for Foundry Toolbox MCP integration.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FoundryToolboxOptions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// lazily connected otherwise.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
 {
     private readonly FoundryToolboxOptions _options;

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedFoundryMemoryProviderScopes.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedFoundryMemoryProviderScopes.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// That happens when the agent runs outside the Foundry hosting layer (e.g., a console app); in
 /// that case write a custom <c>stateInitializer</c> instead of using these helpers.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class HostedFoundryMemoryProviderScopes
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedFoundryMemoryProviderServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedFoundryMemoryProviderServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// Dependency-injection helpers that register a <see cref="FoundryMemoryProvider"/> wired with a
 /// <see cref="HostedFoundryMemoryProviderScopes"/> strategy.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class HostedFoundryMemoryProviderServiceCollectionExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <see cref="HostedSessionContextExtensions.GetHostedContext"/>.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class HostedSessionContext
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionContextExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionContextExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// identity values; consumers (such as <see cref="AIContextProvider"/> implementations) read the values
 /// through the public <see cref="GetHostedContext"/> accessor.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class HostedSessionContextExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionIsolationKeyProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionIsolationKeyProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// 500 from the hosting layer.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public abstract class HostedSessionIsolationKeyProvider
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionJsonUtilities.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedSessionJsonUtilities.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// <summary>
 /// JSON serialization utilities for hosted session identity types.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal static class HostedSessionJsonUtilities
 {
     /// <summary>
@@ -35,5 +35,5 @@ internal static class HostedSessionJsonUtilities
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = false)]
 [JsonSerializable(typeof(HostedSessionContext))]
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal partial class HostedSessionJsonContext : JsonSerializerContext;

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// such as Redis, SQL Server, or Azure Cosmos DB.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class InMemoryAgentSessionStore : AgentSessionStore
 {
     private readonly ConcurrentDictionary<string, JsonElement> _sessions = new();

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/PlatformHostedSessionIsolationKeyProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/PlatformHostedSessionIsolationKeyProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// should register an alternate <see cref="HostedSessionIsolationKeyProvider"/> implementation
 /// that provides fallback values for the missing headers.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class PlatformHostedSessionIsolationKeyProvider : HostedSessionIsolationKeyProvider
 {
     /// <inheritdoc />

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// Extension methods for registering agent-framework agents as Foundry Hosted Agents
 /// using the Azure AI Responses Server SDK.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class FoundryHostingExtensions
 {
     /// <summary>


### PR DESCRIPTION
### Motivation & Context

`Microsoft.Agents.AI.Foundry.Hosting` was inconsistent in which `[Experimental(...)]` diagnostic id it applied to its public APIs. Most MAF-specific types used `DiagnosticIds.Experiments.AIOpenAIResponses` (`OPENAI001`), while only a few (`FoundryToolboxHealthCheck`, `FoundryToolboxStartupStatus`, and the `UserToolboxConsent` API added in #6718) correctly used `DiagnosticIds.Experiments.AgentsAIExperiments` (`MAAI001`).

`OPENAI001` exists only to mirror the OpenAI package's experimental diagnostic so consumers of experimental OpenAI APIs don't need an extra suppression. It is appropriate only for APIs that surface OpenAI experimental types. The AgentServer base types this package builds on (`Azure.AI.AgentServer.Responses.ResponseHandler` / `ResponseContext`) are not `[Experimental]`, and none of this package's public types expose an OpenAI experimental type in their signatures. So `OPENAI001` here was a copy-paste inconsistency, and `MAAI001` is the correct id for these MAF hosting/agent abstractions.

### Description & Review Guide

- **What are the major changes?** Switched the remaining 16 MAF-specific `[Experimental(DiagnosticIds.Experiments.AIOpenAIResponses)]` usages to `DiagnosticIds.Experiments.AgentsAIExperiments` across 15 files in `Microsoft.Agents.AI.Foundry.Hosting` (`AgentFrameworkResponseHandler`, `AgentSessionStore`, `FileSystemAgentSessionStore`, `InMemoryAgentSessionStore`, `FoundryAIToolExtensions`, `FoundryToolboxService`, `FoundryToolboxOptions`, `HostedSessionContext`, `HostedSessionContextExtensions`, `HostedSessionIsolationKeyProvider`, `PlatformHostedSessionIsolationKeyProvider`, `HostedSessionJsonUtilities` (2), `HostedFoundryMemoryProviderScopes`, `HostedFoundryMemoryProviderServiceCollectionExtensions`, `ServiceCollectionExtensions`).
- **What is the impact of these changes?** None at runtime. This only changes which experimental diagnostic id the public surface reports. `MAAI001` is already globally suppressed in `dotnet/tests/Directory.Build.props` and `dotnet/samples/Directory.Build.props`, and `OPENAI001;MEAI001;MAAI001` are all in the package's own `NoWarn`, so tests, samples, and the integration test container keep compiling. The package is pre-release (`VersionSuffix=preview`, package validation disabled), so there is no compatibility concern.
- **What do you want reviewers to focus on?** That no public type genuinely surfaces an OpenAI experimental type (the audit found none; the only `OpenAIRequestPolicies` references in `ServiceCollectionExtensions` are private members/doc comments, not public surface). `FoundryToolboxHealthCheck` and `FoundryToolboxStartupStatus` were already on `MAAI001` and are intentionally left unchanged.

### Related Issue

Fixes #6742

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
