### PR TITLE
Python: Re-enable Azure OpenAI integration tests

### DIFF
--- a/python/packages/openai/tests/openai/test_openai_chat_client_azure.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client_azure.py
@@ -23,8 +23,11 @@ from agent_framework_openai import OpenAIChatClient
 
 pytestmark = pytest.mark.azure
 
-skip_if_azure_openai_integration_tests_disabled = pytest.mark.skip(
-    reason="Azure OpenAI integration tests temporarily disabled: crashes the xdist runner in CI.",
+
+skip_if_azure_openai_integration_tests_disabled = pytest.mark.skipif(
+    os.getenv("AZURE_OPENAI_ENDPOINT", "") in ("", "https://test-endpoint.openai.azure.com")
+    or (os.getenv("AZURE_OPENAI_CHAT_MODEL", "") == "" and os.getenv("AZURE_OPENAI_MODEL", "") == ""),
+    reason="No real Azure OpenAI endpoint or responses deployment provided; skipping integration tests.",
 )
 
 

--- a/python/packages/openai/tests/openai/test_openai_chat_completion_client_azure.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_completion_client_azure.py
@@ -28,8 +28,11 @@ from agent_framework_openai import OpenAIChatCompletionClient
 
 pytestmark = pytest.mark.azure
 
-skip_if_azure_openai_integration_tests_disabled = pytest.mark.skip(
-    reason="Azure OpenAI integration tests temporarily disabled: crashes the xdist runner in CI.",
+
+skip_if_azure_openai_integration_tests_disabled = pytest.mark.skipif(
+    os.getenv("AZURE_OPENAI_ENDPOINT", "") in ("", "https://test-endpoint.openai.azure.com")
+    or (os.getenv("AZURE_OPENAI_CHAT_COMPLETION_MODEL", "") == "" and os.getenv("AZURE_OPENAI_MODEL", "") == ""),
+    reason="No real Azure OpenAI endpoint or chat deployment provided; skipping integration tests.",
 )
 
 

--- a/python/packages/openai/tests/openai/test_openai_embedding_client_azure.py
+++ b/python/packages/openai/tests/openai/test_openai_embedding_client_azure.py
@@ -18,8 +18,11 @@ from agent_framework_openai import OpenAIEmbeddingClient, OpenAIEmbeddingOptions
 
 pytestmark = pytest.mark.azure
 
-skip_if_azure_openai_integration_tests_disabled = pytest.mark.skip(
-    reason="Azure OpenAI integration tests temporarily disabled: crashes the xdist runner in CI.",
+
+skip_if_azure_openai_integration_tests_disabled = pytest.mark.skipif(
+    os.getenv("AZURE_OPENAI_ENDPOINT", "") in ("", "https://test-endpoint.openai.azure.com")
+    or (os.getenv("AZURE_OPENAI_EMBEDDING_MODEL", "") == "" and os.getenv("AZURE_OPENAI_MODEL", "") == ""),
+    reason="No real Azure OpenAI endpoint or embedding deployment provided; skipping integration tests.",
 )
 
 


### PR DESCRIPTION
### Motivation & Context

The Azure OpenAI integration tests were temporarily hard-skipped in #6753 because they were crashing the pytest-xdist runner in the merge queue (all workers reporting `node down: Not properly terminated`). That work is tracked for re-enablement in #6777.

Local investigation shows the **tests themselves are healthy** — they pass when run serially. The CI failure was a runner crash under high xdist parallelism against live Azure services, not a test defect. This PR re-enables the tests so we can validate them in CI (where the required Azure secrets are available).

### Description & Review Guide

- **What are the major changes?**
  - Restore the env-based `skip_if_azure_openai_integration_tests_disabled` guard (`pytest.mark.skipif(...)`) in the three Azure OpenAI test modules, reverting the unconditional `pytest.mark.skip(...)` introduced in #6753:
    - `packages/openai/tests/openai/test_openai_chat_client_azure.py`
    - `packages/openai/tests/openai/test_openai_chat_completion_client_azure.py`
    - `packages/openai/tests/openai/test_openai_embedding_client_azure.py`

- **What is the impact of these changes?**
  - The ~37 Azure OpenAI integration tests run again (locally verified: **36 passed, 1 skipped** — the 1 skip is a pre-existing image-content skip unrelated to this change — **0 failed**, run serially in ~4m).
  - This re-enables them in the merge-queue / integration CI jobs.

### Related Issue

Part of #6777

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
