### PR TITLE
.NET: Foundry Hosting per-user session isolation and Responses v2 protocol fast-fail

### DIFF
--- a/docs/decisions/0031-hosted-per-user-session-storage-isolation.md
+++ b/docs/decisions/0031-hosted-per-user-session-storage-isolation.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+contact: rogerbarreto
+date: 2026-06-30
+deciders: rogerbarreto
+consulted: []
+informed: []
+---
+
+# Per-agent and per-user session-storage isolation for Foundry Hosting
+
+Builds on [ADR-0030](0030-hosted-platform-context-agentserver-2.0.md).
+
+## Context and Problem Statement
+
+A Foundry hosted container can serve many end users (and, in .NET, many agents) over its lifetime. The
+`AgentSessionStore` persists each turn's `AgentSession` (which for a workflow agent carries the workflow
+checkpoint, and which also carries the tool-approval mapping via `ToolApprovalIdMap` in the session state
+bag). [ADR-0030](0030-hosted-platform-context-agentserver-2.0.md) protected cross-user access only through
+the strict-resume identity check (a 403 when the persisted `HostedSessionContext.UserId` does not match the
+live request). The persisted artifacts themselves were keyed by `conversationId` (+ agent name), not
+physically partitioned per user, so a forged `conversation_id` would still resolve to another user's file
+path before the identity check rejected it.
+
+The Python hosting package added physical per-user partitioning (`<root>/<user_id>/<context_id>`) plus a
+reject-style path-traversal guard. We want .NET to provide the same defense-in-depth, adapted to the .NET
+hosting model.
+
+## Decision Drivers
+
+- Defense in depth: a forged/guessed id must not even resolve to another tenant's storage path, independent
+  of the identity check.
+- Multi-agent hosting: a single .NET container hosts multiple agents resolved from keyed DI, so the layout
+  must isolate per agent as well as per user (Python hosts a single agent and needs no agent layer).
+- Path-traversal safety (CWE-22) for the untrusted, platform-injected user id.
+- Back-compat for local development (no `x-agent-user-id` header) and for direct/non-hosted store use.
+- Keep the change contained and avoid the async-iterator `AsyncLocal` revert hazard from ADR-0030.
+
+## Considered Options
+
+- **Path partition inside `FileSystemAgentSessionStore`**, threading the user id explicitly through the
+  `AgentSessionStore` API, with self-describing prefixed segments.
+- A delegating store that prefixes the conversation id with the user id (the
+  `IsolationKeyScopedAgentSessionStore` pattern from `Microsoft.Agents.AI.Hosting`). Rejected: still needs the
+  user id on the read path and yields a flat key rather than nested per-tenant directories.
+- An `AsyncLocal<string?>` user-context set by the handler. Rejected: the session is saved in the handler's
+  `finally` after the streaming `yield`s, where an `AsyncLocal` set up front is reverted (the same hazard
+  that forced explicit call-id re-application in ADR-0030). Explicit threading is safer and clearer.
+- A separate per-user approval store (as in Python). Rejected as unnecessary: see below.
+
+## Decision Outcome
+
+Path layout with self-describing, prefixed segments; user id threaded explicitly:
+
+    {root}/ a-{agentName} / u-{userId} / c-{contextId}.json
+
+- `a-` (agent), `u-` (user), `c-` (context) are constant literals applied to the sanitized/validated value,
+  so a collapsed layout is never ambiguous and a user id can never masquerade as an agent name.
+- `contextId` is `HostedConversationKey.Resolve` (conversation_id, else the partition of
+  previous_response_id, else of the minted response id).
+- The agent and context layers are always present (Foundry always deploys a named agent). The only
+  collapse is the `u-` layer: present when a user id is resolved (Foundry header, or local dev fallback),
+  absent for raw local runs with no header (`{root}/a-{agent}/c-{conv}.json`). There is no user-only or
+  no-agent layout.
+
+Other elements:
+
+- `string? userId` was added as a **required** parameter (no default) on `AgentSessionStore.GetSessionAsync` /
+  `SaveSessionAsync` (a contained, breaking change to the experimental Foundry abstraction; both in-tree
+  implementations and the two handler call sites were updated). It is required rather than optional so a
+  caller can never silently persist a session unscoped; a genuine no-user caller (local without the header,
+  or a non-hosted direct caller) passes `null` explicitly. `AgentFrameworkResponseHandler` resolves the user
+  id before loading the session.
+- Path-traversal guard: the user id is rejected (not sanitized) when it is not a single safe path segment
+  (path separators, NUL, drive letters, rooted paths, all-dot segments). After building the path, the
+  fully-resolved path is asserted to remain under the storage root.
+- The strict-resume 403 identity check from ADR-0030 is **kept** as the second defense layer (it still
+  catches a session that reaches the wrong partition, e.g. via a non-partitioning custom store or in-process
+  tampering).
+- **No separate approval store.** The tool-approval mapping lives in `ToolApprovalIdMap` ->
+  `AgentSessionStateBag`, which is serialized into the session checkpoint, so partitioning the session path
+  isolates pending approvals per tenant automatically. (Python needs a separate per-user approval store only
+  because it models approvals as a standalone store.)
+
+## Consequences
+
+Positive:
+
+- Cross-tenant isolation is now defense-in-depth: physical per-agent/per-user partitioning plus the identity
+  check. Approvals and workflow checkpoints inherit the partitioning because they ride in the session.
+- Self-describing prefixes make the on-disk layout auditable and collision-free across collapse cases.
+
+Negative:
+
+- Breaking change to the experimental Foundry `AgentSessionStore` API (added `userId`).
+- The on-disk layout and leaf filename change (`<conv>.json` -> `c-<conv>.json`), orphaning sessions written
+  by the ADR-0030 release. Acceptable for an experimental package; a fresh session is created on next use.
+
+## Out of scope
+
+- Encryption at rest and quota enforcement remain platform concerns.
+- Non-Foundry hosting layers can adopt an equivalent scheme independently.

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/.env.example
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/.env.example
@@ -10,4 +10,4 @@ PROVISION_SAMPLE_SKILLS=true
 AZURE_BEARER_TOKEN=DefaultAzureCredential
 # When running outside the Foundry platform the platform-injected user-identity key is absent.
 # This variable provides a fallback value for local Docker debugging only.
-HOSTED_USER_ISOLATION_KEY=local-dev-user
+HOSTED_USER_ID=local-dev-user

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/scripts/smoke.ps1
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-AgentSkills/scripts/smoke.ps1
@@ -50,7 +50,7 @@ function Start-Container {
     docker run -d --name $ContainerName -p ${Port}:8088 `
         -e AGENT_NAME=hosted-agent-skills `
         -e AZURE_BEARER_TOKEN=$bearer `
-        -e HOSTED_USER_ISOLATION_KEY=smoke-user `
+        -e HOSTED_USER_ID=smoke-user `
         --env-file .env `
         $ImageName | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "docker run failed." }

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/.env.example
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/.env.example
@@ -8,4 +8,4 @@ AGENT_NAME=hosted-memory-agent
 AZURE_BEARER_TOKEN=DefaultAzureCredential
 # When running outside the Foundry platform the platform-injected user-identity key is absent.
 # This variable provides a fallback value for local Docker debugging only.
-HOSTED_USER_ISOLATION_KEY=local-dev-user
+HOSTED_USER_ID=local-dev-user

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/README.md
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/README.md
@@ -42,7 +42,7 @@ ASPNETCORE_ENVIRONMENT=Development
 For local container runs only (the platform supplies these in production):
 
 ```env
-HOSTED_USER_ISOLATION_KEY=alice
+HOSTED_USER_ID=alice
 ```
 
 > `.env` is gitignored. The `.env.example` template is checked in as a reference.
@@ -57,11 +57,11 @@ HOSTED_USER_ISOLATION_KEY=alice
 | Memory provider | The sample's `stateInitializer` reads `session.GetHostedContext().UserId` and uses it as the `FoundryMemoryProviderScope`. Memories are partitioned per user. |
 
 When running outside the Foundry platform the header is absent. The sample registers
-`DevTemporaryLocalSessionIsolationKeyProvider` (via `AddDevTemporaryLocalContributorSetup`) which
-falls back to the `HOSTED_USER_ISOLATION_KEY` environment variable,
+`DevTemporaryLocalUserIdProvider` (via `AddDevTemporaryLocalContributorSetup`) which
+falls back to the `HOSTED_USER_ID` environment variable,
 defaulting to a single `local-dev-*` bucket when it is not set.
 
-> **Production warning.** Never register `DevTemporaryLocalSessionIsolationKeyProvider` in
+> **Production warning.** Never register `DevTemporaryLocalUserIdProvider` in
 > production. The Foundry platform sets the user-identity key for every inbound request, and
 > client-supplied environment variables can be forged.
 
@@ -118,7 +118,7 @@ export AZURE_BEARER_TOKEN=$(az account get-access-token --resource https://ai.az
 docker run --rm -p 8088:8088 \
   -e AGENT_NAME=hosted-memory-agent \
   -e AZURE_BEARER_TOKEN=$AZURE_BEARER_TOKEN \
-  -e HOSTED_USER_ISOLATION_KEY=alice \
+  -e HOSTED_USER_ID=alice \
   --env-file .env \
   hosted-memory-agent
 ```
@@ -133,7 +133,7 @@ pwsh ./scripts/smoke.ps1
 ```
 
 The script publishes the project, builds the image, runs the container with two distinct
-`HOSTED_USER_ISOLATION_KEY` values, drives a multi-turn conversation per user, asserts that each
+`HOSTED_USER_ID` values, drives a multi-turn conversation per user, asserts that each
 user only sees their own memories, and exits non-zero on failure.
 
 ## Deploying to Foundry (azd spec)
@@ -177,4 +177,4 @@ standard `Dockerfile` instead of `Dockerfile.contributor`. See the commented sec
 | **Agent definition** | Inline (`AsAIAgent(model, instructions)`) | Inline, plus `AIContextProviders = [memoryProvider]` |
 | **State** | None beyond the conversation history | Per-user memories persisted in Foundry Memory |
 | **Identity** | Not used | Required: `HostedSessionContext.UserId` flows into the memory scope |
-| **Local dev** | `AddDevTemporaryLocalContributorSetup()` keeps requests succeeding when isolation headers are absent | Same; additionally honours `HOSTED_USER_ISOLATION_KEY` to simulate distinct users |
+| **Local dev** | `AddDevTemporaryLocalContributorSetup()` keeps requests succeeding when the user-identity header is absent | Same; additionally honours `HOSTED_USER_ID` to simulate distinct users |

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/scripts/smoke.ps1
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-MemoryAgent/scripts/smoke.ps1
@@ -4,7 +4,7 @@
   Local smoke test for the Hosted-MemoryAgent sample.
 .DESCRIPTION
   Publishes the sample, builds the contributor Docker image, runs the container twice with two
-  distinct HOSTED_USER_ISOLATION_KEY values, drives a multi-turn conversation per user via curl
+  distinct HOSTED_USER_ID values, drives a multi-turn conversation per user via curl
   invocations, and asserts that each user only sees their own remembered details.
   Exits non-zero on failure.
 
@@ -49,7 +49,7 @@ function Start-Container([string]$UserKey, [string]$ContainerName) {
     docker run -d --name $ContainerName -p ${Port}:8088 `
         -e AGENT_NAME=hosted-memory-agent `
         -e AZURE_BEARER_TOKEN=$bearer `
-        -e HOSTED_USER_ISOLATION_KEY=$UserKey `
+        -e HOSTED_USER_ID=$UserKey `
         --env-file .env `
         $ImageName | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "docker run failed for $ContainerName." }

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted_Shared_Contributor_Setup/DevTemporaryLocalUserIdProvider.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted_Shared_Contributor_Setup/DevTemporaryLocalUserIdProvider.cs
@@ -12,7 +12,7 @@ namespace Hosted_Shared_Contributor_Setup;
 /// When the Foundry platform's <c>x-agent-user-id</c> header is absent (i.e., when the container is
 /// running outside the Foundry platform), the hosting layer rejects every request with a 500 because
 /// the default <see cref="HostedSessionIsolationKeyProvider"/> returns null. This provider supplies a
-/// fallback value from the <c>HOSTED_USER_ISOLATION_KEY</c> environment variable, defaulting to the
+/// fallback value from the <c>HOSTED_USER_ID</c> environment variable, defaulting to the
 /// constant below when it is not set.
 ///
 /// This should NOT be used in production. The Foundry platform sets the user id for every inbound
@@ -20,18 +20,18 @@ namespace Hosted_Shared_Contributor_Setup;
 /// solely so a contributor can <c>docker run</c> the sample on their laptop and drive a few requests
 /// end to end.
 /// </summary>
-public sealed class DevTemporaryLocalSessionIsolationKeyProvider : HostedSessionIsolationKeyProvider
+public sealed class DevTemporaryLocalUserIdProvider : HostedSessionIsolationKeyProvider
 {
     /// <summary>
-    /// Environment variable that supplies the user isolation key when the platform header is absent.
+    /// Environment variable that supplies the user id when the platform header is absent.
     /// </summary>
-    public const string UserIsolationKeyEnvironmentVariable = "HOSTED_USER_ISOLATION_KEY";
+    public const string UserIdEnvironmentVariable = "HOSTED_USER_ID";
 
     /// <summary>
-    /// Default user isolation key used when neither the platform header nor the environment variable
+    /// Default user id used when neither the platform header nor the environment variable
     /// supplies a value. All local requests collapse onto this single bucket unless overridden.
     /// </summary>
-    public const string DefaultLocalUserIsolationKey = "local-dev-user";
+    public const string DefaultLocalUserId = "local-dev-user";
 
     /// <inheritdoc />
     public override ValueTask<HostedSessionContext?> GetKeysAsync(
@@ -39,14 +39,14 @@ public sealed class DevTemporaryLocalSessionIsolationKeyProvider : HostedSession
         CreateResponse request,
         CancellationToken cancellationToken)
     {
-        var userKey = !string.IsNullOrWhiteSpace(context?.PlatformContext?.UserIdKey)
+        var userId = !string.IsNullOrWhiteSpace(context?.PlatformContext?.UserIdKey)
             ? context!.PlatformContext!.UserIdKey
-            : Environment.GetEnvironmentVariable(UserIsolationKeyEnvironmentVariable);
-        if (string.IsNullOrWhiteSpace(userKey))
+            : Environment.GetEnvironmentVariable(UserIdEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(userId))
         {
-            userKey = DefaultLocalUserIsolationKey;
+            userId = DefaultLocalUserId;
         }
 
-        return new ValueTask<HostedSessionContext?>(new HostedSessionContext(userKey!));
+        return new ValueTask<HostedSessionContext?>(new HostedSessionContext(userId!));
     }
 }

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted_Shared_Contributor_Setup/HostedContributorSetupExtensions.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted_Shared_Contributor_Setup/HostedContributorSetupExtensions.cs
@@ -16,18 +16,17 @@ public static class HostedContributorSetupExtensions
     ///
     /// <para><b>For local Docker debugging only and should not be used in production.</b></para>
     ///
-    /// Currently this method registers a <see cref="DevTemporaryLocalSessionIsolationKeyProvider"/>
-    /// so that requests succeed when the platform's <c>x-agent-user-isolation-key</c> and
-    /// <c>x-agent-chat-isolation-key</c> headers are absent. In production those headers are
-    /// always present and the default platform isolation key provider (registered automatically by
-    /// the hosting layer) is used instead.
+    /// Currently this method registers a <see cref="DevTemporaryLocalUserIdProvider"/>
+    /// so that requests succeed when the platform's <c>x-agent-user-id</c> header is absent. In
+    /// production that header is always present and the default platform user-id provider (registered
+    /// automatically by the hosting layer) is used instead.
     /// </summary>
     /// <param name="services">The service collection to register the developer-only services into.</param>
     /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
     public static IServiceCollection AddDevTemporaryLocalContributorSetup(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-        services.AddSingleton<HostedSessionIsolationKeyProvider, DevTemporaryLocalSessionIsolationKeyProvider>();
+        services.AddSingleton<HostedSessionIsolationKeyProvider, DevTemporaryLocalUserIdProvider>();
         return services;
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
@@ -63,25 +63,9 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         var agent = this.ResolveAgent(request);
         var sessionStore = this.ResolveSessionStore(request);
 
-        // 2. Load or create a new session from the interaction.
-        // Map the request to a stable MAF AgentSession key: conversation_id when present, else the
-        // partition embedded in previous_response_id (chains converge), else the minted response id
-        // (cold start). Container session id is intentionally not used — it spans many conversations.
-        var conversationId = request.GetConversationId();
-        var sessionConversationId = HostedConversationKey.Resolve(
-            conversationId, request.PreviousResponseId, context.ResponseId);
-
-        var chatClientAgent = agent.GetService<ChatClientAgent>();
-
-        AgentSession? session = !string.IsNullOrWhiteSpace(sessionConversationId)
-            ? await sessionStore.GetSessionAsync(agent, sessionConversationId, cancellationToken).ConfigureAwait(false)
-                : chatClientAgent is not null
-                ? await chatClientAgent.CreateSessionAsync(cancellationToken).ConfigureAwait(false)
-                : await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
-
-        // 2.5. Resolve and apply the per-request hosted session identity context.
-        // Fresh sessions are tagged once. Resumed sessions are validated against the live request
-        // to detect cross-user session leaks and in-process tampering of the persisted identity.
+        // 2. Resolve the per-request hosted session identity context FIRST, so the session can be
+        // loaded from a per-user partition. Fresh sessions are tagged once; resumed sessions are
+        // validated against the live request to detect cross-user session leaks and in-process tampering.
         var isolationKeyProvider = this._serviceProvider.GetService<HostedSessionIsolationKeyProvider>()
             ?? s_defaultIsolationKeyProvider;
         var resolvedHostedContext = await isolationKeyProvider.GetKeysAsync(context, request, cancellationToken).ConfigureAwait(false);
@@ -92,6 +76,24 @@ public class AgentFrameworkResponseHandler : ResponseHandler
                 "Ensure the Foundry platform is providing the x-agent-user-id header, " +
                 "or register a custom provider that supplies fallback values for local development.");
         }
+
+        // 3. Load or create a new session from the interaction.
+        // Map the request to a stable MAF AgentSession key: conversation_id when present, else the
+        // partition embedded in previous_response_id (chains converge), else the minted response id
+        // (cold start). Container session id is intentionally not used — it spans many conversations.
+        // The session store partitions persisted state per user via resolvedHostedContext.UserId so one
+        // user can never observe another user's session, even with a forged conversation id.
+        var conversationId = request.GetConversationId();
+        var sessionConversationId = HostedConversationKey.Resolve(
+            conversationId, request.PreviousResponseId, context.ResponseId);
+
+        var chatClientAgent = agent.GetService<ChatClientAgent>();
+
+        AgentSession? session = !string.IsNullOrWhiteSpace(sessionConversationId)
+            ? await sessionStore.GetSessionAsync(agent, sessionConversationId, resolvedHostedContext.UserId, cancellationToken).ConfigureAwait(false)
+                : chatClientAgent is not null
+                ? await chatClientAgent.CreateSessionAsync(cancellationToken).ConfigureAwait(false)
+                : await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
 
         // Capture the platform per-request call id (x-agent-foundry-call-id, protocol 2.0.0 only).
         // It is re-applied to the ambient HostedCallContext immediately before each outbound egress
@@ -411,10 +413,11 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         {
             await enumerator.DisposeAsync().ConfigureAwait(false);
 
-            // Persist session after streaming completes (successful or not)
+            // Persist session after streaming completes (successful or not). The user id partitions the
+            // persisted session per end user, mirroring the load above so multi-turn continuity is preserved.
             if (session is not null && !string.IsNullOrWhiteSpace(sessionConversationId))
             {
-                await sessionStore.SaveSessionAsync(agent, sessionConversationId, session, cancellationToken).ConfigureAwait(false);
+                await sessionStore.SaveSessionAsync(agent, sessionConversationId, session, resolvedHostedContext.UserId, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
@@ -63,7 +63,21 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         var agent = this.ResolveAgent(request);
         var sessionStore = this.ResolveSessionStore(request);
 
-        // 2. Resolve the per-request hosted session identity context FIRST, so the session can be
+        // Fail fast with a clear, actionable error when this 2.0.0-only image is served container
+        // protocol 1.0.0. The x-agent-foundry-call-id header is exclusive to protocol 2.0.0, so when the
+        // container is hosted by Foundry yet receives no call id, the platform is talking 1.0.0 to an
+        // image that does not support it. Detecting this here turns an opaque 500 into a 501 that names
+        // the cause and the fix instead of bubbling up as a generic server error on every request.
+        var unsupportedProtocolError = HostedProtocolCompatibility.GetUnsupportedProtocolError(
+            FoundryEnvironment.IsHosted, context.PlatformContext?.CallId);
+        if (unsupportedProtocolError is not null)
+        {
+            this._logger.LogError(
+                "Hosted container served unsupported Responses protocol 1.0.0 (no x-agent-foundry-call-id header); this image requires protocol 2.0.0.");
+            throw unsupportedProtocolError;
+        }
+
+        // 2. Resolve the per-request hosted session identity context, so the session can be
         // loaded from a per-user partition. Fresh sessions are tagged once; resumed sessions are
         // validated against the live request to detect cross-user session leaks and in-process tampering.
         var isolationKeyProvider = this._serviceProvider.GetService<HostedSessionIsolationKeyProvider>()
@@ -71,6 +85,9 @@ public class AgentFrameworkResponseHandler : ResponseHandler
         var resolvedHostedContext = await isolationKeyProvider.GetKeysAsync(context, request, cancellationToken).ConfigureAwait(false);
         if (resolvedHostedContext is null)
         {
+            // Reached only when the container is NOT hosted by Foundry (local development without a
+            // fallback provider), or in the unexpected case of a 2.0.0 request that carried a call id
+            // but no x-agent-user-id. Hosted 1.0.0 requests are already handled above.
             throw new InvalidOperationException(
                 $"The registered {nameof(HostedSessionIsolationKeyProvider)} returned null for the current request. " +
                 "Ensure the Foundry platform is providing the x-agent-user-id header, " +

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentSessionStore.cs
@@ -24,12 +24,21 @@ public abstract class AgentSessionStore
     /// <param name="agent">The agent that owns this session.</param>
     /// <param name="conversationId">The unique identifier for the conversation/session.</param>
     /// <param name="session">The session to save.</param>
+    /// <param name="userId">
+    /// The platform-injected per-user partition key (<c>x-agent-user-id</c>) that scopes this session to the
+    /// end user who initiated the request. Pass <see langword="null"/> only when there is genuinely no user
+    /// context (for example local development without the platform header, or a non-hosted direct caller).
+    /// The parameter is required (no default) so every caller consciously decides the scope: implementations
+    /// that persist to a shared medium partition by this value so one user can never observe another user's
+    /// sessions, and an accidental unscoped save cannot happen silently.
+    /// </param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous save operation.</returns>
     public abstract ValueTask SaveSessionAsync(
         AIAgent agent,
         string conversationId,
         AgentSession session,
+        string? userId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -37,6 +46,13 @@ public abstract class AgentSessionStore
     /// </summary>
     /// <param name="agent">The agent that owns this session.</param>
     /// <param name="conversationId">The unique identifier for the conversation/session to retrieve.</param>
+    /// <param name="userId">
+    /// The platform-injected per-user partition key (<c>x-agent-user-id</c>) that scopes this session to the
+    /// end user who initiated the request. Pass <see langword="null"/> only when there is genuinely no user
+    /// context (for example local development without the platform header, or a non-hosted direct caller).
+    /// The parameter is required (no default); it must match the value used when the session was saved,
+    /// otherwise a different (or new) session is returned.
+    /// </param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>
     /// A task that represents the asynchronous retrieval operation.
@@ -45,5 +61,6 @@ public abstract class AgentSessionStore
     public abstract ValueTask<AgentSession> GetSessionAsync(
         AIAgent agent,
         string conversationId,
+        string? userId,
         CancellationToken cancellationToken = default);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FileSystemAgentSessionStore.cs
@@ -147,7 +147,7 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
     }
 
     /// <inheritdoc/>
-    public override async ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, CancellationToken cancellationToken = default)
+    public override async ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, string? userId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(agent);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
@@ -155,7 +155,7 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
 
         JsonElement serialized = await agent.SerializeSessionAsync(session, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        string path = this.GetSessionPath(agent, conversationId);
+        string path = this.GetSessionPath(agent, conversationId, userId);
 
         // Each save writes to its own temp file before atomically renaming over the
         // destination. Last writer wins for the final file, but no reader can observe
@@ -208,12 +208,12 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
         $"(for example {nameof(InMemoryAgentSessionStore)}) via AddFoundryResponses(agent, agentSessionStore).";
 
     /// <inheritdoc/>
-    public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, CancellationToken cancellationToken = default)
+    public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, string? userId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(agent);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
 
-        string path = this.GetSessionPath(agent, conversationId);
+        string path = this.GetSessionPath(agent, conversationId, userId);
         if (!File.Exists(path))
         {
             return await agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
@@ -231,20 +231,82 @@ public sealed class FileSystemAgentSessionStore : AgentSessionStore
         return await agent.DeserializeSessionAsync(element, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    private string GetSessionPath(AIAgent agent, string conversationId)
+    private string GetSessionPath(AIAgent agent, string conversationId, string? userId)
     {
-        // When agent.Name is set we bucket sessions into a per-agent subdirectory so
-        // multiple keyed agents sharing a single in-process default store cannot
-        // collide on the same conversationId. agent.Id is intentionally NOT used
-        // because it is regenerated on every startup for in-memory-defined agents.
-        string fileName = $"{Sanitize(conversationId)}.json";
-        if (string.IsNullOrEmpty(agent.Name))
+        // Path layout uses self-describing, prefixed segments so every layer is unambiguous and a
+        // collapsed layout can never be confused with a different layer (e.g. a user id can never
+        // masquerade as an agent name):
+        //
+        //   {root}/a-{agent}/u-{userId}/c-{conversationId}.json
+        //
+        // - a-{agent}  buckets per hosted agent, because a single container hosts multiple keyed
+        //              agents that must not collide on the same conversationId. (agent.Id is NOT
+        //              used: it is regenerated on every startup for in-memory-defined agents.)
+        // - u-{userId} partitions per end user (x-agent-user-id) for multi-tenant isolation. Present
+        //              only when a user id was resolved; absent for local runs with no platform header.
+        // - c-{conv}   the conversation/context key. {conversationId} is HostedConversationKey.Resolve's
+        //              output (conversation_id, else the partition of previous_response_id / response id).
+        //
+        // The prefixes are constant literals applied AFTER sanitizing/validating each untrusted value,
+        // so they can never themselves introduce path traversal.
+        string dir = this.RootDirectory;
+
+        if (!string.IsNullOrEmpty(agent.Name))
         {
-            return Path.Combine(this.RootDirectory, fileName);
+            dir = Path.Combine(dir, "a-" + Sanitize(agent.Name!));
         }
 
-        string agentDir = Path.Combine(this.RootDirectory, Sanitize(agent.Name!));
-        return Path.Combine(agentDir, fileName);
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            // The user id is the platform-injected, untrusted partition key. Reject (do not sanitize)
+            // anything that is not a single safe path component so a forged value cannot escape the root.
+            ValidatePathSegment(userId!, "user id");
+            dir = Path.Combine(dir, "u-" + Sanitize(userId!));
+        }
+
+        string path = Path.Combine(dir, "c-" + Sanitize(conversationId) + ".json");
+
+        // Defense in depth: regardless of per-segment handling, the fully-resolved path must remain
+        // under the storage root. Reject anything that escapes (CWE-22).
+        string fullRoot = Path.GetFullPath(this.RootDirectory);
+        string fullPath = Path.GetFullPath(path);
+        string rootWithSeparator = fullRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? fullRoot
+            : fullRoot + Path.DirectorySeparatorChar;
+        if (!fullPath.StartsWith(rootWithSeparator, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to resolve a session path outside of the storage root '{fullRoot}'.");
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="segment"/> is a single safe path component (CWE-22).
+    /// </summary>
+    /// <remarks>
+    /// The value originates from caller-controlled or platform-injected fields (such as the
+    /// <c>x-agent-user-id</c> partition key). It must be treated as an untrusted single path segment:
+    /// path separators, drive letters, parent references and similar would otherwise let the resulting
+    /// directory escape the configured storage root. We deliberately do not URL-decode the value (the
+    /// hosting layer never decodes these ids before joining them, so forms such as <c>%2e%2e</c> are
+    /// accepted as literal directory names), and we do not "sanitize" by stripping characters because
+    /// that can introduce collisions between distinct ids — a non-conforming value is rejected outright.
+    /// </remarks>
+    private static void ValidatePathSegment(string segment, string kind)
+    {
+        // Reject any value that is not a single safe path component. This covers POSIX/Windows
+        // separators, NUL bytes, drive letters, rooted paths, and all-dot segments (".", "..", "...").
+        if (segment.IndexOf('/') >= 0
+            || segment.IndexOf('\\') >= 0
+            || segment.IndexOf('\0') >= 0
+            || segment.Trim('.').Length == 0
+            || Path.IsPathRooted(segment)
+            || !string.IsNullOrEmpty(Path.GetPathRoot(segment)))
+        {
+            throw new InvalidOperationException($"Invalid {kind}: '{segment}'.");
+        }
     }
 
     private static string Sanitize(string value)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedProtocolCompatibility.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedProtocolCompatibility.cs
@@ -61,7 +61,7 @@ internal static class HostedProtocolCompatibility
     /// </returns>
     internal static ResponsesApiException? GetUnsupportedProtocolError(bool isHosted, string? callId)
     {
-        if (!isHosted || !string.IsNullOrEmpty(callId))
+        if (!isHosted || !string.IsNullOrWhiteSpace(callId))
         {
             return null;
         }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedProtocolCompatibility.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/HostedProtocolCompatibility.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Azure.AI.AgentServer.Responses;
+using Azure.AI.AgentServer.Responses.Models;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting;
+
+/// <summary>
+/// Detects when this image, which targets the Foundry Responses container protocol <c>2.0.0</c>,
+/// is being served the older <c>1.0.0</c> protocol, and turns that mismatch into a clear, actionable
+/// error instead of an opaque <c>500</c> on every request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The container has no startup signal for its negotiated protocol version: the platform injects the
+/// agent identity (<c>FOUNDRY_AGENT_NAME</c>/<c>FOUNDRY_AGENT_VERSION</c>) and a hosted flag
+/// (<c>FOUNDRY_HOSTING_ENVIRONMENT</c>), but not the responses protocol version, and
+/// <c>container_protocol_versions</c> is a control-plane field on the agent definition that is never
+/// passed into the image. The only per-request signal is the presence of the
+/// <c>x-agent-foundry-call-id</c> header, which the platform sends exclusively on protocol
+/// <c>2.0.0</c>.
+/// </para>
+/// <para>
+/// Therefore, when the container is hosted by Foundry yet receives no call id, the platform is talking
+/// <c>1.0.0</c> to a <c>2.0.0</c>-only image. That is a server-side deployment misconfiguration, so the
+/// failure is surfaced as a <c>5xx</c> (<see cref="UnsupportedProtocolStatusCode"/>) whose body names
+/// both the cause and the fix.
+/// </para>
+/// </remarks>
+internal static class HostedProtocolCompatibility
+{
+    /// <summary>
+    /// HTTP status returned when this image is served a container protocol version it does not support.
+    /// <c>501 Not Implemented</c> is a server-side (<c>5xx</c>) classification, because the deployment,
+    /// not the caller, is misconfigured; it is also non-retryable and distinct from the generic
+    /// <c>500</c> so it stands out in platform telemetry.
+    /// </summary>
+    internal const int UnsupportedProtocolStatusCode = 501;
+
+    /// <summary>
+    /// Stable error code emitted in the response body so callers and tooling can match the condition.
+    /// </summary>
+    internal const string UnsupportedProtocolErrorCode = "unsupported_container_protocol_version";
+
+    /// <summary>
+    /// Returns the error to throw when this <c>2.0.0</c>-only image is served container protocol
+    /// <c>1.0.0</c>, or <see langword="null"/> when the request is compatible (or the container is not
+    /// hosted by Foundry, e.g. local development).
+    /// </summary>
+    /// <param name="isHosted">
+    /// Whether the container is running inside Foundry, from <c>FoundryEnvironment.IsHosted</c>
+    /// (<c>FOUNDRY_HOSTING_ENVIRONMENT</c>). Local (non-hosted) runs are never flagged.
+    /// </param>
+    /// <param name="callId">
+    /// The per-request <c>x-agent-foundry-call-id</c> value (protocol <c>2.0.0</c> only). Absence while
+    /// hosted indicates a <c>1.0.0</c> deployment.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ResponsesApiException"/> carrying <see cref="UnsupportedProtocolStatusCode"/> and a
+    /// clear message, or <see langword="null"/> when the request is compatible.
+    /// </returns>
+    internal static ResponsesApiException? GetUnsupportedProtocolError(bool isHosted, string? callId)
+    {
+        if (!isHosted || !string.IsNullOrEmpty(callId))
+        {
+            return null;
+        }
+
+        return new ResponsesApiException(
+            new Error(
+                UnsupportedProtocolErrorCode,
+                "Unsupported responses protocol version. This agent requires responses protocol v2.0.0"),
+            UnsupportedProtocolStatusCode);
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
@@ -33,16 +33,16 @@ public sealed class InMemoryAgentSessionStore : AgentSessionStore
     private readonly ConcurrentDictionary<string, JsonElement> _sessions = new();
 
     /// <inheritdoc/>
-    public override async ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, CancellationToken cancellationToken = default)
+    public override async ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, string? userId, CancellationToken cancellationToken = default)
     {
-        var key = GetKey(conversationId, agent.Id);
+        var key = GetKey(conversationId, agent.Id, userId);
         this._sessions[key] = await agent.SerializeSessionAsync(session, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, CancellationToken cancellationToken = default)
+    public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, string? userId, CancellationToken cancellationToken = default)
     {
-        var key = GetKey(conversationId, agent.Id);
+        var key = GetKey(conversationId, agent.Id, userId);
         JsonElement? sessionContent = this._sessions.TryGetValue(key, out var existingSession) ? existingSession : null;
 
         return sessionContent switch
@@ -52,5 +52,10 @@ public sealed class InMemoryAgentSessionStore : AgentSessionStore
         };
     }
 
-    private static string GetKey(string conversationId, string agentId) => $"{agentId}:{conversationId}";
+    // Keyed with the same a-/u-/c- prefix scheme as FileSystemAgentSessionStore so the in-memory store
+    // partitions per agent and per user identically. The user segment is omitted when no user id is supplied.
+    private static string GetKey(string conversationId, string agentId, string? userId)
+        => string.IsNullOrWhiteSpace(userId)
+            ? $"a-{agentId}:c-{conversationId}"
+            : $"a-{agentId}:u-{userId}:c-{conversationId}";
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/InMemoryAgentSessionStore.cs
@@ -35,14 +35,14 @@ public sealed class InMemoryAgentSessionStore : AgentSessionStore
     /// <inheritdoc/>
     public override async ValueTask SaveSessionAsync(AIAgent agent, string conversationId, AgentSession session, string? userId, CancellationToken cancellationToken = default)
     {
-        var key = GetKey(conversationId, agent.Id, userId);
+        var key = GetKey(agent, conversationId, userId);
         this._sessions[key] = await agent.SerializeSessionAsync(session, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public override async ValueTask<AgentSession> GetSessionAsync(AIAgent agent, string conversationId, string? userId, CancellationToken cancellationToken = default)
     {
-        var key = GetKey(conversationId, agent.Id, userId);
+        var key = GetKey(agent, conversationId, userId);
         JsonElement? sessionContent = this._sessions.TryGetValue(key, out var existingSession) ? existingSession : null;
 
         return sessionContent switch
@@ -53,9 +53,24 @@ public sealed class InMemoryAgentSessionStore : AgentSessionStore
     }
 
     // Keyed with the same a-/u-/c- prefix scheme as FileSystemAgentSessionStore so the in-memory store
-    // partitions per agent and per user identically. The user segment is omitted when no user id is supplied.
-    private static string GetKey(string conversationId, string agentId, string? userId)
-        => string.IsNullOrWhiteSpace(userId)
-            ? $"a-{agentId}:c-{conversationId}"
-            : $"a-{agentId}:u-{userId}:c-{conversationId}";
+    // partitions per agent and per user identically. Like FileSystemAgentSessionStore, the agent segment
+    // uses agent.Name (a stable identity) and is omitted when no name is set; agent.Id is intentionally
+    // NOT used because it is regenerated on every startup for in-memory-defined agents, which would break
+    // session continuity for a transient or recreated agent. The user segment is omitted when no user id
+    // is supplied.
+    private static string GetKey(AIAgent agent, string conversationId, string? userId)
+    {
+        string key = string.Empty;
+        if (!string.IsNullOrEmpty(agent.Name))
+        {
+            key += $"a-{agent.Name}:";
+        }
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            key += $"u-{userId}:";
+        }
+
+        return key + $"c-{conversationId}";
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ToolApprovalIdMap.cs
@@ -15,6 +15,13 @@ namespace Microsoft.Agents.AI.Foundry.Hosting;
 /// the request/response round trip. The mapping is persisted in
 /// <see cref="AgentSessionStateBag"/>.
 /// </summary>
+/// <remarks>
+/// Because this mapping lives in the session state bag, it is serialized as part of the
+/// <see cref="AgentSession"/> by the active <c>AgentSessionStore</c> — there is no separate
+/// approval store. Consequently, partitioning the persisted session per agent and per user
+/// (see <c>FileSystemAgentSessionStore</c>) automatically isolates pending tool approvals
+/// per tenant as well: one user can never resolve another user's saved approval request.
+/// </remarks>
 internal static class ToolApprovalIdMap
 {
     /// <summary>

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/Program.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/Program.cs
@@ -31,6 +31,7 @@ var projectClient = new AIProjectClient(projectEndpoint, new DefaultAzureCredent
 AIAgent agent = scenario switch
 {
     "happy-path" => CreateHappyPathAgent(projectClient, deployment),
+    "unsupported-protocol" => CreateHappyPathAgent(projectClient, deployment),
     "store-config" => CreateStoreConfigAgent(projectClient, deployment),
     "tool-calling" => CreateToolCallingAgent(projectClient, deployment),
     "tool-calling-approval" => CreateToolCallingApprovalAgent(projectClient, deployment),

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/HostedAgentFixture.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/HostedAgentFixture.cs
@@ -69,6 +69,13 @@ public abstract class HostedAgentFixture : IAsyncLifetime
     protected virtual TimeSpan ProvisioningTimeout => TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// Container responses protocol version declared in <c>container_protocol_versions</c>. Defaults to
+    /// <c>2.0.0</c> (the only version this image supports). The unsupported-protocol scenario overrides
+    /// it to <c>1.0.0</c> to assert the container fails fast with a clear, actionable error.
+    /// </summary>
+    protected virtual string ResponsesProtocolVersion => "2.0.0";
+
+    /// <summary>
     /// The wrapped agent. Available after <see cref="InitializeAsync"/>.
     /// </summary>
     public AIAgent Agent { get; private set; } = null!;
@@ -157,7 +164,7 @@ public abstract class HostedAgentFixture : IAsyncLifetime
         {
             Image = image,
         };
-        definition.Versions.Add(new ProtocolVersionRecord(ProjectsAgentProtocol.Responses, "2.0.0"));
+        definition.Versions.Add(new ProtocolVersionRecord(ProjectsAgentProtocol.Responses, this.ResponsesProtocolVersion));
         definition.EnvironmentVariables[ScenarioEnvironmentVariable] = this.ScenarioName;
         // Forward the test-side model deployment to the container so it targets the same model the
         // tests expect. Without this the container falls back to its hard-coded default (gpt-4o),

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/UnsupportedProtocolHostedAgentFixture.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/UnsupportedProtocolHostedAgentFixture.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Foundry.Hosting.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Provisions a dedicated <c>it-unsupported-protocol</c> agent under the legacy responses protocol
+/// <c>1.0.0</c> on purpose. The test container targets protocol <c>2.0.0</c> only, so a request served
+/// as <c>1.0.0</c> (no <c>x-agent-foundry-call-id</c> header) must fail fast with a clear <c>501</c>
+/// rather than an opaque 500. A dedicated agent name keeps this 1.0.0 deployment isolated from the
+/// 2.0.0 scenario agents (notably <c>it-happy-path</c>), whose <c>@latest</c> must stay 2.0.0.
+/// See <see cref="UnsupportedProtocolHostedAgentTests"/>.
+/// </summary>
+public sealed class UnsupportedProtocolHostedAgentFixture : HostedAgentFixture
+{
+    protected override string ScenarioName => "unsupported-protocol";
+
+    protected override string ResponsesProtocolVersion => "1.0.0";
+}

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/UnsupportedProtocolHostedAgentTests.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/UnsupportedProtocolHostedAgentTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.ClientModel;
+using System.Threading.Tasks;
+using Foundry.Hosting.IntegrationTests.Fixtures;
+
+namespace Foundry.Hosting.IntegrationTests;
+
+/// <summary>
+/// Provokes the protocol-compatibility failure on purpose: the test container (which targets responses
+/// protocol <c>2.0.0</c> only) is deployed under responses protocol <c>1.0.0</c>. Invoking it must
+/// surface the clear <c>501</c> error the container emits (see <c>HostedProtocolCompatibility</c>),
+/// rather than an opaque 500.
+/// </summary>
+[Trait("Category", "FoundryHostedAgents")]
+public sealed class UnsupportedProtocolHostedAgentTests(UnsupportedProtocolHostedAgentFixture fixture) : IClassFixture<UnsupportedProtocolHostedAgentFixture>
+{
+    private readonly UnsupportedProtocolHostedAgentFixture _fixture = fixture;
+
+    [Fact]
+    public async Task RunAsync_OnProtocol1_0_0_FailsWith501UnsupportedProtocolAsync()
+    {
+        // Arrange
+        var agent = this._fixture.Agent;
+
+        // Act: a 1.0.0 deployment sends no x-agent-foundry-call-id header, so the container detects the
+        // unsupported protocol and fails fast. The OpenAI responses client surfaces the container's HTTP
+        // error as a ClientResultException.
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => agent.RunAsync("Reply with a short greeting."));
+
+        // Assert: the failure is the deliberate 501, not an opaque 500, and the body names the required
+        // protocol so the operator knows the fix.
+        var clientError = FindClientResultException(ex);
+        Assert.NotNull(clientError);
+        Assert.Equal(501, clientError!.Status);
+        Assert.Contains("2.0.0", clientError.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ClientResultException? FindClientResultException(Exception? ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is ClientResultException clientResultException)
+            {
+                return clientResultException;
+            }
+        }
+
+        return null;
+    }
+}

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/scripts/it-bootstrap-agents.ps1
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/scripts/it-bootstrap-agents.ps1
@@ -50,7 +50,8 @@ $Scenarios = @(
     'memory',
     'azure-search-rag',
     'session-files',
-    'agent-skills'
+    'agent-skills',
+    'unsupported-protocol'
 )
 
 # Resolve project ARM scope from the endpoint.
@@ -91,7 +92,7 @@ foreach ($scenario in $Scenarios) {
         $body = @{
             definition = @{
                 kind = 'hosted'
-                container_protocol_versions = @(@{ protocol = 'responses'; version = '1.0.0' })
+                container_protocol_versions = @(@{ protocol = 'responses'; version = '2.0.0' })
                 cpu = '0.25'
                 memory = '0.5Gi'
                 environment_variables = @{ IT_SCENARIO = $scenario }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/AgentFrameworkResponseHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/AgentFrameworkResponseHandlerTests.cs
@@ -1063,7 +1063,11 @@ public class AgentFrameworkResponseHandlerTests
         var root = NewIsolationTempRoot();
         try
         {
-            // Arrange: a hosted request whose x-agent-user-id was not captured (PlatformContext is null).
+            // Arrange: a non-hosted (local) request whose x-agent-user-id was not captured (PlatformContext
+            // is null). Under unit tests FoundryEnvironment.IsHosted is false, so the protocol-compatibility
+            // gate does not apply; the handler still rejects rather than persisting an unscoped session. The
+            // hosted 1.0.0 path (which returns the clear 501 instead) is covered by
+            // HostedProtocolCompatibilityTests and the UnsupportedProtocol integration test.
             var store = new FileSystemAgentSessionStore(root);
             var handler = BuildMultiAgentHandler(store, ("concierge", new RecordingAgent("concierge")));
             var (req, ctx) = BuildUserRequest("concierge", "trip", userId: null);

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/AgentFrameworkResponseHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/AgentFrameworkResponseHandlerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -961,6 +962,183 @@ public class AgentFrameworkResponseHandlerTests
         Assert.Null(HostedCallContext.CallId);
     }
 
+    // ── Multi-agent / multi-user file-system isolation (handler-driven, no live service) ─────────────
+    // These drive the hosted-agent handler (the in-process "hosted instance") against a REAL
+    // FileSystemAgentSessionStore and the REAL PlatformHostedSessionIsolationKeyProvider (no fake), so the
+    // user id is genuinely captured from the request's x-agent-user-id (ResponseContext.PlatformContext).
+    // They assert the on-disk layout {root}/a-{agent}/u-{userId}/c-{conv}.json for combinations of agent
+    // name and user.
+
+    [Fact]
+    public async Task CreateAsync_MultipleUsersSameAgent_WritePerUserDirectoriesAsync()
+    {
+        var root = NewIsolationTempRoot();
+        try
+        {
+            // Arrange: one store shared by the container, one agent ("concierge"), two users.
+            var store = new FileSystemAgentSessionStore(root);
+            var handler = BuildMultiAgentHandler(store, ("concierge", new RecordingAgent("concierge")));
+
+            // Act: Alice and Bob each drive the same agent and the same conversation id.
+            var (aliceReq, aliceCtx) = BuildUserRequest("concierge", "trip", userId: "alice");
+            await DrainEventsAsync(handler.CreateAsync(aliceReq, aliceCtx.Object, CancellationToken.None));
+            var (bobReq, bobCtx) = BuildUserRequest("concierge", "trip", userId: "bob");
+            await DrainEventsAsync(handler.CreateAsync(bobReq, bobCtx.Object, CancellationToken.None));
+
+            // Assert: each user's session is persisted under its own u-{userId} directory beneath the
+            // shared a-{agent} directory; neither can reach the other's path.
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-concierge", "u-alice", "c-trip.json")));
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-concierge", "u-bob", "c-trip.json")));
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_MultipleAgentsSameUser_WritePerAgentDirectoriesAsync()
+    {
+        var root = NewIsolationTempRoot();
+        try
+        {
+            // Arrange: one store shared by the container, two agents, one user.
+            var store = new FileSystemAgentSessionStore(root);
+            var handler = BuildMultiAgentHandler(store, ("concierge", new RecordingAgent("concierge")), ("scheduler", new RecordingAgent("scheduler")));
+
+            // Act: the same user drives two different agents on the same conversation id.
+            var (req1, ctx1) = BuildUserRequest("concierge", "trip", userId: "alice");
+            await DrainEventsAsync(handler.CreateAsync(req1, ctx1.Object, CancellationToken.None));
+            var (req2, ctx2) = BuildUserRequest("scheduler", "trip", userId: "alice");
+            await DrainEventsAsync(handler.CreateAsync(req2, ctx2.Object, CancellationToken.None));
+
+            // Assert: each agent buckets the user's session under its own a-{agent} directory, so two
+            // agents in the same container cannot collide on a shared conversation id.
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-concierge", "u-alice", "c-trip.json")));
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-scheduler", "u-alice", "c-trip.json")));
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_SecondUserSameConversation_GetsFreshSessionNoLeakAsync()
+    {
+        var root = NewIsolationTempRoot();
+        try
+        {
+            // Arrange.
+            var store = new FileSystemAgentSessionStore(root);
+            var agent = new RecordingAgent("concierge");
+            var handler = BuildMultiAgentHandler(store, ("concierge", agent));
+
+            // Act: Alice drives twice (cold start then resume), then Bob forges the same agent+conversation.
+            var (a1Req, a1Ctx) = BuildUserRequest("concierge", "trip", userId: "alice");
+            await DrainEventsAsync(handler.CreateAsync(a1Req, a1Ctx.Object, CancellationToken.None));
+            var (a2Req, a2Ctx) = BuildUserRequest("concierge", "trip", userId: "alice");
+            await DrainEventsAsync(handler.CreateAsync(a2Req, a2Ctx.Object, CancellationToken.None));
+            var (bobReq, bobCtx) = BuildUserRequest("concierge", "trip", userId: "bob");
+            await DrainEventsAsync(handler.CreateAsync(bobReq, bobCtx.Object, CancellationToken.None));
+
+            // Assert: Alice's second turn restored her persisted session (a deserialize), while Bob's request
+            // produced a freshly created session — Bob never deserialized Alice's state. Two creates total
+            // (Alice turn 1, Bob turn 1) and one restore (Alice turn 2).
+            Assert.Equal(2, agent.CreateCount);
+            Assert.Equal(1, agent.DeserializeCount);
+            // And the files live in distinct per-user directories.
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-concierge", "u-alice", "c-trip.json")));
+            Assert.True(File.Exists(Path.Combine(store.RootDirectory, "a-concierge", "u-bob", "c-trip.json")));
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public async Task CreateAsync_NoUserIdCaptured_IsRejectedAndWritesNoFileAsync()
+    {
+        var root = NewIsolationTempRoot();
+        try
+        {
+            // Arrange: a hosted request whose x-agent-user-id was not captured (PlatformContext is null).
+            var store = new FileSystemAgentSessionStore(root);
+            var handler = BuildMultiAgentHandler(store, ("concierge", new RecordingAgent("concierge")));
+            var (req, ctx) = BuildUserRequest("concierge", "trip", userId: null);
+
+            // Act & Assert: the default platform provider returns null, so the handler rejects the request
+            // rather than persisting an unscoped session — nothing is written to disk.
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await DrainEventsAsync(handler.CreateAsync(req, ctx.Object, CancellationToken.None)));
+            Assert.False(Directory.Exists(store.RootDirectory) && Directory.GetFiles(store.RootDirectory, "*.json", SearchOption.AllDirectories).Length > 0);
+        }
+        finally
+        {
+            CleanupTempRoot(root);
+        }
+    }
+
+    private static string NewIsolationTempRoot()
+        => Path.Combine(Path.GetTempPath(), "handler-fs-isolation-" + Guid.NewGuid().ToString("N"));
+
+    private static void CleanupTempRoot(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private static AgentFrameworkResponseHandler BuildMultiAgentHandler(AgentSessionStore store, params (string Name, AIAgent Agent)[] agents)
+    {
+        var services = new ServiceCollection();
+        // Shared default store for the container; agents resolved by name via keyed DI. No isolation-key
+        // provider is registered so the real PlatformHostedSessionIsolationKeyProvider reads x-agent-user-id.
+        services.AddSingleton(store);
+        foreach (var (name, agent) in agents)
+        {
+            services.AddKeyedSingleton(name, agent);
+        }
+
+        return new AgentFrameworkResponseHandler(services.BuildServiceProvider(), NullLogger<AgentFrameworkResponseHandler>.Instance);
+    }
+
+    private static (CreateResponse Request, Mock<ResponseContext> Context) BuildUserRequest(string agentName, string conversationId, string? userId)
+    {
+        // The agent is selected from the request's Model field (GetAgentName falls back to Model); the
+        // conversation id pins the c-{contextId} leaf.
+        var request = new CreateResponse { Model = agentName };
+        request.Conversation = BinaryData.FromString($"\"{conversationId}\"");
+        request.Input = BinaryData.FromObjectAsJson(new[]
+        {
+            new { type = "message", id = "msg_1", status = "completed", role = "user",
+                  content = new[] { new { type = "input_text", text = "Hello" } } }
+        });
+
+        var ctx = new Mock<ResponseContext>("caresp_" + new string('0', 50)) { CallBase = true };
+        // x-agent-user-id captured -> PlatformContext carries the user id; not captured -> null PlatformContext.
+        if (userId is null)
+        {
+            ctx.Setup(x => x.PlatformContext).Returns((PlatformContext)null!);
+        }
+        else
+        {
+            ctx.Setup(x => x.PlatformContext).Returns(new PlatformContext(userId, null));
+        }
+        ctx.Setup(x => x.GetHistoryAsync(It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<OutputItem>());
+        ctx.Setup(x => x.GetInputItemsAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<Item>());
+        return (request, ctx);
+    }
+
     private static AgentFrameworkResponseHandler BuildHandlerWith(AIAgent agent, HostedSessionIsolationKeyProvider provider, AgentSessionStore store)
     {
         var services = new ServiceCollection();
@@ -1019,6 +1197,44 @@ public class AgentFrameworkResponseHandlerTests
 
         protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions, CancellationToken cancellationToken = default)
             => new(StatefulSession.Deserialize(serializedState));
+    }
+
+    /// <summary>Records how many sessions it created vs deserialized, to prove cross-user no-leak.</summary>
+    private sealed class RecordingAgent : AIAgent
+    {
+        private readonly string? _name;
+
+        public RecordingAgent(string? name = null)
+        {
+            this._name = name;
+        }
+
+        public override string? Name => this._name;
+
+        public int CreateCount { get; private set; }
+        public int DeserializeCount { get; private set; }
+
+        protected override IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+            IEnumerable<ChatMessage> messages, AgentSession? session, AgentRunOptions? options, CancellationToken cancellationToken = default)
+            => ToAsyncEnumerableAsync(new AgentResponseUpdate { MessageId = "resp_msg_1", Contents = [new MeaiTextContent("ok")] });
+
+        protected override Task<AgentResponse> RunCoreAsync(IEnumerable<ChatMessage> messages, AgentSession? session, AgentRunOptions? options, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        protected override ValueTask<AgentSession> CreateSessionCoreAsync(CancellationToken cancellationToken = default)
+        {
+            this.CreateCount++;
+            return new(new StatefulSession());
+        }
+
+        protected override ValueTask<JsonElement> SerializeSessionCoreAsync(AgentSession session, JsonSerializerOptions? jsonSerializerOptions, CancellationToken cancellationToken = default)
+            => new(((StatefulSession)session).Serialize());
+
+        protected override ValueTask<AgentSession> DeserializeSessionCoreAsync(JsonElement serializedState, JsonSerializerOptions? jsonSerializerOptions, CancellationToken cancellationToken = default)
+        {
+            this.DeserializeCount++;
+            return new(StatefulSession.Deserialize(serializedState));
+        }
     }
 
     /// <summary>Reads <see cref="HostedCallContext.CallId"/> during its run, standing in for a downstream tool call.</summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FileSystemAgentSessionStoreTests.cs
@@ -55,7 +55,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var store = new FileSystemAgentSessionStore(this._root);
         var agent = new TestAgent();
 
-        var session = await store.GetSessionAsync(agent, "conv-1");
+        var session = await store.GetSessionAsync(agent, "conv-1", userId: null);
 
         Assert.NotNull(session);
         Assert.Equal(1, agent.CreateCalls);
@@ -70,7 +70,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         File.WriteAllText(Path.Combine(store.RootDirectory, "conv-empty.json"), string.Empty);
 
         var agent = new TestAgent();
-        var session = await store.GetSessionAsync(agent, "conv-empty");
+        var session = await store.GetSessionAsync(agent, "conv-empty", userId: null);
 
         Assert.NotNull(session);
         Assert.Equal(1, agent.CreateCalls);
@@ -85,10 +85,10 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         Assert.False(Directory.Exists(nested));
 
         var agent = new TestAgent("{\"workflow\":\"x\"}");
-        await store.SaveSessionAsync(agent, "conv-2", NewSession());
+        await store.SaveSessionAsync(agent, "conv-2", NewSession(), userId: null);
 
         Assert.True(Directory.Exists(nested));
-        Assert.True(File.Exists(Path.Combine(nested, "conv-2.json")));
+        Assert.True(File.Exists(Path.Combine(nested, "c-conv-2.json")));
     }
 
     [Fact]
@@ -97,8 +97,8 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var store = new FileSystemAgentSessionStore(this._root);
         var agent = new TestAgent("{\"foo\":42}");
 
-        await store.SaveSessionAsync(agent, "round-trip", NewSession());
-        await store.GetSessionAsync(agent, "round-trip");
+        await store.SaveSessionAsync(agent, "round-trip", NewSession(), userId: null);
+        await store.GetSessionAsync(agent, "round-trip", userId: null);
 
         Assert.Equal(1, agent.SerializeCalls);
         Assert.Equal(1, agent.DeserializeCalls);
@@ -114,12 +114,12 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var agentA = new TestAgent("{\"who\":\"a\"}", name: "AgentA");
         var agentB = new TestAgent("{\"who\":\"b\"}", name: "AgentB");
 
-        await store.SaveSessionAsync(agentA, "shared-conv", NewSession());
-        await store.SaveSessionAsync(agentB, "shared-conv", NewSession());
+        await store.SaveSessionAsync(agentA, "shared-conv", NewSession(), userId: null);
+        await store.SaveSessionAsync(agentB, "shared-conv", NewSession(), userId: null);
 
         // Agents with distinct Names get distinct subdirectories so neither overwrites the other.
-        var pathA = Path.Combine(store.RootDirectory, "AgentA", "shared-conv.json");
-        var pathB = Path.Combine(store.RootDirectory, "AgentB", "shared-conv.json");
+        var pathA = Path.Combine(store.RootDirectory, "a-AgentA", "c-shared-conv.json");
+        var pathB = Path.Combine(store.RootDirectory, "a-AgentB", "c-shared-conv.json");
         Assert.True(File.Exists(pathA));
         Assert.True(File.Exists(pathB));
         Assert.Contains("\"a\"", File.ReadAllText(pathA), StringComparison.Ordinal);
@@ -135,7 +135,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var conversationId = new string('a', 200);
         var agent = new TestAgent();
 
-        await store.SaveSessionAsync(agent, conversationId, NewSession());
+        await store.SaveSessionAsync(agent, conversationId, NewSession(), userId: null);
 
         var files = Directory.GetFiles(store.RootDirectory, "*.json");
         Assert.Single(files);
@@ -161,7 +161,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
 
         var conversationId = $"id-with{invalid}invalid-chars";
 
-        await store.SaveSessionAsync(agent, conversationId, NewSession());
+        await store.SaveSessionAsync(agent, conversationId, NewSession(), userId: null);
 
         var files = Directory.GetFiles(store.RootDirectory, "*.json");
         Assert.Single(files);
@@ -182,12 +182,12 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var tasks = new List<Task>();
         for (int i = 0; i < 16; i++)
         {
-            tasks.Add(store.SaveSessionAsync(agent, "concurrent", NewSession()).AsTask());
+            tasks.Add(store.SaveSessionAsync(agent, "concurrent", NewSession(), userId: null).AsTask());
         }
 
         await Task.WhenAll(tasks);
 
-        Assert.True(File.Exists(Path.Combine(store.RootDirectory, "concurrent.json")));
+        Assert.True(File.Exists(Path.Combine(store.RootDirectory, "c-concurrent.json")));
         var leftoverTempFiles = Directory.GetFiles(store.RootDirectory, "*.tmp");
         Assert.Empty(leftoverTempFiles);
     }
@@ -201,7 +201,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var store = new FileSystemAgentSessionStore(this._root);
         var agent = new TestAgent(name: agentName);
 
-        await store.SaveSessionAsync(agent, "conv-dots", NewSession());
+        await store.SaveSessionAsync(agent, "conv-dots", NewSession(), userId: null);
 
         // The session file must land inside RootDirectory, not in (or above) it as a sibling.
         var allFiles = Directory.GetFiles(store.RootDirectory, "*.json", SearchOption.AllDirectories);
@@ -229,8 +229,8 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var agentSlash = new TestAgent(name: "foo/bar");
         var agentUnderscore = new TestAgent(name: "foo_bar");
 
-        await store.SaveSessionAsync(agentSlash, "conv-1", NewSession());
-        await store.SaveSessionAsync(agentUnderscore, "conv-1", NewSession());
+        await store.SaveSessionAsync(agentSlash, "conv-1", NewSession(), userId: null);
+        await store.SaveSessionAsync(agentUnderscore, "conv-1", NewSession(), userId: null);
 
         var bucketDirs = Directory.GetDirectories(store.RootDirectory);
         Assert.Equal(2, bucketDirs.Length);
@@ -243,7 +243,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         var store = new FileSystemAgentSessionStore(this._root);
         var agent = new TestAgent(name: "agent-with-bucket");
 
-        var session = await store.GetSessionAsync(agent, "missing-id");
+        var session = await store.GetSessionAsync(agent, "missing-id", userId: null);
 
         Assert.NotNull(session);
         Assert.False(Directory.Exists(this._root), "Read miss must not create the root directory.");
@@ -337,7 +337,7 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
 
         // Act
         var ex = await Assert.ThrowsAsync<IOException>(
-            async () => await store.SaveSessionAsync(agent, "conv-fatal", NewSession()));
+            async () => await store.SaveSessionAsync(agent, "conv-fatal", NewSession(), userId: null));
 
         // Assert: failure stays fatal but the message is clear and actionable, and the original
         // IO error is preserved as the inner exception.
@@ -346,6 +346,111 @@ public sealed class FileSystemAgentSessionStoreTests : IDisposable
         Assert.Contains(FileSystemAgentSessionStore.DefaultHostedSessionDataDirectory, ex.Message, StringComparison.Ordinal);
         Assert.Contains(store.RootDirectory, ex.Message, StringComparison.Ordinal);
         Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_WithUserId_NestsUnderPrefixedAgentAndUserAsync()
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent("{\"who\":\"alice\"}", name: "Concierge");
+
+        await store.SaveSessionAsync(agent, "conv-1", NewSession(), userId: "alice");
+
+        // Layout: {root}/a-{agent}/u-{userId}/c-{conv}.json
+        var expected = Path.Combine(store.RootDirectory, "a-Concierge", "u-alice", "c-conv-1.json");
+        Assert.True(File.Exists(expected), $"expected session at {expected}");
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_NoUserId_OmitsUserSegmentAsync()
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent(name: "Concierge");
+
+        await store.SaveSessionAsync(agent, "conv-1", NewSession(), userId: null);
+
+        // No user id -> the u- layer collapses: {root}/a-{agent}/c-{conv}.json
+        var expected = Path.Combine(store.RootDirectory, "a-Concierge", "c-conv-1.json");
+        Assert.True(File.Exists(expected), $"expected session at {expected}");
+        Assert.Empty(Directory.GetDirectories(Path.Combine(store.RootDirectory, "a-Concierge")));
+    }
+
+    [Fact]
+    public async Task GetSessionAsync_DifferentUser_DoesNotReadAnotherUsersSessionAsync()
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent("{\"secret\":\"alice-only\"}", name: "Concierge");
+
+        // Alice saves under the same conversationId Bob will guess/forge.
+        await store.SaveSessionAsync(agent, "shared-conv", NewSession(), userId: "alice");
+
+        // Bob requests the same conversationId. The per-user partition means Bob's path is distinct,
+        // so the store returns a fresh session (no leak), not Alice's persisted state.
+        var bobSession = await store.GetSessionAsync(agent, "shared-conv", userId: "bob");
+
+        Assert.NotNull(bobSession);
+        Assert.Equal(1, agent.CreateCalls);     // fresh session created for Bob
+        Assert.Equal(0, agent.DeserializeCalls); // Alice's file never deserialized for Bob
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_UserIdEqualToAgentName_StaysDistinctViaPrefixesAsync()
+    {
+        // Without prefixes, agent "x" + no user could collide with no-agent + user "x". The a-/u-
+        // prefixes keep the layers unambiguous.
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent(name: "x");
+
+        await store.SaveSessionAsync(agent, "conv-1", NewSession(), userId: "x");
+
+        var expected = Path.Combine(store.RootDirectory, "a-x", "u-x", "c-conv-1.json");
+        Assert.True(File.Exists(expected), $"expected session at {expected}");
+    }
+
+    [Theory]
+    [InlineData("../../escape")]
+    [InlineData("..")]
+    [InlineData("user/../../escape")]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData(".")]
+    public async Task SaveSessionAsync_TraversalUserId_IsRejectedAsync(string userId)
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent(name: "Concierge");
+
+        // A forged user id that is not a single safe path segment is rejected outright (CWE-22),
+        // not sanitized — so it can never escape the storage root.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await store.SaveSessionAsync(agent, "conv-1", NewSession(), userId: userId));
+
+        // Nothing was written outside (or inside) the root.
+        Assert.False(Directory.Exists(this._root) && Directory.GetFiles(this._root, "*.json", SearchOption.AllDirectories).Length > 0);
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_AbsoluteOrRootedUserId_IsRejectedAsync()
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent(name: "Concierge");
+
+        var rooted = Path.IsPathRooted("/etc") ? "/etc" : Path.GetFullPath("/etc");
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await store.SaveSessionAsync(agent, "conv-1", NewSession(), userId: rooted));
+    }
+
+    [Fact]
+    public async Task SaveSessionAsync_ThenGetSessionAsync_WithUserId_RoundTripsAsync()
+    {
+        var store = new FileSystemAgentSessionStore(this._root);
+        var agent = new TestAgent("{\"foo\":7}", name: "Concierge");
+
+        await store.SaveSessionAsync(agent, "round-trip", NewSession(), userId: "alice");
+        await store.GetSessionAsync(agent, "round-trip", userId: "alice");
+
+        Assert.Equal(1, agent.SerializeCalls);
+        Assert.Equal(1, agent.DeserializeCalls);
+        Assert.Equal(7, agent.LastDeserialized!.Value.GetProperty("foo").GetInt32());
     }
 
     private static TestSession NewSession() => new();

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedProtocolCompatibilityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedProtocolCompatibilityTests.cs
@@ -27,12 +27,16 @@ public sealed class HostedProtocolCompatibilityTests
     [Fact]
     public void GetUnsupportedProtocolError_HostedWithEmptyCallId_ReturnsUnsupportedProtocolError()
     {
-        // An empty header value is treated the same as an absent one.
-        ResponsesApiException? error = HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: true, callId: "");
+        // An empty or whitespace-only header value is treated the same as an absent one, so a proxy that
+        // injects whitespace cannot bypass the gate.
+        foreach (var callId in new[] { "", "   ", "\t" })
+        {
+            ResponsesApiException? error = HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: true, callId: callId);
 
-        Assert.NotNull(error);
-        Assert.Equal(501, error!.StatusCode);
-        Assert.Equal(HostedProtocolCompatibility.UnsupportedProtocolErrorCode, error.Error.Code);
+            Assert.NotNull(error);
+            Assert.Equal(501, error!.StatusCode);
+            Assert.Equal(HostedProtocolCompatibility.UnsupportedProtocolErrorCode, error.Error.Code);
+        }
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedProtocolCompatibilityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedProtocolCompatibilityTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Azure.AI.AgentServer.Responses;
+
+namespace Microsoft.Agents.AI.Foundry.Hosting.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="HostedProtocolCompatibility"/>, the protocol-version gate that turns an
+/// opaque 500 into a clear 501 when this 2.0.0-only image is served container protocol 1.0.0.
+/// </summary>
+public sealed class HostedProtocolCompatibilityTests
+{
+    [Fact]
+    public void GetUnsupportedProtocolError_HostedWithoutCallId_ReturnsUnsupportedProtocolError()
+    {
+        // Hosted by Foundry (FoundryEnvironment.IsHosted == true) but no x-agent-foundry-call-id header
+        // means the platform is talking protocol 1.0.0 to a 2.0.0-only image.
+        ResponsesApiException? error = HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: true, callId: null);
+
+        Assert.NotNull(error);
+        Assert.Equal(HostedProtocolCompatibility.UnsupportedProtocolStatusCode, error!.StatusCode);
+        Assert.Equal(501, error.StatusCode);
+        Assert.Equal(HostedProtocolCompatibility.UnsupportedProtocolErrorCode, error.Error.Code);
+        Assert.Equal("Unsupported responses protocol version. This agent requires responses protocol v2.0.0", error.Error.Message);
+    }
+
+    [Fact]
+    public void GetUnsupportedProtocolError_HostedWithEmptyCallId_ReturnsUnsupportedProtocolError()
+    {
+        // An empty header value is treated the same as an absent one.
+        ResponsesApiException? error = HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: true, callId: "");
+
+        Assert.NotNull(error);
+        Assert.Equal(501, error!.StatusCode);
+        Assert.Equal(HostedProtocolCompatibility.UnsupportedProtocolErrorCode, error.Error.Code);
+    }
+
+    [Fact]
+    public void GetUnsupportedProtocolError_HostedWithCallId_ReturnsNull()
+    {
+        // Protocol 2.0.0: the platform supplies x-agent-foundry-call-id, so the request is compatible.
+        ResponsesApiException? error = HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: true, callId: "fcid_abc123");
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void GetUnsupportedProtocolError_NotHosted_ReturnsNull()
+    {
+        // Local development (not hosted by Foundry) is never flagged, regardless of the call id.
+        Assert.Null(HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: false, callId: null));
+        Assert.Null(HostedProtocolCompatibility.GetUnsupportedProtocolError(isHosted: false, callId: "fcid_abc123"));
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedSessionIdentityContextTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/HostedSessionIdentityContextTests.cs
@@ -115,8 +115,9 @@ public class HostedSessionIdentityContextTests
 
         // Step 2: persist the session under a known conversation id (mimics what the handler does
         // when it has a conversation id; here we plant it directly so we can drive a resume request).
+        // The session is scoped to the same user ("alice") that will resume it.
         const string ConversationId = "resume-chat-id";
-        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, capturingAgent.LastSession, CancellationToken.None);
+        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, capturingAgent.LastSession, "alice", CancellationToken.None);
 
         // Step 3: drive a resume request with the same isolation keys.
         var (resumeRequest, resumeContext) = BuildResumeRequest(ConversationId);
@@ -144,7 +145,12 @@ public class HostedSessionIdentityContextTests
         var (freshRequest, freshContext) = BuildFreshRequest();
         await DrainAsync(aliceHandler.CreateAsync(freshRequest, freshContext.Object, CancellationToken.None));
         const string ConversationId = "resume-chat-id";
-        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, capturingAgent.LastSession!, CancellationToken.None);
+
+        // Plant Alice's stamped session UNDER BOB'S partition to simulate a session that reached Bob's
+        // key despite the per-user path partitioning (e.g. a non-partitioning custom store, or in-process
+        // tampering). The 403 identity check is the defense-in-depth layer that must still reject it even
+        // when the physical partition was bypassed.
+        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, capturingAgent.LastSession!, "bob", CancellationToken.None);
 
         // Bob attempts to resume Alice's conversation.
         var bobProvider = new FakeHostedSessionIsolationKeyProvider("bob");
@@ -169,7 +175,7 @@ public class HostedSessionIdentityContextTests
         var sessionStore = new InMemoryAgentSessionStore();
         const string ConversationId = "untagged-chat-id";
         var untagged = await capturingAgent.CreateSessionAsync(CancellationToken.None);
-        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, untagged, CancellationToken.None);
+        await sessionStore.SaveSessionAsync(capturingAgent, ConversationId, untagged, "alice", CancellationToken.None);
 
         var fakeProvider = new FakeHostedSessionIsolationKeyProvider("alice");
         var handler = BuildHandler(capturingAgent, fakeProvider, sessionStore);


### PR DESCRIPTION
### Motivation & Context

Foundry hosted agents on the Responses container protocol v2.0 persist per session state (checkpoints, tool approvals) on the container file system. Phase 1 keyed those files by conversation and agent only, so isolation between users relied solely on the runtime 403 identity check. This change partitions persisted state per user on disk as well, so one user can never observe another user's session even with a forged conversation id. It brings the .NET hosting layer to parity with the Python counterpart in #6811.

Separately, a v2.0 only image deployed under the legacy v1.0 protocol previously threw and surfaced an opaque 500 on every request, giving operators no idea why. The container now detects that situation at the first request and fails fast with a clear 501 that names the required protocol.

### Description & Review Guide

- **What are the major changes?**
  - Per agent and per user path partitioning in `FileSystemAgentSessionStore`: persisted state now lives at `<root>/a-<agent>/u-<userId>/c-<contextId>.json`. Segments carry constant `a-`/`u-`/`c-` prefixes on sanitized values so the user layer can collapse unambiguously and a user id can never masquerade as an agent name.
  - A path traversal guard (`ValidatePathSegment` rejecting separators, drive and absolute forms, and all dot names) plus a resolve and assert under root containment check.
  - `AgentSessionStore.GetSessionAsync` and `SaveSessionAsync` take a required, nullable `userId` so scope is always a conscious decision at the call site. This is an experimental API (`AgentsAIExperiments`).
  - The response handler resolves the per request user identity before loading the session, keeps the strict resume 403 identity mismatch check, and forwards the per request call id to outbound toolbox and storage calls.
  - New `HostedProtocolCompatibility` gate: when the container is hosted (`FoundryEnvironment.IsHosted`) yet receives no `x-agent-foundry-call-id` header (the marker that is exclusive to protocol v2.0), it returns a 501 `unsupported_container_protocol_version` instead of an opaque 500.
  - Tests: `HostedProtocolCompatibilityTests`, per user and traversal cases in `FileSystemAgentSessionStoreTests`, multi agent and multi user handler tests, and an integration test that deploys a dedicated `it-unsupported-protocol` agent as v1.0 and asserts the 501. The bootstrap placeholder default is raised to responses v2.0 and the integration fixture protocol version is overridable.
  - ADR `0031-hosted-per-user-session-storage-isolation.md`. Sample rename of the `HOSTED_USER_ISOLATION_KEY` environment variable to `HOSTED_USER_ID` to match the model where there is no separate isolation key.

- **What is the impact of these changes?**
  - Experimental API signature change on `AgentSessionStore` (the new `userId` parameter). Consumers of this experimental type update their call sites or overrides.
  - The hosted file layout changes to the nested per agent and per user form above.
  - A v1.0 hosted environment now returns a clear 501 rather than an opaque 500. v2.0 behaviour is unchanged.

- **What do you want reviewers to focus on?**
  - The path partitioning and traversal guard correctness in `FileSystemAgentSessionStore`.
  - The choice of `x-agent-foundry-call-id` (`PlatformContext.CallId`) as the v2.0 detection signal in `HostedProtocolCompatibility`.

### Related Issue

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
