### PR TITLE
Python: Add multi-tenant hosting hosting security consideration to a2a sample

### DIFF
--- a/python/samples/04-hosting/a2a/README.md
+++ b/python/samples/04-hosting/a2a/README.md
@@ -88,7 +88,7 @@ The default `a2a-sdk` task/push-config stores scope ownership by `user_name` onl
 from a2a.server.tasks import InMemoryTaskStore
 
 def resolve_tenant_user_scope(context):
-    return f"{context.tenant}\x00{context.user.user_name}"
-
+    # Derive tenant + user identity from your host's auth/session context.
+    return f"{context.tenant}:{context.user.user_name}"
 task_store = InMemoryTaskStore(owner_resolver=resolve_tenant_user_scope)
 ```

--- a/python/samples/04-hosting/a2a/README.md
+++ b/python/samples/04-hosting/a2a/README.md
@@ -79,3 +79,16 @@ cd python/samples/02-agents/a2a
 $env:A2A_AGENT_HOST = "http://localhost:5001/"
 uv run python agent_with_a2a.py
 ```
+
+## Security considerations for multi-tenant hosting
+
+The default `a2a-sdk` task/push-config stores scope ownership by `user_name` only. **Any host that mounts tenant-bearing routes must pass a tenant-aware `owner_resolver`** to the stores, e.g.:
+
+```python
+from a2a.server.tasks import InMemoryTaskStore
+
+def resolve_tenant_user_scope(context):
+    return f"{context.tenant}\x00{context.user.user_name}"
+
+task_store = InMemoryTaskStore(owner_resolver=resolve_tenant_user_scope)
+```


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

This pull request adds important documentation about security considerations when using the `a2a-sdk` in multi-tenant hosting scenarios. It explains the default ownership behavior and provides a code example for implementing a tenant-aware `owner_resolver` to ensure proper isolation between tenants.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

* Added a section to the `README.md` in `python/samples/04-hosting/a2a` explaining the need for a tenant-aware `owner_resolver` when hosting tenant-bearing routes, including a sample implementation using `InMemoryTaskStore`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
