### PR TITLE
Python: Fix Anthropic messages and function-loop fallback

### DIFF
--- a/python/packages/anthropic/README.md
+++ b/python/packages/anthropic/README.md
@@ -22,3 +22,21 @@ See the [Anthropic agent examples](../../samples/02-agents/providers/anthropic/)
 
 - Connecting to a Anthropic endpoint with an agent
 - Streaming and non-streaming responses
+
+### Structured system blocks for prompt caching
+
+Use `instructions` with Anthropic-native system blocks when you need structured system prompt content, such as
+prompt-cache `cache_control` metadata. Do not combine structured `instructions` blocks with a leading system message.
+
+```python
+from anthropic.types.beta import BetaTextBlockParam
+
+from agent_framework_anthropic import AnthropicClient
+
+client = AnthropicClient()
+system_blocks: list[BetaTextBlockParam] = [
+    {"type": "text", "text": "Stable instructions", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+]
+
+response = await client.get_response("Hello", options={"instructions": system_blocks})
+```

--- a/python/packages/anthropic/agent_framework_anthropic/__init__.py
+++ b/python/packages/anthropic/agent_framework_anthropic/__init__.py
@@ -3,7 +3,11 @@
 import importlib.metadata
 
 from ._bedrock_client import AnthropicBedrockClient, RawAnthropicBedrockClient
-from ._chat_client import AnthropicChatOptions, AnthropicClient, RawAnthropicClient
+from ._chat_client import (
+    AnthropicChatOptions,
+    AnthropicClient,
+    RawAnthropicClient,
+)
 from ._foundry_client import AnthropicFoundryClient, RawAnthropicFoundryClient
 from ._vertex_client import AnthropicVertexClient, RawAnthropicVertexClient
 

--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -41,6 +41,7 @@ from anthropic.types.beta import (
     BetaRawContentBlockDelta,
     BetaRawMessageStreamEvent,
     BetaTextBlock,
+    BetaTextBlockParam,
     BetaUsage,
 )
 from anthropic.types.beta.beta_bash_code_execution_tool_result_error import (
@@ -126,8 +127,9 @@ class AnthropicChatOptions(ChatOptions[ResponseModelT], Generic[ResponseModelT],
         response_format: Structured output schema.
         metadata: Request metadata with user_id for tracking.
         user: User identifier, translates to ``metadata.user_id`` in Anthropic API.
-        instructions: System instructions for the model,
-            translates to ``system`` in Anthropic API.
+        instructions: System instructions for the model, translating to ``system`` in
+            the Anthropic API. Use a string for generic instructions or structured
+            Anthropic system blocks when you need prompt-cache ``cache_control``.
         top_k: Number of top tokens to consider for sampling.
         service_tier: Service tier ("auto" or "standard_only").
         thinking: Extended thinking configuration for Claude models.
@@ -145,6 +147,9 @@ class AnthropicChatOptions(ChatOptions[ResponseModelT], Generic[ResponseModelT],
 
     # Extended thinking (Claude models)
     thinking: ThinkingConfig
+
+    # Anthropic-native structured system prompt support
+    instructions: str | Sequence[BetaTextBlockParam]  # type: ignore[misc]
 
     # Skills
     container: dict[str, Any]
@@ -573,13 +578,6 @@ class RawAnthropicClient(
         Returns:
             A dictionary of run options for the Anthropic client.
         """
-        # Prepend instructions from options if they exist
-        instructions = options.get("instructions")
-        if instructions:
-            from agent_framework._types import prepend_instructions_to_messages
-
-            messages = prepend_instructions_to_messages(list(messages), instructions, role="system")
-
         # Start with a copy of options, excluding keys we handle separately
         run_options: dict[str, Any] = {
             k: v for k, v in options.items() if v is not None and k not in {"instructions", "response_format"}
@@ -600,6 +598,16 @@ class RawAnthropicClient(
         _apply_option_translations(filtered_kwargs)
         run_options.update(filtered_kwargs)
 
+        # system message - Anthropic expects system instructions as a separate request parameter
+        instructions = options.get("instructions")
+        if instructions is not None:
+            if self._is_text_instructions(instructions):
+                run_options["system"] = self._prepare_text_instructions_for_anthropic(instructions)
+            else:
+                run_options["system"] = self._extract_structured_instructions(messages, instructions)
+        elif messages and isinstance(messages[0], Message) and messages[0].role == "system":
+            run_options["system"] = messages[0].text
+
         # model
         if not run_options.get("model"):
             if not self.model:
@@ -612,10 +620,6 @@ class RawAnthropicClient(
 
         # messages
         run_options["messages"] = self._prepare_messages_for_anthropic(messages)
-
-        # system message - first system message is passed as instructions
-        if messages and isinstance(messages[0], Message) and messages[0].role == "system":
-            run_options["system"] = messages[0].text
 
         # betas
         run_options["betas"] = self._prepare_betas(options)
@@ -642,6 +646,31 @@ class RawAnthropicClient(
             run_options["betas"].add(STRUCTURED_OUTPUTS_BETA_FLAG)
 
         return run_options
+
+    def _extract_structured_instructions(
+        self,
+        messages: Sequence[Message],
+        instructions: Any,
+    ) -> Sequence[BetaTextBlockParam] | Sequence[Mapping[str, Any]]:
+        if messages and isinstance(messages[0], Message) and messages[0].role == "system":
+            raise ValueError("structured Anthropic instructions cannot be combined with a leading system message.")
+
+        return cast(Sequence[BetaTextBlockParam] | Sequence[Mapping[str, Any]], instructions)
+
+    def _prepare_text_instructions_for_anthropic(self, instructions: Any) -> str:
+        if isinstance(instructions, str):
+            return instructions
+
+        return "\n\n".join(cast(Sequence[str], instructions))
+
+    def _is_text_instructions(self, instructions: Any) -> bool:
+        if isinstance(instructions, str):
+            return True
+
+        if not isinstance(instructions, Sequence):
+            return False
+
+        return all(isinstance(instruction, str) for instruction in cast(Sequence[object], instructions))
 
     def _prepare_betas(self, options: Mapping[str, Any]) -> set[str]:
         """Prepare the beta flags for the Anthropic API request.
@@ -709,7 +738,9 @@ class RawAnthropicClient(
         else:
             msgs = list(messages)
 
-        result = [self._prepare_message_for_anthropic(msg) for msg in msgs]
+        result: list[dict[str, Any]] = []
+        for msg in msgs:
+            result.extend(self._prepare_message_groups_for_anthropic(msg))
 
         # Anthropic requires the conversation to end with a user message.
         # Append a synthetic user turn so chained agent outputs work as
@@ -718,6 +749,41 @@ class RawAnthropicClient(
             result.append({"role": "user", "content": "Continue"})
 
         return result
+
+    def _prepare_message_groups_for_anthropic(self, message: Message) -> list[dict[str, Any]]:
+        """Prepare a Message and split Anthropic content blocks into valid role groups."""
+        prepared_message = self._prepare_message_for_anthropic(message)
+        content = prepared_message.get("content")
+        if not isinstance(content, list):
+            return [prepared_message]
+
+        default_role = cast(str, prepared_message.get("role", "user"))
+        result: list[dict[str, Any]] = []
+        current_role: str | None = None
+        current_content: list[dict[str, Any]] = []
+
+        for content_block in cast(list[dict[str, Any]], content):
+            block_role = self._role_for_anthropic_content_block(content_block, default_role)
+            if current_content and current_role != block_role:
+                result.append({"role": current_role, "content": current_content})
+                current_content = []
+            current_role = block_role
+            current_content.append(content_block)
+
+        if current_content:
+            result.append({"role": current_role or default_role, "content": current_content})
+
+        return result or [prepared_message]
+
+    def _role_for_anthropic_content_block(self, content_block: Mapping[str, Any], default_role: str) -> str:
+        """Return the Anthropic message role required for a content block."""
+        match content_block:
+            case {"type": "tool_use" | "mcp_tool_use" | "server_tool_use"}:
+                return "assistant"
+            case {"type": "tool_result" | "mcp_tool_result"}:
+                return "user"
+            case _:
+                return default_role
 
     def _message_has_tool_use(self, message: dict[str, Any]) -> bool:
         """Return whether an Anthropic message contains tool_use blocks."""

--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -602,7 +602,7 @@ class RawAnthropicClient(
         instructions = options.get("instructions")
         if instructions is not None:
             if self._is_text_instructions(instructions):
-                run_options["system"] = self._prepare_text_instructions_for_anthropic(instructions)
+                run_options["system"] = self._prepare_text_instructions_for_anthropic(messages, instructions)
             else:
                 run_options["system"] = self._extract_structured_instructions(messages, instructions)
         elif messages and isinstance(messages[0], Message) and messages[0].role == "system":
@@ -657,11 +657,16 @@ class RawAnthropicClient(
 
         return cast(Sequence[BetaTextBlockParam] | Sequence[Mapping[str, Any]], instructions)
 
-    def _prepare_text_instructions_for_anthropic(self, instructions: Any) -> str:
+    def _prepare_text_instructions_for_anthropic(self, messages: Sequence[Message], instructions: Any) -> str:
         if isinstance(instructions, str):
-            return instructions
+            text_instructions = instructions
+        else:
+            text_instructions = "\n\n".join(cast(Sequence[str], instructions))
 
-        return "\n\n".join(cast(Sequence[str], instructions))
+        if messages and isinstance(messages[0], Message) and messages[0].role == "system":
+            return "\n\n".join(part for part in [text_instructions, messages[0].text] if part)
+
+        return text_instructions
 
     def _is_text_instructions(self, instructions: Any) -> bool:
         if isinstance(instructions, str):

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -964,6 +964,23 @@ async def test_prepare_options_with_system_message(
     assert len(run_options["messages"]) == 1  # System message not in messages list
 
 
+async def test_prepare_options_with_text_instructions_and_system_message(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Text instructions should preserve an existing leading system message."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    messages = [
+        Message(role="system", contents=["You are helpful."]),
+        Message(role="user", contents=["Hello"]),
+    ]
+
+    run_options = client._prepare_options(messages, {"instructions": "Be concise."})
+
+    assert run_options["system"] == "Be concise.\n\nYou are helpful."
+    assert len(run_options["messages"]) == 1
+
+
 async def test_prepare_options_with_structured_system_blocks(
     mock_anthropic_client: MagicMock,
 ) -> None:

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -693,6 +693,33 @@ def test_prepare_messages_for_anthropic_does_not_append_after_tool_use(
     assert result[1]["content"][0]["type"] == "tool_use"
 
 
+def test_prepare_messages_for_anthropic_splits_assistant_embedded_tool_results(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Assistant-embedded tool_result blocks must move to user-role Anthropic messages."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+    messages = [
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_function_call(call_id="call_1", name="first", arguments={}),
+                Content.from_function_result(call_id="call_1", result="ok"),
+                Content.from_function_call(call_id="call_2", name="second", arguments={}),
+            ],
+        ),
+    ]
+
+    result = client._prepare_messages_for_anthropic(messages)
+
+    assert [message["role"] for message in result] == ["assistant", "user", "assistant"]
+    assert [[block["type"] for block in message["content"]] for message in result] == [
+        ["tool_use"],
+        ["tool_result"],
+        ["tool_use"],
+    ]
+    assert result[1]["content"][0]["tool_use_id"] == "call_1"
+
+
 # Tool Conversion Tests
 
 
@@ -935,6 +962,67 @@ async def test_prepare_options_with_system_message(
 
     assert run_options["system"] == "You are helpful."
     assert len(run_options["messages"]) == 1  # System message not in messages list
+
+
+async def test_prepare_options_with_structured_system_blocks(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Structured Anthropic instructions should populate the system request parameter."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+    messages = [Message(role="user", contents=["Hello"])]
+    system_blocks = [
+        {
+            "type": "text",
+            "text": "Stable instructions",
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+        }
+    ]
+
+    run_options = client._prepare_options(messages, {"instructions": system_blocks})
+
+    assert run_options["system"] == system_blocks
+    assert run_options["messages"][0]["role"] == "user"
+
+
+async def test_prepare_options_structured_system_blocks_reject_conflicts(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Structured system blocks should not silently merge with other system instruction sources."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+    messages = [Message(role="system", contents=["Generic system"]), Message(role="user", contents=["Hello"])]
+    options = {"instructions": [{"type": "text", "text": "Structured"}]}
+
+    with pytest.raises(ValueError, match="structured Anthropic instructions"):
+        client._prepare_options(messages, options)
+
+
+async def test_prepare_options_splits_assistant_embedded_tool_results(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Final Anthropic request kwargs should contain Anthropic-valid tool_result role groups."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+    messages = [
+        Message(role="user", contents=["Run both tools."]),
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_function_call(call_id="call_1", name="first", arguments={}),
+                Content.from_function_result(call_id="call_1", result="ok"),
+                Content.from_function_call(call_id="call_2", name="second", arguments={}),
+            ],
+        ),
+    ]
+    chat_options = ChatOptions()
+
+    run_options = client._prepare_options(messages, chat_options)
+
+    prepared_messages = run_options["messages"]
+    assert [message["role"] for message in prepared_messages] == ["user", "assistant", "user", "assistant"]
+    assert [[block["type"] for block in message["content"]] for message in prepared_messages[1:]] == [
+        ["tool_use"],
+        ["tool_result"],
+        ["tool_use"],
+    ]
 
 
 async def test_anthropic_shell_tool_is_invoked_in_function_loop(
@@ -2282,6 +2370,8 @@ def test_prepare_options_with_instructions(mock_anthropic_client: MagicMock) -> 
     # Instructions should be prepended as system message
     assert result["model"] == "claude-3-5-sonnet-20241022"
     assert result["max_tokens"] == 1024
+    assert result["system"] == "You are a helpful assistant"
+    assert result["messages"] == [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
 
 
 def test_prepare_options_missing_model(mock_anthropic_client: MagicMock) -> None:

--- a/python/packages/core/agent_framework/__init__.py
+++ b/python/packages/core/agent_framework/__init__.py
@@ -167,7 +167,6 @@ from ._middleware import (
     chat_middleware,
     function_middleware,
 )
-
 from ._sessions import (
     AgentSession,
     ContextProvider,

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -96,6 +96,7 @@ _FUNCTION_INVOCATION_BUDGET_STATE_KEY: Final[str] = "_function_invocation_budget
 _FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT: Final[str] = (
     "Function invocation limit reached before a final answer could be produced."
 )
+_USER_VISIBLE_CONTENT_TYPES: Final[set[str]] = {"data", "uri", "error", "hosted_file", "hosted_vector_store"}
 ApprovalMode: TypeAlias = Literal["always_require", "never_require"]
 ChatClientT = TypeVar("ChatClientT", bound="SupportsChatGetResponse[Any]")
 ResponseModelBoundT = TypeVar("ResponseModelBoundT", bound=BaseModel)
@@ -1882,9 +1883,9 @@ def _response_has_visible_content(response: ChatResponse[Any]) -> bool:
     for message in response.messages:
         for content in message.contents:
             if content.type == "text":
-                if content.text:
+                if content.text and content.text.strip():
                     return True
-            else:
+            elif content.type in _USER_VISIBLE_CONTENT_TYPES:
                 return True
     return False
 
@@ -2776,6 +2777,14 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                 # Get the finalized response from the inner stream
                 # This triggers the inner stream's finalizer and result hooks
                 response = await inner_stream.get_final_response()
+                response_had_visible_content = _response_has_visible_content(response)
+                function_call_limit_reached = (
+                    mutable_options.get("tool_choice") == "none"
+                    and max_function_calls is not None
+                    and total_function_calls >= max_function_calls
+                )
+                if function_call_limit_reached:
+                    response = _ensure_function_invocation_limit_fallback_response(response)
                 _update_continuation_state(
                     filtered_kwargs,
                     response,
@@ -2788,6 +2797,8 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                     for msg in response.messages
                     for item in msg.contents
                 ):
+                    if function_call_limit_reached and not response_had_visible_content:
+                        yield _function_invocation_limit_fallback_update()
                     return
 
                 if response.conversation_id is not None:

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -93,6 +93,9 @@ SHELL_TOOL_KIND_VALUE: Final[str] = "shell"
 _TOOL_APPROVAL_STATE_KEY: Final[str] = "tool_approval"
 _ALREADY_APPROVED_APPROVAL_REQUEST_GROUPS_KEY: Final[str] = "already_approved_approval_request_groups"
 _FUNCTION_INVOCATION_BUDGET_STATE_KEY: Final[str] = "_function_invocation_budget_state"
+_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT: Final[str] = (
+    "Function invocation limit reached before a final answer could be produced."
+)
 ApprovalMode: TypeAlias = Literal["always_require", "never_require"]
 ChatClientT = TypeVar("ChatClientT", bound="SupportsChatGetResponse[Any]")
 ResponseModelBoundT = TypeVar("ResponseModelBoundT", bound=BaseModel)
@@ -1875,6 +1878,42 @@ def _clear_internal_conversation_id(response: ChatResponse[Any]) -> ChatResponse
     return response
 
 
+def _response_has_visible_content(response: ChatResponse[Any]) -> bool:
+    for message in response.messages:
+        for content in message.contents:
+            if content.type == "text":
+                if content.text:
+                    return True
+            else:
+                return True
+    return False
+
+
+def _ensure_function_invocation_limit_fallback_response(response: ChatResponse[Any]) -> ChatResponse[Any]:
+    if _response_has_visible_content(response):
+        return response
+
+    from ._types import Content, Message
+
+    fallback_content = Content.from_text(_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT)
+    if response.messages:
+        response.messages[-1].role = "assistant"
+        response.messages[-1].contents = [fallback_content]
+    else:
+        response.messages.append(Message(role="assistant", contents=[fallback_content]))
+    return response
+
+
+def _function_invocation_limit_fallback_update() -> ChatResponseUpdate:
+    from ._types import ChatResponseUpdate, Content
+
+    return ChatResponseUpdate(
+        contents=[Content.from_text(_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT)],
+        role="assistant",
+        finish_reason="stop",
+    )
+
+
 def _extract_tools(
     options: dict[str, Any] | None,
 ) -> ToolTypes | Callable[..., Any] | Sequence[ToolTypes | Callable[..., Any]] | None:
@@ -2569,6 +2608,12 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                             client_kwargs=filtered_kwargs,
                         ),
                     )
+                    if (
+                        mutable_options.get("tool_choice") == "none"
+                        and max_function_calls is not None
+                        and total_function_calls >= max_function_calls
+                    ):
+                        response = _ensure_function_invocation_limit_fallback_response(response)
                     aggregated_usage = add_usage_details(aggregated_usage, response.usage_details)
                     _update_continuation_state(
                         filtered_kwargs,
@@ -2649,6 +2694,7 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                         client_kwargs=filtered_kwargs,
                     ),
                 )
+                response = _ensure_function_invocation_limit_fallback_response(response)
                 aggregated_usage = add_usage_details(aggregated_usage, response.usage_details)
                 _update_continuation_state(
                     filtered_kwargs,
@@ -2825,12 +2871,16 @@ class FunctionInvocationLayer(Generic[OptionsCoT]):
                 yield update
             # Finalize the inner stream to trigger its hooks
             final_response = await final_inner_stream.get_final_response()
+            final_response_had_visible_content = _response_has_visible_content(final_response)
+            final_response = _ensure_function_invocation_limit_fallback_response(final_response)
             _update_continuation_state(
                 filtered_kwargs,
                 final_response,
                 session=invocation_session,
                 options=mutable_options,
             )
+            if not final_response_had_visible_content:
+                yield _function_invocation_limit_fallback_update()
 
         def _finalize(updates: Sequence[ChatResponseUpdate]) -> ChatResponse[Any]:
             # Note: stream_result_hooks are already run via inner stream's get_final_response()

--- a/python/packages/core/agent_framework/security.py
+++ b/python/packages/core/agent_framework/security.py
@@ -3267,7 +3267,7 @@ class SecureMCPToolProxy:
         if url is not None:
             from httpx import AsyncClient, Timeout
 
-            from ._mcp import MCPStreamableHTTPTool, MCP_DEFAULT_TIMEOUT, MCP_DEFAULT_SSE_READ_TIMEOUT
+            from ._mcp import MCP_DEFAULT_SSE_READ_TIMEOUT, MCP_DEFAULT_TIMEOUT, MCPStreamableHTTPTool
 
             static_headers = dict(headers or {})
             # Pass headers via an AsyncClient so they are included on ALL requests
@@ -3275,11 +3275,15 @@ class SecureMCPToolProxy:
             # header_provider alone only sets headers via a ContextVar that is
             # populated during call_tool() and would be empty during initialization,
             # causing 401s that silently manifest as anyio cancel-scope errors.
-            http_client = AsyncClient(
-                headers=static_headers,
-                follow_redirects=True,
-                timeout=Timeout(MCP_DEFAULT_TIMEOUT, read=MCP_DEFAULT_SSE_READ_TIMEOUT),
-            ) if static_headers else None
+            http_client = (
+                AsyncClient(
+                    headers=static_headers,
+                    follow_redirects=True,
+                    timeout=Timeout(MCP_DEFAULT_TIMEOUT, read=MCP_DEFAULT_SSE_READ_TIMEOUT),
+                )
+                if static_headers
+                else None
+            )
             mcp_tool = MCPStreamableHTTPTool(
                 name=name or "mcp",
                 url=url,

--- a/python/packages/core/tests/core/test_function_invocation_logic.py
+++ b/python/packages/core/tests/core/test_function_invocation_logic.py
@@ -55,7 +55,10 @@ def _build_approved_tool_roundtrip(
     return function_call, approval_request, approval_response
 
 
-def _force_blank_tool_choice_none_fallback(chat_client_base: Any) -> None:
+def _force_blank_tool_choice_none_fallback(
+    chat_client_base: Any,
+    final_contents: Sequence[Content] | None = None,
+) -> None:
     original_get_non_streaming_response = chat_client_base._get_non_streaming_response
     original_get_streaming_response = chat_client_base._get_streaming_response
 
@@ -66,7 +69,7 @@ def _force_blank_tool_choice_none_fallback(chat_client_base: Any) -> None:
         **kwargs: Any,
     ) -> ChatResponse:
         if options.get("tool_choice") == "none":
-            return ChatResponse(messages=Message(role="assistant", contents=[]))
+            return ChatResponse(messages=Message(role="assistant", contents=list(final_contents or [])))
         return await original_get_non_streaming_response(messages=messages, options=options, **kwargs)
 
     def _get_streaming_response(
@@ -1242,6 +1245,43 @@ async def test_max_iterations_blank_final_fallback_synthesizes_message(chat_clie
     assert last_msg.role == "assistant"
     assert last_msg.text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
     assert not any(content.type == "function_call" for content in last_msg.contents)
+
+
+async def test_max_iterations_reasoning_only_final_fallback_synthesizes_message(
+    chat_client_base: SupportsChatGetResponse,
+):
+    """Reasoning-only provider responses after max_iterations should not suppress the fallback."""
+    _force_blank_tool_choice_none_fallback(
+        chat_client_base,
+        final_contents=[Content.from_text_reasoning(text="thinking")],
+    )
+    exec_counter = 0
+
+    @tool(name="test_function", approval_mode="never_require")
+    def ai_func(arg1: str) -> str:
+        nonlocal exec_counter
+        exec_counter += 1
+        return f"Processed {arg1}"
+
+    chat_client_base.run_responses = [  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        ChatResponse(
+            messages=Message(
+                role="assistant",
+                contents=[
+                    Content.from_function_call(call_id="call_1", name="test_function", arguments='{"arg1": "v1"}')
+                ],
+            )
+        ),
+    ]
+    chat_client_base.function_invocation_configuration["max_iterations"] = 1  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    response = await chat_client_base.get_response(
+        [Message(role="user", contents=["hello"])],
+        options={"tool_choice": "auto", "tools": [ai_func]},
+    )
+
+    assert exec_counter == 1
+    assert response.messages[-1].text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
 
 
 async def test_max_iterations_preserves_all_fcc_messages(chat_client_base: SupportsChatGetResponse):
@@ -3044,8 +3084,45 @@ async def test_streaming_max_iterations_blank_final_fallback_synthesizes_update(
 
     updates = []
     async for update in chat_client_base.get_response(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]
-        "hello",
+        [Message(role="user", contents=["hello"])],
         options={"tool_choice": "auto", "tools": [ai_func]},
+        stream=True,
+    ):
+        updates.append(update)
+
+    assert exec_counter == 1
+    assert updates[-1].role == "assistant"
+    assert updates[-1].text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
+
+
+@pytest.mark.parametrize("max_iterations", [10])
+async def test_streaming_max_function_calls_blank_final_fallback_synthesizes_update(
+    chat_client_base: SupportsChatGetResponse,
+):
+    """Blank streaming provider responses after max_function_calls should emit a final text update."""
+    _force_blank_tool_choice_none_fallback(chat_client_base)
+    exec_counter = 0
+
+    @tool(name="lookup", approval_mode="never_require")
+    def lookup_func(key: str) -> str:
+        nonlocal exec_counter
+        exec_counter += 1
+        return f"Value for {key}"
+
+    chat_client_base.streaming_responses = [  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        [
+            ChatResponseUpdate(
+                contents=[Content.from_function_call(call_id="call_1", name="lookup", arguments='{"key": "a"}')],
+                role="assistant",
+            ),
+        ],
+    ]
+    chat_client_base.function_invocation_configuration["max_function_calls"] = 1  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    updates = []
+    async for update in chat_client_base.get_response(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]
+        [Message(role="user", contents=["look up key"])],
+        options={"tool_choice": "auto", "tools": [lookup_func]},
         stream=True,
     ):
         updates.append(update)

--- a/python/packages/core/tests/core/test_function_invocation_logic.py
+++ b/python/packages/core/tests/core/test_function_invocation_logic.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from typing import Any
 
 import pytest
@@ -13,6 +13,7 @@ from agent_framework import (
     ChatResponseUpdate,
     Content,
     Message,
+    ResponseStream,
     SupportsChatGetResponse,
     chat_middleware,
     tool,
@@ -28,6 +29,10 @@ from agent_framework._compaction import (
     included_token_count,
 )
 from agent_framework._middleware import FunctionInvocationContext, FunctionMiddleware, MiddlewareTermination
+
+_EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT = (
+    "Function invocation limit reached before a final answer could be produced."
+)
 
 
 def _group_id(message: Message) -> str | None:
@@ -48,6 +53,44 @@ def _build_approved_tool_roundtrip(
     approval_request = Content.from_function_approval_request(id=approval_id, function_call=function_call)
     approval_response = approval_request.to_function_approval_response(approved=True)
     return function_call, approval_request, approval_response
+
+
+def _force_blank_tool_choice_none_fallback(chat_client_base: Any) -> None:
+    original_get_non_streaming_response = chat_client_base._get_non_streaming_response
+    original_get_streaming_response = chat_client_base._get_streaming_response
+
+    async def _get_non_streaming_response(
+        *,
+        messages: Sequence[Message],
+        options: dict[str, Any],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        if options.get("tool_choice") == "none":
+            return ChatResponse(messages=Message(role="assistant", contents=[]))
+        return await original_get_non_streaming_response(messages=messages, options=options, **kwargs)
+
+    def _get_streaming_response(
+        *,
+        messages: Sequence[Message],
+        options: dict[str, Any],
+        **kwargs: Any,
+    ) -> ResponseStream[ChatResponseUpdate, ChatResponse]:
+        if options.get("tool_choice") != "none":
+            return original_get_streaming_response(messages=messages, options=options, **kwargs)
+
+        empty_updates: tuple[ChatResponseUpdate, ...] = ()
+
+        async def _stream() -> AsyncIterable[ChatResponseUpdate]:
+            for update in empty_updates:
+                yield update
+
+        def _finalize(updates: Sequence[ChatResponseUpdate]) -> ChatResponse:
+            return ChatResponse.from_updates(updates, output_format_type=options.get("response_format"))
+
+        return ResponseStream(_stream(), finalizer=_finalize)
+
+    chat_client_base._get_non_streaming_response = _get_non_streaming_response
+    chat_client_base._get_streaming_response = _get_streaming_response
 
 
 async def test_base_client_with_function_calling(chat_client_base: SupportsChatGetResponse):
@@ -1166,6 +1209,41 @@ async def test_max_iterations_makes_final_toolchoice_none_call(chat_client_base:
     )
 
 
+async def test_max_iterations_blank_final_fallback_synthesizes_message(chat_client_base: SupportsChatGetResponse):
+    """Blank provider responses after max_iterations should not produce an empty final response."""
+    _force_blank_tool_choice_none_fallback(chat_client_base)
+    exec_counter = 0
+
+    @tool(name="test_function", approval_mode="never_require")
+    def ai_func(arg1: str) -> str:
+        nonlocal exec_counter
+        exec_counter += 1
+        return f"Processed {arg1}"
+
+    chat_client_base.run_responses = [  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        ChatResponse(
+            messages=Message(
+                role="assistant",
+                contents=[
+                    Content.from_function_call(call_id="call_1", name="test_function", arguments='{"arg1": "v1"}')
+                ],
+            )
+        ),
+    ]
+    chat_client_base.function_invocation_configuration["max_iterations"] = 1  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    response = await chat_client_base.get_response(
+        [Message(role="user", contents=["hello"])],
+        options={"tool_choice": "auto", "tools": [ai_func]},
+    )
+
+    assert exec_counter == 1
+    last_msg = response.messages[-1]
+    assert last_msg.role == "assistant"
+    assert last_msg.text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
+    assert not any(content.type == "function_call" for content in last_msg.contents)
+
+
 async def test_max_iterations_preserves_all_fcc_messages(chat_client_base: SupportsChatGetResponse):
     """When max_iterations is reached and a final response is produced, all
     intermediate function call/result messages should be included.
@@ -1393,6 +1471,43 @@ async def test_max_function_calls_single_calls_per_iteration(chat_client_base: S
     # 2 single calls executed, then limit reached, tool_choice="none" forced
     assert exec_counter == 2
     assert "broke out" in response.messages[-1].text
+
+
+@pytest.mark.parametrize("max_iterations", [10])
+async def test_max_function_calls_blank_final_fallback_synthesizes_message(
+    chat_client_base: SupportsChatGetResponse,
+):
+    """Blank provider responses after max_function_calls should not produce an empty final response."""
+    _force_blank_tool_choice_none_fallback(chat_client_base)
+    exec_counter = 0
+
+    @tool(name="lookup", approval_mode="never_require")
+    def lookup_func(key: str) -> str:
+        nonlocal exec_counter
+        exec_counter += 1
+        return f"Value for {key}"
+
+    chat_client_base.run_responses = [  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        ChatResponse(
+            messages=Message(
+                role="assistant",
+                contents=[
+                    Content.from_function_call(call_id="call_1", name="lookup", arguments='{"key": "a"}'),
+                ],
+            )
+        ),
+    ]
+    chat_client_base.function_invocation_configuration["max_function_calls"] = 1  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    response = await chat_client_base.get_response(
+        [Message(role="user", contents=["look up key"])], options={"tool_choice": "auto", "tools": [lookup_func]}
+    )
+
+    assert exec_counter == 1
+    last_msg = response.messages[-1]
+    assert last_msg.role == "assistant"
+    assert last_msg.text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
+    assert not any(content.type == "function_call" for content in last_msg.contents)
 
 
 @pytest.mark.parametrize("max_iterations", [10])
@@ -2898,6 +3013,46 @@ async def test_streaming_max_iterations_limit(chat_client_base: SupportsChatGetR
     # Should have the failsafe message
     last_text = "".join(u.text or "" for u in updates if u.text)
     assert "I broke out of the function invocation loop..." in last_text
+
+
+async def test_streaming_max_iterations_blank_final_fallback_synthesizes_update(
+    chat_client_base: SupportsChatGetResponse,
+):
+    """Blank streaming provider responses after max_iterations should emit a final text update."""
+    _force_blank_tool_choice_none_fallback(chat_client_base)
+    exec_counter = 0
+
+    @tool(name="test_function", approval_mode="never_require")
+    def ai_func(arg1: str) -> str:
+        nonlocal exec_counter
+        exec_counter += 1
+        return f"Processed {arg1}"
+
+    chat_client_base.streaming_responses = [  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        [
+            ChatResponseUpdate(
+                contents=[Content.from_function_call(call_id="call_1", name="test_function", arguments='{"arg1":')],
+                role="assistant",
+            ),
+            ChatResponseUpdate(
+                contents=[Content.from_function_call(call_id="call_1", name="test_function", arguments='"v1"}')],
+                role="assistant",
+            ),
+        ],
+    ]
+    chat_client_base.function_invocation_configuration["max_iterations"] = 1  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+    updates = []
+    async for update in chat_client_base.get_response(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]
+        "hello",
+        options={"tool_choice": "auto", "tools": [ai_func]},
+        stream=True,
+    ):
+        updates.append(update)
+
+    assert exec_counter == 1
+    assert updates[-1].role == "assistant"
+    assert updates[-1].text == _EXPECTED_FUNCTION_INVOCATION_LIMIT_FALLBACK_TEXT
 
 
 async def test_streaming_function_invocation_config_enabled_false(chat_client_base: SupportsChatGetResponse):


### PR DESCRIPTION
### Motivation & Context

Anthropic requests can fail when a single assistant message contains both tool calls and tool results, because Anthropic requires `tool_result` content blocks to be sent in user-role messages. Separately, when function invocation stops because `max_iterations` or `max_function_calls` is reached, the required final no-tool provider call can return an empty response, leaving callers with no useful final assistant message.

This improves Anthropic request compatibility and makes function-loop limit exits produce a deterministic user-visible result when the provider's final response is blank.

### Description & Review Guide

- **What are the major changes?**
  - Split prepared Anthropic content blocks into valid role groups so `tool_result` blocks are sent as user messages while tool-use blocks remain assistant messages.
  - Add a deterministic fallback assistant message when a final no-tool call after a function invocation limit returns no visible content, including the streaming path.
  - Support Anthropic structured system blocks for prompt caching via `instructions: str | Sequence[BetaTextBlockParam]`, mapped to Anthropic's `system` request parameter.
- **What is the impact of these changes?**
  - Anthropic can serialize mixed tool-call/tool-result histories without generating invalid request shapes.
  - Function invocation limit exits no longer produce an empty final response when the provider declines to answer after tools are disabled.
  - Existing string instructions and leading system-message behavior are preserved.
- **What do you want reviewers to focus on?**
  - The fallback boundary: it only applies to final no-tool calls made after function invocation limits are reached and only when the provider response has no visible content.
  - The Anthropic role-splitting behavior for interleaved tool-use/tool-result blocks.
  - The `instructions` typing/serialization path for Anthropic structured system blocks.


### Related Issue

Fixes #5769
Fixes #6450

No other open PRs were found for these issues.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.