### PR TITLE
Make skills source classes public with Experimental attribute

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentInMemorySkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentInMemorySkillsSource.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Agents.AI;
 /// A skill source that holds <see cref="AgentSkill"/> instances in memory.
 /// </summary>
 [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
-internal sealed class AgentInMemorySkillsSource : AgentSkillsSource
+public sealed class AgentInMemorySkillsSource : AgentSkillsSource
 {
     private readonly List<AgentSkill> _skills;
 

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AggregatingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AggregatingAgentSkillsSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Agents.AI;
 /// with each source's skills appended sequentially. No deduplication or filtering is applied.
 /// </remarks>
 [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
-internal sealed class AggregatingAgentSkillsSource : AgentSkillsSource
+public sealed class AggregatingAgentSkillsSource : AgentSkillsSource
 {
     private readonly IEnumerable<AgentSkillsSource> _sources;
 

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/CachingAgentSkillsSource.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -17,7 +19,8 @@ namespace Microsoft.Agents.AI;
 /// a single in-flight fetch and all receive the same cached result.
 /// If the initial fetch fails, the cache is not populated and subsequent calls will retry.
 /// </remarks>
-internal sealed class CachingAgentSkillsSource : DelegatingAgentSkillsSource
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed class CachingAgentSkillsSource : DelegatingAgentSkillsSource
 {
     private const string SharedCacheKey = "CachingAgentSkillsSource-SharedCacheKey";
 
@@ -29,7 +32,7 @@ internal sealed class CachingAgentSkillsSource : DelegatingAgentSkillsSource
     /// </summary>
     /// <param name="innerSource">The inner source whose results will be cached.</param>
     /// <param name="options">Optional cache configuration.</param>
-    internal CachingAgentSkillsSource(AgentSkillsSource innerSource, CachingAgentSkillsSourceOptions? options = null)
+    public CachingAgentSkillsSource(AgentSkillsSource innerSource, CachingAgentSkillsSourceOptions? options = null)
         : base(innerSource)
     {
         this._options = options;

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DeduplicatingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DeduplicatingAgentSkillsSource.cs
@@ -2,17 +2,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// A skill source decorator that removes duplicate skills by name, keeping only the first occurrence.
 /// </summary>
-internal sealed partial class DeduplicatingAgentSkillsSource : DelegatingAgentSkillsSource
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed partial class DeduplicatingAgentSkillsSource : DelegatingAgentSkillsSource
 {
     private readonly ILogger<DeduplicatingAgentSkillsSource> _logger;
 

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DelegatingAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/DelegatingAgentSkillsSource.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -16,7 +18,8 @@ namespace Microsoft.Agents.AI;
 /// enabling the creation of source pipelines where each layer can add functionality (caching, deduplication,
 /// filtering, etc.) while delegating core operations to an underlying source.
 /// </remarks>
-internal abstract class DelegatingAgentSkillsSource : AgentSkillsSource
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public abstract class DelegatingAgentSkillsSource : AgentSkillsSource
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DelegatingAgentSkillsSource"/> class with the specified inner source.

--- a/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/FilteringAgentSkillsSource.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Decorators/FilteringAgentSkillsSource.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -17,7 +19,8 @@ namespace Microsoft.Agents.AI;
 /// Skills for which the predicate returns <see langword="true"/> are included in the result;
 /// skills for which it returns <see langword="false"/> are excluded and logged at debug level.
 /// </remarks>
-internal sealed partial class FilteringAgentSkillsSource : DelegatingAgentSkillsSource
+[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
+public sealed partial class FilteringAgentSkillsSource : DelegatingAgentSkillsSource
 {
     private readonly Func<AgentSkill, AgentSkillsSourceContext, bool> _predicate;
     private readonly ILogger<FilteringAgentSkillsSource> _logger;


### PR DESCRIPTION
Makes all skills source classes in Microsoft.Agents.AI public (sealed or abstract as appropriate) and marks them with the [Experimental] attribute to expose the API for consumers who want to compose custom source pipelines.

Closes: https://github.com/microsoft/agent-framework/issues/6833