### PR TITLE
.NET: [BREAKING] Align ShellPolicy allow/deny semantics with Python

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
@@ -118,24 +118,29 @@ public readonly struct ShellPolicyOutcome : IEquatable<ShellPolicyOutcome>
 /// </para>
 /// <para>
 /// <b>No default patterns.</b> A <see cref="ShellPolicy"/> constructed
-/// with no arguments has an empty deny list and an empty allow list —
-/// it will allow any non-empty command. Operators who want pre-execution
-/// rejection of specific shapes must supply their own
-/// <paramref>denyList</paramref>.
+/// with no arguments has an empty deny list and no allow list (allow list
+/// disabled) — it will allow any non-empty command. Operators who want
+/// pre-execution rejection of specific shapes must supply their own
+/// <paramref>denyList</paramref>, or an <paramref>allowList</paramref> to
+/// deny everything except the explicitly allowed commands.
 /// </para>
 /// <para>
-/// <b>Evaluation order — allow short-circuits deny.</b> Allow patterns are
-/// checked first; a match returns immediately without consulting the deny
-/// list. Use allow patterns sparingly (and prefer narrowly anchored regexes
-/// like <c>^git\s+status$</c> rather than substring matches), because an
-/// over-broad allow pattern can re-enable a command that the deny list was
-/// supposed to block.
+/// <b>Evaluation order — deny-first, the allow list is exclusive.</b> Deny
+/// patterns are checked first and a match wins immediately. If an allow list
+/// is supplied, it is treated as exclusive: any command that matches
+/// <em>none</em> of the allow patterns is denied. Supplying an empty allow
+/// list therefore denies every command; leaving the allow list
+/// <see langword="null"/> disables the allow list entirely. An optional
+/// <c>custom</c> callback gets the final say and may override the outcome.
+/// Prefer narrowly anchored regexes (like <c>^git\s+status$</c>) over
+/// substring matches when building an allow list.
 /// </para>
 /// </remarks>
 public sealed class ShellPolicy
 {
     private readonly IReadOnlyList<Regex> _denies;
-    private readonly IReadOnlyList<Regex> _allows;
+    private readonly IReadOnlyList<Regex>? _allows;
+    private readonly Func<ShellRequest, ShellPolicyOutcome?>? _custom;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ShellPolicy"/> class.
@@ -145,10 +150,21 @@ public sealed class ShellPolicy
     /// empty collection disables the deny list entirely.
     /// </param>
     /// <param name="allowList">
-    /// Optional explicit-allow patterns. A match here short-circuits the
-    /// deny list and is useful when the caller knows the command is safe.
+    /// Optional allow-list patterns. When <see langword="null"/> the allow
+    /// list is disabled. When supplied (including as an empty collection) any
+    /// command matching none of the patterns is denied — an empty collection
+    /// therefore denies every command.
     /// </param>
-    public ShellPolicy(IEnumerable<string>? denyList = null, IEnumerable<string>? allowList = null)
+    /// <param name="custom">
+    /// Optional callback that gets the final say. It runs after the deny and
+    /// allow lists have passed; returning a non-<see langword="null"/> outcome
+    /// overrides the default allow, while <see langword="null"/> leaves the
+    /// default in place.
+    /// </param>
+    public ShellPolicy(
+        IEnumerable<string>? denyList = null,
+        IEnumerable<string>? allowList = null,
+        Func<ShellRequest, ShellPolicyOutcome?>? custom = null)
     {
         var deny = new List<Regex>();
         if (denyList is not null)
@@ -160,24 +176,26 @@ public sealed class ShellPolicy
         }
         this._denies = deny;
 
-        var allow = new List<Regex>();
         if (allowList is not null)
         {
+            var allow = new List<Regex>();
             foreach (var pattern in allowList)
             {
                 allow.Add(new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase));
             }
+            this._allows = allow;
         }
-        this._allows = allow;
+
+        this._custom = custom;
     }
 
     /// <summary>
     /// Evaluate <paramref name="request"/> and return an outcome.
     /// </summary>
     /// <remarks>
-    /// Order of operations: empty-command guard → explicit allow patterns
-    /// (a match short-circuits with <see cref="ShellPolicyOutcome.Allow"/>)
-    /// → deny patterns (first match wins) → default allow.
+    /// Order of operations (first hit wins): empty-command guard → deny
+    /// patterns → allow list (deny when supplied and unmatched) →
+    /// <c>custom</c> callback override → default allow.
     /// </remarks>
     /// <param name="request">The request to evaluate.</param>
     /// <returns>An allow or deny outcome.</returns>
@@ -189,19 +207,38 @@ public sealed class ShellPolicy
             return ShellPolicyOutcome.Deny("empty command");
         }
 
-        foreach (var allow in this._allows)
-        {
-            if (allow.IsMatch(command))
-            {
-                return new ShellPolicyOutcome(true, "matched allow pattern");
-            }
-        }
-
         foreach (var deny in this._denies)
         {
             if (deny.IsMatch(command))
             {
                 return ShellPolicyOutcome.Deny($"matched deny pattern: {deny}");
+            }
+        }
+
+        if (this._allows is not null)
+        {
+            var matched = false;
+            foreach (var allow in this._allows)
+            {
+                if (allow.IsMatch(command))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched)
+            {
+                return ShellPolicyOutcome.Deny("command does not match allow list");
+            }
+        }
+
+        if (this._custom is not null)
+        {
+            var overrideOutcome = this._custom(request);
+            if (overrideOutcome is { } outcome)
+            {
+                return outcome;
             }
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Agents.AI.Tools.Shell;
@@ -140,8 +141,8 @@ public readonly struct ShellPolicyOutcome : IEquatable<ShellPolicyOutcome>
 /// </remarks>
 public sealed class ShellPolicy
 {
-    private readonly IReadOnlyList<Regex> _denies;
-    private readonly IReadOnlyList<Regex>? _allows;
+    private readonly IReadOnlyList<Regex> _denyList;
+    private readonly IReadOnlyList<Regex>? _allowList;
     private readonly Func<ShellRequest, ShellPolicyOutcome?>? _custom;
 
     /// <summary>
@@ -168,25 +169,13 @@ public sealed class ShellPolicy
         IEnumerable<string>? allowList = null,
         Func<ShellRequest, ShellPolicyOutcome?>? custom = null)
     {
-        var deny = new List<Regex>();
-        if (denyList is not null)
-        {
-            foreach (var pattern in denyList)
-            {
-                deny.Add(new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase));
-            }
-        }
-        this._denies = deny;
+        this._denyList = denyList?
+            .Select(pattern => new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase))
+            .ToArray() ?? Array.Empty<Regex>();
 
-        if (allowList is not null)
-        {
-            var allow = new List<Regex>();
-            foreach (var pattern in allowList)
-            {
-                allow.Add(new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase));
-            }
-            this._allows = allow;
-        }
+        this._allowList = allowList?
+            .Select(pattern => new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase))
+            .ToArray();
 
         this._custom = custom;
     }
@@ -209,7 +198,7 @@ public sealed class ShellPolicy
             return ShellPolicyOutcome.Deny("empty command");
         }
 
-        foreach (var deny in this._denies)
+        foreach (var deny in this._denyList)
         {
             if (deny.IsMatch(command))
             {
@@ -217,18 +206,9 @@ public sealed class ShellPolicy
             }
         }
 
-        if (this._allows is not null)
+        if (this._allowList is not null)
         {
-            var matched = false;
-            foreach (var allow in this._allows)
-            {
-                if (allow.IsMatch(command))
-                {
-                    matched = true;
-                    break;
-                }
-            }
-
+            var matched = this._allowList.Any(allow => allow.IsMatch(command));
             if (!matched)
             {
                 return ShellPolicyOutcome.Deny("command does not match allow list");

--- a/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellPolicy.cs
@@ -131,9 +131,11 @@ public readonly struct ShellPolicyOutcome : IEquatable<ShellPolicyOutcome>
 /// <em>none</em> of the allow patterns is denied. Supplying an empty allow
 /// list therefore denies every command; leaving the allow list
 /// <see langword="null"/> disables the allow list entirely. An optional
-/// <c>custom</c> callback gets the final say and may override the outcome.
-/// Prefer narrowly anchored regexes (like <c>^git\s+status$</c>) over
-/// substring matches when building an allow list.
+/// <c>custom</c> callback runs last — after the deny and allow lists have
+/// passed — and may override the default allow (for example, turning it into
+/// a deny); it cannot re-enable a command already rejected by the deny list
+/// or the allow list. Prefer narrowly anchored regexes (like
+/// <c>^git\s+status$</c>) over substring matches when building an allow list.
 /// </para>
 /// </remarks>
 public sealed class ShellPolicy

--- a/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
@@ -101,7 +101,7 @@ public sealed class LocalShellExecutorTests
     }
 
     [Fact]
-    public void Policy_Custom_RunsAfterDenyAndAllowLists()
+    public void Policy_Custom_DoesNotRunWhenDenyListMatches()
     {
         // Deny-list match short-circuits before the custom callback runs, so a
         // permissive custom callback cannot re-enable a denied command.
@@ -109,6 +109,18 @@ public sealed class LocalShellExecutorTests
             denyList: ["echo"],
             custom: _ => ShellPolicyOutcome.Allow);
         Assert.False(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+    }
+
+    [Fact]
+    public void Policy_Custom_DoesNotOverrideAllowListDenial()
+    {
+        // An allow-list denial short-circuits before the custom callback runs,
+        // so a permissive custom callback cannot re-enable a command that is
+        // outside the allow list.
+        var policy = new ShellPolicy(
+            allowList: ["^echo "],
+            custom: _ => ShellPolicyOutcome.Allow);
+        Assert.False(policy.Evaluate(new ShellRequest("ls -la")).Allowed);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
@@ -37,13 +37,78 @@ public sealed class LocalShellExecutorTests
     }
 
     [Fact]
-    public void Policy_AllowList_OverridesDeny()
+    public void Policy_DenyList_TakesPrecedenceOverAllowList()
     {
+        // Under deny-first semantics an allow-list match does NOT override a
+        // deny-list match; deny wins.
         var policy = new ShellPolicy(
             allowList: ["^echo "],
             denyList: ["echo"]);
         var decision = policy.Evaluate(new ShellRequest("echo hello"));
-        Assert.True(decision.Allowed);
+        Assert.False(decision.Allowed);
+        Assert.Contains("deny pattern", decision.Reason ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Policy_AllowList_AllowsMatch()
+    {
+        var policy = new ShellPolicy(allowList: ["^echo "]);
+        Assert.True(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+    }
+
+    [Fact]
+    public void Policy_AllowList_DeniesNonMatch()
+    {
+        var policy = new ShellPolicy(allowList: ["^echo "]);
+        var decision = policy.Evaluate(new ShellRequest("ls -la"));
+        Assert.False(decision.Allowed);
+        Assert.Contains("allow list", decision.Reason ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Policy_EmptyAllowList_DeniesEverything()
+    {
+        // A supplied-but-empty allow list matches nothing, so it denies all.
+        var policy = new ShellPolicy(allowList: []);
+        Assert.False(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+    }
+
+    [Fact]
+    public void Policy_NullAllowList_DisablesAllowList()
+    {
+        var policy = new ShellPolicy(allowList: null);
+        Assert.True(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+    }
+
+    [Fact]
+    public void Policy_Custom_CanOverrideDefaultAllowToDeny()
+    {
+        var policy = new ShellPolicy(
+            custom: req => req.Command.Contains("secret", StringComparison.OrdinalIgnoreCase)
+                ? ShellPolicyOutcome.Deny("custom blocked")
+                : null);
+        Assert.True(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+        var decision = policy.Evaluate(new ShellRequest("cat secret.txt"));
+        Assert.False(decision.Allowed);
+        Assert.Equal("custom blocked", decision.Reason);
+    }
+
+    [Fact]
+    public void Policy_Custom_NullReturn_LeavesDefaultAllow()
+    {
+        var policy = new ShellPolicy(custom: _ => null);
+        Assert.True(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
+    }
+
+    [Fact]
+    public void Policy_Custom_RunsAfterDenyAndAllowLists()
+    {
+        // Deny-list match short-circuits before the custom callback runs, so a
+        // permissive custom callback cannot re-enable a denied command.
+        var policy = new ShellPolicy(
+            denyList: ["echo"],
+            custom: _ => ShellPolicyOutcome.Allow);
+        Assert.False(policy.Evaluate(new ShellRequest("echo hello")).Allowed);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
@@ -50,6 +50,19 @@ public sealed class LocalShellExecutorTests
     }
 
     [Fact]
+    public void Policy_BroadDenyList_OverridesSpecificAllowList()
+    {
+        // A broad deny pattern wins even when a more specific allow pattern
+        // would otherwise permit the command.
+        var policy = new ShellPolicy(
+            allowList: ["^git push origin main$"],
+            denyList: ["git push"]);
+        var decision = policy.Evaluate(new ShellRequest("git push origin main"));
+        Assert.False(decision.Allowed);
+        Assert.Contains("deny pattern", decision.Reason ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Policy_AllowList_AllowsMatch()
     {
         var policy = new ShellPolicy(allowList: ["^echo "]);


### PR DESCRIPTION
### Motivation & Context

The `.NET` `ShellPolicy` (`Microsoft.Agents.AI.Tools.Shell`) and the Python
`ShellPolicy` (`agent_framework_tools.shell`) share the same intent — a layered
allow/deny UX pre-filter for shell commands — but had **incompatible evaluation
semantics**. In particular, the .NET version had **no way to express "deny
everything except an explicitly allowed set"**, which is exactly what
issue #6899 asks for. Its allow list behaved as *exceptions* that
short-circuited the deny list rather than as an exclusive allow list.

This change aligns the .NET behavior with the Python implementation so operators
get a consistent policy model across languages, including the requested
deny-all-except-allowed mode.

### Description & Review Guide

- **What are the major changes?**
  - **Deny-first evaluation order** (matching Python): `empty → deny patterns →
    allow list → custom callback → default allow`. A deny match now wins over an
    allow match (previously allow short-circuited deny).
  - **Allow list is now exclusive**: when supplied, any command matching *none*
    of the allow patterns is denied — this provides the "deny everything except
    the allowed set" behavior requested in #6899.
  - **`null` vs empty allow list distinction**: a `null` allow list disables the
    allow rule entirely; a supplied-but-empty allow list denies every command
    (matching Python).
  - **New `custom` callback**: an optional
    `Func<ShellRequest, ShellPolicyOutcome?>` that gets the final say and may
    override the default allow.
  - Updated XML docs and added/rewrote unit tests covering deny precedence,
    exclusive allow list (match/non-match), empty/null allow list, and the
    custom callback.

- **What is the impact of these changes?**
  - **Breaking** for existing preview users of `ShellPolicy`: the allow-list
    meaning and evaluation precedence change. The feature is experimental, but
    flagged breaking so preview users are aware. Released features are unchanged.
  - .NET-idiomatic naming/shape is retained (no renames of `ShellPolicyOutcome`,
    `Allowed`, `WorkingDirectory`, etc.).

- **What do you want reviewers to focus on?**
  - The evaluation order and the `null` vs empty allow-list semantics in
    `ShellPolicy.Evaluate`.

### Related Issue

Fixes #6899

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.