### PR TITLE
.NET: Enable function approval response content DevUI Extension

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemContentConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemContentConverter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Text.Json;
 using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
 using Microsoft.Extensions.AI;
 
@@ -69,6 +71,13 @@ internal static class ItemContentConverter
                 new DataContent(inputAudio.Data, AudioFormatToMediaType(inputAudio.Format)),
             ItemContentOutputAudio outputAudio =>
                 new DataContent(outputAudio.Data, "audio/*"),
+            ItemContentFunctionApprovalResponse functionApprovalResponse => new ToolApprovalResponseContent(
+                functionApprovalResponse.RequestId,
+                functionApprovalResponse.Approved,
+                new FunctionCallContent(
+                    functionApprovalResponse.FunctionCall.Id,
+                    functionApprovalResponse.FunctionCall.Name,
+                    ParseArguments(functionApprovalResponse.FunctionCall.Arguments))),
 
             _ => null
         };
@@ -158,5 +167,32 @@ internal static class ItemContentConverter
         }
 
         return null;
+    }
+
+    private static Dictionary<string, object?>? ParseArguments(JsonElement argumentsJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(argumentsJson.GetRawText());
+            var result = new Dictionary<string, object?>();
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                result[property.Name] = property.Value.ValueKind switch
+                {
+                    JsonValueKind.String => property.Value.GetString(),
+                    JsonValueKind.Number => property.Value.GetDouble(),
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Null => null,
+                    _ => property.Value.GetRawText()
+                };
+            }
+
+            return result;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemContentConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Converters/ItemContentConverter.cs
@@ -171,6 +171,11 @@ internal static class ItemContentConverter
 
     private static Dictionary<string, object?>? ParseArguments(JsonElement argumentsJson)
     {
+        if (argumentsJson.ValueKind is not JsonValueKind.Object)
+        {
+            return null;
+        }
+
         try
         {
             using var doc = JsonDocument.Parse(argumentsJson.GetRawText());

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemResource.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/Models/ItemResource.cs
@@ -266,6 +266,7 @@ internal enum FunctionToolCallOutputItemResourceStatus
 [JsonDerivedType(typeof(ItemContentOutputText), "output_text")]
 [JsonDerivedType(typeof(ItemContentOutputAudio), "output_audio")]
 [JsonDerivedType(typeof(ItemContentRefusal), "refusal")]
+[JsonDerivedType(typeof(ItemContentFunctionApprovalResponse), "function_approval_response")]
 internal abstract class ItemContent
 {
     /// <summary>
@@ -441,6 +442,58 @@ internal sealed class ItemContentRefusal : ItemContent
     /// </summary>
     [JsonPropertyName("refusal")]
     public required string Refusal { get; init; }
+}
+
+/// <summary>
+/// Represents function call information for approval response item.
+/// </summary>
+internal sealed class FunctionCall
+{
+    /// <summary>
+    /// Gets or initializes the function call ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the function name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the function arguments.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    public required JsonElement Arguments { get; init; }
+}
+
+/// <summary>
+/// Function approval response content.
+/// </summary>
+internal sealed class ItemContentFunctionApprovalResponse : ItemContent
+{
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public override string Type => "function_approval_response";
+
+    /// <summary>
+    /// Gets or initializes the value indicating whether the function call was approved for execution.
+    /// </summary>
+    [JsonPropertyName("approved")]
+    public required bool Approved { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the function call that was subject to approval.
+    /// </summary>
+    [JsonPropertyName("function_call")]
+    public required FunctionCall FunctionCall { get; init; }
+
+    /// <summary>
+    /// Gets or initializes the unique identifier that correlates this response with its corresponding request.
+    /// </summary>
+    [JsonPropertyName("request_id")]
+    public required string RequestId { get; init; }
 }
 
 // Additional ItemResource types from TypeSpec


### PR DESCRIPTION
### Motivation & Context
I can see there are some other MRs for this, and I did review those. Those are definitely AI generated without human tests. This is tested.

.NET DevUI relies on the default OpenAPI response endpoints. And it does not expect to accept the custom `MessageFunctionApprovalResponseContent` from DevUI. This MR enables function approval response content DevUI Extension, so that the tool approval response will be handled.

Concern:
This adds additional behavior into the OpenAPI response endpoints, which may make it not perfectly the same with the specification.

Verified:
<img width="3074" height="1502" alt="image" src="https://github.com/user-attachments/assets/289be0da-0043-4e43-a3e9-5b15e0ee38bc" />

### Related Issue

Fixes #6006 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
