### PR TITLE
Python: fix(ag-ui): record approval-resolved tool result in MESSAGES_SNAPSHOT

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -387,12 +387,22 @@ def _handle_step_based_approval(messages: list[Any]) -> list[BaseEvent]:
     return events
 
 
-def _make_approval_tool_result_events(resolved_approval_results: list[Content]) -> list[ToolCallResultEvent]:
+def _make_approval_tool_result_events(
+    resolved_approval_results: list[Content],
+    flow: FlowState | None = None,
+) -> list[ToolCallResultEvent]:
     """Build TOOL_CALL_RESULT events for tools executed during approval resolution.
 
     Honors ``TOOL_RESULT_DISPLAY_KEY`` so tools returning
     ``state_update(..., tool_result=...)`` route the display payload to the UI
     event even when gated by HITL approval.
+
+    When ``flow`` is provided, each result is also recorded in
+    ``flow.tool_results`` so the end-of-turn ``MESSAGES_SNAPSHOT`` carries the
+    tool-result message. Without this, an approval-gated tool's result is emitted
+    only as a transient ``TOOL_CALL_RESULT`` event and is absent from the snapshot
+    that clients (e.g. CopilotKit) reconcile their rendered state from — so the
+    already-completed tool call visibly reverts to "in progress".
     """
     events: list[ToolCallResultEvent] = []
     for resolved in resolved_approval_results:
@@ -400,14 +410,27 @@ def _make_approval_tool_result_events(resolved_approval_results: list[Content]) 
             raw = resolved.result if resolved.result is not None else ""
             llm_str = _stringify_tool_result(raw)
             ui_str = _resolve_ui_payload(llm_str, _extract_tool_result_display(resolved))
+            message_id = generate_event_id()
             events.append(
                 ToolCallResultEvent(
-                    message_id=generate_event_id(),
+                    message_id=message_id,
                     tool_call_id=resolved.call_id,
                     content=ui_str,
                     role="tool",
                 )
             )
+            if flow is not None and not any(
+                result.get("toolCallId") == resolved.call_id for result in flow.tool_results
+            ):
+                flow.tool_calls_ended.add(resolved.call_id)
+                flow.tool_results.append(
+                    {
+                        "id": message_id,
+                        "role": "tool",
+                        "toolCallId": resolved.call_id,
+                        "content": llm_str,
+                    }
+                )
     return events
 
 
@@ -725,8 +748,21 @@ def _build_messages_snapshot(
         }
         all_messages.append(tool_call_message)
 
-    # Add tool results
-    all_messages.extend(flow.tool_results)
+    # Add tool results, skipping any whose result already appears in the carried
+    # snapshot history. ``_clean_resolved_approvals_from_snapshot`` may have
+    # already folded an approved tool's result into ``snapshot_messages`` keyed by
+    # its call id; appending the same result again from ``flow.tool_results`` would
+    # emit a duplicate tool message for that call.
+    existing_result_ids = {
+        message.get("toolCallId")
+        for message in all_messages
+        if message.get("role") == "tool" and message.get("toolCallId")
+    }
+    for result in flow.tool_results:
+        if result.get("toolCallId") in existing_result_ids:
+            continue
+        all_messages.append(result)
+        existing_result_ids.add(result.get("toolCallId"))
 
     # Add text-only assistant message if there is accumulated text
     # This is a separate message from the tool calls message to maintain
@@ -1074,7 +1110,7 @@ async def run_agent_stream(
                 yield StateSnapshotEvent(snapshot=flow.current_state)
             run_started_emitted = True
 
-            for event in _make_approval_tool_result_events(resolved_approval_results):
+            for event in _make_approval_tool_result_events(resolved_approval_results, flow):
                 yield event
 
         # Feature #4: Detect tool-only messages (no text content)
@@ -1136,7 +1172,7 @@ async def run_agent_stream(
         if state_schema and flow.current_state:
             yield StateSnapshotEvent(snapshot=flow.current_state)
 
-        for event in _make_approval_tool_result_events(resolved_approval_results):
+        for event in _make_approval_tool_result_events(resolved_approval_results, flow):
             yield event
     if response_format is not None and all_updates:
         from agent_framework import AgentResponse

--- a/python/packages/ag-ui/tests/ag_ui/test_approval_result_event.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_approval_result_event.py
@@ -556,3 +556,94 @@ class TestApprovalToolResultDisplayChannel:
 
         assert len(events) == 1
         assert events[0].content == "Sunny in Seattle"
+
+
+class TestApprovalResultRecordedInSnapshot:
+    """An approved tool's result must survive into ``MESSAGES_SNAPSHOT``.
+
+    A ``confirm_changes``-gated tool's result is emitted only as a transient
+    ``TOOL_CALL_RESULT`` event; without recording it in ``flow.tool_results`` the
+    end-of-turn snapshot omits the result message, so a client reconciling state
+    from the snapshot reverts the already-completed tool call to "in progress".
+    """
+
+    def test_make_approval_result_events_records_in_flow(self) -> None:
+        from agent_framework_ag_ui._agent_run import _make_approval_tool_result_events
+        from agent_framework_ag_ui._run_common import FlowState
+
+        flow = FlowState()
+        resolved = Content.from_function_result(call_id="call_rec", result="Sunny in Seattle")
+
+        events = _make_approval_tool_result_events([resolved], flow)
+
+        assert len(events) == 1
+        assert len(flow.tool_results) == 1
+        recorded = flow.tool_results[0]
+        assert recorded["toolCallId"] == "call_rec"
+        assert recorded["content"] == "Sunny in Seattle"
+        assert recorded["role"] == "tool"
+        # The recorded message id matches the emitted event so clients reconcile cleanly.
+        assert recorded["id"] == events[0].message_id
+        # The call is marked ended so it is not treated as a still-open declaration.
+        assert "call_rec" in flow.tool_calls_ended
+
+    def test_make_approval_result_events_without_flow_is_unchanged(self) -> None:
+        """Omitting ``flow`` preserves the original event-only behaviour."""
+        from agent_framework_ag_ui._agent_run import _make_approval_tool_result_events
+
+        resolved = Content.from_function_result(call_id="call_noflow", result="Sunny in Seattle")
+
+        events = _make_approval_tool_result_events([resolved])
+
+        assert len(events) == 1
+        assert events[0].tool_call_id == "call_noflow"
+
+    def test_snapshot_includes_recorded_result(self) -> None:
+        from agent_framework_ag_ui._agent_run import _build_messages_snapshot, _make_approval_tool_result_events
+        from agent_framework_ag_ui._run_common import FlowState
+
+        flow = FlowState()
+        resolved = Content.from_function_result(call_id="call_snap", result="Sunny in Seattle")
+        _make_approval_tool_result_events([resolved], flow)
+
+        # Carried history lists the assistant's gated tool call but no result for it.
+        snapshot_messages = [
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_snap", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                ],
+            }
+        ]
+        snapshot = _build_messages_snapshot(flow, snapshot_messages)
+        dumped = [m.model_dump(by_alias=True, exclude_none=True) for m in snapshot.messages]
+        tool_msgs = [m for m in dumped if m.get("role") == "tool" and m.get("toolCallId") == "call_snap"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "Sunny in Seattle"
+
+    def test_snapshot_does_not_duplicate_existing_result(self) -> None:
+        """If the carried snapshot already has the result, do not add a duplicate."""
+        from agent_framework_ag_ui._agent_run import _build_messages_snapshot, _make_approval_tool_result_events
+        from agent_framework_ag_ui._run_common import FlowState
+
+        flow = FlowState()
+        resolved = Content.from_function_result(call_id="call_dup", result="Sunny in Seattle")
+        _make_approval_tool_result_events([resolved], flow)
+
+        # Carried history already carries the tool result (e.g. via approval-payload
+        # cleaning in the direct approval_mode flow).
+        snapshot_messages = [
+            {
+                "id": "assistant-1",
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_dup", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                ],
+            },
+            {"id": "tool-1", "role": "tool", "toolCallId": "call_dup", "content": "Sunny in Seattle"},
+        ]
+        snapshot = _build_messages_snapshot(flow, snapshot_messages)
+        dumped = [m.model_dump(by_alias=True, exclude_none=True) for m in snapshot.messages]
+        tool_msgs = [m for m in dumped if m.get("role") == "tool" and m.get("toolCallId") == "call_dup"]
+        assert len(tool_msgs) == 1


### PR DESCRIPTION
### Motivation & Context

An approval-gated tool's result, in the AG-UI `confirm_changes` flow (`require_confirmation=True`, as used by CopilotKit), is emitted only as a transient `TOOL_CALL_RESULT` event and never recorded in `flow.tool_results`. The end-of-turn `MESSAGES_SNAPSHOT` therefore omits the tool-result message, and clients that reconcile rendered state from the snapshot revert the already-completed tool call back to "in progress" — the tool chip flips done → running after approval, and again on the next turn.

`_clean_resolved_approvals_from_snapshot` already handles the direct `approval_mode` flow (the approval-response tool message is keyed by the original call id, so it is replaced with the executed result). It does not handle the `confirm_changes` flow, where the HITL tool call has its own id and the original call's result is never folded back into the snapshot.

Fixes #6828

### Description & Review Guide

- **What are the major changes?**
  - `_make_approval_tool_result_events` gains an optional `flow: FlowState | None` parameter. When provided, each executed approval result is also recorded in `flow.tool_results` (same shape as `_emit_tool_result_common`) and the call id is marked ended, so `_build_messages_snapshot` includes the tool-result message. Both call sites in `run_agent_stream` pass `flow`.
  - `_build_messages_snapshot` skips a recorded result whose `toolCallId` already appears as a tool message in the carried snapshot history, so the direct `approval_mode` flow (where `_clean_resolved_approvals_from_snapshot` already injected the result) does not emit a duplicate tool message.
  - Tests added in `tests/ag_ui/test_approval_result_event.py`: result is recorded in `flow.tool_results`; the snapshot includes it; no duplicate when the snapshot already carries it; behaviour unchanged when `flow` is omitted.

- **What is the impact of these changes?**
  - Backward compatible: the new parameter is optional with a default; the private function's existing callers/tests work unchanged. No public API change. Not a breaking change.
  - Completed approval-gated tools now stay completed in clients that reconcile from `MESSAGES_SNAPSHOT`.

- **Verification:** full `packages/ag-ui` test suite passes (772 passed locally; `test_endpoint.py` skipped only due to an uninstalled optional `agent-framework-orchestrations` dep in my env). Verified end-to-end against a CopilotKit client: the gated tool chip reaches "Done" after approval and stays "Done" across the next turn, where previously it reverted to "Running". `ruff check` and `ruff format` clean.

### Related Issue

Fixes #6828

### Contribution Checklist

- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] This PR is linked to an issue and there is no other open PR for this issue
- [x] **This is not a breaking change.**