### PR TITLE
Python: Add Agent typing smoke tests for chat clients

### DIFF
--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from agent_framework import (
+    Agent,
     ChatMiddlewareLayer,
     ChatOptions,
     ChatResponseUpdate,
@@ -134,6 +135,16 @@ def test_anthropic_client_wraps_raw_client_with_standard_layer_order() -> None:
     assert not issubclass(RawAnthropicClient, FunctionInvocationLayer)
     assert not issubclass(RawAnthropicClient, ChatMiddlewareLayer)
     assert not issubclass(RawAnthropicClient, ChatTelemetryLayer)
+
+
+def test_agent_accepts_anthropic_clients() -> None:
+    raw_client = RawAnthropicClient(api_key="test-api-key", model="claude-3-5-sonnet-20241022")
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    client = AnthropicClient(api_key="test-api-key", model="claude-3-5-sonnet-20241022")
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def test_anthropic_client_init_auto_create_client(

--- a/python/packages/anthropic/tests/test_anthropic_provider_clients.py
+++ b/python/packages/anthropic/tests/test_anthropic_provider_clients.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agent_framework import ChatMiddlewareLayer, FunctionInvocationLayer
+from agent_framework import Agent, ChatMiddlewareLayer, FunctionInvocationLayer
 from agent_framework._telemetry import get_user_agent
 from agent_framework.observability import ChatTelemetryLayer
 
@@ -40,6 +40,71 @@ def test_provider_client_wraps_raw_client_with_standard_layer_order(public_clien
     assert mro.index(FunctionInvocationLayer) < mro.index(ChatMiddlewareLayer)
     assert mro.index(ChatMiddlewareLayer) < mro.index(ChatTelemetryLayer)
     assert mro.index(ChatTelemetryLayer) < mro.index(raw_client)
+
+
+def test_agent_accepts_anthropic_foundry_clients() -> None:
+    mock_transport = _create_mock_transport("https://test-resource.services.ai.azure.com/anthropic/")
+    with patch("agent_framework_anthropic._foundry_client.AsyncAnthropicFoundry", return_value=mock_transport):
+        raw_client = RawAnthropicFoundryClient(
+            model="claude-foundry-test",
+            resource="test-resource",
+            api_key="test-key",
+        )
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    with patch("agent_framework_anthropic._foundry_client.AsyncAnthropicFoundry", return_value=mock_transport):
+        client = AnthropicFoundryClient(
+            model="claude-foundry-test",
+            resource="test-resource",
+            api_key="test-key",
+        )
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
+
+
+def test_agent_accepts_anthropic_bedrock_clients() -> None:
+    mock_transport = _create_mock_transport("https://bedrock-runtime.us-east-1.amazonaws.com")
+    with patch("agent_framework_anthropic._bedrock_client.AsyncAnthropicBedrock", return_value=mock_transport):
+        raw_client = RawAnthropicBedrockClient(
+            model="claude-bedrock-test",
+            aws_access_key="access-key",
+            aws_secret_key="secret-key",
+            aws_region="us-east-1",
+        )
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    with patch("agent_framework_anthropic._bedrock_client.AsyncAnthropicBedrock", return_value=mock_transport):
+        client = AnthropicBedrockClient(
+            model="claude-bedrock-test",
+            aws_access_key="access-key",
+            aws_secret_key="secret-key",
+            aws_region="us-east-1",
+        )
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
+
+
+def test_agent_accepts_anthropic_vertex_clients() -> None:
+    mock_transport = _create_mock_transport("https://us-central1-aiplatform.googleapis.com/v1")
+    with patch("agent_framework_anthropic._vertex_client.AsyncAnthropicVertex", return_value=mock_transport):
+        raw_client = RawAnthropicVertexClient(
+            model="claude-vertex-test",
+            region="us-central1",
+            project_id="test-project",
+        )
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    with patch("agent_framework_anthropic._vertex_client.AsyncAnthropicVertex", return_value=mock_transport):
+        client = AnthropicVertexClient(
+            model="claude-vertex-test",
+            region="us-central1",
+            project_id="test-project",
+        )
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def test_raw_anthropic_foundry_client_creates_sdk_client_from_settings(tmp_path) -> None:

--- a/python/packages/bedrock/tests/test_bedrock_client.py
+++ b/python/packages/bedrock/tests/test_bedrock_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from agent_framework import Content, Message
+from agent_framework import Agent, Content, Message
 
 from agent_framework_bedrock import BedrockChatClient
 
@@ -38,6 +38,12 @@ def _make_client() -> BedrockChatClient:
         region="us-west-2",
         client=_StubBedrockRuntime(),  # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type] # pyright: ignore[reportArgumentType]
     )
+
+
+def test_agent_accepts_bedrock_chat_client() -> None:
+    client = _make_client()
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 async def test_get_response_invokes_bedrock_runtime() -> None:

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import pytest
 from agent_framework import (
+    Agent,
     AgentResponse,
     AgentSession,
     ChatContext,
@@ -107,6 +108,20 @@ def test_raw_foundry_agent_chat_client_init_with_agent_name() -> None:
     assert client.agent_name == "test-agent"
     assert client.agent_version == "1.0"
     mock_project.get_openai_client.assert_called_once_with()
+
+
+def test_agent_accepts_raw_foundry_agent_chat_client() -> None:
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+        agent_version="1.0",
+    )
+
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def test_raw_foundry_agent_chat_client_init_passes_agent_name_when_preview_enabled() -> None:

--- a/python/packages/foundry/tests/foundry/test_foundry_chat_client.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_chat_client.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agent_framework import ChatResponse, Content, Message, SupportsChatGetResponse, tool
+from agent_framework import Agent, ChatResponse, Content, Message, SupportsChatGetResponse, tool
 from agent_framework._telemetry import get_user_agent
 from agent_framework.exceptions import ChatClientException, ChatClientInvalidRequestException
 from agent_framework_openai import OpenAIContentFilterException
@@ -1412,3 +1412,17 @@ def test_parse_chunk_surfaces_oauth_consent_requested_event() -> None:
     assert consent_contents[0].consent_link == "https://consent-host.example.com/authorize?code=xyz"
     assert update.role == "assistant"
     assert update.raw_representation is mock_event
+
+
+def test_agent_accepts_foundry_chat_clients() -> None:
+    mock_project = MagicMock()
+    mock_openai = _make_mock_openai_client()
+    mock_project.get_openai_client.return_value = mock_openai
+
+    raw_client = RawFoundryChatClient(project_client=mock_project, model="test-model")
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    client = FoundryChatClient(project_client=mock_project, model="test-model")
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client

--- a/python/packages/foundry_local/tests/test_foundry_local_client.py
+++ b/python/packages/foundry_local/tests/test_foundry_local_client.py
@@ -4,7 +4,7 @@ import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
-from agent_framework import SupportsChatGetResponse
+from agent_framework import Agent, SupportsChatGetResponse
 from agent_framework._settings import load_settings
 from agent_framework.exceptions import SettingNotFoundError
 from agent_framework.foundry import FoundryLocalClient
@@ -65,6 +65,17 @@ def test_foundry_local_client_init(mock_foundry_local_manager: MagicMock) -> Non
         assert client.model == "test-model-id"
         assert client.manager is mock_foundry_local_manager
         assert isinstance(client, SupportsChatGetResponse)
+
+
+def test_agent_accepts_foundry_local_client(mock_foundry_local_manager: MagicMock) -> None:
+    with patch(
+        "agent_framework_foundry_local._foundry_local_client.FoundryLocalManager",
+        return_value=mock_foundry_local_manager,
+    ):
+        client = FoundryLocalClient(model="test-model-id")
+
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def test_foundry_local_client_get_response_uses_explicit_runtime_buckets() -> None:

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -13,7 +13,7 @@ from agent_framework import Agent, Content, FunctionTool, Message
 from google.genai import types
 from pydantic import BaseModel
 
-from agent_framework_gemini import GeminiChatClient, GeminiChatOptions, ThinkingConfig
+from agent_framework_gemini import GeminiChatClient, GeminiChatOptions, RawGeminiChatClient, ThinkingConfig
 
 
 def _has_gemini_integration_credentials() -> bool:
@@ -140,6 +140,20 @@ def _make_gemini_client(
     mock._api_client._http_options.base_url = "https://generativelanguage.googleapis.com/"
     client = GeminiChatClient(client=mock, model=model)
     return client, mock
+
+
+def test_agent_accepts_gemini_chat_clients() -> None:
+    mock = MagicMock()
+    mock._api_client.vertexai = False
+    mock._api_client._http_options.base_url = "https://generativelanguage.googleapis.com/"
+
+    raw_client = RawGeminiChatClient(client=mock, model="gemini-2.5-flash")
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    client, _ = _make_gemini_client(model="gemini-2.5-flash")
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def _parts(content: types.Content) -> list[types.Part]:

--- a/python/packages/ollama/tests/test_ollama_chat_client.py
+++ b/python/packages/ollama/tests/test_ollama_chat_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agent_framework import (
+    Agent,
     BaseChatClient,
     ChatResponseUpdate,
     Content,
@@ -72,6 +73,12 @@ def ollama_unit_test_env(monkeypatch, exclude_list, override_env_param_dict):  #
 @fixture
 def chat_history() -> list[Message]:
     return []
+
+
+def test_agent_accepts_ollama_chat_client(ollama_unit_test_env: dict[str, str]) -> None:
+    client = OllamaChatClient()
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 @fixture

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -227,6 +227,16 @@ def test_raw_openai_chat_client_accepts_preconfigured_client_with_timeout() -> N
     assert client is not None
 
 
+def test_agent_accepts_openai_chat_clients() -> None:
+    raw_client = RawOpenAIChatClient(api_key="test-api-key", model="test-model")
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    client = OpenAIChatClient(api_key="test-api-key", model="test-model")
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
+
+
 def test_openai_chat_client_supports_all_tool_protocols() -> None:
     assert isinstance(OpenAIChatClient, SupportsCodeInterpreterTool)  # pyrefly: ignore[unsafe-overlap]
     assert isinstance(OpenAIChatClient, SupportsWebSearchTool)  # pyrefly: ignore[unsafe-overlap]

--- a/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_completion_client.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from agent_framework import (
+    Agent,
     ChatResponse,
     Content,
     Message,
@@ -68,6 +69,16 @@ def test_init_uses_explicit_parameters() -> None:
     assert "compaction_strategy" in signature.parameters
     assert "tokenizer" in signature.parameters
     assert all(parameter.kind != inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())
+
+
+def test_agent_accepts_openai_chat_completion_clients() -> None:
+    raw_client = RawOpenAIChatCompletionClient(api_key="test-api-key", model="test-model")
+    raw_agent = Agent(client=raw_client, instructions="test agent")
+    assert raw_agent.client is raw_client
+
+    client = OpenAIChatCompletionClient(api_key="test-api-key", model="test-model")
+    agent = Agent(client=client, instructions="test agent")
+    assert agent.client is client
 
 
 def test_supports_web_search_only() -> None:


### PR DESCRIPTION
### Motivation & Context

Issue #6938 reports that `Agent(client=FoundryChatClient(...))` can be rejected by `ty` even though the same client works at runtime. I could not reproduce the diagnostic with the reported `ty==0.0.21`, but the scenario is important enough to keep covered by the test typing matrix.

### Description & Review Guide

- **What are the major changes?**
  Adds cheap, network-free `Agent(client=...)` smoke tests for public chat clients across OpenAI, Anthropic, Bedrock, Gemini, Ollama, Foundry Local, and Foundry, including public raw chat clients.
- **What is the impact of these changes?**
  The public chat client surface is exercised through the same constructor shape customers use, so mypy, pyrefly, ty, zuban, and relaxed pyright can catch protocol mismatches in package tests.
- **What do you want reviewers to focus on?**
  Whether the included client set matches the intended public Agent-compatible chat client surface.


### Related Issue

Fixes #6938

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
