### PR TITLE
.NET: Fix UTF-8 byte truncation in ProcessBridge

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Internal/ProcessBridge.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Internal/ProcessBridge.cs
@@ -327,7 +327,7 @@ internal sealed class ProcessBridge
         }
     }
 
-    private static async Task<(string Text, bool Truncated)> ReadCappedAsync(StreamReader reader, int maxBytes, CancellationToken cancellationToken)
+    internal static async Task<(string Text, bool Truncated)> ReadCappedAsync(StreamReader reader, int maxBytes, CancellationToken cancellationToken)
     {
         var sb = new StringBuilder();
         var buffer = new char[4096];
@@ -351,7 +351,7 @@ internal sealed class ProcessBridge
                     var remaining = Math.Max(0, maxBytes - totalBytes);
                     if (remaining > 0)
                     {
-                        sb.Append(chunk[..Math.Min(chunk.Length, remaining)]);
+                        sb.Append(TruncateToUtf8ByteCount(chunk, remaining));
                     }
 
                     truncated = true;
@@ -374,6 +374,30 @@ internal sealed class ProcessBridge
         }
 
         return (sb.ToString(), truncated);
+    }
+
+    private static string TruncateToUtf8ByteCount(string text, int maxBytes)
+    {
+        if (string.IsNullOrEmpty(text) || maxBytes <= 0)
+        {
+            return string.Empty;
+        }
+
+        var bytesUsed = 0;
+        var charsUsed = 0;
+        foreach (var rune in text.EnumerateRunes())
+        {
+            var runeBytes = rune.Utf8SequenceLength;
+            if (bytesUsed + runeBytes > maxBytes)
+            {
+                break;
+            }
+
+            bytesUsed += runeBytes;
+            charsUsed += rune.Utf16SequenceLength;
+        }
+
+        return charsUsed == text.Length ? text : text[..charsUsed];
     }
 
     private static void TryKill(Process process)

--- a/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/ProcessBridgeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/ProcessBridgeTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.LocalCodeAct.Internal;
+
+namespace Microsoft.Agents.AI.LocalCodeAct.UnitTests;
+
+public sealed class ProcessBridgeTests
+{
+    [Fact]
+    public async Task ReadCappedAsync_ExactUtf8Limit_ReturnsFullTextAsync()
+    {
+        var result = await ReadCappedAsync("A😀B", maxBytes: 6);
+
+        Assert.Equal("A😀B", result.Text);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public async Task ReadCappedAsync_TruncatesAtRuneBoundaryAsync()
+    {
+        var result = await ReadCappedAsync("A😀B", maxBytes: 5);
+
+        Assert.Equal("A😀", result.Text);
+        Assert.True(result.Truncated);
+        Assert.Equal(5, Encoding.UTF8.GetByteCount(result.Text));
+    }
+
+    [Fact]
+    public async Task ReadCappedAsync_DoesNotSplitSurrogatePairWhenRuneDoesNotFitAsync()
+    {
+        var result = await ReadCappedAsync("A😀B", maxBytes: 2);
+
+        Assert.Equal("A", result.Text);
+        Assert.True(result.Truncated);
+        Assert.Equal(1, Encoding.UTF8.GetByteCount(result.Text));
+    }
+
+    private static async Task<(string Text, bool Truncated)> ReadCappedAsync(string text, int maxBytes)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: false);
+        return await ProcessBridge.ReadCappedAsync(reader, maxBytes, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
### Motivation & Context

`ProcessBridge.ReadCappedAsync` tracks stderr limits in UTF-8 bytes, but the overflow path was slicing the string with a UTF-16 character count. That means multi-byte characters could push the returned text past the configured byte cap, and surrogate pairs could be cut in half.

### Description & Review Guide

- **What are the major changes?**
  - Make the overflow path truncate on UTF-8 rune boundaries instead of raw `string` indices.
  - Add focused unit tests covering exact-fit, multi-byte truncation, and surrogate-pair safety.
- **What is the impact of these changes?**
  - `ReadCappedAsync` now respects the configured byte limit without returning invalidly sliced Unicode.
  - The LocalCodeAct stderr capture path is better protected against regressions around non-ASCII output.
- **What do you want reviewers to focus on?**
  - Whether keeping the truncation helper local to `ProcessBridge` is the right scope for now.

### Related Issue

No linked issue. I searched for an existing issue or PR for this specific `ReadCappedAsync` truncation bug and didn't find one.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

### Validation

- `/Users/hoangvu/.dotnet/dotnet test dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/Microsoft.Agents.AI.LocalCodeAct.UnitTests.csproj -f net10.0`
