### PR TITLE
.NET: Disable failing DurableTask and AzureFunctions integration tests

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/AgentEntityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/AgentEntityTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 [Trait("Category", "Integration")]
 public sealed class AgentEntityTests(ITestOutputHelper outputHelper) : IDisposable
 {
+    private const string DisabledDueToFailingCiJob = "Disabled due to persistent CI failures. See #6732.";
+
     private static readonly TimeSpan s_defaultTimeout = Debugger.IsAttached
         ? TimeSpan.FromMinutes(5)
         : TimeSpan.FromSeconds(30);
@@ -36,7 +38,7 @@ public sealed class AgentEntityTests(ITestOutputHelper outputHelper) : IDisposab
 
     public void Dispose() => this._cts.Dispose();
 
-    [Fact]
+    [Fact(Skip = DisabledDueToFailingCiJob)]
     public async Task EntityNamePrefixAsync()
     {
         // Setup
@@ -80,7 +82,7 @@ public sealed class AgentEntityTests(ITestOutputHelper outputHelper) : IDisposab
         Assert.Null(request.OrchestrationId);
     }
 
-    [Theory]
+    [Theory(Skip = DisabledDueToFailingCiJob)]
     [InlineData("run")]
     [InlineData("Run")]
     [InlineData("RunAgentAsync")]
@@ -138,7 +140,7 @@ public sealed class AgentEntityTests(ITestOutputHelper outputHelper) : IDisposab
         Assert.Null(request.OrchestrationId);
     }
 
-    [Fact]
+    [Fact(Skip = DisabledDueToFailingCiJob)]
     public async Task OrchestrationIdSetDuringOrchestrationAsync()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ConsoleAppSamplesValidation.cs
@@ -28,7 +28,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         setEnvVar("REDIS_CONNECTION_STRING", $"localhost:{RedisPort}");
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task SingleAgentSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -67,7 +67,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task SingleAgentOrchestrationChainingSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -103,7 +103,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task MultiAgentConcurrencySampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();
@@ -158,7 +158,7 @@ public sealed class ConsoleAppSamplesValidation(ITestOutputHelper outputHelper) 
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task MultiAgentConditionalSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts();

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ExternalClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/ExternalClientTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Agents.AI.DurableTask.IntegrationTests;
 [Trait("Category", "Integration")]
 public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDisposable
 {
+    private const string DisabledDueToFailingCiJob = "Disabled due to persistent CI failures. See #6732.";
+
     private static readonly TimeSpan s_defaultTimeout = Debugger.IsAttached
         ? TimeSpan.FromMinutes(5)
         : TimeSpan.FromSeconds(120);
@@ -36,7 +38,7 @@ public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDispo
 
     public void Dispose() => this._cts.Dispose();
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task SimplePromptAsync()
     {
         // Setup
@@ -75,7 +77,7 @@ public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDispo
         Assert.Contains(agentLogs, log => log.EventId.Name == "LogAgentResponse");
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task CallFunctionToolsAsync()
     {
         int weatherToolInvocationCount = 0;
@@ -127,7 +129,7 @@ public sealed class ExternalClientTests(ITestOutputHelper outputHelper) : IDispo
         Assert.Equal(1, packingListToolInvocationCount);
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task CallLongRunningFunctionToolsAsync()
     {
         [Description("Starts a greeting workflow and returns the workflow instance ID")]

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/WorkflowConsoleAppSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/WorkflowConsoleAppSamplesValidation.cs
@@ -71,7 +71,7 @@ public sealed class WorkflowConsoleAppSamplesValidation(ITestOutputHelper output
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task ConcurrentWorkflowSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts(s_testTimeout);
@@ -505,7 +505,7 @@ public sealed class WorkflowConsoleAppSamplesValidation(ITestOutputHelper output
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task WorkflowAndAgentsSampleValidationAsync()
     {
         using CancellationTokenSource testTimeoutCts = this.CreateTestTimeoutCts(s_testTimeout);

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests;
 [Trait("Category", "SampleValidation")]
 public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLifetime
 {
+    private const string DisabledDueToFailingCiJob = "Disabled due to persistent CI failures. See #6732.";
+
     private const string AzureFunctionsPort = "7071";
     private const string AzuritePort = "10000";
     private const string DtsPort = "8080";
@@ -60,7 +62,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         await Task.CompletedTask;
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task SingleAgentSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "01_SingleAgent");
@@ -148,7 +150,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task MultiAgentOrchestrationConcurrentSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "03_AgentOrchestration_Concurrency");
@@ -198,7 +200,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task MultiAgentOrchestrationConditionalsSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "04_AgentOrchestration_Conditionals");
@@ -272,7 +274,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task LongRunningToolsSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "06_LongRunningTools");
@@ -362,7 +364,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
         });
     }
 
-    [RetryFact(2, 5000)]
+    [RetryFact(2, 5000, Skip = DisabledDueToFailingCiJob)]
     public async Task AgentAsMcpToolAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "07_AgentAsMcpTool");

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/WorkflowSamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/WorkflowSamplesValidation.cs
@@ -333,7 +333,7 @@ public sealed class WorkflowSamplesValidation(ITestOutputHelper outputHelper) : 
         });
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task WorkflowAndAgentsSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "05_WorkflowAndAgents");
@@ -385,7 +385,7 @@ public sealed class WorkflowSamplesValidation(ITestOutputHelper outputHelper) : 
         });
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled due to persistent CI failures. See #6732.")]
     public async Task ConcurrentWorkflowSampleValidationAsync()
     {
         string samplePath = Path.Combine(s_samplesPath, "02_ConcurrentWorkflow");


### PR DESCRIPTION
## Description

Disables 19 integration tests that are persistently failing in CI (timing out). Each test now has a `Skip` attribute with a reason referencing the tracking issue #6732.

**DurableTask - AgentEntityTests:**
- `EntityNamePrefixAsync`
- `RunAgentMethodNamesAllWorkAsync` (Theory, 3 cases)
- `OrchestrationIdSetDuringOrchestrationAsync`

**DurableTask - ExternalClientTests:**
- `SimplePromptAsync`
- `CallFunctionToolsAsync`
- `CallLongRunningFunctionToolsAsync`

**DurableTask - WorkflowConsoleAppSamplesValidation:**
- `ConcurrentWorkflowSampleValidationAsync`
- `WorkflowAndAgentsSampleValidationAsync`

**DurableTask - ConsoleAppSamplesValidation:**
- `SingleAgentSampleValidationAsync`
- `SingleAgentOrchestrationChainingSampleValidationAsync`
- `MultiAgentConcurrencySampleValidationAsync`
- `MultiAgentConditionalSampleValidationAsync`

**AzureFunctions - SamplesValidation:**
- `SingleAgentSampleValidationAsync`
- `MultiAgentOrchestrationConcurrentSampleValidationAsync`
- `MultiAgentOrchestrationConditionalsSampleValidationAsync`
- `LongRunningToolsSampleValidationAsync`
- `AgentAsMcpToolAsync`

**AzureFunctions - WorkflowSamplesValidation:**
- `WorkflowAndAgentsSampleValidationAsync`
- `ConcurrentWorkflowSampleValidationAsync`

Related to #6732