### PR TITLE
Python: Stop swallowing skill script and resource errors so the model can self-correct

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1843,7 +1843,6 @@ class SkillsProvider(ContextProvider):
         *,
         instruction_template: str | None = None,
         require_script_approval: bool = False,
-        include_detailed_errors: bool = False,
         disable_caching: bool = False,
         source_id: str | None = None,
     ) -> None:
@@ -1882,21 +1881,6 @@ class SkillsProvider(ContextProvider):
                 the user declined. Defaults to ``False``.  See
                 ``samples/02-agents/skills/script_approval/script_approval.py``
                 for the full approval loop pattern.
-            include_detailed_errors: Controls how script-execution failures are
-                surfaced to the model. When ``False`` (the default), the
-                exception is logged and re-raised, delegating error handling to
-                the function-invocation pipeline (which applies its own
-                ``include_detailed_errors`` policy). When ``True``, the
-                exception message is appended to the error string returned
-                directly to the model, enabling it to retry with different
-                arguments. This may disclose raw exception details to the
-                model, so exercise particular caution when enabling it for
-                skills whose scripts originate from untrusted or third-party
-                sources: a maliciously crafted script could throw an exception
-                whose message embeds a prompt-injection payload, which would
-                then be fed back to the model. Only enable this when the skills
-                and their scripts come from a trusted source. Defaults to
-                ``False``.
             disable_caching: When ``True``, rebuilds tools and instructions
                 from the source on every invocation instead of caching
                 after the first build.  Defaults to ``False``.
@@ -1920,7 +1904,6 @@ class SkillsProvider(ContextProvider):
         self._source = source
         self._instruction_template = instruction_template
         self._require_script_approval = require_script_approval
-        self._include_detailed_errors = include_detailed_errors
         self._disable_caching = disable_caching
 
         # Lazy-initialized via _get_or_create_context / _create_context
@@ -1939,7 +1922,6 @@ class SkillsProvider(ContextProvider):
         resource_filter: Callable[[str, str], bool] | None = None,
         instruction_template: str | None = None,
         require_script_approval: bool = False,
-        include_detailed_errors: bool = False,
         disable_caching: bool = False,
         source_id: str | None = None,
     ) -> _TSkillsProvider:
@@ -1987,16 +1969,6 @@ class SkillsProvider(ContextProvider):
                 the user declined. Defaults to ``False``.  See
                 ``samples/02-agents/skills/script_approval/script_approval.py``
                 for the full approval loop pattern.
-            include_detailed_errors: Controls how script-execution failures are
-                surfaced to the model. When ``False`` (the default), the
-                exception is logged and re-raised, delegating error handling to
-                the function-invocation pipeline (which applies its own
-                ``include_detailed_errors`` policy). When ``True``, the
-                exception message is appended to the error string returned
-                directly to the model, enabling it to retry with different
-                arguments. This may disclose raw exception details to the
-                model, so only enable it when the skills and their scripts come
-                from a trusted source. Defaults to ``False``.
             disable_caching: When ``True``, rebuilds tools and instructions
                 from the source on every invocation instead of caching
                 after the first build.
@@ -2020,7 +1992,6 @@ class SkillsProvider(ContextProvider):
             source,
             instruction_template=instruction_template,
             require_script_approval=require_script_approval,
-            include_detailed_errors=include_detailed_errors,
             disable_caching=disable_caching,
             source_id=source_id,
         )
@@ -2348,14 +2319,12 @@ class SkillsProvider(ContextProvider):
 
         Returns:
             The script result. Returns a user-facing error string for
-            validation failures (empty or unknown skill/script name) and,
-            when ``include_detailed_errors`` is ``True``, for execution
-            failures.
+            validation failures (empty or unknown skill/script name).
 
         Raises:
-            Exception: Re-raises any exception raised while running the
-                script when ``include_detailed_errors`` is ``False``,
-                delegating error handling to the function-invocation pipeline.
+            Exception: Re-raises any exception raised while running the script,
+                delegating error handling to the function-invocation pipeline
+                (which applies its own ``include_detailed_errors`` policy).
         """
         if not skill_name or not skill_name.strip():
             return "Error: Skill name cannot be empty."
@@ -2373,10 +2342,8 @@ class SkillsProvider(ContextProvider):
 
         try:
             return await script.run(skill, args, **kwargs)
-        except Exception as ex:
+        except Exception:
             logger.exception("Error running script '%s' in skill '%s'", script_name, skill_name)
-            if self._include_detailed_errors:
-                return f"Error: Failed to run script '{script_name}' in skill '{skill_name}'. Exception: {ex}"
             raise
 
     async def _read_skill_resource(

--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1843,6 +1843,7 @@ class SkillsProvider(ContextProvider):
         *,
         instruction_template: str | None = None,
         require_script_approval: bool = False,
+        include_detailed_errors: bool = False,
         disable_caching: bool = False,
         source_id: str | None = None,
     ) -> None:
@@ -1881,6 +1882,21 @@ class SkillsProvider(ContextProvider):
                 the user declined. Defaults to ``False``.  See
                 ``samples/02-agents/skills/script_approval/script_approval.py``
                 for the full approval loop pattern.
+            include_detailed_errors: Controls how script-execution failures are
+                surfaced to the model. When ``False`` (the default), the
+                exception is logged and re-raised, delegating error handling to
+                the function-invocation pipeline (which applies its own
+                ``include_detailed_errors`` policy). When ``True``, the
+                exception message is appended to the error string returned
+                directly to the model, enabling it to retry with different
+                arguments. This may disclose raw exception details to the
+                model, so exercise particular caution when enabling it for
+                skills whose scripts originate from untrusted or third-party
+                sources: a maliciously crafted script could throw an exception
+                whose message embeds a prompt-injection payload, which would
+                then be fed back to the model. Only enable this when the skills
+                and their scripts come from a trusted source. Defaults to
+                ``False``.
             disable_caching: When ``True``, rebuilds tools and instructions
                 from the source on every invocation instead of caching
                 after the first build.  Defaults to ``False``.
@@ -1904,6 +1920,7 @@ class SkillsProvider(ContextProvider):
         self._source = source
         self._instruction_template = instruction_template
         self._require_script_approval = require_script_approval
+        self._include_detailed_errors = include_detailed_errors
         self._disable_caching = disable_caching
 
         # Lazy-initialized via _get_or_create_context / _create_context
@@ -1922,6 +1939,7 @@ class SkillsProvider(ContextProvider):
         resource_filter: Callable[[str, str], bool] | None = None,
         instruction_template: str | None = None,
         require_script_approval: bool = False,
+        include_detailed_errors: bool = False,
         disable_caching: bool = False,
         source_id: str | None = None,
     ) -> _TSkillsProvider:
@@ -1969,6 +1987,16 @@ class SkillsProvider(ContextProvider):
                 the user declined. Defaults to ``False``.  See
                 ``samples/02-agents/skills/script_approval/script_approval.py``
                 for the full approval loop pattern.
+            include_detailed_errors: Controls how script-execution failures are
+                surfaced to the model. When ``False`` (the default), the
+                exception is logged and re-raised, delegating error handling to
+                the function-invocation pipeline (which applies its own
+                ``include_detailed_errors`` policy). When ``True``, the
+                exception message is appended to the error string returned
+                directly to the model, enabling it to retry with different
+                arguments. This may disclose raw exception details to the
+                model, so only enable it when the skills and their scripts come
+                from a trusted source. Defaults to ``False``.
             disable_caching: When ``True``, rebuilds tools and instructions
                 from the source on every invocation instead of caching
                 after the first build.
@@ -1992,6 +2020,7 @@ class SkillsProvider(ContextProvider):
             source,
             instruction_template=instruction_template,
             require_script_approval=require_script_approval,
+            include_detailed_errors=include_detailed_errors,
             disable_caching=disable_caching,
             source_id=source_id,
         )
@@ -2318,8 +2347,15 @@ class SkillsProvider(ContextProvider):
                 ``agent.run(user_id="123")``).
 
         Returns:
-            The result, or a user-facing error message on
-            failure.
+            The script result. Returns a user-facing error string for
+            validation failures (empty or unknown skill/script name) and,
+            when ``include_detailed_errors`` is ``True``, for execution
+            failures.
+
+        Raises:
+            Exception: Re-raises any exception raised while running the
+                script when ``include_detailed_errors`` is ``False``,
+                delegating error handling to the function-invocation pipeline.
         """
         if not skill_name or not skill_name.strip():
             return "Error: Skill name cannot be empty."
@@ -2337,9 +2373,11 @@ class SkillsProvider(ContextProvider):
 
         try:
             return await script.run(skill, args, **kwargs)
-        except Exception:
+        except Exception as ex:
             logger.exception("Error running script '%s' in skill '%s'", script_name, skill_name)
-            return f"Error: Failed to run script '{script_name}' in skill '{skill_name}'."
+            if self._include_detailed_errors:
+                return f"Error: Failed to run script '{script_name}' in skill '{skill_name}'. Exception: {ex}"
+            raise
 
     async def _read_skill_resource(
         self, skills: Sequence[Skill], skill_name: str, resource_name: str, **kwargs: Any
@@ -2359,8 +2397,16 @@ class SkillsProvider(ContextProvider):
                 ``agent.run(user_id="123")``).
 
         Returns:
-            The resource content (any type), or a user-facing error message on
-            failure.
+            The resource content (any type). Returns a user-facing error
+            string for validation failures (empty or unknown skill/resource
+            name).
+
+        Raises:
+            Exception: Re-raises any exception raised while reading the
+                resource. Resources take no model-supplied arguments, so a
+                swallowed generic error is not actionable by the model;
+                re-raising lets the function-invocation pipeline decide how to
+                surface it.
         """
         if not skill_name or not skill_name.strip():
             return "Error: Skill name cannot be empty."
@@ -2380,7 +2426,7 @@ class SkillsProvider(ContextProvider):
             return await resource.read(**kwargs)
         except Exception:
             logger.exception("Failed to read resource '%s' from skill '%s'", resource_name, skill_name)
-            return f"Error: Failed to read resource '{resource_name}' from skill '{skill_name}'."
+            raise
 
 
 # endregion

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -3816,21 +3816,6 @@ class TestSkillsProviderFactories:
         with pytest.raises(RuntimeError, match="Something went wrong"):
             await run_tool.func(skill_name="my-skill", script_name="boom")
 
-    async def test_code_script_exception_includes_details_when_enabled(self) -> None:
-        """When include_detailed_errors=True, the script error string includes the exception message."""
-
-        def failing_script() -> str:
-            raise RuntimeError("Something went wrong")
-
-        skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
-        skill._scripts.append(InlineSkillScript(name="boom", function=failing_script))
-
-        provider = SkillsProvider([skill], include_detailed_errors=True)
-        await _init_provider(provider)
-        run_tool = next(t for t in _ctx(provider)[2] if hasattr(t, "name") and t.name == "run_skill_script")
-        result = await run_tool.func(skill_name="my-skill", script_name="boom")
-        assert result == "Error: Failed to run script 'boom' in skill 'my-skill'. Exception: Something went wrong"
-
     async def test_custom_template_without_runner_placeholder_raises(self) -> None:
         """Providers accept custom templates without {runner_instructions}."""
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -2802,7 +2802,7 @@ class TestSkillsProviderEdgeCases:
         assert result.startswith("Error:")
         assert "empty" in result
 
-    async def test_read_callable_resource_exception_returns_error(self) -> None:
+    async def test_read_callable_resource_exception_propagates(self) -> None:
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="A skill."), instructions="Body")
 
         @skill.resource
@@ -2811,11 +2811,10 @@ class TestSkillsProviderEdgeCases:
 
         provider = SkillsProvider([skill])
         await _init_provider(provider)
-        result = await provider._read_skill_resource(_raw_skills(provider), "my-skill", "exploding_resource")
-        assert result.startswith("Error:")
-        assert "Failed to read resource" in result
+        with pytest.raises(RuntimeError, match="boom"):
+            await provider._read_skill_resource(_raw_skills(provider), "my-skill", "exploding_resource")
 
-    async def test_read_async_callable_resource_exception_returns_error(self) -> None:
+    async def test_read_async_callable_resource_exception_propagates(self) -> None:
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="A skill."), instructions="Body")
 
         @skill.resource
@@ -2824,8 +2823,8 @@ class TestSkillsProviderEdgeCases:
 
         provider = SkillsProvider([skill])
         await _init_provider(provider)
-        result = await provider._read_skill_resource(_raw_skills(provider), "my-skill", "async_exploding")
-        assert result.startswith("Error:")
+        with pytest.raises(ValueError, match="async boom"):
+            await provider._read_skill_resource(_raw_skills(provider), "my-skill", "async_exploding")
 
     async def test_load_code_skill_xml_escapes_metadata(self) -> None:
         skill = InlineSkill(
@@ -3588,10 +3587,9 @@ class TestSkillsProviderFactories:
         result = await run_tool.func(skill_name="my-skill", script_name="code-s")
         assert result == "ok"
 
-        # File script without runner returns error
-        result = await run_tool.func(skill_name="my-skill", script_name="file-s")
-        assert "Error" in result
-        assert "Failed to run" in result
+        # File script without runner propagates an error by default
+        with pytest.raises(TypeError, match="requires a FileSkill"):
+            await run_tool.func(skill_name="my-skill", script_name="file-s")
 
     async def test_async_code_script_runs_directly(self) -> None:
         async def async_func(x: int = 0) -> str:
@@ -3646,10 +3644,9 @@ class TestSkillsProviderFactories:
         result = await run_tool.func(skill_name="my-skill", script_name="code-s")
         assert result == "ok"
 
-        # Path+function script without runner returns error
-        result = await run_tool.func(skill_name="my-skill", script_name="path-s")
-        assert "Error" in result
-        assert "script_runner" in result or "Failed to run" in result
+        # Path+function script without runner propagates an error by default
+        with pytest.raises(TypeError, match="requires a FileSkill"):
+            await run_tool.func(skill_name="my-skill", script_name="path-s")
 
     async def test_run_skill_script_error_on_missing_skill(self) -> None:
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
@@ -3717,10 +3714,10 @@ class TestSkillsProviderFactories:
 
         provider = SkillsProvider([skill])
         await _init_provider(provider)
-        result = await provider._run_skill_script(
-            _raw_skills(provider), "my-skill", "process", args={"mode": "llm-value"}, mode="runtime-value"
-        )
-        assert "Error" in result
+        with pytest.raises(TypeError):
+            await provider._run_skill_script(
+                _raw_skills(provider), "my-skill", "process", args={"mode": "llm-value"}, mode="runtime-value"
+            )
 
     async def test_run_skill_script_error_on_missing_script(self) -> None:
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
@@ -3804,8 +3801,8 @@ class TestSkillsProviderFactories:
         for t in other_tools:
             assert t.approval_mode == "never_require"
 
-    async def test_code_script_exception_returns_error(self) -> None:
-        """A code script function that raises should return an error string."""
+    async def test_code_script_exception_propagates_by_default(self) -> None:
+        """A code script function that raises should propagate by default."""
 
         def failing_script() -> str:
             raise RuntimeError("Something went wrong")
@@ -3816,10 +3813,23 @@ class TestSkillsProviderFactories:
         provider = SkillsProvider([skill])
         await _init_provider(provider)
         run_tool = next(t for t in _ctx(provider)[2] if hasattr(t, "name") and t.name == "run_skill_script")
+        with pytest.raises(RuntimeError, match="Something went wrong"):
+            await run_tool.func(skill_name="my-skill", script_name="boom")
+
+    async def test_code_script_exception_includes_details_when_enabled(self) -> None:
+        """When include_detailed_errors=True, the script error string includes the exception message."""
+
+        def failing_script() -> str:
+            raise RuntimeError("Something went wrong")
+
+        skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
+        skill._scripts.append(InlineSkillScript(name="boom", function=failing_script))
+
+        provider = SkillsProvider([skill], include_detailed_errors=True)
+        await _init_provider(provider)
+        run_tool = next(t for t in _ctx(provider)[2] if hasattr(t, "name") and t.name == "run_skill_script")
         result = await run_tool.func(skill_name="my-skill", script_name="boom")
-        assert "Error" in result
-        assert "boom" in result
-        assert "Something went wrong" not in result
+        assert result == "Error: Failed to run script 'boom' in skill 'my-skill'. Exception: Something went wrong"
 
     async def test_custom_template_without_runner_placeholder_raises(self) -> None:
         """Providers accept custom templates without {runner_instructions}."""
@@ -5799,17 +5809,16 @@ class TestArrayStyleScriptArgs:
         assert result == "list_result"
         assert captured["args"] == ["input.docx", "--verbose"]
 
-    async def test_run_skill_script_inline_with_list_args_returns_error(self) -> None:
-        """Inline script called with list args through provider returns error (TypeError caught)."""
+    async def test_run_skill_script_inline_with_list_args_propagates_error(self) -> None:
+        """Inline script called with list args through provider propagates the TypeError by default."""
         skill = InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="test"), instructions="body")
         skill._scripts.append(InlineSkillScript(name="s1", function=lambda: "ok"))
 
         provider = SkillsProvider([skill])
         await _init_provider(provider)
         run_tool = next(t for t in _ctx(provider)[2] if hasattr(t, "name") and t.name == "run_skill_script")
-        result = await run_tool.func(skill_name="my-skill", script_name="s1", args=["arg1"])
-        assert "Error" in result
-        assert "Failed to run" in result
+        with pytest.raises(TypeError, match="requires keyword arguments"):
+            await run_tool.func(skill_name="my-skill", script_name="s1", args=["arg1"])
 
     async def test_file_skill_content_includes_scripts_block(self) -> None:
         """FileSkill.content appends an <available_scripts> block when scripts are present."""


### PR DESCRIPTION
### Motivation & Context

The Python `SkillsProvider` swallowed exceptions raised during skill script execution and resource reading, returning a generic, identical error string every time (`"Error: Failed to run script..."`). Because the underlying exception never reached the model, the model could not learn *why* a call failed and could not self-correct by retrying. This addresses #6681, which asks to port the .NET fix from #6680.

### Description & Review Guide

- **What are the major changes?**
  - `_run_skill_script` and `_read_skill_resource` no longer swallow execution/read failures. They now log and **re-raise**, delegating error handling to the function-invocation pipeline.
  - Validation failures (empty or unknown skill/script/resource names) still return user-facing error strings, unchanged.
  - Tests updated to assert propagation for scripts (code, file-without-runner, list-args, conflicting-args) and resources (sync/async callables).

- **Divergence from the .NET port (please confirm):** The .NET PR added a provider-level `IncludeDetailedErrors` option. This Python PR intentionally does **not** add that option, for two reasons:
  1. **It cannot be implemented correctly at the provider level in Python.** A tool function can only *return a value*; it cannot set the `exception` metadata on the function result — that is set exclusively by the pipeline's `except` block (`_tools.py:1516-1536`). Returning a detailed error *string* therefore goes through the success path, leaving `exception=None`. The pipeline detects errors via `function_result.exception is not None` (`_tools.py:1822`) to enforce the consecutive-error limit, so a perpetually-failing script would be treated as success and never counted toward the retry cap — a potential infinite loop.
  2. **It is redundant.** Python already has the exact equivalent of .NET's `FunctionInvokingChatClient.IncludeDetailedErrors`: the pipeline's `include_detailed_errors` configuration (`FunctionInvocationConfiguration`, `_tools.py:1311/1365`). By re-raising, skill scripts and resources now flow through that existing policy, which surfaces the real exception message to the model **and** preserves exception metadata and consecutive-error counting. Users enable it the same way as for any other tool: `client.function_invocation_configuration["include_detailed_errors"] = True`.

- **What is the impact of these changes?**
  - Skill script/resource failures now surface actionable detail to the model via the framework-wide detailed-errors policy, and are correctly marked as errors. The default behavior changes from returning a generic string to re-raising.

- **What do you want reviewers to focus on?**
  - Whether dropping the provider-level option (in favor of the existing pipeline-level `include_detailed_errors`) is the right Python-idiomatic resolution of #6681, given the tool-error-contract constraint above.

### Related Issue

Fixes #6681

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
