### PR TITLE
.NET: Fix invalid EditTable workflow YAML fixtures

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DeclarativeWorkflowTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DeclarativeWorkflowTest.cs
@@ -36,6 +36,42 @@ public sealed class DeclarativeWorkflowTest(ITestOutputHelper output) : Workflow
     }
 
     [Fact]
+    public void WorkflowYamlFixturesBuildSuccessfully()
+    {
+        HashSet<string> invalidFixtures =
+        [
+            "BadEmpty.yaml",
+            "BadId.yaml",
+            "BadKind.yaml",
+        ];
+        List<string> failures = [];
+
+        foreach (string workflowPath in Directory.GetFiles("Workflows", "*.yaml").OrderBy(path => path, StringComparer.Ordinal))
+        {
+            string workflowFile = Path.GetFileName(workflowPath);
+            if (invalidFixtures.Contains(workflowFile))
+            {
+                continue;
+            }
+
+            try
+            {
+                _ = this.CreateWorkflow(workflowFile, "fixture");
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{workflowFile}: {ex.Message}");
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            throw new XunitException(
+                $"Expected every workflow fixture to build successfully.{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+        }
+    }
+
+    [Fact]
     public async Task LoopEachActionAsync()
     {
         await this.RunWorkflowAsync("LoopEach.yaml");

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Workflows/EditTable.yaml
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Workflows/EditTable.yaml
@@ -8,10 +8,10 @@ trigger:
     - kind: SetVariable
       id: set_var
       variable: Local.MyTable
-      value: =[{id: 3}]
+      value: '=[{id: 3}]'
 
     - kind: EditTable
       id: edit_var
       itemsVariable: Local.MyTable
       changeType: Add
-      value: ={id: 7}
+      value: '={id: 7}'

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Workflows/EditTableV2.yaml
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/Workflows/EditTableV2.yaml
@@ -8,11 +8,11 @@ trigger:
     - kind: SetVariable
       id: set_var
       variable: Local.MyTable
-      value: =[{id: 3}]
+      value: '=[{id: 3}]'
 
     - kind: EditTableV2
       id: edit_var
       itemsVariable: Local.MyTable
       changeType:
         kind: AddItemOperation
-        value: ={id: 7}
+        value: '={id: 7}'


### PR DESCRIPTION
### Motivation & Context

`EditTable.yaml` and `EditTableV2.yaml` both used unquoted PowerFx object literals in `value` fields. Those fixtures were not valid YAML, and stock parsers fail on them with `mapping values are not allowed in this context`.

### Description & Review Guide

- **What are the major changes?**
  - Quote the PowerFx object-literal scalars in `EditTable.yaml` and `EditTableV2.yaml`.
  - Add a regression test that builds every workflow fixture except the intentionally invalid `Bad*.yaml` cases.
- **What is the impact of these changes?**
  - The EditTable fixtures are valid YAML again.
  - New malformed workflow fixtures in this directory should be caught earlier by the unit test suite.
- **What do you want reviewers to focus on?**
  - Whether the fixture-wide build test is the right guardrail for this folder.

### Related Issue

No linked issue. I searched for an existing issue or PR covering this fixture breakage and didn't find one.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
