### PR TITLE
.NET: Align WorkflowOutputEvent streaming deserialization with SourceId to ExecutorId rename

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility.
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Added support for durable workflows ([#4436](https://github.com/microsoft/agent-framework/pull/4436))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility.
+- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility ([#6896](https://github.com/microsoft/agent-framework/pull/6896))
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Added support for durable workflows ([#4436](https://github.com/microsoft/agent-framework/pull/4436))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -429,7 +429,7 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
                 ? execIdElem.GetString() ?? string.Empty
                 : root.TryGetProperty("sourceId", out JsonElement srcIdElem)
                     ? srcIdElem.GetString() ?? string.Empty
-                    : string.Empty;
+                    : throw new JsonException("WorkflowOutputEvent is missing required 'executorId' (or legacy 'sourceId') property.");
             object? outputData = GetDataProperty(root);
             return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -425,9 +425,9 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
             }
 
             // WorkflowOutputEvent
-            string sourceId = root.GetProperty("sourceId").GetString() ?? string.Empty;
+            string outputExecutorId = root.GetProperty("executorId").GetString() ?? string.Empty;
             object? outputData = GetDataProperty(root);
-            return new WorkflowOutputEvent(outputData!, sourceId);
+            return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }
 
         return JsonSerializer.Deserialize(json, eventType, DurableSerialization.Options) as WorkflowEvent;

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -425,7 +425,11 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
             }
 
             // WorkflowOutputEvent
-            string outputExecutorId = root.GetProperty("executorId").GetString() ?? string.Empty;
+            string outputExecutorId = root.TryGetProperty("executorId", out JsonElement execIdElem)
+                ? execIdElem.GetString() ?? string.Empty
+                : root.TryGetProperty("sourceId", out JsonElement srcIdElem)
+                    ? srcIdElem.GetString() ?? string.Empty
+                    : string.Empty;
             object? outputData = GetDataProperty(root);
             return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -263,6 +263,37 @@ public sealed class DurableStreamingWorkflowRunTests
     }
 
     [Fact]
+    public async Task WatchStreamAsync_WorkflowOutputEvent_LegacySourceId_RoundTripsCorrectlyAsync()
+    {
+        // Arrange — simulate a legacy payload that uses "sourceId" instead of "executorId"
+        const string legacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
+        string typeName = typeof(WorkflowOutputEvent).AssemblyQualifiedName!;
+        string serializedEvent = JsonSerializer.Serialize(
+            new { typeName, data = legacyEventJson },
+            DurableSerialization.Options);
+        string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
+
+        Mock<DurableTaskClient> mockClient = new("test");
+        mockClient.Setup(c => c.GetInstanceAsync(InstanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadata(OrchestrationRuntimeStatus.Completed, serializedOutput: serializedOutput));
+
+        DurableStreamingWorkflowRun run = new(mockClient.Object, InstanceId, CreateTestWorkflow());
+
+        // Act
+        List<WorkflowEvent> events = [];
+        await foreach (WorkflowEvent evt in run.WatchStreamAsync())
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        Assert.Equal(2, events.Count);
+        WorkflowOutputEvent result = Assert.IsType<WorkflowOutputEvent>(events[0]);
+        Assert.Equal("legacy-executor", result.ExecutorId);
+        Assert.Equal("legacy-data", result.Data?.ToString());
+    }
+
+    [Fact]
     public async Task WatchStreamAsync_CompletedWithoutWrapper_YieldsFailedEventAsync()
     {
         // Arrange — output not wrapped in DurableWorkflowResult (indicates a bug)

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -266,10 +266,10 @@ public sealed class DurableStreamingWorkflowRunTests
     public async Task WatchStreamAsync_WorkflowOutputEvent_LegacySourceId_RoundTripsCorrectlyAsync()
     {
         // Arrange — simulate a legacy payload that uses "sourceId" instead of "executorId"
-        const string legacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
+        const string LegacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
         string typeName = typeof(WorkflowOutputEvent).AssemblyQualifiedName!;
         string serializedEvent = JsonSerializer.Serialize(
-            new { typeName, data = legacyEventJson },
+            new { typeName, data = LegacyEventJson },
             DurableSerialization.Options);
         string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
 

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -234,6 +234,35 @@ public sealed class DurableStreamingWorkflowRunTests
     }
 
     [Fact]
+    public async Task WatchStreamAsync_WorkflowOutputEvent_RoundTripsCorrectlyAsync()
+    {
+        // Arrange
+        WorkflowOutputEvent outputEvent = new("test-data", "executor-1");
+        string serializedEvent = SerializeEvent(outputEvent);
+        string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
+
+        Mock<DurableTaskClient> mockClient = new("test");
+        mockClient.Setup(c => c.GetInstanceAsync(InstanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadata(OrchestrationRuntimeStatus.Completed, serializedOutput: serializedOutput));
+
+        DurableStreamingWorkflowRun run = new(mockClient.Object, InstanceId, CreateTestWorkflow());
+
+        // Act
+        List<WorkflowEvent> events = [];
+        await foreach (WorkflowEvent evt in run.WatchStreamAsync())
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        Assert.Equal(2, events.Count);
+        WorkflowOutputEvent result = Assert.IsType<WorkflowOutputEvent>(events[0]);
+        Assert.Equal("executor-1", result.ExecutorId);
+        Assert.Equal("test-data", result.Data?.ToString());
+        Assert.Empty(result.Tags);
+    }
+
+    [Fact]
     public async Task WatchStreamAsync_CompletedWithoutWrapper_YieldsFailedEventAsync()
     {
         // Arrange — output not wrapped in DurableWorkflowResult (indicates a bug)


### PR DESCRIPTION
### Motivation & Context

PR #3441 renamed `WorkflowOutputEvent.SourceId` to `ExecutorId` (keeping `SourceId` as an `[Obsolete]` + `[JsonIgnore]` alias), but the manual streaming deserialization in `DeserializeEventByType` was not updated. It still calls `root.GetProperty("sourceId")`, which throws a `KeyNotFoundException` at runtime because the serialized JSON contains `"executorId"`.

This causes `WatchStreamAsync` to crash with an unhandled exception whenever the stream includes a `WorkflowOutputEvent` (e.g., when an executor calls `YieldOutputAsync`).

### Description & Review Guide

- **What are the major changes?**
  Updated the `WorkflowOutputEvent` branch in `DeserializeEventByType` to read `"executorId"` from the JSON payload instead of `"sourceId"`. Used variable name `outputExecutorId` to avoid shadowing the `executorId` variable declared in the `ExecutorInvokedEvent`/`ExecutorCompletedEvent` branches above.

- **What is the impact of these changes?**
  Fixes a runtime crash in `WatchStreamAsync` for any durable workflow that yields output. No behavioral change beyond fixing the deserialization to match the current property name.

- **What do you want reviewers to focus on?**
  Confirming there are no other references to the old `"sourceId"` JSON key in the durable task serialization/deserialization paths.

### Related Issue

<!-- File an issue if one doesn't exist yet -->

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**