### PR TITLE
.NET: fix: resolve CA1873 in GitHubCopilotAgent by using LoggerMessage sour…

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
@@ -577,10 +577,7 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
         // Warn so the developer knows the ApprovalRequiredAIFunction marker(s) will not be automatically gated.
         if (sessionConfig.Hooks?.OnPreToolUse is not null)
         {
-            logger.LogWarning(
-                "A custom 'OnPreToolUse' hook is configured on the SessionConfig, so {Count} approval-required tool(s) ({Tools}) " +
-                "will not be automatically gated by GitHubCopilotAgent. The custom hook is responsible for enforcing approval " +
-                "(for example, by returning a 'deny' or 'ask' PreToolUseHookOutput).",
+            logger.LogApprovalGatingSkippedDueToCustomHook(
                 approvalRequiredToolNames.Count,
                 string.Join(", ", approvalRequiredToolNames));
             return sessionConfig;

--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgentLogMessages.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgentLogMessages.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Agents.AI.GitHub.Copilot;
+#pragma warning disable SYSLIB1006 // Multiple logging methods cannot use the same event id within a class
+
+/// <summary>
+/// Extensions for logging <see cref="GitHubCopilotAgent"/> invocations.
+/// </summary>
+/// <remarks>
+/// This extension uses the <see cref="LoggerMessageAttribute"/> to
+/// generate logging code at compile time to achieve optimized code.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+internal static partial class GitHubCopilotAgentLogMessages
+{
+    /// <summary>
+    /// Logs a warning when a custom <c>OnPreToolUse</c> hook is present and approval-gating will not be applied automatically.
+    /// </summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "A custom 'OnPreToolUse' hook is configured on the SessionConfig, so {Count} approval-required tool(s) ({Tools}) " +
+                  "will not be automatically gated by GitHubCopilotAgent. The custom hook is responsible for enforcing approval " +
+                  "(for example, by returning a 'deny' or 'ask' PreToolUseHookOutput).")]
+    public static partial void LogApprovalGatingSkippedDueToCustomHook(
+        this ILogger logger,
+        int count,
+        string tools);
+}


### PR DESCRIPTION
This pull request refactors how warnings are logged when a custom `OnPreToolUse` hook is present in the `SessionConfig`. Instead of using a raw `logger.LogWarning` call, it introduces a strongly-typed logging extension using `LoggerMessageAttribute` for improved performance and maintainability.

Logging improvements:

* Added a new file `GitHubCopilotAgentLogMessages.cs` that defines a `LogApprovalGatingSkippedDueToCustomHook` extension method using `LoggerMessageAttribute` for compile-time optimized logging.
* Updated the logging call in `GitHubCopilotAgent.cs` to use the new `LogApprovalGatingSkippedDueToCustomHook` method instead of a direct `LogWarning` call.