### PR TITLE
Python: fix(copilot): propagate usage details, finish_reason, and model from SDK events

### DIFF
--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -30,6 +30,7 @@ from agent_framework import (
     ResponseStream,
     SessionContext,
     UsageDetails,
+    add_usage_details,
     normalize_messages,
 )
 from agent_framework._settings import load_settings
@@ -640,16 +641,16 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
         if session_context.instructions:
             prompt = "\n".join(session_context.instructions) + "\n" + prompt
 
-        # Subscribe to events before send_and_wait so we can capture the
-        # ASSISTANT_USAGE event, which carries full input+output token counts.
-        # The handler coexists with send_and_wait's internal handler; both
-        # receive every event that the session emits.
-        usage_event_data: Any = None
+        # Subscribe to events before send_and_wait so we can capture every
+        # ASSISTANT_USAGE event.  Multi-turn runs (e.g. with tool calls) emit
+        # one ASSISTANT_USAGE event per model turn; we collect them all and sum
+        # into a per-run total.  The handler coexists with send_and_wait's own
+        # internal handler — both receive every event the session emits.
+        usage_events: list[Any] = []
 
         def _collect_usage(event: SessionEvent) -> None:
-            nonlocal usage_event_data
             if event.type == SessionEventType.ASSISTANT_USAGE:
-                usage_event_data = event.data
+                usage_events.append(event.data)
 
         unsubscribe_usage = copilot_session.on(_collect_usage)
         try:
@@ -680,18 +681,25 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 )
             response_id = message_id
 
-        # Build usage_details and finish_reason from the captured ASSISTANT_USAGE
-        # event.  Fall back to output_tokens on the ASSISTANT_MESSAGE data when no
+        # Build usage_details and finish_reason by aggregating all ASSISTANT_USAGE
+        # events collected during this run.  Summing per-turn counts gives the
+        # same per-run total as the streaming path (which relies on _process_update
+        # to accumulate Content.from_usage() updates).
+        # finish_reason and model are taken from the *last* event so they reflect
+        # the final model turn.
+        # Fall back to output_tokens on the ASSISTANT_MESSAGE data when no
         # dedicated usage event arrived (older CLI versions).
         response_usage: UsageDetails | None = None
         response_finish_reason: str | None = None
         response_model: str | None = None
-        if usage_event_data is not None:
-            response_usage = _parse_copilot_usage(usage_event_data)
-            response_finish_reason = getattr(usage_event_data, "reason", None) or getattr(
-                usage_event_data, "finish_reason", None
-            )
-            response_model = getattr(usage_event_data, "model", None)
+        if usage_events:
+            for evt_data in usage_events:
+                per_turn = _parse_copilot_usage(evt_data)
+                if per_turn:
+                    response_usage = add_usage_details(response_usage, per_turn)
+            last_evt = usage_events[-1]
+            response_finish_reason = getattr(last_evt, "reason", None) or getattr(last_evt, "finish_reason", None)
+            response_model = getattr(last_evt, "model", None)
         elif response_event and response_event.type == SessionEventType.ASSISTANT_MESSAGE:
             output_tokens = getattr(response_event.data, "output_tokens", None)
             if output_tokens is not None:
@@ -830,17 +838,25 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 # Capture per-turn token usage and emit it as a usage update so that
                 # AgentResponse.usage_details and AgentResponse.finish_reason are
                 # populated by the standard _process_update() aggregation path.
+                # Emit whenever usage OR finish_reason is present so finish_reason
+                # is never dropped for events that carry only non-token fields
+                # (e.g. cache-only or reasoning-only turns).
                 usage_data: Any = event.data
                 streamed_usage = _parse_copilot_usage(usage_data)
-                if streamed_usage:
-                    finish_reason: str | None = getattr(
-                        usage_data, "reason", None
-                    ) or getattr(usage_data, "finish_reason", None)
+                stream_finish_reason: str | None = getattr(usage_data, "reason", None) or getattr(
+                    usage_data, "finish_reason", None
+                )
+                if streamed_usage or stream_finish_reason:
+                    usage_contents = (
+                        [Content.from_usage(usage_details=streamed_usage, raw_representation=event)]
+                        if streamed_usage
+                        else []
+                    )
                     usage_update = AgentResponseUpdate(
                         role="assistant",
-                        contents=[Content.from_usage(usage_details=streamed_usage, raw_representation=event)],
+                        contents=usage_contents,
                         raw_representation=event,
-                        finish_reason=finish_reason,
+                        finish_reason=stream_finish_reason,
                     )
                     queue.put_nowait(usage_update)
             elif event.type == SessionEventType.SESSION_IDLE:

--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -691,7 +691,7 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
         # Fall back to output_tokens on the ASSISTANT_MESSAGE data when no
         # dedicated usage event arrived (older CLI versions).
         response_usage: UsageDetails | None = None
-        response_finish_reason: str | None = None
+        response_finish_reason: FinishReason | None = None
         response_model: str | None = None
         if usage_events:
             for evt_data in usage_events:

--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -25,6 +25,7 @@ from agent_framework import (
     BaseAgent,
     Content,
     ContextProvider,
+    FinishReason,
     HistoryProvider,
     Message,
     ResponseStream,
@@ -698,7 +699,8 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 if per_turn:
                     response_usage = add_usage_details(response_usage, per_turn)
             last_evt = usage_events[-1]
-            response_finish_reason = getattr(last_evt, "reason", None) or getattr(last_evt, "finish_reason", None)
+            _raw_reason = getattr(last_evt, "reason", None) or getattr(last_evt, "finish_reason", None)
+            response_finish_reason = FinishReason(_raw_reason) if _raw_reason else None
             response_model = getattr(last_evt, "model", None)
         elif response_event and response_event.type == SessionEventType.ASSISTANT_MESSAGE:
             output_tokens = getattr(response_event.data, "output_tokens", None)
@@ -843,9 +845,10 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 # (e.g. cache-only or reasoning-only turns).
                 usage_data: Any = event.data
                 streamed_usage = _parse_copilot_usage(usage_data)
-                stream_finish_reason: str | None = getattr(usage_data, "reason", None) or getattr(
+                _raw_stream_reason = getattr(usage_data, "reason", None) or getattr(
                     usage_data, "finish_reason", None
                 )
+                stream_finish_reason = FinishReason(_raw_stream_reason) if _raw_stream_reason else None
                 if streamed_usage or stream_finish_reason:
                     usage_contents = (
                         [Content.from_usage(usage_details=streamed_usage, raw_representation=event)]

--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -29,6 +29,7 @@ from agent_framework import (
     Message,
     ResponseStream,
     SessionContext,
+    UsageDetails,
     normalize_messages,
 )
 from agent_framework._settings import load_settings
@@ -129,6 +130,51 @@ def _deny_all_permissions(
 ) -> PermissionRequestResult:
     """Default permission handler that denies all requests."""
     return PermissionDecisionUserNotAvailable()
+
+
+def _parse_copilot_usage(data: Any) -> UsageDetails | None:
+    """Convert the data payload of an ``ASSISTANT_USAGE`` event to :class:`UsageDetails`.
+
+    The Copilot SDK emits an ``assistant.usage`` event after every model turn.
+    In SDK v1.0.2 the payload is a single ``Data`` object whose optional fields
+    include ``input_tokens``, ``output_tokens``, ``cache_read_tokens``, and
+    ``cache_write_tokens``.  Newer SDK releases use a dedicated
+    ``AssistantUsageData`` dataclass with the same attribute names, so this
+    helper accesses all fields via :func:`getattr` for forward compatibility.
+
+    Returns ``None`` when the payload carries no token counts at all so callers
+    can skip emitting an empty usage update.
+
+    Args:
+        data: The ``.data`` attribute of a ``SessionEvent`` whose type is
+            ``SessionEventType.ASSISTANT_USAGE``.
+
+    Returns:
+        A :class:`UsageDetails` dict if any token data is present, else ``None``.
+    """
+    input_tokens = getattr(data, "input_tokens", None)
+    output_tokens = getattr(data, "output_tokens", None)
+    if input_tokens is None and output_tokens is None:
+        return None
+    details = UsageDetails()
+    if input_tokens is not None:
+        details["input_token_count"] = int(input_tokens)
+    if output_tokens is not None:
+        details["output_token_count"] = int(output_tokens)
+    input_count = details.get("input_token_count") or 0
+    output_count = details.get("output_token_count") or 0
+    if input_count or output_count:
+        details["total_token_count"] = input_count + output_count
+    cache_read = getattr(data, "cache_read_tokens", None)
+    if cache_read is not None:
+        details["cache_read_input_token_count"] = int(cache_read)
+    cache_write = getattr(data, "cache_write_tokens", None)
+    if cache_write is not None:
+        details["cache_creation_input_token_count"] = int(cache_write)
+    reasoning = getattr(data, "reasoning_tokens", None)
+    if reasoning is not None:
+        details["reasoning_output_token_count"] = int(reasoning)
+    return details
 
 
 class GitHubCopilotSettings(TypedDict, total=False):
@@ -594,10 +640,25 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
         if session_context.instructions:
             prompt = "\n".join(session_context.instructions) + "\n" + prompt
 
+        # Subscribe to events before send_and_wait so we can capture the
+        # ASSISTANT_USAGE event, which carries full input+output token counts.
+        # The handler coexists with send_and_wait's internal handler; both
+        # receive every event that the session emits.
+        usage_event_data: Any = None
+
+        def _collect_usage(event: SessionEvent) -> None:
+            nonlocal usage_event_data
+            if event.type == SessionEventType.ASSISTANT_USAGE:
+                usage_event_data = event.data
+
+        unsubscribe_usage = copilot_session.on(_collect_usage)
         try:
-            response_event = await copilot_session.send_and_wait(prompt, timeout=timeout)
-        except Exception as ex:
-            raise AgentException(f"GitHub Copilot request failed: {ex}") from ex
+            try:
+                response_event = await copilot_session.send_and_wait(prompt, timeout=timeout)
+            except Exception as ex:
+                raise AgentException(f"GitHub Copilot request failed: {ex}") from ex
+        finally:
+            unsubscribe_usage()
 
         response_messages: list[Message] = []
         response_id: str | None = None
@@ -619,7 +680,30 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                 )
             response_id = message_id
 
-        response = AgentResponse(messages=response_messages, response_id=response_id)
+        # Build usage_details and finish_reason from the captured ASSISTANT_USAGE
+        # event.  Fall back to output_tokens on the ASSISTANT_MESSAGE data when no
+        # dedicated usage event arrived (older CLI versions).
+        response_usage: UsageDetails | None = None
+        response_finish_reason: str | None = None
+        response_model: str | None = None
+        if usage_event_data is not None:
+            response_usage = _parse_copilot_usage(usage_event_data)
+            response_finish_reason = getattr(usage_event_data, "reason", None) or getattr(
+                usage_event_data, "finish_reason", None
+            )
+            response_model = getattr(usage_event_data, "model", None)
+        elif response_event and response_event.type == SessionEventType.ASSISTANT_MESSAGE:
+            output_tokens = getattr(response_event.data, "output_tokens", None)
+            if output_tokens is not None:
+                response_usage = UsageDetails(output_token_count=int(output_tokens))
+
+        response = AgentResponse(
+            messages=response_messages,
+            response_id=response_id,
+            usage_details=response_usage,
+            finish_reason=response_finish_reason,
+            additional_properties={"model": response_model} if response_model else None,
+        )
         session_context._response = response  # type: ignore[assignment]
         await self._run_after_providers(session=session, context=session_context)
         return response
@@ -742,6 +826,23 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
                     raw_representation=event,
                 )
                 queue.put_nowait(update)
+            elif event.type == SessionEventType.ASSISTANT_USAGE:
+                # Capture per-turn token usage and emit it as a usage update so that
+                # AgentResponse.usage_details and AgentResponse.finish_reason are
+                # populated by the standard _process_update() aggregation path.
+                usage_data: Any = event.data
+                streamed_usage = _parse_copilot_usage(usage_data)
+                if streamed_usage:
+                    finish_reason: str | None = getattr(
+                        usage_data, "reason", None
+                    ) or getattr(usage_data, "finish_reason", None)
+                    usage_update = AgentResponseUpdate(
+                        role="assistant",
+                        contents=[Content.from_usage(usage_details=streamed_usage, raw_representation=event)],
+                        raw_representation=event,
+                        finish_reason=finish_reason,
+                    )
+                    queue.put_nowait(usage_update)
             elif event.type == SessionEventType.SESSION_IDLE:
                 queue.put_nowait(None)
             elif event.type == SessionEventType.SESSION_ERROR:

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -937,6 +937,255 @@ class TestGitHubCopilotAgentRunStreaming:
         assert responses[3].contents[0].type == "text"
 
 
+class TestGitHubCopilotAgentUsageMetadata:
+    """Test cases for usage/response-metadata propagation."""
+
+    async def test_run_propagates_usage_details_from_assistant_usage_event(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_message_event: SessionEvent,
+    ) -> None:
+        """Non-streaming run captures usage from ASSISTANT_USAGE event."""
+        usage_event = SessionEvent(
+            data=Data(
+                input_tokens=120,
+                output_tokens=40,
+                model="claude-sonnet-4-5",
+                reason="stop",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        # on() is called once (for _collect_usage). Emit usage event immediately.
+        def mock_on(handler: Any) -> Any:
+            handler(usage_event)
+            return lambda: None
+
+        mock_session.on = mock_on
+        mock_session.send_and_wait.return_value = assistant_message_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        assert response.usage_details is not None
+        assert response.usage_details["input_token_count"] == 120
+        assert response.usage_details["output_token_count"] == 40
+        assert response.usage_details["total_token_count"] == 160
+
+    async def test_run_propagates_finish_reason_from_assistant_usage_event(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_message_event: SessionEvent,
+    ) -> None:
+        """Non-streaming run captures finish_reason from ASSISTANT_USAGE event."""
+        usage_event = SessionEvent(
+            data=Data(
+                input_tokens=10,
+                output_tokens=5,
+                reason="stop",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        def mock_on(handler: Any) -> Any:
+            handler(usage_event)
+            return lambda: None
+
+        mock_session.on = mock_on
+        mock_session.send_and_wait.return_value = assistant_message_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        assert response.finish_reason == "stop"
+
+    async def test_run_fallback_to_output_tokens_when_no_usage_event(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+    ) -> None:
+        """Non-streaming run falls back to output_tokens in ASSISTANT_MESSAGE data."""
+        # Create an ASSISTANT_MESSAGE event with output_tokens
+        msg_data = Data(
+            content="Response",
+            message_id="msg-1",
+            output_tokens=25,
+        )
+        msg_event = SessionEvent(
+            data=msg_data,
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_MESSAGE,
+        )
+        # on() is called but no usage event is emitted
+        mock_session.on = MagicMock(return_value=lambda: None)
+        mock_session.send_and_wait.return_value = msg_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        assert response.usage_details is not None
+        assert response.usage_details["output_token_count"] == 25
+
+    async def test_run_no_usage_when_no_usage_event_and_no_output_tokens(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_message_event: SessionEvent,
+    ) -> None:
+        """Non-streaming run sets no usage_details when no usage data is available."""
+        mock_session.on = MagicMock(return_value=lambda: None)
+        mock_session.send_and_wait.return_value = assistant_message_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        # The assistant_message_event fixture uses Data with no output_tokens, so
+        # usage_details should be None.
+        assert response.usage_details is None
+
+    async def test_run_propagates_model_name_in_additional_properties(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_message_event: SessionEvent,
+    ) -> None:
+        """Non-streaming run stores model name in additional_properties."""
+        usage_event = SessionEvent(
+            data=Data(
+                input_tokens=10,
+                output_tokens=5,
+                model="gpt-5",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        def mock_on(handler: Any) -> Any:
+            handler(usage_event)
+            return lambda: None
+
+        mock_session.on = mock_on
+        mock_session.send_and_wait.return_value = assistant_message_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        assert response.additional_properties.get("model") == "gpt-5"
+
+    async def test_run_streaming_propagates_usage_details(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_delta_event: SessionEvent,
+        session_idle_event: SessionEvent,
+    ) -> None:
+        """Streaming run yields a usage update from ASSISTANT_USAGE event."""
+        usage_event = SessionEvent(
+            data=Data(
+                input_tokens=80,
+                output_tokens=30,
+                cache_read_tokens=5,
+                reason="stop",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        events = [assistant_delta_event, usage_event, session_idle_event]
+
+        def mock_on(handler: Any) -> Any:
+            for event in events:
+                handler(event)
+            return lambda: None
+
+        mock_session.on = mock_on
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        updates: list[AgentResponseUpdate] = []
+        async for update in agent.run("Hello", stream=True):
+            updates.append(update)
+
+        # There should be a text update and a usage update
+        usage_updates = [u for u in updates if any(c.type == "usage" for c in u.contents)]
+        assert len(usage_updates) == 1
+        usage_content = next(c for c in usage_updates[0].contents if c.type == "usage")
+        assert usage_content.usage_details is not None
+        assert usage_content.usage_details["input_token_count"] == 80
+        assert usage_content.usage_details["output_token_count"] == 30
+        assert usage_content.usage_details["total_token_count"] == 110
+        assert usage_content.usage_details.get("cache_read_input_token_count") == 5
+
+    async def test_run_streaming_propagates_finish_reason(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_delta_event: SessionEvent,
+        session_idle_event: SessionEvent,
+    ) -> None:
+        """Streaming run propagates finish_reason from ASSISTANT_USAGE into the final response."""
+        usage_event = SessionEvent(
+            data=Data(
+                input_tokens=10,
+                output_tokens=5,
+                reason="stop",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        events = [assistant_delta_event, usage_event, session_idle_event]
+
+        def mock_on(handler: Any) -> Any:
+            for event in events:
+                handler(event)
+            return lambda: None
+
+        mock_session.on = mock_on
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run(  # type: ignore[misc]
+            "Hello",
+            stream=True,  # type: ignore[call-overload]
+        ).get_final_response()  # type: ignore[union-attr]
+
+        assert response.finish_reason == "stop"
+
+    async def test_run_streaming_no_usage_event_no_crash(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_delta_event: SessionEvent,
+        session_idle_event: SessionEvent,
+    ) -> None:
+        """Streaming run without ASSISTANT_USAGE event doesn't crash and yields no usage update."""
+        events = [assistant_delta_event, session_idle_event]
+
+        def mock_on(handler: Any) -> Any:
+            for event in events:
+                handler(event)
+            return lambda: None
+
+        mock_session.on = mock_on
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        updates: list[AgentResponseUpdate] = []
+        async for update in agent.run("Hello", stream=True):
+            updates.append(update)
+
+        usage_updates = [u for u in updates if any(c.type == "usage" for c in u.contents)]
+        assert len(usage_updates) == 0
+
+
 class TestGitHubCopilotAgentSessionManagement:
     """Test cases for session management."""
 

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -1080,6 +1080,78 @@ class TestGitHubCopilotAgentUsageMetadata:
 
         assert response.additional_properties.get("model") == "gpt-5"
 
+    async def test_run_accumulates_usage_across_multiple_usage_events(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_message_event: SessionEvent,
+    ) -> None:
+        """Non-streaming run sums usage from multiple ASSISTANT_USAGE events (multi-turn tool calls)."""
+        usage_event_1 = SessionEvent(
+            data=Data(input_tokens=50, output_tokens=20, model="gpt-5", reason=None),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+        usage_event_2 = SessionEvent(
+            data=Data(input_tokens=30, output_tokens=15, model="gpt-5", reason="stop"),
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        def mock_on(handler: Any) -> Any:
+            handler(usage_event_1)
+            handler(usage_event_2)
+            return lambda: None
+
+        mock_session.on = mock_on
+        mock_session.send_and_wait.return_value = assistant_message_event
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run("Hello")
+
+        assert response.usage_details is not None
+        assert response.usage_details["input_token_count"] == 80   # 50 + 30
+        assert response.usage_details["output_token_count"] == 35  # 20 + 15
+        assert response.usage_details["total_token_count"] == 115  # 80 + 35
+        # finish_reason and model taken from last event
+        assert response.finish_reason == "stop"
+        assert response.additional_properties.get("model") == "gpt-5"
+
+    async def test_run_streaming_emits_finish_reason_without_token_counts(
+        self,
+        mock_client: MagicMock,
+        mock_session: MagicMock,
+        assistant_delta_event: SessionEvent,
+        session_idle_event: SessionEvent,
+    ) -> None:
+        """Streaming run propagates finish_reason even when no input/output token counts are present."""
+        usage_event = SessionEvent(
+            data=Data(reason="stop"),  # no input_tokens / output_tokens
+            id=uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            type=SessionEventType.ASSISTANT_USAGE,
+        )
+
+        events = [assistant_delta_event, usage_event, session_idle_event]
+
+        def mock_on(handler: Any) -> Any:
+            for event in events:
+                handler(event)
+            return lambda: None
+
+        mock_session.on = mock_on
+
+        agent = GitHubCopilotAgent(client=mock_client)
+        response = await agent.run(  # type: ignore[misc]
+            "Hello",
+            stream=True,  # type: ignore[call-overload]
+        ).get_final_response()  # type: ignore[union-attr]
+
+        assert response.finish_reason == "stop"
+        assert response.usage_details is None  # no token counts → no usage
+
     async def test_run_streaming_propagates_usage_details(
         self,
         mock_client: MagicMock,


### PR DESCRIPTION
Closes #6930

## Summary

The Copilot SDK emits an `ASSISTANT_USAGE` event after every model turn that carries full input/output token counts, cache tokens, reasoning tokens, finish reason (`reason`), and model name. Previously all of this metadata was discarded and `AgentResponse.usage_details`, `AgentResponse.finish_reason`, and model info were always missing.

## Problem

When calling `agent.run()` with the GitHub Copilot agent, `AgentResponse.usage_details` and `AgentResponse.finish_reason` are always `None`.

**Direct SDK invocation emits:**
```
SessionEvent(type=ASSISTANT_USAGE, data=AssistantUsageData(
    model="claude-sonnet-4-5",
    input_tokens=120, output_tokens=40,
    cache_read_tokens=5, reason="stop"
))
```

**Agent Framework before this fix:**
```python
response.usage_details  # None ❌
response.finish_reason  # None ❌
```

**Agent Framework after this fix:**
```python
response.usage_details  # {"input_token_count": 120, "output_token_count": 40, "total_token_count": 160, "cache_read_input_token_count": 5} ✅
response.finish_reason  # "stop" ✅
response.additional_properties["model"]  # "claude-sonnet-4-5" ✅
```

## Changes

### `python/packages/github_copilot/agent_framework_github_copilot/_agent.py`

1. **Adds `UsageDetails` to imports** from `agent_framework`.
2. **Adds `_parse_copilot_usage()`** — converts the SDK event data payload to `UsageDetails` using `getattr` for forward compatibility (works with the `Data` shim in SDK v1.0.2 and with `AssistantUsageData` in newer SDK releases).
3. **Non-streaming (`_run_impl`)** — subscribes an extra event handler before `send_and_wait` to capture `ASSISTANT_USAGE` events. After `send_and_wait` completes, the collected data populates `AgentResponse.usage_details`, `finish_reason`, and model name in `additional_properties`. Falls back to `output_tokens` on `ASSISTANT_MESSAGE` data when no dedicated usage event arrives (older CLI versions).
4. **Streaming (`_stream_updates`)** — handles `SessionEventType.ASSISTANT_USAGE` in the event handler, yielding an `AgentResponseUpdate` with `Content.from_usage()` payload so `_process_update()` aggregates it into `AgentResponse.usage_details`, and propagates `finish_reason`.

### `python/packages/github_copilot/tests/test_github_copilot_agent.py`

Adds 8 tests in `TestGitHubCopilotAgentUsageMetadata`:
- `test_run_propagates_usage_details_from_assistant_usage_event`
- `test_run_propagates_finish_reason_from_assistant_usage_event`
- `test_run_fallback_to_output_tokens_when_no_usage_event`
- `test_run_no_usage_when_no_usage_event_and_no_output_tokens`
- `test_run_propagates_model_name_in_additional_properties`
- `test_run_streaming_propagates_usage_details`
- `test_run_streaming_propagates_finish_reason`
- `test_run_streaming_no_usage_event_no_crash`

## Testing

All 128 existing tests pass. 8 new tests added (136 total).