### PR TITLE
.NET: Prefer HTTPS Aspire DevUI backends

### DIFF
--- a/dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/Program.cs
+++ b/dotnet/samples/05-end-to-end/DevUIAspireIntegration/DevUIIntegration.AppHost/Program.cs
@@ -12,8 +12,8 @@ var existingFoundryResourceGroup = builder.AddParameter("existingFoundryResource
 foundry.AsExisting(existingFoundryName, existingFoundryResourceGroup);
 
 // Add the writer agent service
-var writerAgent = builder.AddProject<Projects.WriterAgent>("writer-agent")
-    .WithHttpHealthCheck("/health")
+var writerAgent = builder.AddProject<Projects.WriterAgent>("writer-agent", launchProfileName: "https")
+    .WithHttpHealthCheck("/health", endpointName: "https")
     .WithReference(foundry).WaitFor(foundry);
 
 // Add the editor agent service

--- a/dotnet/samples/05-end-to-end/DevUIAspireIntegration/README.md
+++ b/dotnet/samples/05-end-to-end/DevUIAspireIntegration/README.md
@@ -7,6 +7,8 @@ The solution contains two agent services:
 - **WriterAgent** — a simple agent that writes short stories (≤ 300 words) about a given topic.
 - **EditorAgent** — an agent that edits stories for grammar and style, selects a title, and formats the result for publishing. It also demonstrates tool use via `AIFunctionFactory`.
 
+The WriterAgent is configured with HTTPS redirection so the Aspire DevUI integration can be tested against an agent service that exposes both HTTP and HTTPS endpoints.
+
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)

--- a/dotnet/samples/05-end-to-end/DevUIAspireIntegration/WriterAgent/Program.cs
+++ b/dotnet/samples/05-end-to-end/DevUIAspireIntegration/WriterAgent/Program.cs
@@ -26,6 +26,8 @@ builder.Services.AddOpenAIConversations();
 
 var app = builder.Build();
 
+app.UseHttpsRedirection();
+
 // Map OpenAI API endpoints — DevUI aggregator routes requests here
 app.MapOpenAIResponses();
 app.MapOpenAIConversations();

--- a/dotnet/samples/05-end-to-end/DevUIAspireIntegration/WriterAgent/Properties/launchSettings.json
+++ b/dotnet/samples/05-end-to-end/DevUIAspireIntegration/WriterAgent/Properties/launchSettings.json
@@ -1,6 +1,15 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7280;http://localhost:5280",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
@@ -30,6 +30,7 @@ namespace Aspire.Hosting.AgentFramework;
 internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
 {
     private static readonly FileExtensionContentTypeProvider s_contentTypeProvider = new();
+    private static readonly string[] s_preferredBackendEndpointNames = ["https", "http"];
 
     private WebApplication? _app;
     private readonly DevUIResource _resource;
@@ -283,7 +284,7 @@ internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
     /// Resolves backend URLs from the resource's <see cref="AgentServiceAnnotation"/> annotations.
     /// This method does not cache results to ensure late-allocated backends are always discovered.
     /// </summary>
-    private Dictionary<string, string> ResolveBackends()
+    internal Dictionary<string, string> ResolveBackends()
     {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -296,21 +297,39 @@ internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
 
             var prefix = annotation.EntityIdPrefix ?? annotation.AgentService.Name;
 
-            try
+            var endpointUrl = this.ResolveBackendUrl(rwe, prefix);
+            if (endpointUrl is not null)
             {
-                var endpoint = rwe.GetEndpoint("http");
-                if (endpoint.IsAllocated)
-                {
-                    result[prefix] = endpoint.Url;
-                }
-            }
-            catch (Exception ex)
-            {
-                this._logger.LogDebug(ex, "Backend '{Prefix}' endpoint not yet available", prefix);
+                result[prefix] = endpointUrl;
             }
         }
 
         return result;
+    }
+
+    private string? ResolveBackendUrl(IResourceWithEndpoints resource, string prefix)
+    {
+        foreach (var endpointName in s_preferredBackendEndpointNames)
+        {
+            try
+            {
+                var endpoint = resource.GetEndpoint(endpointName);
+                if (endpoint.IsAllocated)
+                {
+                    return endpoint.Url;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                this._logger.LogDebug(
+                    ex,
+                    "Backend '{Prefix}' {EndpointName} endpoint not yet available",
+                    prefix,
+                    endpointName);
+            }
+        }
+
+        return null;
     }
 
     private async Task<IResult> AggregateEntitiesAsync(HttpContext context)

--- a/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIAggregatorHostedServiceTests.cs
+++ b/dotnet/tests/Aspire.Hosting.AgentFramework.DevUI.UnitTests/DevUIAggregatorHostedServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Linq;
+using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.AgentFramework.DevUI.UnitTests;
 
@@ -245,6 +247,72 @@ public class DevUIAggregatorHostedServiceTests
 
     #endregion
 
+    #region Backend Endpoint Selection Tests
+
+    /// <summary>
+    /// Verifies that ResolveBackends prefers the HTTPS endpoint when both HTTP and HTTPS are allocated.
+    /// </summary>
+    [Fact]
+    public void ResolveBackends_WithHttpAndHttpsEndpoints_PrefersHttps()
+    {
+        // Arrange
+        var devui = new DevUIResource("devui");
+        var agentService = new TestEndpointResource("writer-agent");
+        AddAllocatedEndpoint(agentService, "http", "http", 5050);
+        AddAllocatedEndpoint(agentService, "https", "https", 7443);
+        devui.Annotations.Add(new AgentServiceAnnotation(agentService));
+        var aggregator = new DevUIAggregatorHostedService(devui, NullLogger.Instance);
+
+        // Act
+        var backends = aggregator.ResolveBackends();
+
+        // Assert
+        Assert.Equal("https://localhost:7443", backends["writer-agent"]);
+    }
+
+    /// <summary>
+    /// Verifies that ResolveBackends falls back to HTTP when the HTTPS endpoint is not present.
+    /// </summary>
+    [Fact]
+    public void ResolveBackends_WithOnlyHttpEndpoint_UsesHttp()
+    {
+        // Arrange
+        var devui = new DevUIResource("devui");
+        var agentService = new TestEndpointResource("writer-agent");
+        AddAllocatedEndpoint(agentService, "http", "http", 5050);
+        devui.Annotations.Add(new AgentServiceAnnotation(agentService));
+        var aggregator = new DevUIAggregatorHostedService(devui, NullLogger.Instance);
+
+        // Act
+        var backends = aggregator.ResolveBackends();
+
+        // Assert
+        Assert.Equal("http://localhost:5050", backends["writer-agent"]);
+    }
+
+    /// <summary>
+    /// Verifies that ResolveBackends falls back to HTTP when the HTTPS endpoint has not been allocated yet.
+    /// </summary>
+    [Fact]
+    public void ResolveBackends_WithUnallocatedHttpsEndpoint_UsesHttp()
+    {
+        // Arrange
+        var devui = new DevUIResource("devui");
+        var agentService = new TestEndpointResource("writer-agent");
+        AddEndpoint(agentService, "https", "https");
+        AddAllocatedEndpoint(agentService, "http", "http", 5050);
+        devui.Annotations.Add(new AgentServiceAnnotation(agentService));
+        var aggregator = new DevUIAggregatorHostedService(devui, NullLogger.Instance);
+
+        // Act
+        var backends = aggregator.ResolveBackends();
+
+        // Assert
+        Assert.Equal("http://localhost:5050", backends["writer-agent"]);
+    }
+
+    #endregion
+
     #region Entity ID Parsing Tests
 
     /// <summary>
@@ -293,6 +361,34 @@ public class DevUIAggregatorHostedServiceTests
 
         return mockBuilder.Object;
     }
+
+    private static void AddAllocatedEndpoint(
+        TestEndpointResource resource,
+        string name,
+        string uriScheme,
+        int port)
+    {
+        var endpoint = AddEndpoint(resource, name, uriScheme);
+        endpoint.AllocatedEndpoint = new AllocatedEndpoint(endpoint, "localhost", port);
+    }
+
+    private static EndpointAnnotation AddEndpoint(
+        TestEndpointResource resource,
+        string name,
+        string uriScheme)
+    {
+        var endpoint = new EndpointAnnotation(
+            ProtocolType.Tcp,
+            uriScheme: uriScheme,
+            name: name,
+            port: null,
+            isProxied: false);
+
+        resource.Annotations.Add(endpoint);
+        return endpoint;
+    }
+
+    private sealed class TestEndpointResource(string name) : Resource(name), IResourceWithEndpoints;
 
     #endregion
 }


### PR DESCRIPTION
### Motivation & Context

Aspire DevUI integration currently resolves agent service backends through the hard-coded HTTP endpoint. When an agent service enables HTTPS redirection, the DevUI proxy forwards the redirect response back to the browser, which bypasses the DevUI prefix routing and breaks requests to the backend.

This change lets the DevUI integration work with agent services that expose both HTTP and HTTPS endpoints and use HTTPS redirection.

### Description & Review Guide

- **What are the major changes?**
  - DevUI backend resolution now prefers an allocated `https` endpoint and falls back to `http` for existing services.
  - Added unit tests covering HTTPS preference, HTTP fallback when HTTPS is missing, and HTTP fallback when HTTPS exists but is not allocated.
  - Updated the DevUI Aspire integration sample so `WriterAgent` launches with an HTTPS profile and uses HTTPS redirection, providing a manual test path for this scenario.
- **What is the impact of these changes?**
  - Agent services configured with HTTPS redirection can be used through Aspire DevUI without leaking raw redirect responses to the browser.
  - Existing HTTP-only agent services continue to work through the fallback behavior.
- **What do you want reviewers to focus on?**
  - Whether preferring `https` over `http` is the right default for DevUI backend resolution, and whether the sample is a useful enough regression scenario for manual validation.


### Related Issue

Fixes #6769

No other open PR was found for this issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.