### PR TITLE
.NET: Validate Foundry toolbox name is a single path segment before building the proxy URL

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
@@ -436,6 +436,7 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(toolboxName);
+        EnsureSafeToolboxName(toolboxName);
 
         if (this._toolboxes.TryGetValue(toolboxName, out var cached))
         {
@@ -485,11 +486,64 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Validates that <paramref name="toolboxName"/> is a single, safe path segment before it is
+    /// interpolated into the toolbox proxy request URL.
+    /// </summary>
+    /// <remarks>
+    /// The name is fully percent-decoded in a bounded loop (so single- and multi-level encoded
+    /// separators are neutralized) and then rejected when the decoded value is empty, contains a
+    /// path separator (<c>/</c> or <c>\</c>), or is a relative-path segment (<c>.</c> or <c>..</c>).
+    /// <see cref="Uri"/> canonicalizes such segments (including their encoded forms) when it builds
+    /// the request URI, so without this guard a caller-influenced name could move the request target
+    /// away from <c>/toolboxes/{name}/mcp</c> to another path on the same host — while the
+    /// managed-identity token is still attached to the outbound request. Keeping the name to a single
+    /// segment also blocks encoded-separator smuggling that a downstream proxy might decode.
+    /// </remarks>
+    /// <param name="toolboxName">The toolbox name to validate.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the name is not a safe single path segment.
+    /// </exception>
+    private static void EnsureSafeToolboxName(string toolboxName)
+    {
+        var decoded = toolboxName;
+        for (var i = 0; i < 5; i++)
+        {
+            var next = Uri.UnescapeDataString(decoded);
+            if (string.Equals(next, decoded, StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            decoded = next;
+        }
+
+        var invalid =
+            decoded.Length == 0
+            || decoded.IndexOf('/') >= 0
+            || decoded.IndexOf('\\') >= 0
+            || string.Equals(decoded, ".", StringComparison.Ordinal)
+            || string.Equals(decoded, "..", StringComparison.Ordinal);
+
+        if (invalid)
+        {
+            throw new InvalidOperationException(
+                $"Toolbox name '{toolboxName}' is not a valid single-segment identifier. " +
+                "Toolbox names must not contain path separators or relative-path segments.");
+        }
+    }
+
     private async Task<ToolboxOpenResult> OpenToolboxAsync(
         string toolboxName,
         string? version,
         CancellationToken cancellationToken)
     {
+        // Defense-in-depth: every open path (startup, lazy per-request, consent retry, deferred
+        // retry) funnels through here, so validate the name at the single point where it is used to
+        // build the request URL. This guarantees a name that is not a safe single path segment can
+        // never form the proxy target, independent of the caller.
+        EnsureSafeToolboxName(toolboxName);
+
         // Test seam: when set, the open behavior (the only part that does real network I/O via the
         // MCP transport) is supplied by the test so the consent/tools resolution logic can be
         // exercised without a live toolbox proxy. Never set in production.

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
@@ -492,13 +492,15 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// The name is fully percent-decoded in a bounded loop (so single- and multi-level encoded
-    /// separators are neutralized) and then rejected when the decoded value is empty, contains a
-    /// path separator (<c>/</c> or <c>\</c>), or is a relative-path segment (<c>.</c> or <c>..</c>).
+    /// separators are neutralized) and then rejected when the decoded value is empty, still contains
+    /// a percent sign (residual/over-deep encoding), contains a path separator (<c>/</c> or <c>\</c>),
+    /// or is a relative-path segment (<c>.</c> or <c>..</c>).
     /// <see cref="Uri"/> canonicalizes such segments (including their encoded forms) when it builds
     /// the request URI, so without this guard a caller-influenced name could move the request target
     /// away from <c>/toolboxes/{name}/mcp</c> to another path on the same host — while the
-    /// managed-identity token is still attached to the outbound request. Keeping the name to a single
-    /// segment also blocks encoded-separator smuggling that a downstream proxy might decode.
+    /// managed-identity token is still attached to the outbound request. Rejecting a residual percent
+    /// sign also blocks encoding nested deeper than the decode cap, which a downstream proxy might
+    /// still resolve to a separator.
     /// </remarks>
     /// <param name="toolboxName">The toolbox name to validate.</param>
     /// <exception cref="InvalidOperationException">
@@ -520,6 +522,7 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
 
         var invalid =
             decoded.Length == 0
+            || decoded.IndexOf('%') >= 0
             || decoded.IndexOf('/') >= 0
             || decoded.IndexOf('\\') >= 0
             || string.Equals(decoded, ".", StringComparison.Ordinal)

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/FoundryToolboxService.cs
@@ -436,7 +436,7 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(toolboxName);
-        EnsureSafeToolboxName(toolboxName);
+        this.EnsureSafeToolboxName(toolboxName);
 
         if (this._toolboxes.TryGetValue(toolboxName, out var cached))
         {
@@ -487,53 +487,64 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
     }
 
     /// <summary>
-    /// Validates that <paramref name="toolboxName"/> is a single, safe path segment before it is
-    /// interpolated into the toolbox proxy request URL.
+    /// Validates that <paramref name="toolboxName"/> resolves to a single, intact path segment in the
+    /// toolbox proxy request URL, so a caller-influenced name cannot change the request target.
     /// </summary>
     /// <remarks>
-    /// The name is fully percent-decoded in a bounded loop (so single- and multi-level encoded
-    /// separators are neutralized) and then rejected when the decoded value is empty, still contains
-    /// a percent sign (residual/over-deep encoding), contains a path separator (<c>/</c> or <c>\</c>),
-    /// or is a relative-path segment (<c>.</c> or <c>..</c>).
-    /// <see cref="Uri"/> canonicalizes such segments (including their encoded forms) when it builds
-    /// the request URI, so without this guard a caller-influenced name could move the request target
-    /// away from <c>/toolboxes/{name}/mcp</c> to another path on the same host — while the
-    /// managed-identity token is still attached to the outbound request. Rejecting a residual percent
-    /// sign also blocks encoding nested deeper than the decode cap, which a downstream proxy might
-    /// still resolve to a separator.
+    /// Rather than block-listing characters, this builds the proxy URL exactly as
+    /// <see cref="OpenToolboxAsync"/> does and confirms, via <see cref="Uri"/>, that the name lands as
+    /// one path segment between <c>toolboxes</c> and <c>mcp</c> and alters nothing else: the scheme and
+    /// authority still match the configured endpoint, no fragment is introduced, the path is still
+    /// <c>{base}/toolboxes/{name}/mcp</c>, and that single segment round-trips back to the original
+    /// name. This is deliberately forgiving — any character that stays inside the segment (for example
+    /// <c>:</c>, <c>@</c>, <c>~</c>, or a dot that is not a standalone <c>.</c>/<c>..</c>) is allowed —
+    /// while a name that would move the target is rejected: path separators (<c>/</c>, <c>\</c>),
+    /// <c>.</c>/<c>..</c> traversal, a <c>?</c>/<c>#</c> that ends the path early, and their
+    /// percent-encoded forms (an encoded separator does not round-trip, so it is rejected before a
+    /// downstream proxy could decode it).
     /// </remarks>
     /// <param name="toolboxName">The toolbox name to validate.</param>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the name is not a safe single path segment.
+    /// Thrown when the name would not resolve to a single, intact path segment.
     /// </exception>
-    private static void EnsureSafeToolboxName(string toolboxName)
+    private void EnsureSafeToolboxName(string toolboxName)
     {
-        var decoded = toolboxName;
-        for (var i = 0; i < 5; i++)
+        // No endpoint resolved yet means there is no URL to protect; the caller surfaces the
+        // missing-endpoint error separately, so skip the effect-based check here.
+        if (string.IsNullOrEmpty(this._resolvedEndpoint))
         {
-            var next = Uri.UnescapeDataString(decoded);
-            if (string.Equals(next, decoded, StringComparison.Ordinal))
+            return;
+        }
+
+        var baseUri = new Uri(this._resolvedEndpoint, UriKind.Absolute);
+        var candidate = $"{this._resolvedEndpoint}/toolboxes/{toolboxName}/mcp?api-version={this._options.ApiVersion}";
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri)
+            && string.Equals(uri.Scheme, baseUri.Scheme, StringComparison.Ordinal)
+            && string.Equals(uri.Authority, baseUri.Authority, StringComparison.Ordinal)
+            && string.IsNullOrEmpty(uri.Fragment))
+        {
+            var prefix = $"{baseUri.AbsolutePath.TrimEnd('/')}/toolboxes/";
+            const string Suffix = "/mcp";
+            var path = uri.AbsolutePath;
+
+            if (path.Length > prefix.Length + Suffix.Length
+                && path.StartsWith(prefix, StringComparison.Ordinal)
+                && path.EndsWith(Suffix, StringComparison.Ordinal))
             {
-                break;
+                var segment = path.Substring(prefix.Length, path.Length - prefix.Length - Suffix.Length);
+                if (segment.Length > 0
+                    && segment.IndexOf('/') < 0
+                    && string.Equals(Uri.UnescapeDataString(segment), toolboxName, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
-
-            decoded = next;
         }
 
-        var invalid =
-            decoded.Length == 0
-            || decoded.IndexOf('%') >= 0
-            || decoded.IndexOf('/') >= 0
-            || decoded.IndexOf('\\') >= 0
-            || string.Equals(decoded, ".", StringComparison.Ordinal)
-            || string.Equals(decoded, "..", StringComparison.Ordinal);
-
-        if (invalid)
-        {
-            throw new InvalidOperationException(
-                $"Toolbox name '{toolboxName}' is not a valid single-segment identifier. " +
-                "Toolbox names must not contain path separators or relative-path segments.");
-        }
+        throw new InvalidOperationException(
+            $"Toolbox name '{toolboxName}' is not a valid single-segment identifier. " +
+            "Toolbox names must resolve to a single path segment and must not alter the request target.");
     }
 
     private async Task<ToolboxOpenResult> OpenToolboxAsync(
@@ -545,7 +556,7 @@ public sealed class FoundryToolboxService : IHostedService, IAsyncDisposable
         // retry) funnels through here, so validate the name at the single point where it is used to
         // build the request URL. This guarantees a name that is not a safe single path segment can
         // never form the proxy target, independent of the caller.
-        EnsureSafeToolboxName(toolboxName);
+        this.EnsureSafeToolboxName(toolboxName);
 
         // Test seam: when set, the open behavior (the only part that does real network I/O via the
         // MCP transport) is supplied by the test so the consent/tools resolution logic can be

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
@@ -265,13 +265,18 @@ public class FoundryToolboxServiceTests
     [InlineData("..")]
     [InlineData(".")]
     [InlineData("box\\..\\secret")]
+    [InlineData("foo?x=1")]
+    [InlineData("foo#frag")]
+    [InlineData("bad%3fx=1")]
+    [InlineData("tb%23frag")]
+    [InlineData("a%2fb")]
     public async Task GetToolboxToolsAsync_RejectsNonSingleSegmentToolboxNameAsync(string unsafeName)
     {
         // Arrange: non-strict mode with a resolved endpoint and a benign opener seam, so a
-        // well-formed single-segment name would resolve successfully. A name carrying path
-        // separators or relative-path segments (including their percent-encoded forms, or encoding
-        // nested deeper than the decode cap) must be rejected before any request URL is built, so it
-        // can never move the request target and carry the managed-identity token to an unintended
+        // well-formed single-segment name would resolve successfully. A name that would move the
+        // request target — path separators, relative-path segments, a query/fragment delimiter that
+        // ends the path early, or any of their percent-encoded forms — must be rejected before any
+        // request URL is built, so it can never carry the managed-identity token to an unintended
         // endpoint.
         var options = new FoundryToolboxOptions
         {
@@ -301,11 +306,16 @@ public class FoundryToolboxServiceTests
     [InlineData("sales")]
     [InlineData("box.v2")]
     [InlineData("a..b")]
+    [InlineData("tb:v1")]
+    [InlineData("tb@1")]
+    [InlineData("a(b)")]
     public async Task GetToolboxToolsAsync_AllowsWellFormedSingleSegmentNameAsync(string validName)
     {
-        // Arrange: a well-formed single-segment name (including names that merely contain a dot
-        // that is not a standalone relative-path segment) must still resolve through the opener,
-        // so the hardening does not reject legitimate toolbox names.
+        // Arrange: a well-formed single-segment name — including names that merely contain a
+        // character which stays inside the path segment (a dot that is not a standalone relative-path
+        // segment, or reserved characters such as ':' , '@' , and parentheses) — must still resolve
+        // through the opener. Validation is effect-based (does the name change the request target?),
+        // so it does not lock out legitimate names.
         AITool tool = AIFunctionFactory.Create(() => "ok", name: "some_tool");
         var options = new FoundryToolboxOptions
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
@@ -260,6 +260,7 @@ public class FoundryToolboxServiceTests
     [InlineData("../../admin")]
     [InlineData("..%2f..%2fadmin")]
     [InlineData("%2e%2e/%2e%2e/admin")]
+    [InlineData("%25252525252f")]
     [InlineData("a/b")]
     [InlineData("..")]
     [InlineData(".")]
@@ -268,15 +269,16 @@ public class FoundryToolboxServiceTests
     {
         // Arrange: non-strict mode with a resolved endpoint and a benign opener seam, so a
         // well-formed single-segment name would resolve successfully. A name carrying path
-        // separators or relative-path segments (including their percent-encoded forms) must be
-        // rejected before any request URL is built, so it can never move the request target and
-        // carry the managed-identity token to an unintended endpoint.
+        // separators or relative-path segments (including their percent-encoded forms, or encoding
+        // nested deeper than the decode cap) must be rejected before any request URL is built, so it
+        // can never move the request target and carry the managed-identity token to an unintended
+        // endpoint.
         var options = new FoundryToolboxOptions
         {
             StrictMode = false,
             EndpointOverride = "https://proj.example/api/projects/proj",
         };
-        var service = new FoundryToolboxService(
+        await using var service = new FoundryToolboxService(
             Options.Create(options),
             Mock.Of<TokenCredential>())
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryToolboxServiceTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -252,5 +254,79 @@ public class FoundryToolboxServiceTests
         Assert.Equal(FoundryToolboxStartupStatus.Healthy, service.StartupStatus);
         Assert.Empty(service.FailedToolboxNames);
         Assert.Empty(service.Tools);
+    }
+
+    [Theory]
+    [InlineData("../../admin")]
+    [InlineData("..%2f..%2fadmin")]
+    [InlineData("%2e%2e/%2e%2e/admin")]
+    [InlineData("a/b")]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData("box\\..\\secret")]
+    public async Task GetToolboxToolsAsync_RejectsNonSingleSegmentToolboxNameAsync(string unsafeName)
+    {
+        // Arrange: non-strict mode with a resolved endpoint and a benign opener seam, so a
+        // well-formed single-segment name would resolve successfully. A name carrying path
+        // separators or relative-path segments (including their percent-encoded forms) must be
+        // rejected before any request URL is built, so it can never move the request target and
+        // carry the managed-identity token to an unintended endpoint.
+        var options = new FoundryToolboxOptions
+        {
+            StrictMode = false,
+            EndpointOverride = "https://proj.example/api/projects/proj",
+        };
+        var service = new FoundryToolboxService(
+            Options.Create(options),
+            Mock.Of<TokenCredential>())
+        {
+            ToolboxOpener = (name, _, _) => Task.FromResult(
+                new FoundryToolboxService.ToolboxOpenResult(
+                    new FoundryToolboxService.CachedToolbox(Client: null, new HttpClient(), []),
+                    Consents: null)),
+        };
+        await service.StartAsync(CancellationToken.None);
+
+        // Act + Assert: resolution is refused for the caller-influenced marker name.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await service.GetToolboxToolsAsync(unsafeName, version: null, CancellationToken.None));
+
+        Assert.Contains(unsafeName, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("my-toolbox")]
+    [InlineData("sales")]
+    [InlineData("box.v2")]
+    [InlineData("a..b")]
+    public async Task GetToolboxToolsAsync_AllowsWellFormedSingleSegmentNameAsync(string validName)
+    {
+        // Arrange: a well-formed single-segment name (including names that merely contain a dot
+        // that is not a standalone relative-path segment) must still resolve through the opener,
+        // so the hardening does not reject legitimate toolbox names.
+        AITool tool = AIFunctionFactory.Create(() => "ok", name: "some_tool");
+        var options = new FoundryToolboxOptions
+        {
+            StrictMode = false,
+            EndpointOverride = "https://proj.example/api/projects/proj",
+        };
+        await using var service = new FoundryToolboxService(
+            Options.Create(options),
+            Mock.Of<TokenCredential>())
+        {
+            ToolboxOpener = (name, _, _) => Task.FromResult(
+                new FoundryToolboxService.ToolboxOpenResult(
+                    new FoundryToolboxService.CachedToolbox(Client: null, new HttpClient(), [tool]),
+                    Consents: null)),
+        };
+        await service.StartAsync(CancellationToken.None);
+
+        // Act
+        var resolution = await service.GetToolboxToolsAsync(validName, version: null, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(resolution.Consents);
+        Assert.Single(resolution.Tools);
+        Assert.Same(tool, resolution.Tools[0]);
     }
 }


### PR DESCRIPTION
### Motivation & Context

Hardens the Foundry Toolbox hosting integration. A toolbox name resolved from a request-supplied
marker was interpolated into the toolbox MCP proxy URL without a single-segment/canonicalization
check, so relative-path segments could change the request target. This is an input-validation /
request-target-consistency gap.

### Description & Review Guide

- **What are the major changes?**
  - `FoundryToolboxService` now validates that a toolbox name is a single, safe path segment before
    it is used to build the proxy URL. The name is fully percent-decoded and rejected when it is
    empty, contains a path separator (`/` or `\`), or is a relative-path segment (`.` or `..`).
  - Validation runs at both the per-request marker resolution (`GetToolboxToolsAsync`) and the shared
    open path (`OpenToolboxAsync`), so every open path is covered.
  - Added unit tests covering rejected (separator / relative-path, incl. percent-encoded) and
    accepted (well-formed) names.

- **What is the impact of these changes?**
  - .NET only. The Python port resolves the toolbox name from trusted environment configuration and
    has no request-influenced path, so no change is needed there.
  - No public API change; behavior only differs for names that were never valid single-segment
    identifiers.

### Related Issue

N/A — hardening change, not linked to an issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [x] **This is not a breaking change.**
