### PR TITLE
Python: Emit SSE keepalive comments during idle AG-UI event streams

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
@@ -111,6 +111,9 @@ def add_agent_framework_fastapi_endpoint(
             connection during long silent model runs (e.g. reasoning models). Defaults to 15. Set to None
             or 0 to disable.
     """
+    if keepalive_seconds is not None and keepalive_seconds < 0:
+        raise ValueError("keepalive_seconds must be >= 0 (use 0 or None to disable).")
+
     protocol_runner: AgentFrameworkAgent | AgentFrameworkWorkflow
     if isinstance(agent, AgentFrameworkWorkflow):
         protocol_runner = agent
@@ -178,7 +181,7 @@ def add_agent_framework_fastapi_endpoint(
 
                 # Producer task keeps the generator in a stable asyncio.Context (required for
                 # ContextVar.reset() in OTel hooks). See issue #6941.
-                queue: asyncio.Queue[Any] = asyncio.Queue()
+                queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=1)
                 producer_error: dict[str, BaseException] = {}
 
                 async def _producer() -> None:

--- a/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import copy
 import logging
 from collections.abc import AsyncGenerator, Sequence
@@ -82,6 +84,7 @@ def add_agent_framework_fastapi_endpoint(
     dependencies: Sequence[Depends] | None = None,
     snapshot_store: AGUIThreadSnapshotStore | None = None,
     snapshot_scope_resolver: SnapshotScopeResolver | None = None,
+    keepalive_seconds: int | None = 15,
 ) -> None:
     """Add an AG-UI endpoint to a FastAPI app.
 
@@ -103,6 +106,10 @@ def add_agent_framework_fastapi_endpoint(
             explicit Snapshot Scope resolver.
         snapshot_scope_resolver: Optional resolver for the application-defined Snapshot Scope. Required whenever
             a snapshot store is configured because an AG-UI Thread id is not an authorization boundary.
+        keepalive_seconds: Interval in seconds between SSE keepalive comments emitted during idle gaps in the
+            event stream. Prevents reverse proxies and browser runtimes from closing an otherwise-healthy
+            connection during long silent model runs (e.g. reasoning models). Defaults to 15. Set to None
+            or 0 to disable.
     """
     protocol_runner: AgentFrameworkAgent | AgentFrameworkWorkflow
     if isinstance(agent, AgentFrameworkWorkflow):
@@ -163,8 +170,46 @@ def add_agent_framework_fastapi_endpoint(
             async def event_generator() -> AsyncGenerator[str]:
                 encoder = EventEncoder()
                 event_count = 0
+                keepalive_interval = keepalive_seconds if keepalive_seconds else None
+
+                # Sentinels used to signal end-of-stream and errors across the queue.
+                done_sentinel = object()
+                error_sentinel = object()
+
+                # Producer task keeps the generator in a stable asyncio.Context (required for
+                # ContextVar.reset() in OTel hooks). See issue #6941.
+                queue: asyncio.Queue[Any] = asyncio.Queue()
+                producer_error: dict[str, BaseException] = {}
+
+                async def _producer() -> None:
+                    try:
+                        async for evt in protocol_runner.run(input_data):
+                            await queue.put(evt)
+                    except BaseException as producer_exc:  # noqa: BLE001
+                        producer_error["exc"] = producer_exc
+                        await queue.put(error_sentinel)
+                    else:
+                        await queue.put(done_sentinel)
+
+                producer_task = asyncio.create_task(_producer(), name=f"ag-ui-event-producer:{path}")
+
                 try:
-                    async for event in protocol_runner.run(input_data):
+                    while True:
+                        if keepalive_interval:
+                            try:
+                                item = await asyncio.wait_for(queue.get(), timeout=keepalive_interval)
+                            except asyncio.TimeoutError:
+                                yield ": keepalive\n\n"
+                                continue
+                        else:
+                            item = await queue.get()
+
+                        if item is done_sentinel:
+                            break
+                        if item is error_sentinel:
+                            raise producer_error["exc"]
+
+                        event = item
                         event_count += 1
                         event_type_name = getattr(event, "type", type(event).__name__)
                         # Log important events at INFO level
@@ -207,6 +252,11 @@ def add_agent_framework_fastapi_endpoint(
                         yield encoder.encode(run_error)
                     except Exception:
                         logger.exception("[%s] Failed to encode RUN_ERROR event", path)
+                finally:
+                    if not producer_task.done():
+                        producer_task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await producer_task
 
             return StreamingResponse(
                 event_generator(),

--- a/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
@@ -2,6 +2,7 @@
 
 """Tests for FastAPI endpoint creation (_endpoint.py)."""
 
+import asyncio
 import json
 from typing import Any, cast
 
@@ -1286,6 +1287,78 @@ async def test_endpoint_streaming_error_emits_run_error_event():
 
     assert "RUN_STARTED" in event_types
     assert "RUN_ERROR" in event_types
+
+
+class _SlowStreamWorkflow(AgentFrameworkWorkflow):
+    """Workflow that emits RUN_STARTED, waits, then finishes.
+
+    Used to exercise the SSE keepalive path: while the generator is parked on
+    the sleep, no real events flow and any idle timeout in the transport would
+    close the connection unless a keepalive comment is emitted.
+    """
+
+    def __init__(self, silent_seconds: float) -> None:
+        super().__init__()
+        self._silent_seconds = silent_seconds
+
+    async def run(self, input_data: dict[str, Any]):  # type: ignore[override]
+        del input_data
+        yield RunStartedEvent(run_id="run-1", thread_id="thread-1")
+        await asyncio.sleep(self._silent_seconds)
+
+
+async def test_endpoint_emits_sse_keepalive_during_idle_gap():
+    """During a silent run the endpoint should interleave `: keepalive` comments."""
+    app = FastAPI()
+    add_agent_framework_fastapi_endpoint(
+        app,
+        _SlowStreamWorkflow(silent_seconds=1.3),
+        path="/keepalive",
+        keepalive_seconds=1,
+    )
+    client = TestClient(app)
+    response = client.post("/keepalive", json={"messages": [{"role": "user", "content": "Hi"}]})
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    # At least one keepalive comment must appear during the silent 1.3s window
+    # (with keepalive_seconds=1 the timer should fire at least once).
+    assert ": keepalive" in content, f"expected keepalive comment in stream, got: {content!r}"
+    # And the real event must still be present and parseable.
+    event_types = [json.loads(line[6:]).get("type") for line in content.split("\n") if line.startswith("data: ")]
+    assert "RUN_STARTED" in event_types
+
+
+async def test_endpoint_no_keepalive_when_disabled():
+    """Setting keepalive_seconds=None (or 0) must disable keepalive comments."""
+    app = FastAPI()
+    add_agent_framework_fastapi_endpoint(
+        app,
+        _SlowStreamWorkflow(silent_seconds=0.4),
+        path="/no-keepalive",
+        keepalive_seconds=None,
+    )
+    client = TestClient(app)
+    response = client.post("/no-keepalive", json={"messages": [{"role": "user", "content": "Hi"}]})
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert ": keepalive" not in content
+
+
+async def test_endpoint_no_keepalive_when_stream_is_fast(build_chat_client):
+    """Fast streams should not have keepalive comments interleaved."""
+    app = FastAPI()
+    agent = Agent(name="test", instructions="Test agent", client=build_chat_client())
+    add_agent_framework_fastapi_endpoint(app, agent, path="/fast", keepalive_seconds=30)
+
+    client = TestClient(app)
+    response = client.post("/fast", json={"messages": [{"role": "user", "content": "Hi"}]})
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    # Fast synthetic stream finishes well under the 30s keepalive interval.
+    assert ": keepalive" not in content
 
 
 async def test_endpoint_with_dependencies_blocks_unauthorized(build_chat_client):


### PR DESCRIPTION
Reverse proxies and browser EventSource runtimes close connections that go silent for too long. Reasoning models can think for 30-60s without emitting events, triggering these timeouts.

Adds a `keepalive_seconds` parameter (default 15) to `add_agent_framework_fastapi_endpoint`. The event iterator runs in a dedicated producer task feeding an `asyncio.Queue` so `wait_for` timeouts only cancel `queue.get()` rather than the generator itself, which would corrupt ContextVar state used by OTel hooks.

Fixes #6941