### PR TITLE
.NET: [BREAKING] Extract caching from AgentSkillsProvider into CachingAgentSkillsSource

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/CompatibilitySuppressions.xml
+++ b/dotnet/src/Microsoft.Agents.AI/CompatibilitySuppressions.xml
@@ -94,7 +94,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_DisableCaching</Target>
+    <Left>lib/net10.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net10.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_ScriptApproval</Target>
+    <Left>lib/net10.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net10.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.set_DisableCaching(System.Boolean)</Target>
     <Left>lib/net10.0/Microsoft.Agents.AI.dll</Left>
     <Right>lib/net10.0/Microsoft.Agents.AI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -199,7 +213,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_DisableCaching</Target>
+    <Left>lib/net472/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net472/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_ScriptApproval</Target>
+    <Left>lib/net472/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net472/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.set_DisableCaching(System.Boolean)</Target>
     <Left>lib/net472/Microsoft.Agents.AI.dll</Left>
     <Right>lib/net472/Microsoft.Agents.AI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -304,7 +332,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_DisableCaching</Target>
+    <Left>lib/net8.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net8.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_ScriptApproval</Target>
+    <Left>lib/net8.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net8.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.set_DisableCaching(System.Boolean)</Target>
     <Left>lib/net8.0/Microsoft.Agents.AI.dll</Left>
     <Right>lib/net8.0/Microsoft.Agents.AI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -409,7 +451,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_DisableCaching</Target>
+    <Left>lib/net9.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net9.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_ScriptApproval</Target>
+    <Left>lib/net9.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/net9.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.set_DisableCaching(System.Boolean)</Target>
     <Left>lib/net9.0/Microsoft.Agents.AI.dll</Left>
     <Right>lib/net9.0/Microsoft.Agents.AI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -514,7 +570,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_DisableCaching</Target>
+    <Left>lib/netstandard2.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.get_ScriptApproval</Target>
+    <Left>lib/netstandard2.0/Microsoft.Agents.AI.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Agents.AI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Agents.AI.AgentSkillsProviderOptions.set_DisableCaching(System.Boolean)</Target>
     <Left>lib/netstandard2.0/Microsoft.Agents.AI.dll</Left>
     <Right>lib/netstandard2.0/Microsoft.Agents.AI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -122,7 +122,6 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
     private readonly AgentSkillsSource _source;
     private readonly AgentSkillsProviderOptions? _options;
     private readonly ILogger<AgentSkillsProvider> _logger;
-    private Task<AIContext>? _contextTask;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentSkillsProvider"/> class
@@ -162,7 +161,8 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         ILoggerFactory? loggerFactory = null)
         : this(
             new DeduplicatingAgentSkillsSource(
-                new AgentFileSkillsSource(skillPaths, scriptRunner, fileOptions, loggerFactory),
+                new CachingAgentSkillsSource(
+                    new AgentFileSkillsSource(skillPaths, scriptRunner, fileOptions, loggerFactory)),
                 loggerFactory),
             options,
             loggerFactory)
@@ -192,7 +192,8 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
         ILoggerFactory? loggerFactory = null)
         : this(
             new DeduplicatingAgentSkillsSource(
-                new AgentInMemorySkillsSource(Throw.IfNull(skills)),
+                new CachingAgentSkillsSource(
+                    new AgentInMemorySkillsSource(Throw.IfNull(skills))),
                 loggerFactory),
             options,
             loggerFactory)
@@ -222,16 +223,6 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
     /// <inheritdoc />
     protected override async ValueTask<AIContext> ProvideAIContextAsync(InvokingContext context, CancellationToken cancellationToken = default)
     {
-        if (this._options?.DisableCaching == true)
-        {
-            return await this.CreateContextAsync(context, cancellationToken).ConfigureAwait(false);
-        }
-
-        return await this.GetOrCreateContextAsync(context, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<AIContext> CreateContextAsync(InvokingContext context, CancellationToken cancellationToken)
-    {
         var skills = await this._source.GetSkillsAsync(cancellationToken).ConfigureAwait(false);
         if (skills is not { Count: > 0 })
         {
@@ -243,29 +234,6 @@ public sealed partial class AgentSkillsProvider : AIContextProvider
             Instructions = this.BuildSkillsInstructions(skills),
             Tools = this.BuildTools(skills),
         };
-    }
-
-    private async Task<AIContext> GetOrCreateContextAsync(InvokingContext context, CancellationToken cancellationToken)
-    {
-        var tcs = new TaskCompletionSource<AIContext>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        if (Interlocked.CompareExchange(ref this._contextTask, tcs.Task, null) is { } existing)
-        {
-            return await existing.ConfigureAwait(false);
-        }
-
-        try
-        {
-            var result = await this.CreateContextAsync(context, cancellationToken).ConfigureAwait(false);
-            tcs.SetResult(result);
-            return result;
-        }
-        catch (Exception ex)
-        {
-            this._contextTask = null;
-            tcs.TrySetException(ex);
-            throw;
-        }
     }
 
     private IList<AIFunction> BuildTools(IList<AgentSkill> skills)

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderBuilder.cs
@@ -47,6 +47,7 @@ public sealed class AgentSkillsProviderBuilder
     private ILoggerFactory? _loggerFactory;
     private AgentFileSkillScriptRunner? _scriptRunner;
     private Func<AgentSkill, bool>? _filter;
+    private bool _disableCaching;
 
     /// <summary>
     /// Adds a file-based skill source that discovers skills from a filesystem directory.
@@ -208,6 +209,17 @@ public sealed class AgentSkillsProviderBuilder
     }
 
     /// <summary>
+    /// Disables caching of the resolved skill list. By default, skills are fetched once and cached;
+    /// calling this method causes the source pipeline to be invoked on every request.
+    /// </summary>
+    /// <returns>This builder instance for chaining.</returns>
+    public AgentSkillsProviderBuilder DisableCaching()
+    {
+        this._disableCaching = true;
+        return this;
+    }
+
+    /// <summary>
     /// Builds the <see cref="AgentSkillsProvider"/>.
     /// </summary>
     /// <returns>A configured <see cref="AgentSkillsProvider"/>.</returns>
@@ -227,6 +239,11 @@ public sealed class AgentSkillsProviderBuilder
         else
         {
             source = new AggregatingAgentSkillsSource(resolvedSources);
+        }
+
+        if (!this._disableCaching)
+        {
+            source = new CachingAgentSkillsSource(source);
         }
 
         // Apply user-specified filter, then dedup.

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProviderOptions.cs
@@ -35,12 +35,4 @@ public sealed class AgentSkillsProviderOptions
     /// Only enable this when the skills and their scripts come from a trusted source.
     /// </remarks>
     public bool IncludeDetailedErrors { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether caching of tools and instructions is disabled.
-    /// When <see langword="false"/> (the default), the provider caches the tools and instructions
-    /// after the first build and returns the cached instance on subsequent calls.
-    /// Set to <see langword="true"/> to rebuild tools and instructions on every invocation.
-    /// </summary>
-    public bool DisableCaching { get; set; }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// A skill source decorator that caches the result of the inner source's <see cref="AgentSkillsSource.GetSkillsAsync"/>
+/// call, returning the cached list on subsequent invocations.
+/// </summary>
+/// <remarks>
+/// The cache uses a lock-free, thread-safe pattern so that concurrent callers share
+/// a single in-flight fetch and all receive the same cached result.
+/// If the initial fetch fails, the cache is not populated and subsequent calls will retry.
+/// </remarks>
+internal sealed class CachingAgentSkillsSource : DelegatingAgentSkillsSource
+{
+    private Task<IList<AgentSkill>>? _cachedTask;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingAgentSkillsSource"/> class.
+    /// </summary>
+    /// <param name="innerSource">The inner source whose results will be cached.</param>
+    internal CachingAgentSkillsSource(AgentSkillsSource innerSource)
+        : base(innerSource)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IList<AgentSkill>> GetSkillsAsync(CancellationToken cancellationToken = default)
+    {
+        var tcs = new TaskCompletionSource<IList<AgentSkill>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (Interlocked.CompareExchange(ref this._cachedTask, tcs.Task, null) is { } existing)
+        {
+            return await existing.ConfigureAwait(false);
+        }
+
+        try
+        {
+            var result = await this.InnerSource.GetSkillsAsync(cancellationToken).ConfigureAwait(false);
+            tcs.SetResult(result);
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            Volatile.Write(ref this._cachedTask, null);
+            tcs.TrySetCanceled(cancellationToken);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Volatile.Write(ref this._cachedTask, null);
+            tcs.TrySetException(ex);
+            throw;
+        }
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DeduplicatingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DeduplicatingAgentSkillsSource.cs
@@ -2,19 +2,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// A skill source decorator that removes duplicate skills by name, keeping only the first occurrence.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed partial class DeduplicatingAgentSkillsSource : DelegatingAgentSkillsSource
 {
     private readonly ILogger<DeduplicatingAgentSkillsSource> _logger;

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DelegatingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DelegatingAgentSkillsSource.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -18,7 +16,6 @@ namespace Microsoft.Agents.AI;
 /// enabling the creation of source pipelines where each layer can add functionality (caching, deduplication,
 /// filtering, etc.) while delegating core operations to an underlying source.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal abstract class DelegatingAgentSkillsSource : AgentSkillsSource
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/FilteringAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/FilteringAgentSkillsSource.cs
@@ -2,12 +2,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -19,7 +17,6 @@ namespace Microsoft.Agents.AI;
 /// Skills for which the predicate returns <see langword="true"/> are included in the result;
 /// skills for which it returns <see langword="false"/> are excluded and logged at debug level.
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed partial class FilteringAgentSkillsSource : DelegatingAgentSkillsSource
 {
     private readonly Func<AgentSkill, bool> _predicate;

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderBuilderTests.cs
@@ -111,25 +111,6 @@ public sealed class AgentSkillsProviderBuilderTests
     }
 
     [Fact]
-    public async Task Build_WithCacheDisabled_ReloadsOnEachCallAsync()
-    {
-        // Arrange
-        var countingSource = new CountingSource(
-            new TestAgentSkill("skill-a", "A", "Instructions."));
-        var provider = new AgentSkillsProviderBuilder()
-            .UseSource(countingSource)
-            .UseOptions(o => o.DisableCaching = true)
-            .Build();
-
-        // Act
-        await provider.InvokingAsync(this.CreateInvokingContext(), CancellationToken.None);
-        await provider.InvokingAsync(this.CreateInvokingContext(), CancellationToken.None);
-
-        // Assert — inner source should be called each time (dedup still calls through)
-        Assert.True(countingSource.CallCount >= 2);
-    }
-
-    [Fact]
     public async Task Build_WithCacheEnabled_CachesSkillsAsync()
     {
         // Arrange
@@ -145,6 +126,26 @@ public sealed class AgentSkillsProviderBuilderTests
 
         // Assert — inner source should only be called once due to caching
         Assert.Equal(1, countingSource.CallCount);
+    }
+
+    [Fact]
+    public async Task Build_WithCacheDisabled_InvokesSourceOnEachCallAsync()
+    {
+        // Arrange
+        var countingSource = new CountingSource(
+            new TestAgentSkill("skill-a", "A", "Instructions."));
+        var provider = new AgentSkillsProviderBuilder()
+            .UseSource(countingSource)
+            .DisableCaching()
+            .Build();
+
+        // Act
+        await provider.InvokingAsync(this.CreateInvokingContext(), CancellationToken.None);
+        await provider.InvokingAsync(this.CreateInvokingContext(), CancellationToken.None);
+        await provider.InvokingAsync(this.CreateInvokingContext(), CancellationToken.None);
+
+        // Assert — without caching, each call should hit the inner source
+        Assert.Equal(3, countingSource.CallCount);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -264,7 +264,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
         [
             new AgentInlineSkill("concurrent-skill", "Concurrent test", "Body.")
         ]);
-        var provider = new AgentSkillsProvider(source);
+        var provider = new AgentSkillsProvider(new CachingAgentSkillsSource(source));
 
         var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
 
@@ -274,7 +274,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
             .ToArray();
         await Task.WhenAll(tasks);
 
-        // Assert — GetSkillsAsync should have been called exactly once (provider-level caching)
+        // Assert — GetSkillsAsync should have been called exactly once (source-level caching)
         Assert.Equal(1, source.GetSkillsCallCount);
     }
 
@@ -347,7 +347,6 @@ public sealed class AgentSkillsProviderTests : IDisposable
         var provider = new AgentSkillsProviderBuilder()
             .UseFileSkill(this._testRoot, options)
             .UseFileScriptRunner(s_noOpExecutor)
-            .UseOptions(o => o.DisableCaching = true)
             .Build();
 
         // Act
@@ -373,7 +372,6 @@ public sealed class AgentSkillsProviderTests : IDisposable
         var provider = new AgentSkillsProviderBuilder()
             .UseFileSkills(new[] { dir1, dir2 }, options)
             .UseFileScriptRunner(s_noOpExecutor)
-            .UseOptions(o => o.DisableCaching = true)
             .Build();
 
         // Act
@@ -897,29 +895,6 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task Build_WithCachingDisabled_ReloadsSkillsOnEachCallAsync()
-    {
-        // Arrange
-        var source = new CountingAgentSkillsSource(
-        [
-            new AgentInlineSkill("no-cache-skill", "No cache test", "Body.")
-        ]);
-        var provider = new AgentSkillsProviderBuilder()
-            .UseSource(source)
-            .UseOptions(o => o.DisableCaching = true)
-            .Build();
-
-        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
-
-        // Act
-        await provider.InvokingAsync(invokingContext, CancellationToken.None);
-        await provider.InvokingAsync(invokingContext, CancellationToken.None);
-
-        // Assert — source should be called more than once since caching is disabled
-        Assert.True(source.GetSkillsCallCount > 1);
-    }
-
-    [Fact]
     public async Task Build_WithCachingEnabled_CachesSkillsAsync()
     {
         // Arrange
@@ -979,7 +954,6 @@ public sealed class AgentSkillsProviderTests : IDisposable
             .UseSkills(inlineSkill)
             .UseFileSkill(dir2)
             .UseFileScriptRunner(s_noOpExecutor)
-            .UseOptions(o => o.DisableCaching = true)
             .Build();
 
         var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
@@ -1020,7 +994,6 @@ public sealed class AgentSkillsProviderTests : IDisposable
             .UseSkills(inlineSkill)
             .UseFileSkill(dir)
             .UseFileScriptRunner(s_noOpExecutor)
-            .UseOptions(o => o.DisableCaching = true)
             .Build();
 
         var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
@@ -1107,42 +1080,24 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task InvokingCoreAsync_MultipleInvocations_ToolsAreSharedWhenCachedAsync()
+    public async Task InvokingCoreAsync_MultipleInvocations_SourceIsCalledOnceWhenCachedAsync()
     {
-        // Arrange — with default caching, tools should be the same reference
-        this.CreateSkill("cached-tools-skill", "Cached tools test", "Body.");
-        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
-        var provider = new AgentSkillsProvider(source);
+        // Arrange — with CachingAgentSkillsSource, the inner source should only be called once
+        var source = new CountingAgentSkillsSource(
+        [
+            new AgentInlineSkill("cached-tools-skill", "Cached tools test", "Body.")
+        ]);
+        var provider = new AgentSkillsProvider(new CachingAgentSkillsSource(source));
         var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
 
         // Act
         var result1 = await provider.InvokingAsync(invokingContext, CancellationToken.None);
         var result2 = await provider.InvokingAsync(invokingContext, CancellationToken.None);
 
-        // Assert — tool lists should be the same reference (cached)
+        // Assert — source should be called exactly once (cached at source level)
         Assert.NotNull(result1.Tools);
         Assert.NotNull(result2.Tools);
-        Assert.Same(result1.Tools, result2.Tools);
-    }
-
-    [Fact]
-    public async Task InvokingCoreAsync_MultipleInvocations_ToolsAreNotSharedWhenCachingDisabledAsync()
-    {
-        // Arrange — with caching disabled, tools should be rebuilt per invocation
-        this.CreateSkill("fresh-tools-skill", "Fresh tools test", "Body.");
-        var source = new AgentFileSkillsSource(this._testRoot, s_noOpExecutor);
-        var options = new AgentSkillsProviderOptions { DisableCaching = true };
-        var provider = new AgentSkillsProvider(source, options);
-        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
-
-        // Act
-        var result1 = await provider.InvokingAsync(invokingContext, CancellationToken.None);
-        var result2 = await provider.InvokingAsync(invokingContext, CancellationToken.None);
-
-        // Assert — tool lists should not be the same reference
-        Assert.NotNull(result1.Tools);
-        Assert.NotNull(result2.Tools);
-        Assert.NotSame(result1.Tools, result2.Tools);
+        Assert.Equal(1, source.GetSkillsCallCount);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/CachingAgentSkillsSourceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/CachingAgentSkillsSourceTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.AI.UnitTests.AgentSkills;
+
+/// <summary>
+/// Unit tests for <see cref="CachingAgentSkillsSource"/>.
+/// </summary>
+public sealed class CachingAgentSkillsSourceTests
+{
+    [Fact]
+    public async Task GetSkillsAsync_MultipleInvocations_CallsInnerSourceOnceAsync()
+    {
+        // Arrange
+        var inner = new CountingSkillsSource(
+        [
+            new AgentInlineSkill("skill-a", "A", "Instructions A."),
+        ]);
+        var source = new CachingAgentSkillsSource(inner);
+
+        // Act
+        var result1 = await source.GetSkillsAsync(CancellationToken.None);
+        var result2 = await source.GetSkillsAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Same(result1, result2);
+        Assert.Equal(1, inner.CallCount);
+    }
+
+    [Fact]
+    public async Task GetSkillsAsync_ConcurrentInvocations_CallsInnerSourceOnceAsync()
+    {
+        // Arrange
+        var inner = new CountingSkillsSource(
+        [
+            new AgentInlineSkill("skill-b", "B", "Instructions B."),
+        ]);
+        var source = new CachingAgentSkillsSource(inner);
+
+        // Act
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => source.GetSkillsAsync(CancellationToken.None))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        // Assert
+        Assert.Equal(1, inner.CallCount);
+        foreach (var result in results)
+        {
+            Assert.Same(results[0], result);
+        }
+    }
+
+    [Fact]
+    public async Task GetSkillsAsync_InnerSourceThrows_DoesNotCacheErrorAsync()
+    {
+        // Arrange
+        var inner = new FailingSkillsSource(failOnFirstCall: true);
+        var source = new CachingAgentSkillsSource(inner);
+
+        // Act — first call fails
+        await Assert.ThrowsAsync<InvalidOperationException>(() => source.GetSkillsAsync(CancellationToken.None));
+
+        // Act — second call succeeds (cache was cleared)
+        var result = await source.GetSkillsAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(2, inner.CallCount);
+    }
+
+    [Fact]
+    public async Task GetSkillsAsync_ReturnsResultFromInnerSourceAsync()
+    {
+        // Arrange
+        var skills = new AgentSkill[]
+        {
+            new AgentInlineSkill("skill-x", "X", "Body X."),
+            new AgentInlineSkill("skill-y", "Y", "Body Y."),
+        };
+        var inner = new CountingSkillsSource(skills);
+        var source = new CachingAgentSkillsSource(inner);
+
+        // Act
+        var result = await source.GetSkillsAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("skill-x", result[0].Frontmatter.Name);
+        Assert.Equal("skill-y", result[1].Frontmatter.Name);
+    }
+
+    private sealed class CountingSkillsSource : AgentSkillsSource
+    {
+        private readonly IList<AgentSkill> _skills;
+        private int _callCount;
+
+        public CountingSkillsSource(IList<AgentSkill> skills)
+        {
+            this._skills = skills;
+        }
+
+        public int CallCount => this._callCount;
+
+        public override Task<IList<AgentSkill>> GetSkillsAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref this._callCount);
+            return Task.FromResult(this._skills);
+        }
+    }
+
+    private sealed class FailingSkillsSource : AgentSkillsSource
+    {
+        private readonly bool _failOnFirstCall;
+        private int _callCount;
+
+        public FailingSkillsSource(bool failOnFirstCall)
+        {
+            this._failOnFirstCall = failOnFirstCall;
+        }
+
+        public int CallCount => this._callCount;
+
+        public override Task<IList<AgentSkill>> GetSkillsAsync(CancellationToken cancellationToken = default)
+        {
+            var count = Interlocked.Increment(ref this._callCount);
+            if (this._failOnFirstCall && count == 1)
+            {
+                throw new InvalidOperationException("Simulated failure.");
+            }
+
+            return Task.FromResult<IList<AgentSkill>>(new List<AgentSkill>
+            {
+                new AgentInlineSkill("recovered-skill", "Recovered", "Body."),
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation & Context

`AgentSkillsProvider` mixes context construction with caching. This extracts caching into a composable `CachingAgentSkillsSource` decorator, consistent with the existing `Deduplicating`/`Filtering`/`DelegatingAgentSkillsSource` patterns.

### Description & Review Guide

- **What are the major changes?**
  - New internal `CachingAgentSkillsSource` decorator (lock-free, thread-safe; clears on failure).
  - Builder applies caching after aggregation, before filter/dedup; adds `DisableCaching()` opt-out.
  - Convenience constructors wrap with `CachingAgentSkillsSource` before dedup.
  - Removed `DisableCaching` from `AgentSkillsProviderOptions` and caching logic from the provider.

- **What is the impact of these changes?**
  - Caching is a composable pipeline layer instead of provider-internal logic.
  - The custom-source constructor no longer caches implicitly - use the builder or wrap explicitly.

Closes #6765

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue
- [x] **This is not a breaking change.**