### PR TITLE
Python: Auto-inject local history when non-history context providers are present

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -1197,11 +1197,16 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):
         # Resolve conversation_id from the same combined view so an agent-level default is honored
         # when the runtime omits it (a live session id still takes precedence below).
         effective_conversation_id = effective_options.get("conversation_id")
-        # Auto-inject InMemoryHistoryProvider when session is provided, no context providers
-        # registered, and no service-side storage indicators
+        # Auto-inject InMemoryHistoryProvider when a session is provided and no
+        # loading history provider exists yet. Gating on history providers (not
+        # any context provider) keeps local history when non-history providers
+        # like SkillsProvider are present, so multi-turn flows on stateless
+        # clients don't lose prior messages.
         if (
             session is not None
-            and not self.context_providers
+            and not any(
+                provider.load_messages for provider in self.context_providers if isinstance(provider, HistoryProvider)
+            )
             and not session.service_session_id
             and not effective_conversation_id
             and not service_stores_history

--- a/python/packages/core/tests/core/test_agents.py
+++ b/python/packages/core/tests/core/test_agents.py
@@ -2534,6 +2534,63 @@ async def test_stores_by_default_with_store_false_in_default_options_injects_inm
     assert any(isinstance(p, InMemoryHistoryProvider) for p in agent.context_providers)
 
 
+async def test_non_history_context_provider_still_injects_inmemory(
+    client: SupportsChatGetResponse,
+) -> None:
+    """A non-history context provider must not suppress local history injection.
+
+    Regression for the case where registering a context provider that is not a
+    HistoryProvider (e.g. SkillsProvider, FileAccessProvider, or a RAG memory
+    provider) prevented the auto-injected InMemoryHistoryProvider. Without local
+    history, multi-turn flows on stateless clients (such as the tool-approval
+    resume turn) drop the prior assistant function_call.
+    """
+    from agent_framework._sessions import InMemoryHistoryProvider
+
+    agent = Agent(client=client, context_providers=[MockContextProvider()])
+    session = agent.create_session()
+
+    await agent.run("Hello", session=session)
+
+    # The non-history provider should not block local-history injection.
+    assert any(isinstance(p, InMemoryHistoryProvider) for p in agent.context_providers)
+
+
+async def test_existing_loading_history_provider_skips_inmemory_injection(
+    client: SupportsChatGetResponse,
+) -> None:
+    """An existing loading HistoryProvider suppresses injection even with other providers."""
+    from agent_framework._sessions import InMemoryHistoryProvider
+
+    existing = InMemoryHistoryProvider("custom", load_messages=True)
+    agent = Agent(client=client, context_providers=[existing, MockContextProvider()])
+    session = agent.create_session()
+
+    await agent.run("Hello", session=session)
+
+    history_providers = [p for p in agent.context_providers if isinstance(p, InMemoryHistoryProvider)]
+    assert history_providers == [existing]
+
+
+async def test_persist_only_history_provider_still_injects_inmemory(
+    client: SupportsChatGetResponse,
+) -> None:
+    """A persist-only (load_messages=False) HistoryProvider does not satisfy the loading need."""
+    from agent_framework._sessions import InMemoryHistoryProvider
+
+    audit = InMemoryHistoryProvider("audit", load_messages=False)
+    agent = Agent(client=client, context_providers=[audit])
+    session = agent.create_session()
+
+    await agent.run("Hello", session=session)
+
+    loading_providers = [
+        p for p in agent.context_providers if isinstance(p, InMemoryHistoryProvider) and p.load_messages
+    ]
+    assert len(loading_providers) == 1
+    assert loading_providers[0] is not audit
+
+
 async def test_shared_local_storage_cross_provider_responses_history_does_not_leak_fc_id() -> None:
     """Responses-specific replay metadata should stay local to Responses when session storage is shared."""
     from openai.types.chat.chat_completion import ChatCompletion, Choice


### PR DESCRIPTION
### Motivation & Context

`InMemoryHistoryProvider` is auto-injected to give agents local conversation history on stateless clients. The injection was gated on there being *no context providers at all*, so registering **any** non-history context provider — `SkillsProvider`, `FileAccessProvider`, or a RAG memory provider — suppressed local history.

On stateless clients (e.g. `OpenAIChatCompletionClient`) this drops prior messages across turns. The most visible failure is the tool-approval resume turn: `agent.run(approval_responses)` is sent without the prior assistant `function_call`, and the API rejects it with `400 "Expected toolResult blocks"`. This is especially relevant now that skill tools require approval by default.

### Description & Review Guide

- **What are the major changes?**
  - In `_agents.py`, gate the `InMemoryHistoryProvider` auto-injection on the absence of a *loading* `HistoryProvider` (`any(p.load_messages for p in context_providers if isinstance(p, HistoryProvider))`) instead of the absence of any context provider. This mirrors the pattern already used in `_workflows/_agent.py`.
  - Add regression tests in `test_agents.py`: a non-history provider no longer suppresses injection; an existing loading provider still suppresses it; a persist-only (`load_messages=False`) provider still triggers a loading injection.

- **What is the impact of these changes?**
  - Agents that combine a session with a non-history context provider now get local history on stateless clients, fixing multi-turn and tool-approval-resume flows. When a real loading `HistoryProvider` is registered, behavior is unchanged (no double-injection).

- **What do you want reviewers to focus on?**
  - Whether gating on `load_messages` (vs. simply "any `HistoryProvider`") is the desired semantics — chosen here to match `_workflows/_agent.py`.

### Related Issue

Fixes #5672

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
