### PR TITLE
.NET: Add defense-in-depth for MCP cross origin request

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.Mcp/DefaultMcpToolHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.Mcp/DefaultMcpToolHandler.cs
@@ -50,6 +50,13 @@ public sealed class DefaultMcpToolHandler : IMcpToolHandler, IAsyncDisposable
     /// An optional callback that provides an <see cref="HttpClient"/> for each MCP server.
     /// The callback receives (serverUrl, cancellationToken) and should return an HttpClient
     /// configured with any required authentication. Return <see langword="null"/> to use a default HttpClient with no auth.
+    /// <para>
+    /// Security: HttpClients created by this handler pin credential headers to the configured server
+    /// origin and disable auto-redirect. When you supply your own <see cref="HttpClient"/>, you are
+    /// responsible for equivalent protection — attach credentials only for the configured server origin
+    /// (for example via a <see cref="DelegatingHandler"/>) so a server-advertised endpoint or redirect on
+    /// a different origin cannot capture the Authorization token.
+    /// </para>
     /// </param>
     public DefaultMcpToolHandler(Func<string, CancellationToken, Task<HttpClient?>>? httpClientProvider = null)
     {
@@ -201,9 +208,25 @@ public sealed class DefaultMcpToolHandler : IMcpToolHandler, IAsyncDisposable
             // Disable cookies so handler-level state (cookie jar) cannot cross the cache-key
             // isolation boundary established by GetOrCreateClientAsync. The actual MCP auth
             // travels via AdditionalHeaders (set per-transport below), not session cookies.
+            // Disable auto-redirect so an HTTP redirect cannot carry credential headers to a
+            // different origin (defense-in-depth alongside the origin pinning applied below).
             // CheckCertificateRevocationList satisfies CA5399 since we're explicitly constructing the handler.
-            HttpClientHandler handler = new() { UseCookies = false, CheckCertificateRevocationList = true };
-            httpClient = new HttpClient(handler);
+            HttpClientHandler handler = new()
+            {
+                UseCookies = false,
+                AllowAutoRedirect = false,
+                CheckCertificateRevocationList = true
+            };
+
+            // Pin credential headers to the configured server origin as defense-in-depth. Forcing
+            // StreamableHttp (below) already removes the primary vector (a server-advertised cross-origin
+            // SSE message endpoint), and AllowAutoRedirect=false blocks auto-redirects. This handler is the
+            // backstop: it guarantees the Authorization token and other credentials never leave the pinned
+            // origin even if a future change re-enables AutoDetect or redirects, or the SDK constructs a
+            // request to a new URI (AdditionalHeaders are re-stamped by the transport, so HttpClient's own
+            // redirect header-stripping does not cover them).
+            OriginPinningHandler pinningHandler = new(new Uri(serverUrl)) { InnerHandler = handler };
+            httpClient = new HttpClient(pinningHandler);
             this._ownedHttpClients[httpClientCacheKey] = httpClient;
         }
 
@@ -212,7 +235,11 @@ public sealed class DefaultMcpToolHandler : IMcpToolHandler, IAsyncDisposable
             Endpoint = new Uri(serverUrl),
             Name = serverLabel ?? "McpClient",
             AdditionalHeaders = headers,
-            TransportMode = HttpTransportMode.AutoDetect
+            // Use Streamable HTTP rather than AutoDetect so the client does not negotiate down to the
+            // legacy HTTP+SSE transport, which trusts a server-advertised message endpoint. That
+            // server-controlled endpoint is the primary vector for redirecting the Authorization token
+            // to a different origin; Streamable HTTP keeps every request on the configured origin.
+            TransportMode = HttpTransportMode.StreamableHttp
         };
 
         HttpClientTransport transport = new(transportOptions, httpClient);
@@ -392,5 +419,87 @@ public sealed class DefaultMcpToolHandler : IMcpToolHandler, IAsyncDisposable
         }
 
         return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+    }
+}
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> that strips credential-bearing headers from any outbound request
+/// whose origin does not match the origin the MCP client was configured with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This pins the Authorization token (and other credential headers) to the trusted server origin so a
+/// compromised or malicious MCP server cannot redirect them to a different origin — for example by
+/// advertising a cross-origin SSE message endpoint or issuing an HTTP redirect. Same-origin requests are
+/// left untouched so legitimate MCP traffic continues to carry its credentials.
+/// </para>
+/// <para>
+/// This is a defense-in-depth control. Using <see cref="HttpTransportMode.StreamableHttp"/> already removes
+/// the primary vector (a server-advertised cross-origin message endpoint) and disabling auto-redirect blocks
+/// redirect-based leakage; this handler backstops both so credentials stay pinned even if those settings
+/// change or the SDK builds a request to a new URI (<c>AdditionalHeaders</c> are re-stamped by the transport
+/// and are therefore not covered by <see cref="HttpClient"/>'s own redirect header-stripping).
+/// </para>
+/// <para>
+/// Caveat for future maintainers: this strips credentials on <em>every</em> cross-origin request. That is safe
+/// today because <see cref="DefaultMcpToolHandler"/> carries auth via static request headers, not the SDK's
+/// built-in OAuth flow. If OAuth support is ever added here, requests to the authorization server (a different
+/// origin than the MCP resource server) legitimately carry credentials, so those auth-server origins would need
+/// to be allow-listed to avoid breaking the token exchange.
+/// </para>
+/// </remarks>
+internal sealed class OriginPinningHandler : DelegatingHandler
+{
+    // Credential-bearing headers that must never cross the pinned-origin boundary.
+    private static readonly string[] s_credentialHeaderNames =
+    [
+        "Authorization",
+        "Proxy-Authorization",
+        "Cookie",
+    ];
+
+    private readonly string _pinnedOrigin;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OriginPinningHandler"/> class.
+    /// </summary>
+    /// <param name="pinnedEndpoint">The configured MCP server endpoint whose origin credentials are pinned to.</param>
+    public OriginPinningHandler(Uri pinnedEndpoint)
+    {
+        Throw.IfNull(pinnedEndpoint);
+        this._pinnedOrigin = pinnedEndpoint.GetLeftPart(UriPartial.Authority);
+    }
+
+    /// <inheritdoc/>
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        StripCredentialHeadersOnCrossOrigin(request, this._pinnedOrigin);
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes credential headers from <paramref name="request"/> when its origin differs from
+    /// <paramref name="pinnedOrigin"/>. Same-origin requests are left untouched. Origin comparison covers
+    /// scheme, host, and port (case-insensitive), matching the standard web-origin definition.
+    /// </summary>
+    internal static void StripCredentialHeadersOnCrossOrigin(HttpRequestMessage request, string pinnedOrigin)
+    {
+        Throw.IfNull(request);
+
+        if (request.RequestUri is not { } requestUri)
+        {
+            return;
+        }
+
+        string requestOrigin = requestUri.GetLeftPart(UriPartial.Authority);
+        if (string.Equals(requestOrigin, pinnedOrigin, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        foreach (string headerName in s_credentialHeaderNames)
+        {
+            request.Headers.Remove(headerName);
+        }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.Mcp/DefaultMcpToolHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative.Mcp/DefaultMcpToolHandler.cs
@@ -458,41 +458,49 @@ internal sealed class OriginPinningHandler : DelegatingHandler
         "Cookie",
     ];
 
-    private readonly string _pinnedOrigin;
+    private readonly Uri _pinnedEndpoint;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OriginPinningHandler"/> class.
     /// </summary>
-    /// <param name="pinnedEndpoint">The configured MCP server endpoint whose origin credentials are pinned to.</param>
+    /// <param name="pinnedEndpoint">The configured MCP server endpoint whose origin credentials are pinned to. Must be an absolute URI.</param>
     public OriginPinningHandler(Uri pinnedEndpoint)
     {
         Throw.IfNull(pinnedEndpoint);
-        this._pinnedOrigin = pinnedEndpoint.GetLeftPart(UriPartial.Authority);
+        if (!pinnedEndpoint.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The pinned endpoint must be an absolute URI.", nameof(pinnedEndpoint));
+        }
+
+        this._pinnedEndpoint = pinnedEndpoint;
     }
 
     /// <inheritdoc/>
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        StripCredentialHeadersOnCrossOrigin(request, this._pinnedOrigin);
+        StripCredentialHeadersOnCrossOrigin(request, this._pinnedEndpoint);
         return base.SendAsync(request, cancellationToken);
     }
 
     /// <summary>
-    /// Removes credential headers from <paramref name="request"/> when its origin differs from
-    /// <paramref name="pinnedOrigin"/>. Same-origin requests are left untouched. Origin comparison covers
-    /// scheme, host, and port (case-insensitive), matching the standard web-origin definition.
+    /// Removes credential headers from <paramref name="request"/> when its origin differs from that of
+    /// <paramref name="pinnedEndpoint"/>. Same-origin requests are left untouched. Origin comparison covers
+    /// scheme, host, and port (case-insensitive) via <see cref="Uri.Compare"/>, which normalizes default
+    /// ports so an explicit default port (for example <c>:443</c> for https) matches an omitted one. A
+    /// relative request URI is resolved by <see cref="HttpClient"/> against its base address (the pinned
+    /// origin) and so can never target a different origin; its headers are left untouched.
     /// </summary>
-    internal static void StripCredentialHeadersOnCrossOrigin(HttpRequestMessage request, string pinnedOrigin)
+    internal static void StripCredentialHeadersOnCrossOrigin(HttpRequestMessage request, Uri pinnedEndpoint)
     {
         Throw.IfNull(request);
+        Throw.IfNull(pinnedEndpoint);
 
-        if (request.RequestUri is not { } requestUri)
+        if (request.RequestUri is not { IsAbsoluteUri: true } requestUri)
         {
             return;
         }
 
-        string requestOrigin = requestUri.GetLeftPart(UriPartial.Authority);
-        if (string.Equals(requestOrigin, pinnedOrigin, StringComparison.OrdinalIgnoreCase))
+        if (Uri.Compare(requestUri, pinnedEndpoint, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
         {
             return;
         }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.Mcp.UnitTests/DefaultMcpToolHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.Mcp.UnitTests/DefaultMcpToolHandlerTests.cs
@@ -947,7 +947,7 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert — same origin, credential is preserved
         request.Headers.Contains("Authorization").Should().BeTrue();
@@ -961,7 +961,7 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert — credential must not cross the origin boundary
         request.Headers.Contains("Authorization").Should().BeFalse();
@@ -975,10 +975,41 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert
         request.Headers.Contains("Authorization").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_ExplicitDefaultPort_RetainsAuthorization()
+    {
+        // Arrange — pinned endpoint carries an explicit :443 while the request omits it; these are
+        // the same origin and Uri.Compare must normalize the default port rather than strip.
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://trusted.example.com/mcp/message");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com:443/mcp"));
+
+        // Assert — explicit vs implicit default port is the same origin
+        request.Headers.Contains("Authorization").Should().BeTrue();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_RelativeRequestUri_RetainsAuthorization()
+    {
+        // Arrange — a relative URI resolves against the client's base address (the pinned origin) and
+        // therefore can never target a foreign origin. It must not throw and must retain credentials.
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/mcp/message", UriKind.Relative));
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        Action act = () => OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
+
+        // Assert — does not throw and leaves the credential in place
+        act.Should().NotThrow();
+        request.Headers.Contains("Authorization").Should().BeTrue();
     }
 
     [Fact]
@@ -989,7 +1020,7 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert
         request.Headers.Contains("Authorization").Should().BeFalse();
@@ -1005,7 +1036,7 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("Proxy-Authorization", "Bearer proxy-token");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert — all credential-bearing headers are stripped
         request.Headers.Contains("Authorization").Should().BeFalse();
@@ -1022,7 +1053,7 @@ public sealed class DefaultMcpToolHandlerTests
         request.Headers.TryAddWithoutValidation("X-Trace-Id", "trace-123");
 
         // Act
-        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, new Uri("https://trusted.example.com"));
 
         // Assert — only credential headers are removed; other headers are untouched
         request.Headers.Contains("Authorization").Should().BeFalse();
@@ -1044,6 +1075,7 @@ public sealed class DefaultMcpToolHandlerTests
         using HttpResponseMessage response = await invoker.SendAsync(request, CancellationToken.None);
 
         // Assert — the credential never reached the inner handler for the foreign origin
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         inner.LastRequestHadAuthorization.Should().BeFalse();
     }
 
@@ -1062,6 +1094,7 @@ public sealed class DefaultMcpToolHandlerTests
         using HttpResponseMessage response = await invoker.SendAsync(request, CancellationToken.None);
 
         // Assert — same-origin credential flows through normally
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         inner.LastRequestHadAuthorization.Should().BeTrue();
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.Mcp.UnitTests/DefaultMcpToolHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.Mcp.UnitTests/DefaultMcpToolHandlerTests.cs
@@ -936,4 +936,145 @@ public sealed class DefaultMcpToolHandlerTests
     }
 
     #endregion
+
+    #region Origin Pinning Tests
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_SameOrigin_RetainsAuthorization()
+    {
+        // Arrange
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://trusted.example.com/mcp/message");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert — same origin, credential is preserved
+        request.Headers.Contains("Authorization").Should().BeTrue();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_DifferentHost_RemovesAuthorization()
+    {
+        // Arrange — server-advertised endpoint on an attacker origin
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://attacker.example/collect");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert — credential must not cross the origin boundary
+        request.Headers.Contains("Authorization").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_DifferentPort_RemovesAuthorization()
+    {
+        // Arrange — same host but a different port is a different origin
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://trusted.example.com:8443/mcp");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert
+        request.Headers.Contains("Authorization").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_DifferentScheme_RemovesAuthorization()
+    {
+        // Arrange — downgrade to http is a different origin (and would leak over plaintext)
+        using HttpRequestMessage request = new(HttpMethod.Post, "http://trusted.example.com/mcp");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert
+        request.Headers.Contains("Authorization").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_CrossOrigin_RemovesCookieAndProxyAuthorization()
+    {
+        // Arrange
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://attacker.example/collect");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+        request.Headers.TryAddWithoutValidation("Cookie", "session=abc");
+        request.Headers.TryAddWithoutValidation("Proxy-Authorization", "Bearer proxy-token");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert — all credential-bearing headers are stripped
+        request.Headers.Contains("Authorization").Should().BeFalse();
+        request.Headers.Contains("Cookie").Should().BeFalse();
+        request.Headers.Contains("Proxy-Authorization").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripCredentialHeadersOnCrossOrigin_CrossOrigin_PreservesNonCredentialHeaders()
+    {
+        // Arrange
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://attacker.example/collect");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+        request.Headers.TryAddWithoutValidation("X-Trace-Id", "trace-123");
+
+        // Act
+        OriginPinningHandler.StripCredentialHeadersOnCrossOrigin(request, "https://trusted.example.com");
+
+        // Assert — only credential headers are removed; other headers are untouched
+        request.Headers.Contains("Authorization").Should().BeFalse();
+        request.Headers.Contains("X-Trace-Id").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OriginPinningHandler_CrossOriginRequest_DoesNotForwardAuthorizationAsync()
+    {
+        // Arrange — capture what the inner handler actually receives on the wire
+        CapturingHandler inner = new();
+        using OriginPinningHandler pinning = new(new Uri("https://trusted.example.com/mcp")) { InnerHandler = inner };
+        using HttpMessageInvoker invoker = new(pinning);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://attacker.example/collect");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        using HttpResponseMessage response = await invoker.SendAsync(request, CancellationToken.None);
+
+        // Assert — the credential never reached the inner handler for the foreign origin
+        inner.LastRequestHadAuthorization.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task OriginPinningHandler_SameOriginRequest_ForwardsAuthorizationAsync()
+    {
+        // Arrange
+        CapturingHandler inner = new();
+        using OriginPinningHandler pinning = new(new Uri("https://trusted.example.com/mcp")) { InnerHandler = inner };
+        using HttpMessageInvoker invoker = new(pinning);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://trusted.example.com/mcp/message");
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer secret-token");
+
+        // Act
+        using HttpResponseMessage response = await invoker.SendAsync(request, CancellationToken.None);
+
+        // Assert — same-origin credential flows through normally
+        inner.LastRequestHadAuthorization.Should().BeTrue();
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public bool LastRequestHadAuthorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.LastRequestHadAuthorization = request.Headers.Contains("Authorization");
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->
A customer reported an origin-pinning weakness reachable through the declarative-workflows MCP handler. DefaultMcpToolHandler created its transport with HttpTransportMode.AutoDetect and passed caller-supplied credentials (including an Authorization: Bearer token) via HttpClientTransportOptions.AdditionalHeaders. Under AutoDetect, the client can negotiate down to the legacy HTTP+SSE transport, which trusts a server-advertised message endpoint. A malicious or compromised MCP server could advertise a cross-origin endpoint (or issue a redirect) and capture the bearer token, since the SDK re-stamps AdditionalHeaders onto requests built from that unverified URL. The owned HttpClient also left auto-redirect enabled, a second cross-origin leakage path.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
  - DefaultMcpToolHandler now forces HttpTransportMode.StreamableHttp instead of AutoDetect, removing the legacy-SSE server-advertised-endpoint vector.
  - The owned HttpClient handler now sets AllowAutoRedirect = false, blocking redirect-based credential leakage.
  - Added an OriginPinningHandler (DelegatingHandler) that strips credential headers (Authorization, Proxy-Authorization, Cookie) from any request whose origin differs from the configured server origin, leaving same-origin traffic untouched.
  - Documented the layered (defense-in-depth) design and a caveat for future maintainers: the handler strips credentials on all cross-origin requests, which would need auth-server origin allow-listing if SDK OAuth support is ever added here.
  - Added regression tests covering OriginPinningHandler behavior and StripCredentialHeadersOnCrossOrigin (same-origin pass-through, cross-origin scheme/host/port strip, case-insensitive origin match).
- **What is the impact of these changes?**
  - Credentials supplied to the handler are pinned to the configured server origin across three independent layers, so a compromised server, redirect, or future config regression cannot redirect them to another origin.
Behavioral note: the transport no longer negotiates down to legacy SSE. Servers reachable only via the legacy /sse + /message flow will need the standard Streamable HTTP endpoint. This is consistent with the MCP SDK's own default of disabling legacy SSE.
  - The httpClientProvider path is unchanged; callers supplying their own HttpClient remain responsible for equivalent pinning, now called out in the XML docs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
