### PR TITLE
.NET: Support retrieval of chat history in workflows

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
@@ -719,7 +719,7 @@ internal sealed class WorkflowSession : AgentSession
     public override object? GetService(Type serviceType, object? serviceKey = null)
     {
         _ = Throw.IfNull(serviceType);
-        bool isHistoryProvider = serviceKey is null && serviceType.IsInstanceOfType(this.ChatHistoryProvider);
+        bool isHistoryProvider = serviceKey is null && serviceType == typeof(ChatHistoryProvider);
         return isHistoryProvider ? this.ChatHistoryProvider : base.GetService(serviceType, serviceKey);
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
@@ -714,4 +714,12 @@ internal sealed class WorkflowSession : AgentSession
         public AgentSessionStateBag StateBag { get; } = stateBag ?? new();
         public Dictionary<string, ExternalRequest>? PendingRequests { get; } = pendingRequests;
     }
+
+    //// <inheritdoc/>
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        _ = Throw.IfNull(serviceType);
+        bool isHistoryProvider = serviceKey is null && serviceType.IsInstanceOfType(this.ChatHistoryProvider);
+        return isHistoryProvider ? this.ChatHistoryProvider : base.GetService(serviceType, serviceKey);
+    }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowSession.cs
@@ -715,7 +715,7 @@ internal sealed class WorkflowSession : AgentSession
         public Dictionary<string, ExternalRequest>? PendingRequests { get; } = pendingRequests;
     }
 
-    //// <inheritdoc/>
+    /// <inheritdoc/>
     public override object? GetService(Type serviceType, object? serviceKey = null)
     {
         _ = Throw.IfNull(serviceType);

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowHostSmokeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowHostSmokeTests.cs
@@ -759,6 +759,29 @@ public class WorkflowHostSmokeTests : AIAgentHostingExecutorTestsBase
         await action.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Fact]
+    public async Task Test_AsAgent_SessionGetServiceReturnsReadableChatHistoryProviderAsync()
+    {
+        // Arrange
+        TestReplayAgent replayAgent = new(TestMessages, TestAgentId, TestAgentName);
+        Workflow workflow = new WorkflowBuilder(replayAgent).Build();
+        AIAgent workflowAgent = workflow.AsAIAgent();
+        AgentSession session = await workflowAgent.CreateSessionAsync();
+
+        // Act
+        AgentResponse response = await workflowAgent.RunAsync(session);
+        ChatHistoryProvider? chatHistoryProvider = session.GetService<ChatHistoryProvider>();
+        List<ChatMessage> history = chatHistoryProvider is null
+            ? []
+            : [.. await chatHistoryProvider.InvokingAsync(new ChatHistoryProvider.InvokingContext(workflowAgent, session, []))];
+
+        // Assert
+        chatHistoryProvider.Should().NotBeNull();
+        history.Should().HaveSameCount(response.Messages);
+        history.Select(m => m.Role).Should().Equal(response.Messages.Select(m => m.Role));
+        history.Select(m => m.Text).Should().Equal(response.Messages.Select(m => m.Text));
+    }
+
     private async Task Run_AsAgent_OutgoingMessagesInHistoryAsync(Workflow workflow, bool runAsync)
     {
         // Arrange


### PR DESCRIPTION
### Motivation & Context

Workflow-hosted agents persist chat history in the workflow session, but callers could not retrieve it through the public `AgentSession` surface because both `WorkflowSession` and `WorkflowChatHistoryProvider` are internal.

This change makes the workflow session expose its existing chat history provider through the standard `GetService<T>()` service lookup pattern. This allows callers with an `AgentSession` returned from `workflow.AsAIAgent()` to retrieve `ChatHistoryProvider` and inspect conversation history.

### Description & Review Guide

- **What are the major changes?**
  - `WorkflowSession` now overrides `GetService(Type, object?)`.
  - When callers request `ChatHistoryProvider`, the session returns its internal workflow chat history provider through the public base type.
  - Added a unit test that runs a workflow-hosted agent, retrieves `ChatHistoryProvider` from the session, and verifies that persisted history can be read.

- **What is the impact of these changes?**
  - This does not change how workflow chat history is stored or replayed.
  - It exposes an already-existing session service through the framework’s established service discovery pattern.
  - Existing callers are unaffected unless they opt into `session.GetService<ChatHistoryProvider>()`.

### Related Issue

Fixes #6946

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
