### PR TITLE
.NET: Allow customizing the HarnessAgent shell tool name

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
@@ -274,7 +274,9 @@ public sealed class HarnessAgent : DelegatingAIAgent
         if (options?.ShellExecutor is ShellExecutor shellExecutor)
         {
             result.Tools ??= [];
-            result.Tools.Add(shellExecutor.AsAIFunction());
+            result.Tools.Add(options.ShellToolName is string shellToolName
+                ? shellExecutor.AsAIFunction(shellToolName)
+                : shellExecutor.AsAIFunction());
         }
 #endif
 

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
@@ -380,5 +380,16 @@ public sealed class HarnessAgentOptions
     /// This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
     /// </remarks>
     public ShellEnvironmentProviderOptions? ShellEnvironmentProviderOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the shell execution tool exposed to the model.
+    /// </summary>
+    /// <remarks>
+    /// When set, this value is passed to <see cref="ShellExecutor.AsAIFunction"/> as the function name
+    /// the model sees when invoking the shell tool. When <see langword="null"/> (the default), the
+    /// executor's own default name (<c>run_shell</c>) is used.
+    /// This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
+    /// </remarks>
+    public string? ShellToolName { get; set; }
 #endif
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -1575,6 +1575,41 @@ public class HarnessAgentTests
     }
 
     /// <summary>
+    /// Verify that a custom <see cref="HarnessAgentOptions.ShellToolName"/> flows through to
+    /// <see cref="ShellExecutor.AsAIFunction"/> so the shell tool is exposed under that name.
+    /// </summary>
+    [Fact]
+    public async Task ShellExecutor_CustomToolNameIsUsedAsync()
+    {
+        // Arrange
+        ChatOptions? capturedOptions = null;
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((_, opts, _) => capturedOptions = opts)
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+
+        var executorMock = new Mock<ShellExecutor>();
+        executorMock.Setup(e => e.AsAIFunction(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns<string, string?, bool>((name, _, _) => AIFunctionFactory.Create(() => "shell output", name));
+
+        var options = CreateAllDisabledOptions();
+        options.DisableWebSearch = true;
+        options.ShellExecutor = executorMock.Object;
+        options.ShellToolName = "execute_command";
+
+        // Act
+        var agent = new HarnessAgent(chatClientMock.Object, options);
+        var session = await agent.CreateSessionAsync();
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert — the shell tool should be exposed under the custom name, not the default
+        Assert.NotNull(capturedOptions?.Tools);
+        Assert.Contains(capturedOptions!.Tools!, t => t is AIFunction f && f.Name == "execute_command");
+        Assert.DoesNotContain(capturedOptions.Tools!, t => t is AIFunction f && f.Name == "run_shell");
+    }
+
+    /// <summary>
     /// Verify that ShellEnvironmentProvider is present when ShellEnvironmentProviderOptions is also specified.
     /// </summary>
     [Fact]


### PR DESCRIPTION
## Summary

`HarnessAgent` registers the shell tool with `shellExecutor.AsAIFunction()`, which always uses the default name `run_shell`. `ShellExecutor.AsAIFunction(string name = "run_shell", ...)` already supports a custom name, but `HarnessAgent` had no way to set it. This adds a `ShellToolName` option that flows through to `AsAIFunction`.

Closes #6789

## Changes

- `HarnessAgentOptions.ShellToolName` (`string?`, .NET-only, alongside the other shell options). When `null` (default), the executor's own default name is used and behavior is unchanged.
- `HarnessAgent` passes `ShellToolName` to `AsAIFunction` when set; otherwise it keeps the parameterless call so the existing default is preserved exactly.

## Test

- `ShellExecutor_CustomToolNameIsUsedAsync`: sets `ShellToolName` and asserts the registered tool is exposed under that name (and not under `run_shell`). Verified red before the change (tool was still `run_shell`), green after.
- Full `Microsoft.Agents.AI.Harness.UnitTests` suite passes (82 tests, net10.0).

<!-- oss-radar:idempotency=auto-20260629-150941.w9.microsoft_agent-framework.6789 -->
