### PR TITLE
Fix malformed frontmatter in agent skills ADR

### DIFF
--- a/docs/decisions/0021-agent-skills-design.md
+++ b/docs/decisions/0021-agent-skills-design.md
@@ -1,3 +1,4 @@
+---
 status: proposed
 date: 2026-03-23
 contact: sergeymenshykh


### PR DESCRIPTION
### Motivation & Context

`docs/decisions/0021-agent-skills-design.md` was missing the opening `---` delimiter for its YAML frontmatter. That makes the ADR metadata inconsistent with the rest of the decisions directory and can cause frontmatter-aware tooling to ignore the metadata block.

### Description & Review Guide

- **What are the major changes?**
  - Add the missing opening frontmatter delimiter to ADR 0021.
- **What is the impact of these changes?**
  - Frontmatter parsers can recognize the ADR metadata again.
  - Generated docs or indexing that rely on ADR metadata should stop skipping this file.
- **What do you want reviewers to focus on?**
  - Just the delimiter placement; this is intended to be a tiny docs-only fix.

### Related Issue

No linked issue. I didn't find an existing issue or PR for this specific frontmatter bug.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

### Validation

- Confirmed the file now begins with `---`
- Confirmed the closing `---` still wraps the metadata block
