### PR TITLE
.NET: [BREAKING] Refactor OpenAI Hosting OptionsMapping to disallow passing options by default

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/AIAgentChatCompletionsProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/AIAgentChatCompletionsProcessor.cs
@@ -18,19 +18,32 @@ namespace Microsoft.Agents.AI.Hosting.OpenAI.ChatCompletions;
 
 internal static class AIAgentChatCompletionsProcessor
 {
-    public static async Task<IResult> CreateChatCompletionAsync(AIAgent agent, CreateChatCompletion request, CancellationToken cancellationToken)
+    public static async Task<IResult> CreateChatCompletionAsync(AIAgent agent, CreateChatCompletion request, OpenAIChatCompletionsMapOptions? mapOptions, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(agent);
 
+        var runOptionsFactory = (mapOptions ?? new OpenAIChatCompletionsMapOptions()).RunOptionsFactory;
+
+        AgentRunOptions? runOptions;
+        try
+        {
+            // The hosting developer controls, via OpenAIChatCompletionsMapOptions.RunOptionsFactory, which (if any)
+            // request settings are mapped onto the agent run. By default no request setting is mapped.
+            runOptions = runOptionsFactory(request.ToRequestInfo());
+        }
+        catch (NotSupportedException ex)
+        {
+            return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest, title: "unsupported_parameter");
+        }
+
         var chatMessages = request.Messages.Select(i => i.ToChatMessage());
-        var chatClientAgentRunOptions = request.BuildOptions();
 
         if (request.Stream == true)
         {
-            return new StreamingResponse(agent, request, chatMessages, chatClientAgentRunOptions);
+            return new StreamingResponse(agent, request, chatMessages, runOptions);
         }
 
-        var response = await agent.RunAsync(chatMessages, options: chatClientAgentRunOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await agent.RunAsync(chatMessages, options: runOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
         return Results.Ok(response.ToChatCompletion(request));
     }
 
@@ -38,7 +51,7 @@ internal static class AIAgentChatCompletionsProcessor
         AIAgent agent,
         CreateChatCompletion request,
         IEnumerable<ChatMessage> chatMessages,
-        ChatClientAgentRunOptions? options) : IResult
+        AgentRunOptions? options) : IResult
     {
         public Task ExecuteAsync(HttpContext httpContext)
         {

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/AIAgentChatCompletionsProcessor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/AIAgentChatCompletionsProcessor.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Agents.AI.Hosting.OpenAI.ChatCompletions.Converters;
 using Microsoft.Agents.AI.Hosting.OpenAI.ChatCompletions.Models;
+using Microsoft.Agents.AI.Hosting.OpenAI.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.AI;
@@ -33,7 +34,15 @@ internal static class AIAgentChatCompletionsProcessor
         }
         catch (NotSupportedException ex)
         {
-            return Results.Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest, title: "unsupported_parameter");
+            return Results.BadRequest(new ErrorResponse
+            {
+                Error = new ErrorDetails
+                {
+                    Message = ex.Message,
+                    Type = "invalid_request_error",
+                    Code = "unsupported_parameter"
+                }
+            });
         }
 
         var chatMessages = request.Messages.Select(i => i.ToChatMessage());

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Converters/ChatClientAgentRunOptionsConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/ChatCompletions/Converters/ChatClientAgentRunOptionsConverter.cs
@@ -12,35 +12,24 @@ internal static class ChatClientAgentRunOptionsConverter
 {
     private static readonly JsonElement s_emptyJson = JsonElement.Parse("{}");
 
-    public static ChatClientAgentRunOptions BuildOptions(this CreateChatCompletion request)
+    /// <summary>
+    /// Projects the request-supplied generation and tool settings into a public
+    /// <see cref="OpenAIChatCompletionRequestInfo"/> for use by a hosting-developer mapping callback.
+    /// </summary>
+    public static OpenAIChatCompletionRequestInfo ToRequestInfo(this CreateChatCompletion request) => new()
     {
-        ChatOptions chatOptions = new()
-        {
-            Temperature = request.Temperature,
-            MaxOutputTokens = request.MaxCompletionTokens,
-            FrequencyPenalty = request.FrequencyPenalty,
-            PresencePenalty = request.PresencePenalty,
-            Seed = request.Seed,
-            TopP = request.TopP,
-            StopSequences = request.Stop?.SequenceList ?? [],
-            ResponseFormat = request.ResponseFormat?.ToChatResponseFormat()
-        };
-
-        if (request.ToolChoice is not null)
-        {
-            chatOptions.ToolMode = request.ToolChoice.ToChatToolMode();
-        }
-
-        if (request.Tools?.Count > 0)
-        {
-            chatOptions.Tools = request.Tools.Select(x => x.ToAITool()).ToList();
-        }
-
-        return new()
-        {
-            ChatOptions = chatOptions
-        };
-    }
+        Temperature = request.Temperature,
+        TopP = request.TopP,
+        MaxOutputTokens = request.MaxCompletionTokens,
+        FrequencyPenalty = request.FrequencyPenalty,
+        PresencePenalty = request.PresencePenalty,
+        Seed = request.Seed,
+        StopSequences = request.Stop?.SequenceList is { Count: > 0 } sequences ? [.. sequences] : null,
+        ResponseFormat = request.ResponseFormat?.ToChatResponseFormat(),
+        Model = request.Model,
+        ToolChoice = request.ToolChoice?.ToChatToolMode(),
+        Tools = request.Tools is { Count: > 0 } tools ? tools.Select(x => x.ToAITool()).ToList() : null,
+    };
 
     private static ChatResponseFormat ToChatResponseFormat(this ResponseFormat responseFormat)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/EndpointRouteBuilderExtensions.ChatCompletions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/EndpointRouteBuilderExtensions.ChatCompletions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting;
+using Microsoft.Agents.AI.Hosting.OpenAI;
 using Microsoft.Agents.AI.Hosting.OpenAI.ChatCompletions;
 using Microsoft.Agents.AI.Hosting.OpenAI.ChatCompletions.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -29,10 +30,11 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the OpenAI ChatCompletions endpoints to.</param>
     /// <param name="agentBuilder">The builder for <see cref="AIAgent"/> to map the OpenAI ChatCompletions endpoints for.</param>
     /// <param name="path">Custom route path for the chat completions endpoint.</param>
-    public static IEndpointConventionBuilder MapOpenAIChatCompletions(this IEndpointRouteBuilder endpoints, IHostedAgentBuilder agentBuilder, string? path)
+    /// <param name="mapOptions">Optional options controlling how incoming requests are mapped onto the agent run.</param>
+    public static IEndpointConventionBuilder MapOpenAIChatCompletions(this IEndpointRouteBuilder endpoints, IHostedAgentBuilder agentBuilder, string? path, OpenAIChatCompletionsMapOptions? mapOptions = null)
     {
         var agent = endpoints.ServiceProvider.GetRequiredKeyedService<AIAgent>(agentBuilder.Name);
-        return MapOpenAIChatCompletions(endpoints, agent, path);
+        return MapOpenAIChatCompletions(endpoints, agent, path, mapOptions);
     }
 
     /// <summary>
@@ -49,10 +51,12 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the OpenAI ChatCompletions endpoints to.</param>
     /// <param name="agent">The <see cref="AIAgent"/> instance to map the OpenAI ChatCompletions endpoints for.</param>
     /// <param name="path">Custom route path for the chat completions endpoint.</param>
+    /// <param name="mapOptions">Optional options controlling how incoming requests are mapped onto the agent run.</param>
     public static IEndpointConventionBuilder MapOpenAIChatCompletions(
         this IEndpointRouteBuilder endpoints,
         AIAgent agent,
-        [StringSyntax("Route")] string? path)
+        [StringSyntax("Route")] string? path,
+        OpenAIChatCompletionsMapOptions? mapOptions = null)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(agent);
@@ -64,7 +68,7 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
         var endpointAgentName = agent.Name ?? agent.Id;
 
         group.MapPost("/", async ([FromBody] CreateChatCompletion request, CancellationToken cancellationToken)
-            => await AIAgentChatCompletionsProcessor.CreateChatCompletionAsync(agent, request, cancellationToken).ConfigureAwait(false))
+            => await AIAgentChatCompletionsProcessor.CreateChatCompletionAsync(agent, request, mapOptions, cancellationToken).ConfigureAwait(false))
             .WithName(endpointAgentName + "/CreateChatCompletion");
 
         return group;

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/EndpointRouteBuilderExtensions.Responses.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/EndpointRouteBuilderExtensions.Responses.cs
@@ -32,13 +32,14 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the OpenAI Responses endpoints to.</param>
     /// <param name="agentBuilder">The builder for <see cref="AIAgent"/> to map the OpenAI Responses endpoints for.</param>
     /// <param name="path">Custom route path for the OpenAI Responses endpoint.</param>
-    public static IEndpointConventionBuilder MapOpenAIResponses(this IEndpointRouteBuilder endpoints, IHostedAgentBuilder agentBuilder, string? path)
+    /// <param name="mapOptions">Optional options controlling how incoming requests are mapped onto the agent run.</param>
+    public static IEndpointConventionBuilder MapOpenAIResponses(this IEndpointRouteBuilder endpoints, IHostedAgentBuilder agentBuilder, string? path, OpenAIResponsesMapOptions? mapOptions = null)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(agentBuilder);
 
         var agent = endpoints.ServiceProvider.GetRequiredKeyedService<AIAgent>(agentBuilder.Name);
-        return MapOpenAIResponses(endpoints, agent, path);
+        return MapOpenAIResponses(endpoints, agent, path, mapOptions);
     }
 
     /// <summary>
@@ -55,10 +56,12 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the OpenAI Responses endpoints to.</param>
     /// <param name="agent">The <see cref="AIAgent"/> instance to map the OpenAI Responses endpoints for.</param>
     /// <param name="responsesPath">Custom route path for the responses endpoint.</param>
+    /// <param name="mapOptions">Optional options controlling how incoming requests are mapped onto the agent run.</param>
     public static IEndpointConventionBuilder MapOpenAIResponses(
         this IEndpointRouteBuilder endpoints,
         AIAgent agent,
-        [StringSyntax("Route")] string? responsesPath)
+        [StringSyntax("Route")] string? responsesPath,
+        OpenAIResponsesMapOptions? mapOptions = null)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentNullException.ThrowIfNull(agent);
@@ -68,7 +71,7 @@ public static partial class MicrosoftAgentAIHostingOpenAIEndpointRouteBuilderExt
         responsesPath ??= $"/{agent.Name}/v1/responses";
 
         // Create an executor for this agent
-        var executor = new AIAgentResponseExecutor(agent);
+        var executor = new AIAgentResponseExecutor(agent, mapOptions);
         var storageOptions = endpoints.ServiceProvider.GetService<InMemoryStorageOptions>() ?? new InMemoryStorageOptions();
         var conversationStorage = endpoints.ServiceProvider.GetService<IConversationStorage>();
         var responsesService = new InMemoryResponsesService(executor, storageOptions, conversationStorage);

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionRequestInfo.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionRequestInfo.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI;
+
+/// <summary>
+/// Exposes the request-supplied generation and tool settings of an OpenAI ChatCompletions
+/// <c>create chat completion</c> request that a hosting developer may choose to map onto the
+/// <see cref="AgentRunOptions"/> used to run the target <see cref="AIAgent"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is passed to <see cref="OpenAIChatCompletionsMapOptions.RunOptionsFactory"/>. By default no
+/// request setting is mapped onto the agent, because an agent is typically self-contained and
+/// allowing callers to override its configuration (for example which tools it may invoke) can cause
+/// it to behave in ways its author did not intend.
+/// </para>
+/// <para>
+/// Tool and response-format settings are surfaced using their <c>Microsoft.Extensions.AI</c>
+/// equivalents so that a hosting developer can map them directly without re-parsing the wire format.
+/// </para>
+/// </remarks>
+public sealed class OpenAIChatCompletionRequestInfo
+{
+    /// <summary>
+    /// Gets or sets the sampling temperature supplied on the request, if any.
+    /// </summary>
+    public float? Temperature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the nucleus sampling value (<c>top_p</c>) supplied on the request, if any.
+    /// </summary>
+    public float? TopP { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of completion tokens (<c>max_completion_tokens</c>) supplied on the request, if any.
+    /// </summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the frequency penalty supplied on the request, if any.
+    /// </summary>
+    public float? FrequencyPenalty { get; set; }
+
+    /// <summary>
+    /// Gets or sets the presence penalty supplied on the request, if any.
+    /// </summary>
+    public float? PresencePenalty { get; set; }
+
+    /// <summary>
+    /// Gets or sets the deterministic sampling seed supplied on the request, if any.
+    /// </summary>
+    public long? Seed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stop sequences supplied on the request, if any.
+    /// </summary>
+    public IReadOnlyList<string>? StopSequences { get; set; }
+
+    /// <summary>
+    /// Gets or sets the response format supplied on the request, if any.
+    /// </summary>
+    public ChatResponseFormat? ResponseFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the model identifier supplied on the request, if any.
+    /// </summary>
+    /// <remarks>
+    /// This value is informational. It is not applied to local agent execution (the agent runs with
+    /// its own <see cref="IChatClient"/>), and the OpenAI ChatCompletions
+    /// wire format requires it on every request, so it is intentionally excluded from the default
+    /// <see cref="OpenAIChatCompletionsMapOptions.RejectRequestSettings"/> rejection.
+    /// </remarks>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tool selection mode (<c>tool_choice</c>) supplied on the request, if any.
+    /// </summary>
+    public ChatToolMode? ToolChoice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tools supplied on the request, if any.
+    /// </summary>
+    public IReadOnlyList<AITool>? Tools { get; set; }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
@@ -30,7 +30,14 @@ public sealed class OpenAIChatCompletionsMapOptions
     /// Returning <see langword="null"/> runs the agent with its own configuration only.
     /// </para>
     /// </remarks>
-    public Func<OpenAIChatCompletionRequestInfo, AgentRunOptions?> RunOptionsFactory { get; set; } = RejectRequestSettings;
+    public Func<OpenAIChatCompletionRequestInfo, AgentRunOptions?> RunOptionsFactory
+    {
+        get;
+        set
+        {
+            field = Throw.IfNull(value);
+        }
+    } = RejectRequestSettings;
 
     /// <summary>
     /// The default <see cref="RunOptionsFactory"/> implementation. Throws a <see cref="NotSupportedException"/>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
@@ -57,56 +57,56 @@ public sealed class OpenAIChatCompletionsMapOptions
         Throw.IfNull(request);
 
         List<string>? unsupported = null;
-        void Add(string name) => (unsupported ??= []).Add(name);
+        void LocalAdd(string name) => (unsupported ??= []).Add(name);
 
         if (request.Temperature is not null)
         {
-            Add("temperature");
+            LocalAdd("temperature");
         }
 
         if (request.TopP is not null)
         {
-            Add("top_p");
+            LocalAdd("top_p");
         }
 
         if (request.MaxOutputTokens is not null)
         {
-            Add("max_completion_tokens");
+            LocalAdd("max_completion_tokens");
         }
 
         if (request.FrequencyPenalty is not null)
         {
-            Add("frequency_penalty");
+            LocalAdd("frequency_penalty");
         }
 
         if (request.PresencePenalty is not null)
         {
-            Add("presence_penalty");
+            LocalAdd("presence_penalty");
         }
 
         if (request.Seed is not null)
         {
-            Add("seed");
+            LocalAdd("seed");
         }
 
         if (request.StopSequences is { Count: > 0 })
         {
-            Add("stop");
+            LocalAdd("stop");
         }
 
         if (request.ResponseFormat is not null)
         {
-            Add("response_format");
+            LocalAdd("response_format");
         }
 
         if (request.Tools is { Count: > 0 })
         {
-            Add("tools");
+            LocalAdd("tools");
         }
 
         if (request.ToolChoice is not null)
         {
-            Add("tool_choice");
+            LocalAdd("tool_choice");
         }
 
         if (unsupported is not null)

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIChatCompletionsMapOptions.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI;
+
+/// <summary>
+/// Options that control how an OpenAI ChatCompletions endpoint maps incoming requests onto the target
+/// <see cref="AIAgent"/>.
+/// </summary>
+public sealed class OpenAIChatCompletionsMapOptions
+{
+    /// <summary>
+    /// Gets or sets the callback used to produce the <see cref="AgentRunOptions"/> for a request from
+    /// the request-supplied generation and tool settings.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default this is set to <see cref="RejectRequestSettings"/>, which throws when the request
+    /// carries any setting that would otherwise be mapped onto the agent (for example
+    /// <c>temperature</c>, <c>tools</c> or <c>tool_choice</c>). This prevents a caller from silently
+    /// overriding the configuration of a self-contained agent.
+    /// </para>
+    /// <para>
+    /// Hosting developers that want to honor specific request settings can supply their own callback
+    /// that maps the desired fields onto an <see cref="AgentRunOptions"/> (or a subclass such as
+    /// <see cref="ChatClientAgentRunOptions"/>), and may choose to throw, map, or ignore any field.
+    /// Returning <see langword="null"/> runs the agent with its own configuration only.
+    /// </para>
+    /// </remarks>
+    public Func<OpenAIChatCompletionRequestInfo, AgentRunOptions?> RunOptionsFactory { get; set; } = RejectRequestSettings;
+
+    /// <summary>
+    /// The default <see cref="RunOptionsFactory"/> implementation. Throws a <see cref="NotSupportedException"/>
+    /// when the request specifies any setting that would otherwise be mapped onto the agent, and otherwise
+    /// returns <see langword="null"/> so that the agent runs with its own configuration only.
+    /// </summary>
+    /// <param name="request">The request-supplied settings.</param>
+    /// <returns>Always <see langword="null"/> when no unsupported setting is present.</returns>
+    /// <remarks>
+    /// <see cref="OpenAIChatCompletionRequestInfo.Model"/> is intentionally not treated as an unsupported
+    /// setting: it is informational, is not applied to local execution, and is a required field of the
+    /// OpenAI ChatCompletions wire format (present on every request).
+    /// </remarks>
+    /// <exception cref="NotSupportedException">One or more request settings are not supported.</exception>
+    public static AgentRunOptions? RejectRequestSettings(OpenAIChatCompletionRequestInfo request)
+    {
+        Throw.IfNull(request);
+
+        List<string>? unsupported = null;
+        void Add(string name) => (unsupported ??= []).Add(name);
+
+        if (request.Temperature is not null)
+        {
+            Add("temperature");
+        }
+
+        if (request.TopP is not null)
+        {
+            Add("top_p");
+        }
+
+        if (request.MaxOutputTokens is not null)
+        {
+            Add("max_completion_tokens");
+        }
+
+        if (request.FrequencyPenalty is not null)
+        {
+            Add("frequency_penalty");
+        }
+
+        if (request.PresencePenalty is not null)
+        {
+            Add("presence_penalty");
+        }
+
+        if (request.Seed is not null)
+        {
+            Add("seed");
+        }
+
+        if (request.StopSequences is { Count: > 0 })
+        {
+            Add("stop");
+        }
+
+        if (request.ResponseFormat is not null)
+        {
+            Add("response_format");
+        }
+
+        if (request.Tools is { Count: > 0 })
+        {
+            Add("tools");
+        }
+
+        if (request.ToolChoice is not null)
+        {
+            Add("tool_choice");
+        }
+
+        if (unsupported is not null)
+        {
+            throw new NotSupportedException(
+                $"The following request setting(s) are not supported by this agent endpoint: {string.Join(", ", unsupported)}. " +
+                "Configure an OpenAIChatCompletionsMapOptions.RunOptionsFactory to map these settings onto the agent if they should be honored.");
+        }
+
+        return null;
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponseRequestInfo.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponseRequestInfo.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI;
+
+/// <summary>
+/// Exposes the request-supplied generation and tool settings of an OpenAI Responses
+/// <c>create response</c> request that a hosting developer may choose to map onto the
+/// <see cref="AgentRunOptions"/> used to run the target <see cref="AIAgent"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is passed to <see cref="OpenAIResponsesMapOptions.RunOptionsFactory"/>. By default no
+/// request setting is mapped onto the agent, because an agent is typically self-contained and
+/// allowing callers to override its configuration (for example its instructions or which tools it
+/// may invoke) can cause it to behave in ways its author did not intend.
+/// </para>
+/// <para>
+/// Only the subset of request fields that are meaningful to map onto a local agent run are exposed.
+/// The raw wire model is intentionally not surfaced.
+/// </para>
+/// </remarks>
+public sealed class OpenAIResponseRequestInfo
+{
+    /// <summary>
+    /// Gets or sets the sampling temperature supplied on the request, if any.
+    /// </summary>
+    public double? Temperature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the nucleus sampling value (<c>top_p</c>) supplied on the request, if any.
+    /// </summary>
+    public double? TopP { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of output tokens supplied on the request, if any.
+    /// </summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the instructions supplied on the request, if any.
+    /// </summary>
+    public string? Instructions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the model identifier supplied on the request, if any.
+    /// </summary>
+    /// <remarks>
+    /// This value is informational. It is not applied to local agent execution (the agent runs with
+    /// its own <see cref="IChatClient"/>), so it is intentionally excluded
+    /// from the default <see cref="OpenAIResponsesMapOptions.RejectRequestSettings"/> rejection.
+    /// </remarks>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Gets or sets the raw <c>tools</c> array supplied on the request, if any.
+    /// </summary>
+    /// <remarks>
+    /// The OpenAI Responses wire format represents tools as JSON tool declarations rather than
+    /// executable functions, so they are surfaced here as the raw <see cref="JsonElement"/> values.
+    /// </remarks>
+    public IReadOnlyList<JsonElement>? Tools { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tool selection mode (<c>tool_choice</c>) supplied on the request, if any.
+    /// </summary>
+    /// <remarks>
+    /// The OpenAI Responses <c>tool_choice</c> value is mapped onto its
+    /// <see cref="ChatToolMode"/> equivalent (<c>none</c>, <c>auto</c>,
+    /// <c>required</c>, or a specific function). Values that have no equivalent are surfaced as
+    /// <see langword="null"/>.
+    /// </remarks>
+    public ChatToolMode? ToolChoice { get; set; }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
@@ -56,36 +56,36 @@ public sealed class OpenAIResponsesMapOptions
         ArgumentNullException.ThrowIfNull(request);
 
         List<string>? unsupported = null;
-        void Add(string name) => (unsupported ??= []).Add(name);
+        void LocalAdd(string name) => (unsupported ??= []).Add(name);
 
         if (request.Temperature is not null)
         {
-            Add("temperature");
+            LocalAdd("temperature");
         }
 
         if (request.TopP is not null)
         {
-            Add("top_p");
+            LocalAdd("top_p");
         }
 
         if (request.MaxOutputTokens is not null)
         {
-            Add("max_output_tokens");
+            LocalAdd("max_output_tokens");
         }
 
         if (request.Instructions is not null)
         {
-            Add("instructions");
+            LocalAdd("instructions");
         }
 
         if (request.Tools is { Count: > 0 })
         {
-            Add("tools");
+            LocalAdd("tools");
         }
 
         if (request.ToolChoice is not null)
         {
-            Add("tool_choice");
+            LocalAdd("tool_choice");
         }
 
         if (unsupported is not null)

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Hosting.OpenAI;
 
@@ -29,7 +30,14 @@ public sealed class OpenAIResponsesMapOptions
     /// Returning <see langword="null"/> runs the agent with its own configuration only.
     /// </para>
     /// </remarks>
-    public Func<OpenAIResponseRequestInfo, AgentRunOptions?> RunOptionsFactory { get; set; } = RejectRequestSettings;
+    public Func<OpenAIResponseRequestInfo, AgentRunOptions?> RunOptionsFactory
+    {
+        get;
+        set
+        {
+            field = Throw.IfNull(value);
+        }
+    } = RejectRequestSettings;
 
     /// <summary>
     /// The default <see cref="RunOptionsFactory"/> implementation. Throws a <see cref="NotSupportedException"/>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/OpenAIResponsesMapOptions.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI;
+
+/// <summary>
+/// Options that control how an OpenAI Responses endpoint maps incoming requests onto the target
+/// <see cref="AIAgent"/>.
+/// </summary>
+public sealed class OpenAIResponsesMapOptions
+{
+    /// <summary>
+    /// Gets or sets the callback used to produce the <see cref="AgentRunOptions"/> for a request from
+    /// the request-supplied generation and tool settings.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default this is set to <see cref="RejectRequestSettings"/>, which throws when the request
+    /// carries any setting that would otherwise be mapped onto the agent (for example
+    /// <c>temperature</c>, <c>instructions</c>, <c>tools</c> or <c>tool_choice</c>). This prevents a
+    /// caller from silently overriding the configuration of a self-contained agent.
+    /// </para>
+    /// <para>
+    /// Hosting developers that want to honor specific request settings can supply their own callback
+    /// that maps the desired fields onto an <see cref="AgentRunOptions"/> (or a subclass such as
+    /// <see cref="ChatClientAgentRunOptions"/>), and may choose to throw, map, or ignore any field.
+    /// Returning <see langword="null"/> runs the agent with its own configuration only.
+    /// </para>
+    /// </remarks>
+    public Func<OpenAIResponseRequestInfo, AgentRunOptions?> RunOptionsFactory { get; set; } = RejectRequestSettings;
+
+    /// <summary>
+    /// The default <see cref="RunOptionsFactory"/> implementation. Throws a <see cref="NotSupportedException"/>
+    /// when the request specifies any setting that would otherwise be mapped onto the agent, and otherwise
+    /// returns <see langword="null"/> so that the agent runs with its own configuration only.
+    /// </summary>
+    /// <param name="request">The request-supplied settings.</param>
+    /// <returns>Always <see langword="null"/> when no unsupported setting is present.</returns>
+    /// <remarks>
+    /// <see cref="OpenAIResponseRequestInfo.Model"/> is intentionally not treated as an unsupported
+    /// setting: it is informational and is not applied to local execution.
+    /// </remarks>
+    /// <exception cref="NotSupportedException">One or more request settings are not supported.</exception>
+    public static AgentRunOptions? RejectRequestSettings(OpenAIResponseRequestInfo request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        List<string>? unsupported = null;
+        void Add(string name) => (unsupported ??= []).Add(name);
+
+        if (request.Temperature is not null)
+        {
+            Add("temperature");
+        }
+
+        if (request.TopP is not null)
+        {
+            Add("top_p");
+        }
+
+        if (request.MaxOutputTokens is not null)
+        {
+            Add("max_output_tokens");
+        }
+
+        if (request.Instructions is not null)
+        {
+            Add("instructions");
+        }
+
+        if (request.Tools is { Count: > 0 })
+        {
+            Add("tools");
+        }
+
+        if (request.ToolChoice is not null)
+        {
+            Add("tool_choice");
+        }
+
+        if (unsupported is not null)
+        {
+            throw new NotSupportedException(
+                $"The following request setting(s) are not supported by this agent endpoint: {string.Join(", ", unsupported)}. " +
+                "Configure an OpenAIResponsesMapOptions.RunOptionsFactory to map these settings onto the agent if they should be honored.");
+        }
+
+        return null;
+    }
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/AIAgentResponseExecutor.cs
@@ -17,16 +17,38 @@ namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses;
 internal sealed class AIAgentResponseExecutor : IResponseExecutor
 {
     private readonly AIAgent _agent;
+    private readonly Func<OpenAIResponseRequestInfo, AgentRunOptions?> _runOptionsFactory;
 
-    public AIAgentResponseExecutor(AIAgent agent)
+    public AIAgentResponseExecutor(AIAgent agent, OpenAIResponsesMapOptions? mapOptions = null)
     {
         ArgumentNullException.ThrowIfNull(agent);
         this._agent = agent;
+        this._runOptionsFactory = (mapOptions ?? new OpenAIResponsesMapOptions()).RunOptionsFactory;
     }
 
     public ValueTask<ResponseError?> ValidateRequestAsync(
         CreateResponse request,
-        CancellationToken cancellationToken = default) => ValueTask.FromResult<ResponseError?>(null);
+        CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(this.ValidateRunOptions(request));
+
+    internal ResponseError? ValidateRunOptions(CreateResponse request)
+    {
+        try
+        {
+            // Invoke the factory during validation so that unsupported request settings are surfaced
+            // as a clean request error rather than an unhandled exception during execution.
+            _ = this._runOptionsFactory(request.ToRequestInfo());
+            return null;
+        }
+        catch (NotSupportedException ex)
+        {
+            return new ResponseError
+            {
+                Code = "unsupported_parameter",
+                Message = ex.Message
+            };
+        }
+    }
 
     public async IAsyncEnumerable<StreamingResponseEvent> ExecuteAsync(
         AgentInvocationContext context,
@@ -34,23 +56,9 @@ internal sealed class AIAgentResponseExecutor : IResponseExecutor
         IReadOnlyList<ChatMessage>? conversationHistory = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Create options with properties from the request
-        var chatOptions = new ChatOptions
-        {
-            // Note: We intentionally do NOT set ConversationId on ChatOptions here.
-            // The conversation ID from the client request is used by the hosting layer
-            // to manage conversation storage, but should not be forwarded to the underlying
-            // IChatClient as it has its own concept of conversations (or none at all).
-            // ---
-            // ConversationId = request.Conversation?.Id,
-
-            Temperature = (float?)request.Temperature,
-            TopP = (float?)request.TopP,
-            MaxOutputTokens = request.MaxOutputTokens,
-            Instructions = request.Instructions,
-            ModelId = request.Model,
-        };
-        var options = new ChatClientAgentRunOptions(chatOptions);
+        // The hosting developer controls, via OpenAIResponsesMapOptions.RunOptionsFactory, which (if any)
+        // request settings are mapped onto the agent run. By default no request setting is mapped.
+        AgentRunOptions? options = this._runOptionsFactory(request.ToRequestInfo());
 
         // Convert input to chat messages, prepending conversation history if available
         var messages = new List<ChatMessage>();

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/HostedAgentResponseExecutor.cs
@@ -21,21 +21,25 @@ internal sealed class HostedAgentResponseExecutor : IResponseExecutor
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<HostedAgentResponseExecutor> _logger;
+    private readonly Func<OpenAIResponseRequestInfo, AgentRunOptions?> _runOptionsFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HostedAgentResponseExecutor"/> class.
     /// </summary>
     /// <param name="serviceProvider">The service provider used to resolve hosted agents.</param>
     /// <param name="logger">The logger instance.</param>
+    /// <param name="mapOptions">Options controlling how incoming requests are mapped onto the agent run.</param>
     public HostedAgentResponseExecutor(
         IServiceProvider serviceProvider,
-        ILogger<HostedAgentResponseExecutor> logger)
+        ILogger<HostedAgentResponseExecutor> logger,
+        OpenAIResponsesMapOptions? mapOptions = null)
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
         ArgumentNullException.ThrowIfNull(logger);
 
         this._serviceProvider = serviceProvider;
         this._logger = logger;
+        this._runOptionsFactory = (mapOptions ?? new OpenAIResponsesMapOptions()).RunOptionsFactory;
     }
 
     /// <inheritdoc/>
@@ -75,6 +79,21 @@ internal sealed class HostedAgentResponseExecutor : IResponseExecutor
             });
         }
 
+        // Surface unsupported request settings as a clean request error rather than an unhandled
+        // exception during execution.
+        try
+        {
+            _ = this._runOptionsFactory(request.ToRequestInfo());
+        }
+        catch (NotSupportedException ex)
+        {
+            return ValueTask.FromResult<ResponseError?>(new ResponseError
+            {
+                Code = "unsupported_parameter",
+                Message = ex.Message
+            });
+        }
+
         return ValueTask.FromResult<ResponseError?>(null);
     }
 
@@ -88,22 +107,9 @@ internal sealed class HostedAgentResponseExecutor : IResponseExecutor
         string agentName = GetAgentName(request)!;
         AIAgent agent = this._serviceProvider.GetRequiredKeyedService<AIAgent>(agentName);
 
-        var chatOptions = new ChatOptions
-        {
-            // Note: We intentionally do NOT set ConversationId on ChatOptions here.
-            // The conversation ID from the client request is used by the hosting layer
-            // to manage conversation storage, but should not be forwarded to the underlying
-            // IChatClient as it has its own concept of conversations (or none at all).
-            // ---
-            // ConversationId = request.Conversation?.Id,
-
-            Temperature = (float?)request.Temperature,
-            TopP = (float?)request.TopP,
-            MaxOutputTokens = request.MaxOutputTokens,
-            Instructions = request.Instructions,
-            ModelId = request.Model,
-        };
-        var options = new ChatClientAgentRunOptions(chatOptions);
+        // The hosting developer controls, via OpenAIResponsesMapOptions.RunOptionsFactory, which (if any)
+        // request settings are mapped onto the agent run. By default no request setting is mapped.
+        AgentRunOptions? options = this._runOptionsFactory(request.ToRequestInfo());
         var messages = new List<ChatMessage>();
 
         if (conversationHistory is not null)

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/OpenAIResponseRequestInfoBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/OpenAIResponseRequestInfoBuilder.cs
@@ -42,7 +42,12 @@ internal static class OpenAIResponseRequestInfoBuilder
                 };
 
             case JsonValueKind.Object:
-                if (toolChoice.TryGetProperty("name", out JsonElement name) && name.ValueKind == JsonValueKind.String &&
+                // Only a function tool selection (for example { "type": "function", "name": "..." })
+                // has a ChatToolMode equivalent. Other object shapes (e.g. hosted tool selections) are
+                // not mapped so that they are not mistaken for a specific function.
+                if (toolChoice.TryGetProperty("type", out JsonElement type) && type.ValueKind == JsonValueKind.String &&
+                    type.GetString() == "function" &&
+                    toolChoice.TryGetProperty("name", out JsonElement name) && name.ValueKind == JsonValueKind.String &&
                     name.GetString() is { Length: > 0 } functionName)
                 {
                     return ChatToolMode.RequireSpecific(functionName);

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/OpenAIResponseRequestInfoBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/OpenAIResponseRequestInfoBuilder.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses;
+
+internal static class OpenAIResponseRequestInfoBuilder
+{
+    public static OpenAIResponseRequestInfo ToRequestInfo(this CreateResponse request) => new()
+    {
+        Temperature = request.Temperature,
+        TopP = request.TopP,
+        MaxOutputTokens = request.MaxOutputTokens,
+        Instructions = request.Instructions,
+        Model = request.Model,
+        Tools = request.Tools is { Count: > 0 } tools ? new List<JsonElement>(tools) : null,
+        ToolChoice = request.ToolChoice?.ToChatToolMode(),
+    };
+
+    /// <summary>
+    /// Maps an OpenAI Responses <c>tool_choice</c> value onto its <see cref="ChatToolMode"/> equivalent.
+    /// </summary>
+    /// <remarks>
+    /// The Responses <c>tool_choice</c> is either a string (<c>none</c>, <c>auto</c> or <c>required</c>)
+    /// or an object identifying a specific tool (for example <c>{ "type": "function", "name": "..." }</c>).
+    /// Values that have no <see cref="ChatToolMode"/> equivalent are mapped to <see langword="null"/>.
+    /// </remarks>
+    private static ChatToolMode? ToChatToolMode(this JsonElement toolChoice)
+    {
+        switch (toolChoice.ValueKind)
+        {
+            case JsonValueKind.String:
+                return toolChoice.GetString() switch
+                {
+                    "none" => ChatToolMode.None,
+                    "auto" => ChatToolMode.Auto,
+                    "required" => ChatToolMode.RequireAny,
+                    _ => null
+                };
+
+            case JsonValueKind.Object:
+                if (toolChoice.TryGetProperty("name", out JsonElement name) && name.ValueKind == JsonValueKind.String &&
+                    name.GetString() is { Length: > 0 } functionName)
+                {
+                    return ChatToolMode.RequireSpecific(functionName);
+                }
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/ConformanceTestBase.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/ConformanceTestBase.cs
@@ -198,8 +198,8 @@ public abstract class ConformanceTestBase : IAsyncDisposable
 
         this._app = builder.Build();
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
-        this._app.MapOpenAIResponses(agent);
-        this._app.MapOpenAIChatCompletions(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
+        this._app.MapOpenAIChatCompletions(agent, path: null, PermissiveMapOptions.ChatCompletions());
 
         await this._app.StartAsync();
 
@@ -229,8 +229,8 @@ public abstract class ConformanceTestBase : IAsyncDisposable
 
         this._app = builder.Build();
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
-        this._app.MapOpenAIResponses(agent);
-        this._app.MapOpenAIChatCompletions(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
+        this._app.MapOpenAIChatCompletions(agent, path: null, PermissiveMapOptions.ChatCompletions());
 
         await this._app.StartAsync();
 
@@ -261,8 +261,8 @@ public abstract class ConformanceTestBase : IAsyncDisposable
 
         this._app = builder.Build();
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
-        this._app.MapOpenAIResponses(agent);
-        this._app.MapOpenAIChatCompletions(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
+        this._app.MapOpenAIChatCompletions(agent, path: null, PermissiveMapOptions.ChatCompletions());
 
         await this._app.StartAsync();
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIConversationsConformanceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIConversationsConformanceTests.cs
@@ -108,7 +108,7 @@ public sealed class OpenAIConversationsConformanceTests : IAsyncDisposable
         this._app = builder.Build();
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
         this._app.MapOpenAIConversations();
-        this._app.MapOpenAIResponses(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
 
         await this._app.StartAsync();
 
@@ -137,7 +137,7 @@ public sealed class OpenAIConversationsConformanceTests : IAsyncDisposable
 
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
         this._app.MapOpenAIConversations();
-        this._app.MapOpenAIResponses(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
 
         await this._app.StartAsync();
 
@@ -166,7 +166,7 @@ public sealed class OpenAIConversationsConformanceTests : IAsyncDisposable
 
         AIAgent agent = this._app.Services.GetRequiredKeyedService<AIAgent>(agentName);
         this._app.MapOpenAIConversations();
-        this._app.MapOpenAIResponses(agent);
+        this._app.MapOpenAIResponses(agent, responsesPath: null, PermissiveMapOptions.Responses());
 
         await this._app.StartAsync();
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIMapOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIMapOptionsTests.cs
@@ -71,7 +71,7 @@ public sealed class OpenAIMapOptionsTests
             "top_p" => new OpenAIResponseRequestInfo { TopP = 0.5 },
             "max_output_tokens" => new OpenAIResponseRequestInfo { MaxOutputTokens = 100 },
             "instructions" => new OpenAIResponseRequestInfo { Instructions = "be brief" },
-            "tools" => new OpenAIResponseRequestInfo { Tools = [JsonDocument.Parse("{}").RootElement] },
+            "tools" => new OpenAIResponseRequestInfo { Tools = [ParseElement("{}")] },
             "tool_choice" => new OpenAIResponseRequestInfo { ToolChoice = ChatToolMode.None },
             _ => throw new ArgumentOutOfRangeException(nameof(setting))
         };
@@ -162,6 +162,41 @@ public sealed class OpenAIMapOptionsTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    [Fact]
+    public async Task ChatCompletions_DefaultEndpoint_RejectsRequestWithSettingsAsync()
+    {
+        // Arrange
+        using var app = await CreateChatCompletionsServerAsync("reject-agent", mapOptions: null);
+        HttpClient client = GetClient(app);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("/reject-agent/v1/chat/completions", UriKind.Relative),
+            new StringContent("""{"model":"myModel","messages":[{"role":"user","content":"hello"}],"temperature":0.5}""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("temperature", body, StringComparison.Ordinal);
+        Assert.Contains("invalid_request_error", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ChatCompletions_ConfiguredEndpoint_HonorsRequestSettingsAsync()
+    {
+        // Arrange
+        using var app = await CreateChatCompletionsServerAsync("map-agent", PermissiveMapOptions.ChatCompletions());
+        HttpClient client = GetClient(app);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("/map-agent/v1/chat/completions", UriKind.Relative),
+            new StringContent("""{"model":"myModel","messages":[{"role":"user","content":"hello"}],"temperature":0.5}""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
     private static async Task<WebApplication> CreateResponsesServerAsync(string agentName, OpenAIResponsesMapOptions? mapOptions)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -185,5 +220,29 @@ public sealed class OpenAIMapOptionsTests
         TestServer testServer = app.Services.GetRequiredService<IServer>() as TestServer
             ?? throw new InvalidOperationException("TestServer not found");
         return testServer.CreateClient();
+    }
+
+    private static async Task<WebApplication> CreateChatCompletionsServerAsync(string agentName, OpenAIChatCompletionsMapOptions? mapOptions)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        IChatClient mockChatClient = new TestHelpers.SimpleMockChatClient("Hello there.");
+        builder.Services.AddKeyedSingleton("chat-client", mockChatClient);
+        builder.AddAIAgent(agentName, "You are a helpful assistant.", chatClientServiceKey: "chat-client");
+        builder.AddOpenAIChatCompletions();
+
+        WebApplication app = builder.Build();
+        AIAgent agent = app.Services.GetRequiredKeyedService<AIAgent>(agentName);
+        app.MapOpenAIChatCompletions(agent, path: null, mapOptions);
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static JsonElement ParseElement(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIMapOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIMapOptionsTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="OpenAIResponsesMapOptions"/> and <see cref="OpenAIChatCompletionsMapOptions"/>,
+/// including the default behavior that rejects request-supplied settings so that callers cannot
+/// override the configuration of a self-contained agent.
+/// </summary>
+public sealed class OpenAIMapOptionsTests
+{
+    [Fact]
+    public void Responses_DefaultRunOptionsFactory_IsRejectRequestSettings()
+    {
+        // Arrange & Act
+        var options = new OpenAIResponsesMapOptions();
+
+        // Assert
+        Assert.Equal(OpenAIResponsesMapOptions.RejectRequestSettings, options.RunOptionsFactory);
+    }
+
+    [Fact]
+    public void ChatCompletions_DefaultRunOptionsFactory_IsRejectRequestSettings()
+    {
+        // Arrange & Act
+        var options = new OpenAIChatCompletionsMapOptions();
+
+        // Assert
+        Assert.Equal(OpenAIChatCompletionsMapOptions.RejectRequestSettings, options.RunOptionsFactory);
+    }
+
+    [Fact]
+    public void Responses_RejectRequestSettings_ReturnsNull_WhenNoSettingsSpecified()
+    {
+        // Arrange
+        var request = new OpenAIResponseRequestInfo { Model = "gpt-4o" };
+
+        // Act
+        AgentRunOptions? result = OpenAIResponsesMapOptions.RejectRequestSettings(request);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("temperature")]
+    [InlineData("top_p")]
+    [InlineData("max_output_tokens")]
+    [InlineData("instructions")]
+    [InlineData("tools")]
+    [InlineData("tool_choice")]
+    public void Responses_RejectRequestSettings_Throws_WhenSettingSpecified(string setting)
+    {
+        // Arrange
+        var request = setting switch
+        {
+            "temperature" => new OpenAIResponseRequestInfo { Temperature = 0.5 },
+            "top_p" => new OpenAIResponseRequestInfo { TopP = 0.5 },
+            "max_output_tokens" => new OpenAIResponseRequestInfo { MaxOutputTokens = 100 },
+            "instructions" => new OpenAIResponseRequestInfo { Instructions = "be brief" },
+            "tools" => new OpenAIResponseRequestInfo { Tools = [JsonDocument.Parse("{}").RootElement] },
+            "tool_choice" => new OpenAIResponseRequestInfo { ToolChoice = ChatToolMode.None },
+            _ => throw new ArgumentOutOfRangeException(nameof(setting))
+        };
+
+        // Act & Assert
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => OpenAIResponsesMapOptions.RejectRequestSettings(request));
+        Assert.Contains(setting, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ChatCompletions_RejectRequestSettings_ReturnsNull_WhenNoSettingsSpecified()
+    {
+        // Arrange
+        var request = new OpenAIChatCompletionRequestInfo { Model = "gpt-4o" };
+
+        // Act
+        AgentRunOptions? result = OpenAIChatCompletionsMapOptions.RejectRequestSettings(request);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("temperature")]
+    [InlineData("top_p")]
+    [InlineData("max_completion_tokens")]
+    [InlineData("frequency_penalty")]
+    [InlineData("presence_penalty")]
+    [InlineData("seed")]
+    [InlineData("stop")]
+    [InlineData("response_format")]
+    [InlineData("tools")]
+    [InlineData("tool_choice")]
+    public void ChatCompletions_RejectRequestSettings_Throws_WhenSettingSpecified(string setting)
+    {
+        // Arrange
+        var request = setting switch
+        {
+            "temperature" => new OpenAIChatCompletionRequestInfo { Temperature = 0.5f },
+            "top_p" => new OpenAIChatCompletionRequestInfo { TopP = 0.5f },
+            "max_completion_tokens" => new OpenAIChatCompletionRequestInfo { MaxOutputTokens = 100 },
+            "frequency_penalty" => new OpenAIChatCompletionRequestInfo { FrequencyPenalty = 0.5f },
+            "presence_penalty" => new OpenAIChatCompletionRequestInfo { PresencePenalty = 0.5f },
+            "seed" => new OpenAIChatCompletionRequestInfo { Seed = 42 },
+            "stop" => new OpenAIChatCompletionRequestInfo { StopSequences = ["stop"] },
+            "response_format" => new OpenAIChatCompletionRequestInfo { ResponseFormat = ChatResponseFormat.Json },
+            "tools" => new OpenAIChatCompletionRequestInfo { Tools = [AIFunctionFactory.Create(() => "x", "f")] },
+            "tool_choice" => new OpenAIChatCompletionRequestInfo { ToolChoice = ChatToolMode.None },
+            _ => throw new ArgumentOutOfRangeException(nameof(setting))
+        };
+
+        // Act & Assert
+        NotSupportedException ex = Assert.Throws<NotSupportedException>(() => OpenAIChatCompletionsMapOptions.RejectRequestSettings(request));
+        Assert.Contains(setting, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Responses_DefaultEndpoint_RejectsRequestWithSettingsAsync()
+    {
+        // Arrange
+        using var app = await CreateResponsesServerAsync("reject-agent", mapOptions: null);
+        HttpClient client = GetClient(app);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("/reject-agent/v1/responses", UriKind.Relative),
+            new StringContent("""{"input":"hello","temperature":0.5}""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("temperature", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Responses_ConfiguredEndpoint_HonorsRequestSettingsAsync()
+    {
+        // Arrange
+        using var app = await CreateResponsesServerAsync("map-agent", PermissiveMapOptions.Responses());
+        HttpClient client = GetClient(app);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("/map-agent/v1/responses", UriKind.Relative),
+            new StringContent("""{"input":"hello","temperature":0.5}""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static async Task<WebApplication> CreateResponsesServerAsync(string agentName, OpenAIResponsesMapOptions? mapOptions)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        IChatClient mockChatClient = new TestHelpers.SimpleMockChatClient("Hello there.");
+        builder.Services.AddKeyedSingleton("chat-client", mockChatClient);
+        builder.AddAIAgent(agentName, "You are a helpful assistant.", chatClientServiceKey: "chat-client");
+        builder.AddOpenAIResponses();
+
+        WebApplication app = builder.Build();
+        AIAgent agent = app.Services.GetRequiredKeyedService<AIAgent>(agentName);
+        app.MapOpenAIResponses(agent, responsesPath: null, mapOptions);
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static HttpClient GetClient(WebApplication app)
+    {
+        TestServer testServer = app.Services.GetRequiredService<IServer>() as TestServer
+            ?? throw new InvalidOperationException("TestServer not found");
+        return testServer.CreateClient();
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponseRequestInfoBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponseRequestInfoBuilderTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="OpenAIResponseRequestInfoBuilder"/>, in particular the mapping of the OpenAI
+/// Responses <c>tool_choice</c> wire value onto its <see cref="ChatToolMode"/> equivalent.
+/// </summary>
+public sealed class OpenAIResponseRequestInfoBuilderTests
+{
+    [Fact]
+    public void ToRequestInfo_MapsToolChoiceNone_ToChatToolModeNone()
+    {
+        // Arrange
+        CreateResponse request = CreateRequestWithToolChoice("\"none\"");
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        Assert.Equal(ChatToolMode.None, info.ToolChoice);
+    }
+
+    [Fact]
+    public void ToRequestInfo_MapsToolChoiceAuto_ToChatToolModeAuto()
+    {
+        // Arrange
+        CreateResponse request = CreateRequestWithToolChoice("\"auto\"");
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        Assert.Equal(ChatToolMode.Auto, info.ToolChoice);
+    }
+
+    [Fact]
+    public void ToRequestInfo_MapsToolChoiceRequired_ToRequireAny()
+    {
+        // Arrange
+        CreateResponse request = CreateRequestWithToolChoice("\"required\"");
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        Assert.Equal(ChatToolMode.RequireAny, info.ToolChoice);
+    }
+
+    [Fact]
+    public void ToRequestInfo_MapsSpecificFunctionToolChoice_ToRequireSpecific()
+    {
+        // Arrange
+        CreateResponse request = CreateRequestWithToolChoice("""{"type":"function","name":"get_weather"}""");
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        RequiredChatToolMode required = Assert.IsType<RequiredChatToolMode>(info.ToolChoice);
+        Assert.Equal("get_weather", required.RequiredFunctionName);
+    }
+
+    [Fact]
+    public void ToRequestInfo_MapsUnrecognizedToolChoice_ToNull()
+    {
+        // Arrange
+        CreateResponse request = CreateRequestWithToolChoice("\"something_else\"");
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        Assert.Null(info.ToolChoice);
+    }
+
+    [Fact]
+    public void ToRequestInfo_NoToolChoice_MapsToNull()
+    {
+        // Arrange
+        CreateResponse request = new() { Input = "hello" };
+
+        // Act
+        OpenAIResponseRequestInfo info = request.ToRequestInfo();
+
+        // Assert
+        Assert.Null(info.ToolChoice);
+    }
+
+    private static CreateResponse CreateRequestWithToolChoice(string toolChoiceJson) => new()
+    {
+        Input = "hello",
+        ToolChoice = JsonDocument.Parse(toolChoiceJson).RootElement,
+    };
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponseRequestInfoBuilderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponseRequestInfoBuilderTests.cs
@@ -92,9 +92,13 @@ public sealed class OpenAIResponseRequestInfoBuilderTests
         Assert.Null(info.ToolChoice);
     }
 
-    private static CreateResponse CreateRequestWithToolChoice(string toolChoiceJson) => new()
+    private static CreateResponse CreateRequestWithToolChoice(string toolChoiceJson)
     {
-        Input = "hello",
-        ToolChoice = JsonDocument.Parse(toolChoiceJson).RootElement,
-    };
+        using JsonDocument document = JsonDocument.Parse(toolChoiceJson);
+        return new()
+        {
+            Input = "hello",
+            ToolChoice = document.RootElement.Clone(),
+        };
+    }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/PermissiveMapOptions.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/PermissiveMapOptions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.UnitTests;
+
+/// <summary>
+/// Provides permissive <see cref="OpenAIResponsesMapOptions"/> and <see cref="OpenAIChatCompletionsMapOptions"/>
+/// that map the request-supplied generation and tool settings onto the agent run.
+/// </summary>
+/// <remarks>
+/// The production default rejects request-supplied settings so that callers cannot override a
+/// self-contained agent. These helpers opt in to the legacy behavior for conformance tests that
+/// exercise the wire format end-to-end.
+/// </remarks>
+internal static class PermissiveMapOptions
+{
+    public static OpenAIResponsesMapOptions Responses() => new()
+    {
+        RunOptionsFactory = static request =>
+        {
+            var chatOptions = new ChatOptions
+            {
+                Temperature = (float?)request.Temperature,
+                TopP = (float?)request.TopP,
+                MaxOutputTokens = request.MaxOutputTokens,
+                Instructions = request.Instructions,
+                ModelId = request.Model,
+            };
+
+            return new ChatClientAgentRunOptions(chatOptions);
+        }
+    };
+
+    public static OpenAIChatCompletionsMapOptions ChatCompletions() => new()
+    {
+        RunOptionsFactory = static request =>
+        {
+            var chatOptions = new ChatOptions
+            {
+                Temperature = request.Temperature,
+                TopP = request.TopP,
+                MaxOutputTokens = request.MaxOutputTokens,
+                FrequencyPenalty = request.FrequencyPenalty,
+                PresencePenalty = request.PresencePenalty,
+                Seed = request.Seed,
+                StopSequences = request.StopSequences is { Count: > 0 } stop ? [.. stop] : null,
+                ResponseFormat = request.ResponseFormat,
+                ToolMode = request.ToolChoice,
+                Tools = request.Tools is { Count: > 0 } tools ? tools.ToList() : null,
+                ModelId = request.Model,
+            };
+
+            return new ChatClientAgentRunOptions(chatOptions);
+        }
+    };
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/PermissiveMapOptions.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/PermissiveMapOptions.cs
@@ -27,6 +27,7 @@ internal static class PermissiveMapOptions
                 MaxOutputTokens = request.MaxOutputTokens,
                 Instructions = request.Instructions,
                 ModelId = request.Model,
+                ToolMode = request.ToolChoice,
             };
 
             return new ChatClientAgentRunOptions(chatOptions);


### PR DESCRIPTION
### Motivation & Context

Hosting an agent over an inference protocol is not ideal since inference protocols support lots of fine grained settings, while agents may not support any of these settings, or actually break if some of these settings are applied to the agent.  An agent is after all typically a self contained entity that has already been built to perform a specific task.  Allowing a consumer to modify it, may interfere with the choices the agent developer made to have the agent work as required.

### Description & Review Guide

- Allow developers to configure what settings are passed from the request to the agent
- Disallow passing settings by default

### Related Issue

Fixes #6854

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
