### PR TITLE
Python: [BREAKING] Treat nested SKILL.md content as part of the parent skill

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -2953,13 +2953,12 @@ class FileSkillsSource(SkillsSource):
 
             resources.append(rel_path)
 
-        # Recurse into subdirectories if within depth limit
+        # Recurse into subdirectories if within depth limit.
+        # Subdirectories that contain their own SKILL.md are NOT skipped: a nested
+        # SKILL.md is not an independent skill (see _discover_skill_directories), so
+        # its contents belong to this skill.
         if current_depth < self._search_depth:
             for subdir in subdirectories:
-                # Skip subdirectories that contain their own SKILL.md — they are
-                # separate skills and their files should not be attached to this one.
-                if (subdir / SKILL_FILE_NAME).is_file():
-                    continue
                 self._scan_directory_for_resources(
                     target_dir=subdir,
                     skill_dir=skill_dir,
@@ -3104,13 +3103,12 @@ class FileSkillsSource(SkillsSource):
 
             scripts.append(rel_path)
 
-        # Recurse into subdirectories if within depth limit
+        # Recurse into subdirectories if within depth limit.
+        # Subdirectories that contain their own SKILL.md are NOT skipped: a nested
+        # SKILL.md is not an independent skill (see _discover_skill_directories), so
+        # its contents belong to this skill.
         if current_depth < self._search_depth:
             for subdir in subdirectories:
-                # Skip subdirectories that contain their own SKILL.md — they are
-                # separate skills and their files should not be attached to this one.
-                if (subdir / SKILL_FILE_NAME).is_file():
-                    continue
                 self._scan_directory_for_scripts(
                     target_dir=subdir,
                     skill_dir=skill_dir,
@@ -3327,7 +3325,10 @@ class FileSkillsSource(SkillsSource):
     def _discover_skill_directories(skill_paths: Sequence[str]) -> list[str]:
         """Return absolute paths of all directories that contain a ``SKILL.md`` file.
 
-        Recursively searches each root path up to :data:`MAX_SEARCH_DEPTH`.
+        Recursively searches each root path up to :data:`MAX_SEARCH_DEPTH`. Once a
+        ``SKILL.md`` is found in a directory, that directory is the skill root and the
+        search does not descend into its subdirectories: everything beneath a skill
+        boundary is part of that skill, not an independent skill root.
 
         Args:
             skill_paths: Root directory paths to search.
@@ -3340,6 +3341,8 @@ class FileSkillsSource(SkillsSource):
         def _search(directory: str, current_depth: int) -> None:
             dir_path = Path(directory)
             if (dir_path / SKILL_FILE_NAME).is_file():
+                # This directory is a skill root. Subdirectories are part of this
+                # skill and must not be treated as independent skill roots.
                 discovered.append(str(dir_path.absolute()))
                 return
 

--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -3341,6 +3341,7 @@ class FileSkillsSource(SkillsSource):
             dir_path = Path(directory)
             if (dir_path / SKILL_FILE_NAME).is_file():
                 discovered.append(str(dir_path.absolute()))
+                return
 
             if current_depth >= MAX_SEARCH_DEPTH:
                 return

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -1807,8 +1807,8 @@ class TestFileSkillsSourceSearchDepthAndFilters:
         assert "keep.md" in resource_names
         assert "drop.md" not in resource_names
 
-    async def test_nested_skill_directory_not_crossed(self, tmp_path: Path) -> None:
-        """Files in a nested skill directory are NOT attached to the parent skill."""
+    async def test_nested_skill_directory_absorbed_into_parent(self, tmp_path: Path) -> None:
+        """A nested SKILL.md is not an independent skill; its contents belong to the parent."""
         parent_dir = tmp_path / "parent-skill"
         child_dir = parent_dir / "child-skill"
         child_dir.mkdir(parents=True)
@@ -1828,22 +1828,19 @@ class TestFileSkillsSourceSearchDepthAndFilters:
         skills = await source.get_skills()
         skills_dict = {s.frontmatter.name: s for s in skills}
 
-        # Both skills are discovered
+        # Only the parent skill is discovered; the nested SKILL.md is not its own skill.
         assert "parent-skill" in skills_dict
-        assert "child-skill" in skills_dict
+        assert "child-skill" not in skills_dict
 
-        # Parent does NOT pick up child's files
+        # The parent absorbs the nested directory's resources and scripts.
         parent_resources = [r.name for r in skills_dict["parent-skill"]._resources]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         parent_scripts = [s.name for s in skills_dict["parent-skill"]._scripts]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         assert "parent-resource.md" in parent_resources
-        assert "child-skill/child-resource.md" not in parent_resources
-        assert "child-skill/child-script.py" not in parent_scripts
+        assert "child-skill/child-resource.md" in parent_resources
+        assert "child-skill/child-script.py" in parent_scripts
 
-        # Child has its own files
-        child_resources = [r.name for r in skills_dict["child-skill"]._resources]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-        child_scripts = [s.name for s in skills_dict["child-skill"]._scripts]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-        assert "child-resource.md" in child_resources
-        assert "child-script.py" in child_scripts
+        # The nested SKILL.md file itself is never surfaced as a resource.
+        assert "child-skill/SKILL.md" not in parent_resources
 
 
 # ---------------------------------------------------------------------------

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -1996,6 +1996,17 @@ class TestDiscoverSkillDirectories:
         assert len(dirs) == 1
         assert str(sub.absolute()) in dirs[0]
 
+    def test_stops_searching_below_skill_boundary(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "parent-skill"
+        nested_skill_dir = skill_dir / "nested-skill"
+        nested_skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: parent-skill\ndescription: d\n---\n", encoding="utf-8")
+        (nested_skill_dir / "SKILL.md").write_text("---\nname: nested-skill\ndescription: d\n---\n", encoding="utf-8")
+
+        dirs = FileSkillsSource._discover_skill_directories([str(tmp_path)])
+
+        assert dirs == [str(skill_dir.absolute())]
+
     def test_skips_empty_path_string(self) -> None:
         dirs = FileSkillsSource._discover_skill_directories(["", "   "])
         assert dirs == []


### PR DESCRIPTION
### Motivation & Context

File-based skill discovery kept descending past a `SKILL.md`, so a `SKILL.md` nested inside another skill's directory was treated as an independent skill root, and content beneath a skill boundary was split away from its skill. Discovery should stop at the first skill boundary, and everything beneath that boundary should belong to that skill.

### Description & Review Guide

- **What are the major changes?**
  - `_discover_skill_directories`: stop recursing once a `SKILL.md` is found, so a nested `SKILL.md` is no longer discovered as a separate skill.
  - `_scan_directory_for_resources` / `_scan_directory_for_scripts`: no longer skip subdirectories that contain their own `SKILL.md`, so resources and scripts beneath a skill boundary are attached to that skill (the `SKILL.md` file itself is still excluded as a resource).
  - Updated the discovery docstring, reworked the nested-skill test to assert the new behavior, and added a discovery-level regression test.
- **What is the impact of these changes?**
  - Standard flat skill layouts are unchanged. For nested layouts, a directory that previously produced a separate child skill now contributes its content to the enclosing skill instead. This is a `[BREAKING — experimental]` change to the skills feature (`ExperimentalFeature.SKILLS`).
- **What do you want reviewers to focus on?** The boundary behavior in `_discover_skill_directories` and the recursion in the resource/script scans.

### Related Issue

Fixes #6682

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and the title prefix in sync automatically.
