### PR TITLE
Fix README stars badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![MS Learn Documentation](https://img.shields.io/badge/MS%20Learn-Documentation-blue)](https://learn.microsoft.com/en-us/agent-framework/)
 [![PyPI](https://img.shields.io/pypi/v/agent-framework)](https://pypi.org/project/agent-framework/)
 [![NuGet](https://img.shields.io/nuget/v/Microsoft.Agents.AI)](https://www.nuget.org/profiles/MicrosoftAgentFramework/)
-[![GitHub stars](https://img.shields.io/github/stars/microsoft/agent-framework?style=social)](https://github.com/microsoft/agent-framework/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/microsoft/agent-framework?style=social)](https://github.com/microsoft/agent-framework)
 
 
 Microsoft Agent Framework (MAF) is an open, multi-language framework for building **production-grade AI agents and multi-agent workflows** in **.NET and Python**.


### PR DESCRIPTION
### Motivation & Context

The markdown link check is failing because the root README stars badge links to `https://github.com/microsoft/agent-framework/stargazers`, which returns `404` to the link checker.

### Description & Review Guide

- **What are the major changes?**
  - Update the GitHub stars badge click target to the repository root while keeping the same visible shields.io stars badge.
- **What is the impact of these changes?**
  - Keeps the badge visible and clickable while avoiding the failing `/stargazers` link check target.
- **What do you want reviewers to focus on?**
  - Confirm the badge should link to the repo root instead of the stargazers page.

### Related Issue

N/A - fixes a failing markdown link check on the root README badge.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
