### PR TITLE
.NET: fix: resolve CA1873 in GitHubCopilotAgent by using LoggerMessage sour…

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/GitHubCopilotAgent.cs
@@ -577,9 +577,13 @@ public sealed class GitHubCopilotAgent : AIAgent, IAsyncDisposable
         // Warn so the developer knows the ApprovalRequiredAIFunction marker(s) will not be automatically gated.
         if (sessionConfig.Hooks?.OnPreToolUse is not null)
         {
-            logger.LogApprovalGatingSkippedDueToCustomHook(
-                approvalRequiredToolNames.Count,
-                string.Join(", ", approvalRequiredToolNames));
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogApprovalGatingSkippedDueToCustomHook(
+                    approvalRequiredToolNames.Count,
+                    string.Join(", ", approvalRequiredToolNames));
+            }
+
             return sessionConfig;
         }
 


### PR DESCRIPTION
This pull request makes a minor update to the `ConvertToAgentResponseUpdate` method in `GitHubCopilotAgent.cs`. The change ensures that warning logs about approval gating being skipped due to a custom hook are only emitted if the logger is configured to show warnings, preventing unnecessary log output.

* Logging improvements:
  * Added a check for `logger.IsEnabled(LogLevel.Warning)` before logging a warning when a custom `OnPreToolUse` hook is present, ensuring that warnings are only logged if enabled.