### PR TITLE
.NET: Make default-approval harness features configurable + customizable shell tool

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
@@ -274,7 +274,9 @@ public sealed class HarnessAgent : DelegatingAIAgent
         if (options?.ShellExecutor is ShellExecutor shellExecutor)
         {
             result.Tools ??= [];
-            result.Tools.Add(shellExecutor.AsAIFunction());
+            result.Tools.Add(options.ShellToolName is { } shellToolName
+                ? shellExecutor.AsAIFunction(shellToolName, options.ShellToolDescription, options.ShellToolRequireApproval)
+                : shellExecutor.AsAIFunction(description: options.ShellToolDescription, requireApproval: options.ShellToolRequireApproval));
         }
 #endif
 

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgent.cs
@@ -275,8 +275,8 @@ public sealed class HarnessAgent : DelegatingAIAgent
         {
             result.Tools ??= [];
             result.Tools.Add(options.ShellToolName is { } shellToolName
-                ? shellExecutor.AsAIFunction(shellToolName, options.ShellToolDescription, options.ShellToolRequireApproval)
-                : shellExecutor.AsAIFunction(description: options.ShellToolDescription, requireApproval: options.ShellToolRequireApproval));
+                ? shellExecutor.AsAIFunction(shellToolName, options.ShellToolDescription, !options.DisableShellToolApproval)
+                : shellExecutor.AsAIFunction(description: options.ShellToolDescription, requireApproval: !options.DisableShellToolApproval));
         }
 #endif
 

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
@@ -372,6 +372,34 @@ public sealed class HarnessAgentOptions
     public ShellExecutor? ShellExecutor { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the shell execution tool exposed to the model.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/> (the default), the shell executor's default tool name (<c>run_shell</c>) is used.
+    /// This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
+    /// </remarks>
+    public string? ShellToolName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the shell execution tool shown to the model.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/> (the default), the shell executor's built-in description is used.
+    /// This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
+    /// </remarks>
+    public string? ShellToolDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the shell execution tool requires approval before each invocation.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="true"/> (the default), the shell tool is wrapped in an <see cref="ApprovalRequiredAIFunction"/>
+    /// so every command requires explicit approval before executing. When <see langword="false"/>, the tool can be invoked
+    /// without approval. This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
+    /// </remarks>
+    public bool ShellToolRequireApproval { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets optional configuration for the <see cref="ShellEnvironmentProvider"/>.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Harness/HarnessAgentOptions.cs
@@ -390,14 +390,25 @@ public sealed class HarnessAgentOptions
     public string? ShellToolDescription { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the shell execution tool requires approval before each invocation.
+    /// Gets or sets a value indicating whether approval is disabled for the shell execution tool.
     /// </summary>
     /// <remarks>
-    /// When <see langword="true"/> (the default), the shell tool is wrapped in an <see cref="ApprovalRequiredAIFunction"/>
-    /// so every command requires explicit approval before executing. When <see langword="false"/>, the tool can be invoked
+    /// <para>
+    /// When <see langword="false"/> (the default), the shell tool is wrapped in an <see cref="ApprovalRequiredAIFunction"/>
+    /// so every command requires explicit approval before executing. When <see langword="true"/>, the tool can be invoked
     /// without approval. This property is ignored when <see cref="ShellExecutor"/> is <see langword="null"/>.
+    /// </para>
+    /// <para>
+    /// Setting this to <see langword="true"/> also requires the underlying <see cref="ShellExecutor"/> to permit
+    /// unapproved use. The inverse of this value is forwarded as the <c>requireApproval</c> argument to
+    /// <see cref="ShellExecutor.AsAIFunction"/>, and some executors enforce their own security boundary:
+    /// <see cref="LocalShellExecutor"/> throws an <see cref="System.InvalidOperationException"/> unless it was
+    /// constructed with <see cref="LocalShellExecutorOptions.AcknowledgeUnsafe"/> set to <see langword="true"/>,
+    /// because running unapproved commands directly on the host is inherently unsafe. Sandboxed executors such as
+    /// <see cref="DockerShellExecutor"/> impose no such requirement.
+    /// </para>
     /// </remarks>
-    public bool ShellToolRequireApproval { get; set; } = true;
+    public bool DisableShellToolApproval { get; set; }
 
     /// <summary>
     /// Gets or sets optional configuration for the <see cref="ShellEnvironmentProvider"/>.

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
@@ -46,7 +46,10 @@ namespace Microsoft.Agents.AI;
 /// (<c>file_access_read</c>, <c>file_access_ls</c>, and <c>file_access_grep</c>) are exposed.
 /// </para>
 /// <para>
-/// All of these tools always require approval: each is exposed as an <see cref="ApprovalRequiredAIFunction"/>.
+/// By default, all of these tools require approval: each is exposed as an <see cref="ApprovalRequiredAIFunction"/>.
+/// Approval can be disabled per group via <see cref="FileAccessProviderOptions.DisableReadOnlyToolApproval"/>
+/// (read, ls, and grep) and <see cref="FileAccessProviderOptions.DisableWriteToolApproval"/>
+/// (write, delete, replace, and replace_lines).
 /// </para>
 /// <para>
 /// To auto-approve these tools without prompting, use the <see cref="ToolApprovalAgent"/> and add one of the provided rules to
@@ -130,6 +133,8 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     private readonly AgentFileStore _fileStore;
     private readonly string _instructions;
     private readonly bool _disableWriteTools;
+    private readonly bool _disableReadOnlyToolApproval;
+    private readonly bool _disableWriteToolApproval;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private AITool[]? _tools;
 
@@ -149,6 +154,8 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
         this._fileStore = fileStore;
         this._instructions = options?.Instructions ?? DefaultInstructions;
         this._disableWriteTools = options?.DisableWriteTools ?? false;
+        this._disableReadOnlyToolApproval = options?.DisableReadOnlyToolApproval ?? false;
+        this._disableWriteToolApproval = options?.DisableWriteToolApproval ?? false;
     }
 
     /// <summary>
@@ -157,7 +164,7 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tools exposed by <see cref="FileAccessProvider"/> always require approval. Add this rule to
+    /// By default, the tools exposed by <see cref="FileAccessProvider"/> require approval. Add this rule to
     /// <see cref="ToolApprovalAgentOptions.AutoApprovalRules"/> to automatically approve only the tools
     /// that read from the file store, while still prompting for tools that modify it
     /// (<see cref="WriteToolName"/>, <see cref="DeleteFileToolName"/>, <see cref="ReplaceToolName"/>,
@@ -178,7 +185,7 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tools exposed by <see cref="FileAccessProvider"/> always require approval. Add this rule to
+    /// By default, the tools exposed by <see cref="FileAccessProvider"/> require approval. Add this rule to
     /// <see cref="ToolApprovalAgentOptions.AutoApprovalRules"/> to automatically approve every file access
     /// tool without prompting the user.
     /// </para>
@@ -410,24 +417,31 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     {
         var serializerOptions = AgentJsonUtilities.DefaultOptions;
 
-        // All file access tools always require approval. Callers can use the
-        // ReadOnlyToolsAutoApprovalRule or AllToolsAutoApprovalRule with the ToolApprovalAgent
-        // to automatically approve these tools.
+        // Read-only and store-modifying tools require approval by default. Approval can be disabled
+        // per group via FileAccessProviderOptions.DisableReadOnlyToolApproval and DisableWriteToolApproval;
+        // otherwise callers can use the ReadOnlyToolsAutoApprovalRule or AllToolsAutoApprovalRule with the
+        // ToolApprovalAgent to automatically approve these tools.
+        bool readOnlyRequiresApproval = !this._disableReadOnlyToolApproval;
+        bool writeRequiresApproval = !this._disableWriteToolApproval;
+
         var tools = new List<AITool>
         {
-            new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.ReadAsync, new AIFunctionFactoryOptions { Name = ReadFileToolName, SerializerOptions = serializerOptions })),
-            new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.LsAsync, new AIFunctionFactoryOptions { Name = LsToolName, SerializerOptions = serializerOptions })),
-            new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.GrepAsync, new AIFunctionFactoryOptions { Name = GrepToolName, SerializerOptions = serializerOptions })),
+            WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.ReadAsync, new AIFunctionFactoryOptions { Name = ReadFileToolName, SerializerOptions = serializerOptions }), readOnlyRequiresApproval),
+            WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.LsAsync, new AIFunctionFactoryOptions { Name = LsToolName, SerializerOptions = serializerOptions }), readOnlyRequiresApproval),
+            WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.GrepAsync, new AIFunctionFactoryOptions { Name = GrepToolName, SerializerOptions = serializerOptions }), readOnlyRequiresApproval),
         };
 
         if (!this._disableWriteTools)
         {
-            tools.Add(new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.WriteAsync, new AIFunctionFactoryOptions { Name = WriteToolName, SerializerOptions = serializerOptions })));
-            tools.Add(new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.DeleteAsync, new AIFunctionFactoryOptions { Name = DeleteFileToolName, SerializerOptions = serializerOptions })));
-            tools.Add(new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.ReplaceAsync, new AIFunctionFactoryOptions { Name = ReplaceToolName, SerializerOptions = serializerOptions })));
-            tools.Add(new ApprovalRequiredAIFunction(AIFunctionFactory.Create(this.ReplaceLinesAsync, new AIFunctionFactoryOptions { Name = ReplaceLinesToolName, SerializerOptions = serializerOptions })));
+            tools.Add(WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.WriteAsync, new AIFunctionFactoryOptions { Name = WriteToolName, SerializerOptions = serializerOptions }), writeRequiresApproval));
+            tools.Add(WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.DeleteAsync, new AIFunctionFactoryOptions { Name = DeleteFileToolName, SerializerOptions = serializerOptions }), writeRequiresApproval));
+            tools.Add(WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.ReplaceAsync, new AIFunctionFactoryOptions { Name = ReplaceToolName, SerializerOptions = serializerOptions }), writeRequiresApproval));
+            tools.Add(WrapWithApprovalIfRequired(AIFunctionFactory.Create(this.ReplaceLinesAsync, new AIFunctionFactoryOptions { Name = ReplaceLinesToolName, SerializerOptions = serializerOptions }), writeRequiresApproval));
         }
 
         return tools.ToArray();
     }
+
+    private static AITool WrapWithApprovalIfRequired(AIFunction function, bool requireApproval)
+        => requireApproval ? new ApprovalRequiredAIFunction(function) : function;
 }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProviderOptions.cs
@@ -30,4 +30,38 @@ public sealed class FileAccessProviderOptions
     /// <c>file_access_replace</c>, and <c>file_access_replace_lines</c>) are hidden.
     /// </value>
     public bool DisableWriteTools { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether approval is disabled for the read-only file access tools
+    /// (<see cref="FileAccessProvider.ReadFileToolName"/>, <see cref="FileAccessProvider.LsToolName"/>,
+    /// and <see cref="FileAccessProvider.GrepToolName"/>).
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="false"/> (the default), these tools require approval before invocation.
+    /// When <see langword="true"/>, they can be invoked without approval.
+    /// If any other tool in the same response still requires approval, set
+    /// <see cref="ChatClientAgentOptions.EnableNonApprovalRequiredFunctionBypassing"/>
+    /// to <see langword="true"/> so these tools are not surfaced as approval requests.
+    /// When approval is required, auto-approval rules (e.g. <see cref="FileAccessProvider.ReadOnlyToolsAutoApprovalRule"/>
+    /// or <see cref="FileAccessProvider.AllToolsAutoApprovalRule"/>) can be used to automatically approve calls.
+    /// </remarks>
+    public bool DisableReadOnlyToolApproval { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether approval is disabled for the tools that modify the file store
+    /// (<see cref="FileAccessProvider.WriteToolName"/>, <see cref="FileAccessProvider.DeleteFileToolName"/>,
+    /// <see cref="FileAccessProvider.ReplaceToolName"/>, and <see cref="FileAccessProvider.ReplaceLinesToolName"/>).
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="false"/> (the default), these tools require approval before invocation.
+    /// When <see langword="true"/>, they can be invoked without approval.
+    /// If any other tool in the same response still requires approval, set
+    /// <see cref="ChatClientAgentOptions.EnableNonApprovalRequiredFunctionBypassing"/>
+    /// to <see langword="true"/> so these tools are not surfaced as approval requests.
+    /// When approval is required, the <see cref="FileAccessProvider.AllToolsAutoApprovalRule"/> can be used
+    /// to automatically approve calls.
+    /// This setting has no effect when <see cref="DisableWriteTools"/> is <see langword="true"/>, since the
+    /// tools that modify the store are not exposed in that case.
+    /// </remarks>
+    public bool DisableWriteToolApproval { get; set; }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -1606,7 +1606,7 @@ public class HarnessAgentTests
         options.ShellExecutor = executorMock.Object;
         options.ShellToolName = "custom_shell";
         options.ShellToolDescription = "Run a custom command.";
-        options.ShellToolRequireApproval = false;
+        options.DisableShellToolApproval = true;
 
         // Act
         var agent = new HarnessAgent(chatClientMock.Object, options);
@@ -1634,9 +1634,14 @@ public class HarnessAgentTests
             .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
 
         bool? capturedRequireApproval = null;
+        string? capturedName = null;
         var executorMock = new Mock<ShellExecutor>();
         executorMock.Setup(e => e.AsAIFunction(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
-            .Callback<string, string?, bool>((_, _, requireApproval) => capturedRequireApproval = requireApproval)
+            .Callback<string, string?, bool>((name, _, requireApproval) =>
+            {
+                capturedName = name;
+                capturedRequireApproval = requireApproval;
+            })
             .Returns(AIFunctionFactory.Create(() => "shell output", "run_shell"));
 
         var options = CreateAllDisabledOptions();
@@ -1648,8 +1653,44 @@ public class HarnessAgentTests
         var session = await agent.CreateSessionAsync();
         await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
 
-        // Assert — approval is required by default.
+        // Assert — approval is required by default and the executor's default name is used.
         Assert.True(capturedRequireApproval);
+        Assert.Equal("run_shell", capturedName);
+    }
+
+    /// <summary>
+    /// Verify that disabling shell approval is honored end-to-end when the underlying executor permits unapproved use:
+    /// a real <see cref="LocalShellExecutor"/> constructed with <see cref="LocalShellExecutorOptions.AcknowledgeUnsafe"/>
+    /// set to <see langword="true"/> plus <see cref="HarnessAgentOptions.DisableShellToolApproval"/> set to
+    /// <see langword="true"/> yields a shell tool that is not wrapped in an <see cref="ApprovalRequiredAIFunction"/>.
+    /// </summary>
+    [Fact]
+    public async Task ShellExecutor_ApprovalDisabledWithAcknowledgedExecutorProducesNonApprovalToolAsync()
+    {
+        // Arrange
+        ChatOptions? capturedOptions = null;
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((_, opts, _) => capturedOptions = opts)
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+
+        await using var executor = new LocalShellExecutor(new LocalShellExecutorOptions { AcknowledgeUnsafe = true });
+
+        var options = CreateAllDisabledOptions();
+        options.DisableWebSearch = true;
+        options.ShellExecutor = executor;
+        options.DisableShellToolApproval = true;
+
+        // Act
+        var agent = new HarnessAgent(chatClientMock.Object, options);
+        var session = await agent.CreateSessionAsync();
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert — the shell tool is registered but not gated by approval.
+        Assert.NotNull(capturedOptions?.Tools);
+        var shellTool = Assert.Single(capturedOptions!.Tools!, t => t is AIFunction f && f.Name == "run_shell");
+        Assert.IsNotType<ApprovalRequiredAIFunction>(shellTool);
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -1575,6 +1575,84 @@ public class HarnessAgentTests
     }
 
     /// <summary>
+    /// Verify that a custom shell tool name, description, and approval flag are forwarded to the executor.
+    /// </summary>
+    [Fact]
+    public async Task ShellExecutor_CustomToolNameDescriptionAndApprovalForwardedAsync()
+    {
+        // Arrange
+        ChatOptions? capturedOptions = null;
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((_, opts, _) => capturedOptions = opts)
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+
+        string? capturedName = null;
+        string? capturedDescription = null;
+        bool? capturedRequireApproval = null;
+        var executorMock = new Mock<ShellExecutor>();
+        executorMock.Setup(e => e.AsAIFunction(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Callback<string, string?, bool>((name, description, requireApproval) =>
+            {
+                capturedName = name;
+                capturedDescription = description;
+                capturedRequireApproval = requireApproval;
+            })
+            .Returns(AIFunctionFactory.Create(() => "shell output", "custom_shell"));
+
+        var options = CreateAllDisabledOptions();
+        options.DisableWebSearch = true;
+        options.ShellExecutor = executorMock.Object;
+        options.ShellToolName = "custom_shell";
+        options.ShellToolDescription = "Run a custom command.";
+        options.ShellToolRequireApproval = false;
+
+        // Act
+        var agent = new HarnessAgent(chatClientMock.Object, options);
+        var session = await agent.CreateSessionAsync();
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert — the configured values are passed through to the executor and the tool is registered.
+        Assert.Equal("custom_shell", capturedName);
+        Assert.Equal("Run a custom command.", capturedDescription);
+        Assert.False(capturedRequireApproval);
+        Assert.NotNull(capturedOptions?.Tools);
+        Assert.Contains(capturedOptions!.Tools!, t => t is AIFunction f && f.Name == "custom_shell");
+    }
+
+    /// <summary>
+    /// Verify that the shell tool defaults to requiring approval and the executor's default name when not configured.
+    /// </summary>
+    [Fact]
+    public async Task ShellExecutor_DefaultsToApprovalAndDefaultNameAsync()
+    {
+        // Arrange
+        var chatClientMock = new Mock<IChatClient>();
+        chatClientMock
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, "done")));
+
+        bool? capturedRequireApproval = null;
+        var executorMock = new Mock<ShellExecutor>();
+        executorMock.Setup(e => e.AsAIFunction(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Callback<string, string?, bool>((_, _, requireApproval) => capturedRequireApproval = requireApproval)
+            .Returns(AIFunctionFactory.Create(() => "shell output", "run_shell"));
+
+        var options = CreateAllDisabledOptions();
+        options.DisableWebSearch = true;
+        options.ShellExecutor = executorMock.Object;
+
+        // Act
+        var agent = new HarnessAgent(chatClientMock.Object, options);
+        var session = await agent.CreateSessionAsync();
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert — approval is required by default.
+        Assert.True(capturedRequireApproval);
+    }
+
+    /// <summary>
     /// Verify that ShellEnvironmentProvider is present when ShellEnvironmentProviderOptions is also specified.
     /// </summary>
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessProviderTests.cs
@@ -59,6 +59,59 @@ public class FileAccessProviderTests
         Assert.All(tools, tool => Assert.IsType<ApprovalRequiredAIFunction>(tool));
     }
 
+    [Fact]
+    public async Task DisableReadOnlyToolApproval_ReadOnlyToolsNotWrappedAsync()
+    {
+        // Arrange
+        var tools = (await CreateToolsAsync(new FileAccessProviderOptions { DisableReadOnlyToolApproval = true })).ToList();
+
+        // Assert — read-only tools are bare functions; store-modifying tools still require approval.
+        AssertRequiresApproval(tools, FileAccessProvider.ReadFileToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.LsToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.GrepToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.WriteToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.DeleteFileToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.ReplaceToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.ReplaceLinesToolName, expected: true);
+    }
+
+    [Fact]
+    public async Task DisableWriteToolApproval_WriteToolsNotWrappedAsync()
+    {
+        // Arrange
+        var tools = (await CreateToolsAsync(new FileAccessProviderOptions { DisableWriteToolApproval = true })).ToList();
+
+        // Assert — store-modifying tools are bare functions; read-only tools still require approval.
+        AssertRequiresApproval(tools, FileAccessProvider.ReadFileToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.LsToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.GrepToolName, expected: true);
+        AssertRequiresApproval(tools, FileAccessProvider.WriteToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.DeleteFileToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.ReplaceToolName, expected: false);
+        AssertRequiresApproval(tools, FileAccessProvider.ReplaceLinesToolName, expected: false);
+    }
+
+    [Fact]
+    public async Task DisableBothToolApprovals_NoToolsWrappedAsync()
+    {
+        // Arrange
+        var tools = (await CreateToolsAsync(new FileAccessProviderOptions
+        {
+            DisableReadOnlyToolApproval = true,
+            DisableWriteToolApproval = true,
+        })).ToList();
+
+        // Assert — no tool requires approval.
+        Assert.Equal(7, tools.Count);
+        Assert.DoesNotContain(tools, tool => tool is ApprovalRequiredAIFunction);
+    }
+
+    private static void AssertRequiresApproval(IEnumerable<AITool> tools, string toolName, bool expected)
+    {
+        var tool = tools.OfType<AIFunction>().First(t => t.Name == toolName);
+        Assert.Equal(expected, tool is ApprovalRequiredAIFunction);
+    }
+
     [Theory]
     [InlineData(FileAccessProvider.ReadFileToolName, true)]
     [InlineData(FileAccessProvider.LsToolName, true)]
@@ -998,8 +1051,11 @@ public class FileAccessProviderTests
     #region Helper Methods
 
     private static async Task<IEnumerable<AITool>> CreateToolsAsync(InMemoryAgentFileStore? store = null)
+        => await CreateToolsAsync(null, store);
+
+    private static async Task<IEnumerable<AITool>> CreateToolsAsync(FileAccessProviderOptions? options, InMemoryAgentFileStore? store = null)
     {
-        var provider = new FileAccessProvider(store ?? new InMemoryAgentFileStore());
+        var provider = new FileAccessProvider(store ?? new InMemoryAgentFileStore(), options);
         var agent = new Mock<AIAgent>().Object;
         var session = new ChatClientAgentSession();
 #pragma warning disable MAAI001


### PR DESCRIPTION
### Motivation & Context

Several harness features register their function tools as approval-required and provide no way to opt out at the source. `FileAccessProvider` wraps every tool in an `ApprovalRequiredAIFunction`, and the `HarnessAgent` shell tool is always approval-required. Today the only way to avoid these prompts is to add auto-approval rules at the `ToolApprovalAgent` level, which forces a round-trip all the way up the stack and back down again just to suppress approval — inefficient and awkward when you already know at construction time that approval isn't wanted.

Separately, `ShellExecutor.AsAIFunction(name, description, requireApproval)` already supports a custom tool name/description/approval, but `HarnessAgent` called it with defaults only, so the shell tool was always exposed as `run_shell` with mandatory approval.

This makes both configurable at the source.

Fixes #6875
Fixes #6789

### Description & Review Guide

- **What are the major changes?**
  - `FileAccessProviderOptions` gains `DisableReadOnlyToolApproval` and `DisableWriteToolApproval` (both default `false` = approval required), matching the existing read-only/write split used by `ReadOnlyToolsAutoApprovalRule` / `AllToolsAutoApprovalRule`. `FileAccessProvider` now wraps each tool via a `WrapWithApprovalIfRequired` helper (mirroring `AgentSkillsProvider`) instead of hardcoding `ApprovalRequiredAIFunction`.
  - `HarnessAgentOptions` gains `ShellToolName`, `ShellToolDescription`, and `ShellToolRequireApproval` (default `true`). `HarnessAgent` forwards these to `ShellExecutor.AsAIFunction(...)`, falling back to the executor's own default name (`run_shell`) when `ShellToolName` is `null`.

- **What is the impact of these changes?**
  - Non-breaking and additive: all new options default to preserving today's behavior (all file-access tools and the shell tool still require approval; the shell tool is still named `run_shell`).
  - Python parity is intentionally out of scope — these are .NET-only issues; the Python providers currently also hardcode file-access approval and lack the harness shell-tool passthrough. Aligning Python can be done in a follow-up.

- **What do you want reviewers to focus on?**
  - The read-only vs. write approval granularity on `FileAccessProviderOptions`, and the null-fallback behavior for the shell tool name.

**Supersedes #6793.** That PR (also linked to #6789) adds only `ShellToolName`. This PR is a superset: it additionally forwards the shell tool description and approval flag, and addresses #6875 (per-group approval opt-out for `FileAccessProvider`). #6793 can be closed as superseded once this merges.

### Related Issue

Fixes #6875
Fixes #6789

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
