### PR TITLE
.NET: CopilotStudio: populate AgentResponse metadata from IActivity

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/ActivityProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/ActivityProcessor.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.AI;
@@ -13,6 +16,13 @@ namespace Microsoft.Agents.AI.CopilotStudio;
 /// </summary>
 internal static class ActivityProcessor
 {
+    /// <summary>
+    /// Processes Copilot Studio activities and yields the corresponding <see cref="ChatMessage"/> instances.
+    /// </summary>
+    /// <param name="activities">The activities returned by the Copilot Studio client.</param>
+    /// <param name="streaming">A value indicating whether the response is being processed in streaming mode.</param>
+    /// <param name="logger">The logger used to record processing warnings.</param>
+    /// <returns>An asynchronous sequence of <see cref="ChatMessage"/> objects.</returns>
     public static async IAsyncEnumerable<ChatMessage> ProcessActivityAsync(IAsyncEnumerable<IActivity> activities, bool streaming, ILogger logger)
     {
         await foreach (IActivity activity in activities.ConfigureAwait(false))
@@ -35,11 +45,92 @@ internal static class ActivityProcessor
         }
     }
 
-    private static ChatMessage CreateChatMessageFromActivity(IActivity activity, IEnumerable<AIContent> messageContent) =>
-        new(ChatRole.Assistant, [.. messageContent])
+    /// <summary>
+    /// Creates an <see cref="AgentResponse"/> from processed messages and the last source activity.
+    /// </summary>
+    /// <param name="agentId">The identifier of the agent that produced the response.</param>
+    /// <param name="messages">The response messages produced by the agent.</param>
+    /// <param name="lastActivity">The last underlying activity, when available.</param>
+    /// <returns>An <see cref="AgentResponse"/> with populated metadata.</returns>
+    internal static AgentResponse CreateAgentResponse(string agentId, IList<ChatMessage> messages, IActivity? lastActivity)
+    {
+        ChatMessage? lastMessage = messages.LastOrDefault();
+
+        DateTimeOffset? createdAt = lastMessage?.CreatedAt;
+        if (createdAt is null && lastActivity is not null)
+        {
+            createdAt = ResolveActivityCreatedAt(lastActivity);
+        }
+
+        AdditionalPropertiesDictionary? additionalProperties = lastMessage?.AdditionalProperties;
+        if (additionalProperties is null && lastActivity is not null)
+        {
+            additionalProperties = ResolveActivityAdditionalProperties(lastActivity);
+        }
+
+        return new AgentResponse(messages)
+        {
+            AgentId = agentId,
+            ResponseId = lastMessage?.MessageId,
+            CreatedAt = createdAt,
+            FinishReason = messages.Count > 0 ? ChatFinishReason.Stop : null,
+            RawRepresentation = lastActivity,
+            AdditionalProperties = additionalProperties,
+        };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="AgentResponseUpdate"/> from a processed <see cref="ChatMessage"/>.
+    /// </summary>
+    /// <param name="agentId">The identifier of the agent that produced the update.</param>
+    /// <param name="message">The chat message represented by the update.</param>
+    /// <param name="isTerminalUpdate">A value indicating whether this is the final update in the stream.</param>
+    /// <returns>An <see cref="AgentResponseUpdate"/> with populated metadata.</returns>
+    internal static AgentResponseUpdate CreateAgentResponseUpdate(string agentId, ChatMessage message, bool isTerminalUpdate)
+    {
+        return new AgentResponseUpdate(message.Role, message.Contents)
+        {
+            AgentId = agentId,
+            AdditionalProperties = message.AdditionalProperties,
+            AuthorName = message.AuthorName,
+            RawRepresentation = message.RawRepresentation,
+            ResponseId = message.MessageId,
+            MessageId = message.MessageId,
+            CreatedAt = message.CreatedAt,
+            FinishReason = isTerminalUpdate ? ChatFinishReason.Stop : null,
+        };
+    }
+
+    private static ChatMessage CreateChatMessageFromActivity(IActivity activity, IEnumerable<AIContent> messageContent)
+    {
+        return new(ChatRole.Assistant, [.. messageContent])
         {
             AuthorName = activity.From?.Name,
             MessageId = activity.Id,
-            RawRepresentation = activity
+            CreatedAt = ResolveActivityCreatedAt(activity),
+            AdditionalProperties = ResolveActivityAdditionalProperties(activity),
+            RawRepresentation = activity,
         };
+    }
+
+    private static DateTimeOffset? ResolveActivityCreatedAt(IActivity activity)
+    {
+        return activity.Timestamp ?? activity.LocalTimestamp;
+    }
+
+    private static AdditionalPropertiesDictionary? ResolveActivityAdditionalProperties(IActivity activity)
+    {
+        if (activity.Properties is not { Count: > 0 } properties)
+        {
+            return null;
+        }
+
+        AdditionalPropertiesDictionary additionalProperties = new();
+        foreach (KeyValuePair<string, JsonElement> property in properties)
+        {
+            additionalProperties[property.Key] = property.Value;
+        }
+
+        return additionalProperties;
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/CopilotStudioAgent.cs
@@ -91,21 +91,23 @@ public class CopilotStudioAgent : AIAgent
 
         // Invoke the Copilot Studio agent with the provided messages.
         string question = string.Join("\n", messages.Select(m => m.Text));
-        var responseMessages = ActivityProcessor.ProcessActivityAsync(this.Client.AskQuestionAsync(question, typedSession.ConversationId, cancellationToken), streaming: false, this._logger);
-        var responseMessagesList = new List<ChatMessage>();
-        await foreach (var message in responseMessages.ConfigureAwait(false))
+        IAsyncEnumerable<ChatMessage> responseMessages = ActivityProcessor.ProcessActivityAsync(
+            this.Client.AskQuestionAsync(question, typedSession.ConversationId, cancellationToken),
+            streaming: false,
+            this._logger);
+
+        List<ChatMessage> responseMessagesList = [];
+        IActivity? lastActivity = null;
+        await foreach (ChatMessage message in responseMessages.ConfigureAwait(false))
         {
             responseMessagesList.Add(message);
+            if (message.RawRepresentation is IActivity activity)
+            {
+                lastActivity = activity;
+            }
         }
 
-        // TODO: Review list of ChatResponse properties to ensure we set all availble values.
-        // Setting ResponseId and MessageId end up being particularly important for streaming consumers
-        // so that they can tell things like response boundaries.
-        return new AgentResponse(responseMessagesList)
-        {
-            AgentId = this.Id,
-            ResponseId = responseMessagesList.LastOrDefault()?.MessageId,
-        };
+        return ActivityProcessor.CreateAgentResponse(this.Id, responseMessagesList, lastActivity);
     }
 
     /// <inheritdoc/>
@@ -119,7 +121,6 @@ public class CopilotStudioAgent : AIAgent
 
         // Ensure that we have a valid session to work with.
         // If the session ID is null, we need to start a new conversation and set the session ID accordingly.
-
         session ??= await this.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
         if (session is not CopilotStudioAgentSession typedSession)
         {
@@ -130,23 +131,14 @@ public class CopilotStudioAgent : AIAgent
 
         // Invoke the Copilot Studio agent with the provided messages.
         string question = string.Join("\n", messages.Select(m => m.Text));
-        var responseMessages = ActivityProcessor.ProcessActivityAsync(this.Client.AskQuestionAsync(question, typedSession.ConversationId, cancellationToken), streaming: true, this._logger);
+        IAsyncEnumerable<ChatMessage> responseMessages = ActivityProcessor.ProcessActivityAsync(
+            this.Client.AskQuestionAsync(question, typedSession.ConversationId, cancellationToken),
+            streaming: true,
+            this._logger);
 
-        // Enumerate the response messages
-        await foreach (ChatMessage message in responseMessages.ConfigureAwait(false))
+        await foreach (AgentResponseUpdate update in CreateStreamingUpdatesAsync(this.Id, responseMessages, cancellationToken).ConfigureAwait(false))
         {
-            // TODO: Review list of ChatResponse properties to ensure we set all availble values.
-            // Setting ResponseId and MessageId end up being particularly important for streaming consumers
-            // so that they can tell things like response boundaries.
-            yield return new AgentResponseUpdate(message.Role, message.Contents)
-            {
-                AgentId = this.Id,
-                AdditionalProperties = message.AdditionalProperties,
-                AuthorName = message.AuthorName,
-                RawRepresentation = message.RawRepresentation,
-                ResponseId = message.MessageId,
-                MessageId = message.MessageId,
-            };
+            yield return update;
         }
     }
 
@@ -167,6 +159,34 @@ public class CopilotStudioAgent : AIAgent
         }
 
         return conversationId!;
+    }
+
+    private static async IAsyncEnumerable<AgentResponseUpdate> CreateStreamingUpdatesAsync(
+        string agentId,
+        IAsyncEnumerable<ChatMessage> responseMessages,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        IAsyncEnumerator<ChatMessage> enumerator = responseMessages.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                yield break;
+            }
+
+            ChatMessage currentMessage = enumerator.Current;
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                yield return ActivityProcessor.CreateAgentResponseUpdate(agentId, currentMessage, isTerminalUpdate: false);
+                currentMessage = enumerator.Current;
+            }
+
+            yield return ActivityProcessor.CreateAgentResponseUpdate(agentId, currentMessage, isTerminalUpdate: true);
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Microsoft.Agents.AI.CopilotStudio/Microsoft.Agents.AI.CopilotStudio.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.CopilotStudio/Microsoft.Agents.AI.CopilotStudio.csproj
@@ -25,4 +25,8 @@
     <Description>Provides Microsoft Agent Framework support for Copilot Studio.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Agents.AI.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ActivityProcessorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ActivityProcessorTests.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.CopilotStudio;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Agents.AI.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="ActivityProcessor"/>.
+/// </summary>
+public class ActivityProcessorTests
+{
+    [Fact]
+    public async Task ProcessActivityAsync_WithTimestamp_SetsCreatedAtAsync()
+    {
+        // Arrange
+        DateTimeOffset timestamp = new(2026, 6, 29, 12, 0, 0, TimeSpan.Zero);
+        Activity activity = CreateMessageActivity("activity-1", "Hello", timestamp: timestamp);
+
+        // Act
+        ChatMessage message = await GetSingleMessageAsync(
+            ActivityProcessor.ProcessActivityAsync(CreateActivitiesAsync(activity), streaming: false, NullLogger.Instance));
+
+        // Assert
+        Assert.Equal(timestamp, message.CreatedAt);
+    }
+
+    [Fact]
+    public async Task ProcessActivityAsync_WithLocalTimestampOnly_SetsCreatedAtAsync()
+    {
+        // Arrange
+        DateTimeOffset localTimestamp = new(2026, 6, 29, 15, 0, 0, TimeSpan.Zero);
+        Activity activity = CreateMessageActivity("activity-1", "Hello", localTimestamp: localTimestamp);
+
+        // Act
+        ChatMessage message = await GetSingleMessageAsync(
+            ActivityProcessor.ProcessActivityAsync(CreateActivitiesAsync(activity), streaming: false, NullLogger.Instance));
+
+        // Assert
+        Assert.Equal(localTimestamp, message.CreatedAt);
+    }
+
+    [Fact]
+    public async Task ProcessActivityAsync_WithProperties_SetsAdditionalPropertiesAsync()
+    {
+        // Arrange
+        Activity activity = CreateMessageActivity("activity-1", "Hello", timestamp: new DateTimeOffset(2026, 6, 29, 12, 0, 0, TimeSpan.Zero));
+        activity.Properties = new Dictionary<string, JsonElement>
+        {
+            ["conversationId"] = JsonSerializer.SerializeToElement("conversation-123", AIJsonUtilities.DefaultOptions),
+        };
+
+        // Act
+        ChatMessage message = await GetSingleMessageAsync(
+            ActivityProcessor.ProcessActivityAsync(CreateActivitiesAsync(activity), streaming: false, NullLogger.Instance));
+
+        // Assert
+        Assert.NotNull(message.AdditionalProperties);
+        Assert.True(message.AdditionalProperties.TryGetValue("conversationId", out object? value));
+        Assert.Equal("conversation-123", Assert.IsType<JsonElement>(value).GetString());
+    }
+
+    [Fact]
+    public void CreateAgentResponse_WithMessagesAndActivity_SetsResponseMetadata()
+    {
+        // Arrange
+        DateTimeOffset createdAt = new(2026, 6, 29, 12, 0, 0, TimeSpan.Zero);
+        Activity activity = CreateMessageActivity("activity-1", "Hello", timestamp: createdAt);
+        ChatMessage message = new(ChatRole.Assistant, [new TextContent("Hello")])
+        {
+            MessageId = activity.Id,
+            CreatedAt = createdAt,
+            RawRepresentation = activity,
+        };
+
+        // Act
+        AgentResponse response = ActivityProcessor.CreateAgentResponse("agent-1", [message], activity);
+
+        // Assert
+        Assert.Equal("agent-1", response.AgentId);
+        Assert.Equal("activity-1", response.ResponseId);
+        Assert.Equal(createdAt, response.CreatedAt);
+        Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        Assert.Same(activity, response.RawRepresentation);
+    }
+
+    [Fact]
+    public void CreateAgentResponse_WithNoMessages_DoesNotSetFinishReason()
+    {
+        // Arrange & Act
+        AgentResponse response = ActivityProcessor.CreateAgentResponse("agent-1", [], lastActivity: null);
+
+        // Assert
+        Assert.Null(response.FinishReason);
+        Assert.Null(response.ResponseId);
+        Assert.Null(response.RawRepresentation);
+    }
+
+    [Fact]
+    public void CreateAgentResponseUpdate_WithTerminalUpdate_SetsFinishReason()
+    {
+        // Arrange
+        DateTimeOffset createdAt = new(2026, 6, 29, 12, 0, 0, TimeSpan.Zero);
+        ChatMessage message = new(ChatRole.Assistant, [new TextContent("Hello")])
+        {
+            MessageId = "activity-1",
+            CreatedAt = createdAt,
+        };
+
+        // Act
+        AgentResponseUpdate intermediateUpdate = ActivityProcessor.CreateAgentResponseUpdate("agent-1", message, isTerminalUpdate: false);
+        AgentResponseUpdate terminalUpdate = ActivityProcessor.CreateAgentResponseUpdate("agent-1", message, isTerminalUpdate: true);
+
+        // Assert
+        Assert.Null(intermediateUpdate.FinishReason);
+        Assert.Equal(ChatFinishReason.Stop, terminalUpdate.FinishReason);
+        Assert.Equal(createdAt, terminalUpdate.CreatedAt);
+        Assert.Equal("activity-1", terminalUpdate.MessageId);
+        Assert.Equal("activity-1", terminalUpdate.ResponseId);
+    }
+
+    [Fact]
+    public async Task ProcessActivityAsync_WithTypingActivityWhenStreaming_ReturnsChatMessageAsync()
+    {
+        // Arrange
+        DateTimeOffset timestamp = new(2026, 6, 29, 12, 0, 0, TimeSpan.Zero);
+        Activity activity = CreateTypingActivity("activity-1", "Hello", timestamp: timestamp);
+
+        // Act
+        ChatMessage message = await GetSingleMessageAsync(
+            ActivityProcessor.ProcessActivityAsync(CreateActivitiesAsync(activity), streaming: true, NullLogger.Instance));
+
+        // Assert
+        Assert.Equal("Hello", message.Text);
+        Assert.Equal(timestamp, message.CreatedAt);
+    }
+
+    private static Activity CreateMessageActivity(string id, string text, DateTimeOffset? timestamp = null, DateTimeOffset? localTimestamp = null)
+    {
+        return new Activity
+        {
+            Type = "message",
+            Id = id,
+            Text = text,
+            Timestamp = timestamp,
+            LocalTimestamp = localTimestamp,
+            From = new ChannelAccount { Name = "copilot" },
+        };
+    }
+
+    private static Activity CreateTypingActivity(string id, string text, DateTimeOffset? timestamp = null)
+    {
+        return new Activity
+        {
+            Type = "typing",
+            Id = id,
+            Text = text,
+            Timestamp = timestamp,
+            From = new ChannelAccount { Name = "copilot" },
+        };
+    }
+
+    private static async Task<ChatMessage> GetSingleMessageAsync(IAsyncEnumerable<ChatMessage> messages)
+    {
+        List<ChatMessage> collectedMessages = [];
+        await foreach (ChatMessage message in messages.ConfigureAwait(false))
+        {
+            collectedMessages.Add(message);
+        }
+
+        return Assert.Single(collectedMessages);
+    }
+
+    private static async IAsyncEnumerable<IActivity> CreateActivitiesAsync(params IActivity[] activities)
+    {
+        foreach (IActivity activity in activities)
+        {
+            yield return activity;
+            await Task.Yield();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation & Context

`CopilotStudioAgent` returned `AgentResponse` and `AgentResponseUpdate` with incomplete metadata. Streaming consumers could not reliably identify response boundaries because fields such as `ResponseId`, `CreatedAt`, `FinishReason`, and `RawRepresentation` were often unset. `ChatMessage` instances produced from Copilot Studio activities also did not carry activity timestamps or properties.

This change maps `IActivity` metadata through to `ChatMessage`, `AgentResponse`, and `AgentResponseUpdate`, aligning Copilot Studio with patterns used by other agent providers.

### Description & Review Guide

- **What are the major changes?**
  - `ActivityProcessor` maps `IActivity.Timestamp` / `LocalTimestamp` and `Properties` to `ChatMessage.CreatedAt` and `AdditionalProperties`.
  - Added `ActivityProcessor.CreateAgentResponse` and `CreateAgentResponseUpdate` to populate response metadata (`AgentId`, `ResponseId`, `CreatedAt`, `FinishReason`, `RawRepresentation`, `AdditionalProperties`).
  - `CopilotStudioAgent.RunCoreAsync` and `RunCoreStreamingAsync` use the new helpers; streaming sets `FinishReason` only on the terminal update.
  - Added `ActivityProcessorTests` (7 unit tests) and `InternalsVisibleTo` for `Microsoft.Agents.AI.UnitTests`.

- **What is the impact of these changes?**
  - Copilot Studio callers receive richer, more consistent `AgentResponse` / `AgentResponseUpdate` metadata.
  - No public API changes; behavior is additive for metadata population.

- **What do you want reviewers to focus on?**
  - Metadata fallback logic in `CreateAgentResponse` (message vs. last activity).
  - Terminal vs. intermediate streaming updates in `CreateStreamingUpdatesAsync`.

### Related Issue

Fixes #6790

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.