### PR TITLE
Python: Fix Foundry hosted session SDK calls

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -479,19 +479,7 @@ class RawFoundryAgentChatClient(
         """Return the agent version if available, else None."""
         if self.agent_version is not None:
             return self.agent_version
-        if not self.allow_preview:
-            return None
-        agent_details = await cast(Any, self.project_client.beta.agents).get(agent_name=self.agent_name)
-        versions_object = getattr(agent_details, "versions", None)
-        if not isinstance(versions_object, Mapping):
-            raise TypeError("Foundry agent details did not include a versions mapping.")
-        versions = cast(Mapping[str, Any], versions_object)
-        latest_version = versions.get("latest")
-        agent_version = getattr(cast(Any, latest_version), "version", None)
-        if not isinstance(agent_version, str):
-            raise TypeError("Foundry agent details did not include a latest version string.")
-        self.agent_version = agent_version
-        return agent_version
+        return None
 
     async def close(self) -> None:
         """Close the project client if we created it."""
@@ -740,7 +728,7 @@ class RawFoundryAgent(
 
         create_session_kwargs: dict[str, Any] = {
             "agent_name": self.client.agent_name,
-            "isolation_key": self._resolve_service_session_isolation_key(isolation_key),
+            "user_isolation_key": self._resolve_service_session_isolation_key(isolation_key),
         }
         if version := await self.client.get_agent_version():
             from azure.ai.projects.models import VersionRefIndicator

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -129,6 +129,22 @@ def test_raw_foundry_agent_chat_client_init_passes_agent_name_when_preview_enabl
     )
 
 
+async def test_raw_foundry_agent_chat_client_get_agent_version_skips_sdk_lookup() -> None:
+    """Test hosted agents can create sessions when the SDK has no agent-name lookup method."""
+
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+    mock_project.beta = SimpleNamespace(agents=SimpleNamespace())
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="hosted-agent",
+        allow_preview=True,
+    )
+
+    assert await client.get_agent_version() is None
+
+
 def test_raw_foundry_agent_chat_client_init_uses_explicit_parameters() -> None:
     signature = inspect.signature(RawFoundryAgentChatClient.__init__)
 
@@ -884,7 +900,7 @@ async def test_raw_foundry_agent_prepare_run_context_creates_service_session_fro
     mock_project.beta.agents.create_session.assert_awaited_once()
     create_session_kwargs = mock_project.beta.agents.create_session.await_args.kwargs
     assert create_session_kwargs["agent_name"] == "test-agent"
-    assert create_session_kwargs["isolation_key"] == "iso-key"
+    assert create_session_kwargs["user_isolation_key"] == "iso-key"
     assert "version_indicator" in create_session_kwargs
     mock_prepare_run_context.assert_awaited_once()
 


### PR DESCRIPTION
### Motivation & Context

Hosted FoundryAgent sessions currently fail against `azure-ai-projects==2.2.0` when `allow_preview=True` and an `isolation_key` is provided. The Foundry SDK no longer exposes the agent-name `.get(...)` lookup used by `get_agent_version()`, and `create_session(...)` expects `user_isolation_key` instead of `isolation_key`.

### Description & Review Guide

- **What are the major changes?**
  - Stop looking up a hosted agent version through the missing `project_client.beta.agents.get(...)` API when no explicit `agent_version` is configured.
  - Pass `user_isolation_key` to `project_client.beta.agents.create_session(...)`.
  - Add a regression test for SDK objects without the removed lookup method and update the session creation assertion.
- **What is the impact of these changes?**
  - Hosted session creation can proceed with the current Azure SDK shape while preserving explicit `agent_version` behavior when callers provide one.
  - Checked with:
    - `uv run pytest tests/foundry/test_foundry_agent.py::test_raw_foundry_agent_chat_client_get_agent_version_skips_sdk_lookup tests/foundry/test_foundry_agent.py::test_raw_foundry_agent_prepare_run_context_creates_service_session_from_isolation_key -q`
    - `uv run pytest tests/foundry/test_foundry_agent.py -q`
    - `uv run poe test -P foundry -m "not integration"`
    - `uv run ruff check packages/foundry/agent_framework_foundry/_agent.py packages/foundry/tests/foundry/test_foundry_agent.py`
    - `uv run ruff format --check packages/foundry/agent_framework_foundry/_agent.py packages/foundry/tests/foundry/test_foundry_agent.py`
    - `uv run pyright packages/foundry/agent_framework_foundry/_agent.py`
- **What do you want reviewers to focus on?**
  - Whether hosted sessions should continue omitting `version_indicator` when callers do not pass `agent_version`.

### Related Issue

Fixes #6857

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
