### PR TITLE
.NET: Populate AgentResponse metadata in CopilotStudioAgent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/ActivityProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/ActivityProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.AI;
@@ -38,8 +39,27 @@ internal static class ActivityProcessor
     private static ChatMessage CreateChatMessageFromActivity(IActivity activity, IEnumerable<AIContent> messageContent) =>
         new(ChatRole.Assistant, [.. messageContent])
         {
+            AdditionalProperties = MapAdditionalProperties(activity),
             AuthorName = activity.From?.Name,
+            CreatedAt = activity.Timestamp,
             MessageId = activity.Id,
             RawRepresentation = activity
         };
+
+    private static AdditionalPropertiesDictionary? MapAdditionalProperties(IActivity activity)
+    {
+        IDictionary<string, JsonElement>? properties = activity.Properties;
+        if (properties is null || properties.Count == 0)
+        {
+            return null;
+        }
+
+        var additionalProperties = new AdditionalPropertiesDictionary();
+        foreach (KeyValuePair<string, JsonElement> property in properties)
+        {
+            additionalProperties[property.Key] = property.Value;
+        }
+
+        return additionalProperties;
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -98,14 +99,7 @@ public class CopilotStudioAgent : AIAgent
             responseMessagesList.Add(message);
         }
 
-        // TODO: Review list of ChatResponse properties to ensure we set all availble values.
-        // Setting ResponseId and MessageId end up being particularly important for streaming consumers
-        // so that they can tell things like response boundaries.
-        return new AgentResponse(responseMessagesList)
-        {
-            AgentId = this.Id,
-            ResponseId = responseMessagesList.LastOrDefault()?.MessageId,
-        };
+        return CreateAgentResponse(responseMessagesList, this.Id);
     }
 
     /// <inheritdoc/>
@@ -132,23 +126,112 @@ public class CopilotStudioAgent : AIAgent
         string question = string.Join("\n", messages.Select(m => m.Text));
         var responseMessages = ActivityProcessor.ProcessActivityAsync(this.Client.AskQuestionAsync(question, typedSession.ConversationId, cancellationToken), streaming: true, this._logger);
 
-        // Enumerate the response messages
-        await foreach (ChatMessage message in responseMessages.ConfigureAwait(false))
+        await foreach (AgentResponseUpdate update in CreateAgentResponseUpdatesAsync(responseMessages, this.Id, cancellationToken).ConfigureAwait(false))
         {
-            // TODO: Review list of ChatResponse properties to ensure we set all availble values.
-            // Setting ResponseId and MessageId end up being particularly important for streaming consumers
-            // so that they can tell things like response boundaries.
-            yield return new AgentResponseUpdate(message.Role, message.Contents)
-            {
-                AgentId = this.Id,
-                AdditionalProperties = message.AdditionalProperties,
-                AuthorName = message.AuthorName,
-                RawRepresentation = message.RawRepresentation,
-                ResponseId = message.MessageId,
-                MessageId = message.MessageId,
-            };
+            yield return update;
         }
     }
+
+    /// <summary>
+    /// Builds an <see cref="AgentResponse"/> from the messages returned by the Copilot Studio agent,
+    /// populating the response-level metadata (such as <see cref="AgentResponse.CreatedAt"/>,
+    /// <see cref="AgentResponse.FinishReason"/> and <see cref="AgentResponse.RawRepresentation"/>) from the
+    /// final message so that consumers see the same surface as other <see cref="AIAgent"/> implementations.
+    /// </summary>
+    internal static AgentResponse CreateAgentResponse(IList<ChatMessage> messages, string? agentId)
+    {
+        ChatMessage? lastMessage = messages.Count > 0 ? messages[messages.Count - 1] : null;
+
+        return new AgentResponse(messages)
+        {
+            AgentId = agentId,
+            ResponseId = lastMessage?.MessageId,
+            CreatedAt = lastMessage?.CreatedAt,
+            FinishReason = ChatFinishReason.Stop,
+            RawRepresentation = lastMessage?.RawRepresentation,
+            AdditionalProperties = lastMessage?.AdditionalProperties,
+        };
+    }
+
+    /// <summary>
+    /// Projects the streamed <see cref="ChatMessage"/> sequence onto <see cref="AgentResponseUpdate"/> instances,
+    /// carrying per-update metadata and setting <see cref="AgentResponseUpdate.FinishReason"/> only on the terminal
+    /// update so streaming consumers can detect the response boundary.
+    /// </summary>
+    internal static async IAsyncEnumerable<AgentResponseUpdate> CreateAgentResponseUpdatesAsync(
+        IAsyncEnumerable<ChatMessage> messages,
+        string? agentId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Buffer a single message so we know which update is the terminal one (it carries the finish reason).
+        // Manual enumeration lets us still emit any already-received content if the source faults mid-stream,
+        // preserving the original streaming behavior, before re-throwing the original exception.
+        ChatMessage? pending = null;
+        ExceptionDispatchInfo? failure = null;
+
+        IAsyncEnumerator<ChatMessage> enumerator = messages.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (true)
+            {
+                bool moved;
+                try
+                {
+                    moved = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    failure = ExceptionDispatchInfo.Capture(ex);
+                    break;
+                }
+
+                if (!moved)
+                {
+                    break;
+                }
+
+                if (pending is not null)
+                {
+                    yield return CreateAgentResponseUpdate(pending, agentId, finishReason: null);
+                }
+
+                pending = enumerator.Current;
+            }
+        }
+        finally
+        {
+            try
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+            catch when (failure is not null)
+            {
+                // A fault was already captured from the stream; don't let a disposal
+                // exception override the original streaming exception.
+            }
+        }
+
+        if (pending is not null)
+        {
+            // The last received message is the terminal update only when the stream completed successfully.
+            yield return CreateAgentResponseUpdate(pending, agentId, finishReason: failure is null ? ChatFinishReason.Stop : null);
+        }
+
+        failure?.Throw();
+    }
+
+    private static AgentResponseUpdate CreateAgentResponseUpdate(ChatMessage message, string? agentId, ChatFinishReason? finishReason) =>
+        new(message.Role, message.Contents)
+        {
+            AgentId = agentId,
+            AdditionalProperties = message.AdditionalProperties,
+            AuthorName = message.AuthorName,
+            CreatedAt = message.CreatedAt,
+            FinishReason = finishReason,
+            RawRepresentation = message.RawRepresentation,
+            ResponseId = message.MessageId,
+            MessageId = message.MessageId,
+        };
 
     private async Task<string> StartNewConversationAsync(CancellationToken cancellationToken)
     {

--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/Microsoft.Agents.AI.CopilotStudio.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/Microsoft.Agents.AI.CopilotStudio.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.Agents.CopilotStudio.Client" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Agents.AI.UnitTests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- NuGet Package Settings -->
     <Title>Microsoft Agent Framework Copilot Studio</Title>

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/CopilotStudioAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/CopilotStudioAgentTests.cs
@@ -1,8 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.Agents.AI.CopilotStudio;
 using Microsoft.Agents.CopilotStudio.Client;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -173,6 +179,245 @@ public class CopilotStudioAgentTests
         Assert.IsType<AIAgentMetadata>(result1);
         var metadata = (AIAgentMetadata)result1;
         Assert.Equal("copilot-studio", metadata.ProviderName);
+    }
+
+    #endregion
+
+    #region Metadata Mapping Tests
+
+    /// <summary>
+    /// Verify that <see cref="ActivityProcessor"/> maps the available <see cref="IActivity"/> fields,
+    /// including the timestamp, onto the resulting <see cref="ChatMessage"/> in the non-streaming path.
+    /// </summary>
+    [Fact]
+    public async Task ProcessActivity_NonStreaming_MapsActivityMetadataToChatMessage()
+    {
+        // Arrange
+        var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        using var channelIdDocument = JsonDocument.Parse("\"webchat\"");
+        var properties = new Dictionary<string, JsonElement> { ["channelId"] = channelIdDocument.RootElement.Clone() };
+        IActivity activity = CreateActivity("message", "Hello", "activity-1", timestamp, "bot", properties);
+
+        // Act
+        var messages = await CollectAsync(ActivityProcessor.ProcessActivityAsync(ToAsyncEnumerableAsync(activity), streaming: false, NullLogger.Instance));
+
+        // Assert
+        var message = Assert.Single(messages);
+        Assert.Equal("activity-1", message.MessageId);
+        Assert.Equal("bot", message.AuthorName);
+        Assert.Equal(timestamp, message.CreatedAt);
+        Assert.Same(activity, message.RawRepresentation);
+        Assert.NotNull(message.AdditionalProperties);
+        Assert.True(message.AdditionalProperties.ContainsKey("channelId"));
+    }
+
+    /// <summary>
+    /// Verify that an activity without extra properties does not allocate an empty additional-properties bag.
+    /// </summary>
+    [Fact]
+    public async Task ProcessActivity_NoActivityProperties_LeavesAdditionalPropertiesNull()
+    {
+        // Arrange
+        var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        IActivity activity = CreateActivity("message", "Hello", "activity-1", timestamp, "bot");
+
+        // Act
+        var messages = await CollectAsync(ActivityProcessor.ProcessActivityAsync(ToAsyncEnumerableAsync(activity), streaming: false, NullLogger.Instance));
+
+        // Assert
+        var message = Assert.Single(messages);
+        Assert.Null(message.AdditionalProperties);
+    }
+
+    /// <summary>
+    /// Verify that the streaming path also maps the activity timestamp onto the <see cref="ChatMessage"/>.
+    /// </summary>
+    [Fact]
+    public async Task ProcessActivity_Streaming_MapsActivityMetadataToChatMessage()
+    {
+        // Arrange
+        var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        IActivity activity = CreateActivity("typing", "partial", "activity-2", timestamp, "bot");
+
+        // Act
+        var messages = await CollectAsync(ActivityProcessor.ProcessActivityAsync(ToAsyncEnumerableAsync(activity), streaming: true, NullLogger.Instance));
+
+        // Assert
+        var message = Assert.Single(messages);
+        Assert.Equal("activity-2", message.MessageId);
+        Assert.Equal(timestamp, message.CreatedAt);
+        Assert.Same(activity, message.RawRepresentation);
+    }
+
+    /// <summary>
+    /// Verify that the non-streaming response carries the response-level metadata expected by consumers.
+    /// </summary>
+    [Fact]
+    public void CreateAgentResponse_PopulatesResponseMetadata()
+    {
+        // Arrange
+        var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var rawActivity = new object();
+        var additionalProperties = new AdditionalPropertiesDictionary { ["key"] = "value" };
+        var message = new ChatMessage(ChatRole.Assistant, "Hi")
+        {
+            MessageId = "msg-1",
+            CreatedAt = timestamp,
+            RawRepresentation = rawActivity,
+            AdditionalProperties = additionalProperties,
+        };
+
+        // Act
+        var response = CopilotStudioAgent.CreateAgentResponse([message], "agent-1");
+
+        // Assert
+        Assert.Equal("agent-1", response.AgentId);
+        Assert.Equal("msg-1", response.ResponseId);
+        Assert.Equal(timestamp, response.CreatedAt);
+        Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        Assert.Same(rawActivity, response.RawRepresentation);
+        Assert.Same(additionalProperties, response.AdditionalProperties);
+        Assert.Same(message, Assert.Single(response.Messages));
+    }
+
+    /// <summary>
+    /// Verify that an empty response still reports a successful completion without throwing.
+    /// </summary>
+    [Fact]
+    public void CreateAgentResponse_NoMessages_ReportsSuccessfulCompletion()
+    {
+        // Act
+        var response = CopilotStudioAgent.CreateAgentResponse([], "agent-1");
+
+        // Assert
+        Assert.Equal("agent-1", response.AgentId);
+        Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        Assert.Null(response.ResponseId);
+        Assert.Null(response.CreatedAt);
+    }
+
+    /// <summary>
+    /// Verify that streaming updates carry per-update metadata and that the terminal update alone reports a finish reason.
+    /// </summary>
+    [Fact]
+    public async Task CreateAgentResponseUpdates_SetsFinishReasonOnTerminalUpdateOnly()
+    {
+        // Arrange
+        var firstTimestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var secondTimestamp = firstTimestamp.AddSeconds(1);
+        var rawActivity = new object();
+        var additionalProperties = new AdditionalPropertiesDictionary { ["key"] = "value" };
+        var first = new ChatMessage(ChatRole.Assistant, "part 1") { MessageId = "m1", CreatedAt = firstTimestamp };
+        var second = new ChatMessage(ChatRole.Assistant, "part 2")
+        {
+            MessageId = "m2",
+            CreatedAt = secondTimestamp,
+            AuthorName = "bot",
+            RawRepresentation = rawActivity,
+            AdditionalProperties = additionalProperties,
+        };
+
+        // Act
+        var updates = await CollectAsync(CopilotStudioAgent.CreateAgentResponseUpdatesAsync(ToAsyncEnumerableAsync(first, second), "agent-1"));
+
+        // Assert
+        Assert.Equal(2, updates.Count);
+        Assert.Equal("agent-1", updates[0].AgentId);
+        Assert.Equal("m1", updates[0].MessageId);
+        Assert.Equal(firstTimestamp, updates[0].CreatedAt);
+        Assert.Null(updates[0].FinishReason);
+        Assert.Equal("m2", updates[1].MessageId);
+        Assert.Equal("m2", updates[1].ResponseId);
+        Assert.Equal("bot", updates[1].AuthorName);
+        Assert.Equal(secondTimestamp, updates[1].CreatedAt);
+        Assert.Same(rawActivity, updates[1].RawRepresentation);
+        Assert.Same(additionalProperties, updates[1].AdditionalProperties);
+        Assert.Equal(ChatFinishReason.Stop, updates[1].FinishReason);
+    }
+
+    /// <summary>
+    /// Verify that content already received before the source stream faults is still emitted (without a finish
+    /// reason) and that the original exception propagates, preserving the pre-existing streaming behavior.
+    /// </summary>
+    [Fact]
+    public async Task CreateAgentResponseUpdates_SourceFaultsMidStream_EmitsReceivedContentThenThrows()
+    {
+        // Arrange
+        var message = new ChatMessage(ChatRole.Assistant, "partial") { MessageId = "m1" };
+        var boom = new InvalidOperationException("stream failed");
+        var updates = new List<AgentResponseUpdate>();
+
+        // Act
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var update in CopilotStudioAgent.CreateAgentResponseUpdatesAsync(ThrowAfterAsync(message, boom), "agent-1"))
+            {
+                updates.Add(update);
+            }
+        });
+
+        // Assert
+        Assert.Same(boom, thrown);
+        var emitted = Assert.Single(updates);
+        Assert.Equal("m1", emitted.MessageId);
+        Assert.Null(emitted.FinishReason);
+    }
+
+    /// <summary>
+    /// Verify that a single streaming update is treated as the terminal update.
+    /// </summary>
+    [Fact]
+    public async Task CreateAgentResponseUpdates_SingleMessage_SetsFinishReason()
+    {
+        // Arrange
+        var message = new ChatMessage(ChatRole.Assistant, "only") { MessageId = "m1" };
+
+        // Act
+        var updates = await CollectAsync(CopilotStudioAgent.CreateAgentResponseUpdatesAsync(ToAsyncEnumerableAsync(message), "agent-1"));
+
+        // Assert
+        var update = Assert.Single(updates);
+        Assert.Equal(ChatFinishReason.Stop, update.FinishReason);
+    }
+
+    private static IActivity CreateActivity(string type, string text, string id, DateTimeOffset timestamp, string authorName, IDictionary<string, JsonElement>? properties = null)
+    {
+        var activity = new Mock<IActivity>();
+        activity.SetupGet(a => a.Type).Returns(type);
+        activity.SetupGet(a => a.Text).Returns(text);
+        activity.SetupGet(a => a.Id).Returns(id);
+        activity.SetupGet(a => a.Timestamp).Returns(timestamp);
+        activity.SetupGet(a => a.From).Returns(new ChannelAccount { Name = authorName });
+        activity.SetupGet(a => a.Properties).Returns(properties!);
+        return activity.Object;
+    }
+
+    private static async IAsyncEnumerable<ChatMessage> ThrowAfterAsync(ChatMessage message, Exception exception)
+    {
+        yield return message;
+        await Task.CompletedTask;
+        throw exception;
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerableAsync<T>(params T[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var items = new List<T>();
+        await foreach (var item in source)
+        {
+            items.Add(item);
+        }
+
+        return items;
     }
 
     #endregion

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/CopilotStudioAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/CopilotStudioAgentTests.cs
@@ -190,7 +190,7 @@ public class CopilotStudioAgentTests
     /// including the timestamp, onto the resulting <see cref="ChatMessage"/> in the non-streaming path.
     /// </summary>
     [Fact]
-    public async Task ProcessActivity_NonStreaming_MapsActivityMetadataToChatMessage()
+    public async Task ProcessActivity_NonStreaming_MapsActivityMetadataToChatMessageAsync()
     {
         // Arrange
         var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
@@ -215,7 +215,7 @@ public class CopilotStudioAgentTests
     /// Verify that an activity without extra properties does not allocate an empty additional-properties bag.
     /// </summary>
     [Fact]
-    public async Task ProcessActivity_NoActivityProperties_LeavesAdditionalPropertiesNull()
+    public async Task ProcessActivity_NoActivityProperties_LeavesAdditionalPropertiesNullAsync()
     {
         // Arrange
         var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
@@ -233,7 +233,7 @@ public class CopilotStudioAgentTests
     /// Verify that the streaming path also maps the activity timestamp onto the <see cref="ChatMessage"/>.
     /// </summary>
     [Fact]
-    public async Task ProcessActivity_Streaming_MapsActivityMetadataToChatMessage()
+    public async Task ProcessActivity_Streaming_MapsActivityMetadataToChatMessageAsync()
     {
         // Arrange
         var timestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
@@ -300,7 +300,7 @@ public class CopilotStudioAgentTests
     /// Verify that streaming updates carry per-update metadata and that the terminal update alone reports a finish reason.
     /// </summary>
     [Fact]
-    public async Task CreateAgentResponseUpdates_SetsFinishReasonOnTerminalUpdateOnly()
+    public async Task CreateAgentResponseUpdates_SetsFinishReasonOnTerminalUpdateOnlyAsync()
     {
         // Arrange
         var firstTimestamp = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
@@ -340,7 +340,7 @@ public class CopilotStudioAgentTests
     /// reason) and that the original exception propagates, preserving the pre-existing streaming behavior.
     /// </summary>
     [Fact]
-    public async Task CreateAgentResponseUpdates_SourceFaultsMidStream_EmitsReceivedContentThenThrows()
+    public async Task CreateAgentResponseUpdates_SourceFaultsMidStream_EmitsReceivedContentThenThrowsAsync()
     {
         // Arrange
         var message = new ChatMessage(ChatRole.Assistant, "partial") { MessageId = "m1" };
@@ -367,7 +367,7 @@ public class CopilotStudioAgentTests
     /// Verify that a single streaming update is treated as the terminal update.
     /// </summary>
     [Fact]
-    public async Task CreateAgentResponseUpdates_SingleMessage_SetsFinishReason()
+    public async Task CreateAgentResponseUpdates_SingleMessage_SetsFinishReasonAsync()
     {
         // Arrange
         var message = new ChatMessage(ChatRole.Assistant, "only") { MessageId = "m1" };


### PR DESCRIPTION
Closes #6790.

`CopilotStudioAgent` only set `AgentId`/`ResponseId` on the non-streaming `AgentResponse`, leaving `CreatedAt`, `FinishReason`, `RawRepresentation` and `AdditionalProperties` unset; the streaming path was also missing `CreatedAt` and `FinishReason`. This brings the provider in line with the others (e.g. `A2AAgent`) and clears the existing `TODO`s in the source.

Changes:
- `ActivityProcessor` maps the activity `Timestamp` to `ChatMessage.CreatedAt` and copies `IActivity.Properties` into `ChatMessage.AdditionalProperties` (left `null` when there are none).
- Non-streaming `RunAsync` populates `CreatedAt`, `FinishReason` (`Stop`), `RawRepresentation` and `AdditionalProperties` from the final message.
- Streaming `RunStreamingAsync` carries `CreatedAt` on each update and sets `FinishReason` only on the terminal update. It uses one-message lookahead but still emits already-received content and rethrows if the underlying stream faults, so the prior streaming behavior is preserved on the error path.
- Added unit tests covering the activity-to-message mapping, response-level metadata, the terminal finish reason, single-message streams, and the mid-stream fault case. `ActivityProcessor` is exposed to the test project via `InternalsVisibleTo`.

`Usage` is left unset since the Copilot Studio client does not currently surface token usage.

<!-- oss-radar:idempotency=auto-20260629-150941.w8.microsoft_agent-framework.6790 -->

