### PR TITLE
.NET: Return 404 for a response created against a nonexistent conversation

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/InMemoryResponsesService.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/InMemoryResponsesService.cs
@@ -156,9 +156,26 @@ internal sealed class InMemoryResponsesService : IResponsesService, IDisposable
         {
             return new ResponseError
             {
-                Code = "invalid_request",
+                Code = ResponseErrorCodes.InvalidRequest,
                 Message = "Mutually exclusive parameters: 'conversation' and 'previous_response_id'. Ensure you are only providing one of: 'previous_response_id' or 'conversation'."
             };
+        }
+
+        // When a conversation store is configured and the request references a conversation,
+        // verify it exists up front. This surfaces a missing conversation as a clean not-found
+        // error (mapped to HTTP 404, consistent with the Conversations API) instead of failing
+        // mid-execution and reporting a generic server error.
+        if (this._conversationStorage is not null && request.Conversation?.Id is { Length: > 0 } conversationId)
+        {
+            var conversation = await this._conversationStorage.GetConversationAsync(conversationId, cancellationToken).ConfigureAwait(false);
+            if (conversation is null)
+            {
+                return new ResponseError
+                {
+                    Code = ResponseErrorCodes.ConversationNotFound,
+                    Message = $"Conversation with id '{conversationId}' not found."
+                };
+            }
         }
 
         return await this._executor.ValidateRequestAsync(request, cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/ResponseErrorCodes.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/ResponseErrorCodes.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.Responses;
+
+/// <summary>
+/// Well-known error codes returned by response request validation, together with their mapping to
+/// the HTTP status code a handler should return for each. Centralizing the codes avoids scattering
+/// string literals and keeps the status mapping in a single place.
+/// </summary>
+internal static class ResponseErrorCodes
+{
+    /// <summary>
+    /// The request was malformed or violated a request-level constraint (HTTP 400).
+    /// </summary>
+    public const string InvalidRequest = "invalid_request";
+
+    /// <summary>
+    /// A conversation referenced by the request does not exist (HTTP 404).
+    /// </summary>
+    public const string ConversationNotFound = "conversation_not_found";
+
+    /// <summary>
+    /// Maps a validation error code to the HTTP status code and the wire error code a handler should
+    /// return for it. Not-found codes map to <see cref="StatusCodes.Status404NotFound"/> with a
+    /// <see langword="null"/> wire code (matching the OpenAI error body, whose semantics are carried
+    /// by the error <c>type</c>); every other validation failure maps to
+    /// <see cref="StatusCodes.Status400BadRequest"/> and keeps its code.
+    /// </summary>
+    /// <param name="code">The <see cref="Models.ResponseError.Code"/> to map.</param>
+    /// <returns>The HTTP status code and the wire error code to return for the given error code.</returns>
+    public static (int StatusCode, string? WireCode) MapValidationError(string? code) => code switch
+    {
+        ConversationNotFound => (StatusCodes.Status404NotFound, null),
+        _ => (StatusCodes.Status400BadRequest, code),
+    };
+}

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/ResponsesHttpHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.OpenAI/Responses/ResponsesHttpHandler.cs
@@ -38,15 +38,21 @@ internal sealed class ResponsesHttpHandler
         ResponseError? validationError = await this._responsesService.ValidateRequestAsync(request, cancellationToken).ConfigureAwait(false);
         if (validationError is not null)
         {
-            return Results.BadRequest(new ErrorResponse
+            var (statusCode, wireCode) = ResponseErrorCodes.MapValidationError(validationError.Code);
+            var errorResponse = new ErrorResponse
             {
                 Error = new ErrorDetails
                 {
                     Message = validationError.Message,
                     Type = "invalid_request_error",
-                    Code = validationError.Code
+                    Code = wireCode
                 }
-            });
+            };
+
+            // Not-found codes become a 404; other validation failures are 400 bad requests.
+            return statusCode == StatusCodes.Status404NotFound
+                ? Results.NotFound(errorResponse)
+                : Results.BadRequest(errorResponse);
         }
 
         try

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/InMemoryResponsesServiceTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/InMemoryResponsesServiceTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Hosting.OpenAI.Conversations;
+using Microsoft.Agents.AI.Hosting.OpenAI.Conversations.Models;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses;
+using Microsoft.Agents.AI.Hosting.OpenAI.Responses.Models;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.OpenAI.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryResponsesService"/> request validation.
+/// </summary>
+public sealed class InMemoryResponsesServiceTests
+{
+    [Fact]
+    public async Task ValidateRequestAsync_NonexistentConversation_ReturnsNotFoundErrorAsync()
+    {
+        // Arrange
+        using var storage = new InMemoryConversationStorage();
+        using var service = new InMemoryResponsesService(
+            new StubResponseExecutor(), new InMemoryStorageOptions(), storage);
+        var request = new CreateResponse
+        {
+            Input = ResponseInput.FromText("hello"),
+            Conversation = ConversationReference.FromId("conv_does_not_exist")
+        };
+
+        // Act
+        ResponseError? error = await service.ValidateRequestAsync(request);
+
+        // Assert
+        Assert.NotNull(error);
+        Assert.Equal("conversation_not_found", error.Code);
+    }
+
+    [Fact]
+    public async Task ValidateRequestAsync_ExistingConversation_ReturnsNullAsync()
+    {
+        // Arrange
+        using var storage = new InMemoryConversationStorage();
+        var conversation = new Conversation
+        {
+            Id = "conv_" + Guid.NewGuid().ToString("N"),
+            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+        };
+        await storage.CreateConversationAsync(conversation);
+        using var service = new InMemoryResponsesService(
+            new StubResponseExecutor(), new InMemoryStorageOptions(), storage);
+        var request = new CreateResponse
+        {
+            Input = ResponseInput.FromText("hello"),
+            Conversation = ConversationReference.FromId(conversation.Id)
+        };
+
+        // Act
+        ResponseError? error = await service.ValidateRequestAsync(request);
+
+        // Assert
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public async Task ValidateRequestAsync_ConversationSuppliedButNoStorage_ReturnsNullAsync()
+    {
+        // Arrange - without a conversation store there is no existence to verify.
+        using var service = new InMemoryResponsesService(
+            new StubResponseExecutor(), new InMemoryStorageOptions());
+        var request = new CreateResponse
+        {
+            Input = ResponseInput.FromText("hello"),
+            Conversation = ConversationReference.FromId("conv_does_not_exist")
+        };
+
+        // Act
+        ResponseError? error = await service.ValidateRequestAsync(request);
+
+        // Assert
+        Assert.Null(error);
+    }
+
+    private sealed class StubResponseExecutor : IResponseExecutor
+    {
+        public ValueTask<ResponseError?> ValidateRequestAsync(CreateResponse request, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<ResponseError?>(null);
+
+        public async IAsyncEnumerable<StreamingResponseEvent> ExecuteAsync(
+            AgentInvocationContext context,
+            CreateResponse request,
+            IReadOnlyList<ChatMessage>? conversationHistory = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            yield break;
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.OpenAI.UnitTests/OpenAIResponsesIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -1247,6 +1248,52 @@ public sealed class OpenAIResponsesIntegrationTests : IAsyncDisposable
         Assert.Equal(ChatRole.User, mockChatClient.CallHistory[1][0].Role);
         Assert.Equal(ChatRole.Assistant, mockChatClient.CallHistory[1][1].Role);
         Assert.Equal(ChatRole.User, mockChatClient.CallHistory[1][2].Role);
+    }
+
+    /// <summary>
+    /// Verifies that creating a response against a conversation id that does not exist returns
+    /// HTTP 404 with an error body matching the OpenAI Responses API (type "invalid_request_error",
+    /// null code), rather than surfacing as a server error during execution. Covers both the
+    /// non-streaming and streaming request forms, which OpenAI both reject with a 404 before any
+    /// response is produced.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateResponse_WithNonexistentConversation_ReturnsNotFoundAsync(bool stream)
+    {
+        // Arrange
+        const string AgentName = "notfound-agent";
+        const string Instructions = "You are a helpful assistant.";
+        const string ConversationId = "conv_does_not_exist";
+
+        this._httpClient = await this.CreateTestServerWithConversationsAsync(AgentName, Instructions);
+
+        var requestBody = new
+        {
+            input = "Test",
+            agent = new { name = AgentName },
+            conversation = ConversationId,
+            stream
+        };
+        string requestJson = System.Text.Json.JsonSerializer.Serialize(requestBody);
+        using StringContent content = new(requestJson, Encoding.UTF8, "application/json");
+
+        // Act
+        HttpResponseMessage httpResponse = await this._httpClient.PostAsync(
+            new Uri($"/{AgentName}/v1/responses", UriKind.Relative), content);
+
+        // Assert - 404 with the OpenAI-shaped error body (application/json, not an SSE stream)
+        Assert.Equal(HttpStatusCode.NotFound, httpResponse.StatusCode);
+        Assert.Equal("application/json", httpResponse.Content.Headers.ContentType?.MediaType);
+
+        string responseJson = await httpResponse.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(responseJson);
+        var error = doc.RootElement.GetProperty("error");
+        Assert.Equal("invalid_request_error", error.GetProperty("type").GetString());
+        Assert.Equal(System.Text.Json.JsonValueKind.Null, error.GetProperty("code").ValueKind);
+        Assert.Contains(ConversationId, error.GetProperty("message").GetString());
+        Assert.Contains("not found", error.GetProperty("message").GetString());
     }
 
     private async Task<HttpResponseMessage> SendRawResponseAsync(


### PR DESCRIPTION
### Motivation & Context

A create-response request that references a nonexistent conversation id previously failed
mid-execution and returned HTTP 500. This returns a clean 404 instead, matching the Conversations
API.

### Description & Review Guide

- Validate conversation existence up front in `ValidateRequestAsync`; a missing conversation returns
  `conversation_not_found`.
- Add `ResponseErrorCodes` to map validation codes to an HTTP status (404 vs 400) in one place.
- Add unit and HTTP integration tests.

### Related Issue

N/A.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] **This is not a breaking change.**
