### PR TITLE
Python: Fix: coalesce reasoning deltas into single block when content.id is None

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
@@ -944,7 +944,12 @@ def _emit_text_reasoning(content: Content, flow: FlowState | None = None) -> lis
     if not text and content.protected_data is None:
         return []
 
-    message_id = content.id or generate_event_id()
+    if content.id:
+        message_id = content.id
+    elif flow is not None and flow.reasoning_message_id:
+        message_id = flow.reasoning_message_id
+    else:
+        message_id = generate_event_id()
 
     events: list[BaseEvent] = []
 

--- a/python/packages/ag-ui/tests/ag_ui/test_run_common.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run_common.py
@@ -6,6 +6,11 @@ import logging
 
 import pytest
 from ag_ui.core import EventType
+from ag_ui.core.events import (
+    ReasoningMessageContentEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+)
 from agent_framework import Content
 
 from agent_framework_ag_ui import state_update
@@ -13,7 +18,9 @@ from agent_framework_ag_ui._orchestration._predictive_state import PredictiveSta
 from agent_framework_ag_ui._run_common import (
     FlowState,
     _build_run_finished_event,
+    _close_reasoning_block,
     _emit_mcp_tool_result,
+    _emit_text_reasoning,
     _emit_tool_result,
     _extract_resume_payload,
     _extract_tool_result_state,
@@ -548,3 +555,53 @@ class TestEmitMcpToolResultWithDisplay:
         assert _json.loads(result_events[0].content) == display_payload  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         # LLM-side accumulator keeps the short text.
         assert flow.tool_results[-1]["content"] == "2 rows returned"
+
+
+class TestReasoningCoalescing:
+    """Verify reasoning deltas without content.id coalesce into one block.
+
+    Regression test: Ollama streams reasoning with content.id=None, which
+    previously caused a new reasoning block per delta instead of one per turn.
+    """
+
+    def test_reasoning_coalesces_without_content_id(self):
+        """Multiple reasoning deltas without content.id share one message_id."""
+        flow = FlowState()
+
+        events1 = _emit_text_reasoning(Content.from_text_reasoning(text="First"), flow)
+        events2 = _emit_text_reasoning(Content.from_text_reasoning(text=" chunk"), flow)
+        events3 = _emit_text_reasoning(Content.from_text_reasoning(text=" here."), flow)
+
+        all_events = events1 + events2 + events3
+
+        content_events = [e for e in all_events if isinstance(e, ReasoningMessageContentEvent)]
+        ids = {e.message_id for e in content_events}
+        assert len(ids) == 1, f"Expected one message_id, got {ids}"
+
+        start_events = [e for e in all_events if isinstance(e, (ReasoningStartEvent, ReasoningMessageStartEvent))]
+        assert len(start_events) == 2, f"Expected 2 start events, got {len(start_events)}"
+
+    def test_reasoning_respects_explicit_content_id(self):
+        """When content.id is provided, it should be used."""
+        flow = FlowState()
+        custom_id = "my-custom-reasoning-id"
+
+        events = _emit_text_reasoning(Content.from_text_reasoning(id=custom_id, text="thinking"), flow)
+
+        content_events = [e for e in events if isinstance(e, ReasoningMessageContentEvent)]
+        assert all(e.message_id == custom_id for e in content_events)
+
+    def test_new_turn_gets_new_reasoning_id(self):
+        """After closing a reasoning block, a new one gets a fresh ID."""
+        flow = FlowState()
+
+        _emit_text_reasoning(Content.from_text_reasoning(text="Turn 1"), flow)
+        id1 = flow.reasoning_message_id
+        _close_reasoning_block(flow)
+
+        _emit_text_reasoning(Content.from_text_reasoning(text="Turn 2"), flow)
+        id2 = flow.reasoning_message_id
+
+        assert id1 is not None
+        assert id2 is not None
+        assert id1 != id2, "New turn should get a new reasoning message_id"


### PR DESCRIPTION
### Motivation & Context

1. **Why is this change required?** When a provider (like Ollama) streams model reasoning ("thinking"), it often does not provide a stable `content.id` per chunk, resulting in `content.id=None` for every delta.
2. **What problem does it solve?** The AG-UI reasoning emitter (`_emit_text_reasoning`) was calling `generate_event_id()` on every single delta when `content.id` was `None`. This caused the stream to emit a `REASONING_START -> CONTENT -> REASONING_END` lifecycle per token, instead of one lifecycle per turn.
3. **What scenario does it contribute to?** Any AG-UI frontend (e.g., CopilotKit) connected to a "thinking" model (like DeepSeek-R1 via Ollama) was rendering dozens of fragmented "Thought for a few seconds" accordions, with sentences chopped mid-word across them. 


### Description & Review Guide

- **What are the major changes?**
  Changed the `message_id` assignment logic in `_emit_text_reasoning()` (`_run_common.py`). It now reuses the existing `flow.reasoning_message_id` when `content.id` is `None`, falling back to `generate_event_id()` only on the very first delta of a turn. This brings it into parity with how `_emit_text()` already handles text deltas via `flow.message_id`. Added 3 regression tests.
- **What is the impact of these changes?**
  Frontends will now correctly receive a single `REASONING_START -> (many) REASONING_MESSAGE_CONTENT -> REASONING_END` block per turn. This is a non-breaking change; providers that *do* supply a `content.id` continue to use it exactly as before.
- **What do you want reviewers to focus on?**
  Please verify the 5-line logic swap in `_emit_text_reasoning` and the 3 new tests in `TestReasoningCoalescing` to ensure the coalescing behavior correctly mirrors `_emit_text`.

####  Remaining Work (Out of Scope for this PR)
The original issue report contained a **second, distinct bug** regarding parallel tool calls. When Ollama issues the same tool twice in one turn, `agent-framework-ollama`'s `_parse_tool_calls_from_ollama` reuses the function name as the `call_id`, causing a collision. **That bug is located in `agent-framework-ollama` and will be addressed in a separate PR.**

### Related Issue

Partially addresses #6788 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).