### PR TITLE
Python: normalize single Anthropic tools

### DIFF
--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -28,7 +28,7 @@ from agent_framework import (
 )
 from agent_framework._settings import SecretString, load_settings
 from agent_framework._telemetry import get_user_agent
-from agent_framework._tools import SHELL_TOOL_KIND_VALUE
+from agent_framework._tools import SHELL_TOOL_KIND_VALUE, normalize_tools
 from agent_framework._types import _get_data_bytes_as_str  # type: ignore
 from agent_framework.observability import ChatTelemetryLayer
 from anthropic import AsyncAnthropic, AsyncAnthropicFoundry
@@ -950,7 +950,7 @@ class RawAnthropicClient(
             tool_list: list[Any] = []
             mcp_server_list: list[Any] = []
             tool_name_aliases: dict[str, str] = {}
-            for tool in tools:
+            for tool in normalize_tools(tools):
                 if isinstance(tool, FunctionTool) and tool.kind == SHELL_TOOL_KIND_VALUE:
                     api_type = (tool.additional_properties or {}).get("type", "bash_20250124")
                     tool_name_aliases["bash"] = tool.name

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -756,7 +756,7 @@ def test_prepare_tools_for_anthropic_single_tool(mock_anthropic_client: MagicMoc
         """Get weather for a location."""
         return f"Weather for {location}"
 
-    chat_options = ChatOptions(tools=get_weather)  # type: ignore[arg-type]
+    chat_options = ChatOptions(tools=get_weather)
     result = client._prepare_tools_for_anthropic(chat_options)
 
     assert result is not None

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -944,7 +944,7 @@ def test_prepare_tools_for_anthropic_single_dict_tool(
 ) -> None:
     """Test passing through a single dict tool."""
     client = create_test_anthropic_client(mock_anthropic_client)
-    chat_options = ChatOptions(tools={"type": "custom", "name": "custom_tool", "description": "A custom tool"})  # type: ignore[arg-type]
+    chat_options = ChatOptions(tools={"type": "custom", "name": "custom_tool", "description": "A custom tool"})
 
     result = client._prepare_tools_for_anthropic(chat_options)
 

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -745,6 +745,27 @@ def test_prepare_tools_for_anthropic_tool(mock_anthropic_client: MagicMock) -> N
     assert "Get weather for a location" in result["tools"][0]["description"]
 
 
+def test_prepare_tools_for_anthropic_single_tool(mock_anthropic_client: MagicMock) -> None:
+    """Test converting a single FunctionTool to Anthropic format."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    @tool(approval_mode="never_require")
+    def get_weather(
+        location: Annotated[str, Field(description="Location to get weather for")],
+    ) -> str:
+        """Get weather for a location."""
+        return f"Weather for {location}"
+
+    chat_options = ChatOptions(tools=get_weather)  # type: ignore[arg-type]
+    result = client._prepare_tools_for_anthropic(chat_options)
+
+    assert result is not None
+    assert "tools" in result
+    assert len(result["tools"]) == 1
+    assert result["tools"][0]["type"] == "custom"
+    assert result["tools"][0]["name"] == "get_weather"
+
+
 def test_prepare_tools_for_anthropic_web_search(
     mock_anthropic_client: MagicMock,
 ) -> None:
@@ -909,6 +930,21 @@ def test_prepare_tools_for_anthropic_dict_tool(
     """Test converting dict tool to Anthropic format."""
     client = create_test_anthropic_client(mock_anthropic_client)
     chat_options = ChatOptions(tools=[{"type": "custom", "name": "custom_tool", "description": "A custom tool"}])
+
+    result = client._prepare_tools_for_anthropic(chat_options)
+
+    assert result is not None
+    assert "tools" in result
+    assert len(result["tools"]) == 1
+    assert result["tools"][0]["name"] == "custom_tool"
+
+
+def test_prepare_tools_for_anthropic_single_dict_tool(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Test passing through a single dict tool."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+    chat_options = ChatOptions(tools={"type": "custom", "name": "custom_tool", "description": "A custom tool"})  # type: ignore[arg-type]
 
     result = client._prepare_tools_for_anthropic(chat_options)
 


### PR DESCRIPTION
### Motivation & Context

#### What Problem This Solves

The Python Anthropic provider accepted `options["tools"]` at the provider boundary, but then treated that value as though it were always an iterable sequence during request preparation. That is narrower than the framework-level `ChatOptions.tools` contract, where a caller can naturally pass either one tool-like value or a sequence of tool-like values.

This is a real triggerable path, not just a typing edge case. A caller can pass a single decorated callable, `FunctionTool`, or dict tool specification directly through `ChatOptions(tools=tool)`. That shape should be normalized before Anthropic-specific request preparation begins, so the provider maps the same logical single tool the same way whether it arrives as `tools=tool` or `tools=[tool]`.

Direct iteration created two different single-tool failure modes:

- A single `FunctionTool` or decorated callable could fail before the Anthropic payload was built, because the provider attempted to iterate the tool object itself.
- A single `dict` tool could be silently misread, because Python dict iteration yields keys. The provider could therefore see `"type"`, `"name"`, and `"description"` as separate tool items instead of preserving the dictionary as one Anthropic tool specification.

The bug therefore sits at the framework-to-provider boundary. Core normalization should decide whether the caller supplied one tool or many; the Anthropic provider should then perform Anthropic-specific conversion on already-normalized tool entries.

#### Changes

This PR normalizes `options["tools"]` with the shared core `normalize_tools()` helper before Anthropic-specific tool handling runs.

That keeps the responsibility split clean:

- Core tool normalization decides whether the caller supplied one tool or many tools.
- Anthropic-specific preparation continues to translate already-normalized tool objects and tool specifications into Anthropic request payloads.
- Existing Anthropic branches for custom tools, dict tools, shell tool alias handling, MCP server routing, tool name aliases, and tool choice behavior remain downstream of the same provider mapping function.

The production change is intentionally small: `_prepare_tools_for_anthropic(...)` now iterates over `normalize_tools(tools)` instead of iterating over `tools` directly. In practical terms, `tools=<single tool>` now reaches the same Anthropic preparation logic as `tools=[<single tool>]`.

#### Evidence

Focused Anthropic regression coverage now exercises the two single-tool shapes that exposed the bug:

```text
ChatOptions(tools=<decorated function tool>)
ChatOptions(tools={"type": "custom", "name": "custom_tool", ...})
```

The tests verify that these inputs prepare one Anthropic tool entry with the expected name/type fields. That proves the provider no longer treats a single tool object as the iterable container, and no longer splits a single dict tool into mapping keys.

The reviewer follow-up also removed unnecessary `type: ignore[arg-type]` comments from the new single-tool tests, so the tests now exercise the typed `ChatOptions.tools` surface directly instead of hiding the accepted input shape behind ignores.

This evidence is intentionally scoped to the PR diff, focused Anthropic regression tests, reviewer feedback, and visible PR checks. It does not claim a full repository CI or repository-wide typecheck run.

#### Possible call chain / impact

Before this change, a representative failing path was:

```text
caller builds ChatOptions(tools=<single FunctionTool/callable/dict>)
  -> AnthropicChatClient._prepare_tools_for_anthropic(...)
  -> direct iteration of options["tools"]
  -> TypeError for a non-iterable tool object, or key-by-key iteration for a dict
  -> request preparation fails or produces the wrong tool payload before reaching Anthropic
```

After this change, the path is:

```text
caller builds ChatOptions(tools=<single FunctionTool/callable/dict or sequence>)
  -> AnthropicChatClient._prepare_tools_for_anthropic(...)
  -> normalize_tools(tools)
  -> existing Anthropic-specific FunctionTool / dict / MCP / shell-tool conversion
  -> Anthropic request payload tools
```

The compatibility impact should be narrow and positive. Existing callers that already pass a list or other supported sequence continue through the same Anthropic conversion logic after normalization. The newly fixed callers are the ones using the broader framework API shape with a single tool, which now behaves like the equivalent one-item sequence for the covered request-preparation fields.

This is a localized Anthropic provider compatibility fix, not a broad tool-calling rewrite or a change to Anthropic request semantics.

### Description & Review Guide

- **What are the major changes?**
  - Reuse core `normalize_tools()` before Anthropic-specific tool conversion.
  - Add regression coverage for a single decorated function tool and a single dict tool.

- **What is the impact of these changes?**
  - Single-tool inputs now prepare the same Anthropic request payload as the equivalent one-item list.
  - Existing list/sequence inputs, shell tool aliasing, MCP routing, and tool choice behavior stay on the same conversion path.

- **What do you want reviewers to focus on?**
  - Whether using the shared core tool normalization helper is the right provider-level boundary before Anthropic-specific mapping.

### Related Issue

Fixes #6901

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.

