### PR TITLE
.NET: Align AgentOpenTelemetry sample with Foundry-first startup/docs and add Azure OpenAI fallback support

### DIFF
--- a/dotnet/samples/02-agents/AgentOpenTelemetry/AgentOpenTelemetry.csproj
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/AgentOpenTelemetry.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.Foundry\Microsoft.Agents.AI.Foundry.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI.OpenAI\Microsoft.Agents.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.Agents.AI\Microsoft.Agents.AI.csproj" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
@@ -1,9 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+// In the samples build, the global `Environment` alias resolves to SampleHelpers.SampleEnvironment,
+// which interactively prompts the user when a variable is missing. Use System.Environment directly
+// for all reads here so that missing optional/detection variables return null silently.
+using SystemEnvironment = System.Environment;
+
+using System.ClientModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Azure.AI.OpenAI;
 using Azure.AI.Projects;
+using OpenAI.Chat;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Agents.AI;
@@ -23,9 +31,9 @@ const string SourceName = "OpenTelemetryAspire.ConsoleApp";
 const string ServiceName = "AgentOpenTelemetry";
 
 // Configure OpenTelemetry for Aspire dashboard
-var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317";
+var otlpEndpoint = SystemEnvironment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ?? "http://localhost:4317";
 
-var applicationInsightsConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+var applicationInsightsConnectionString = SystemEnvironment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
 
 // Create a resource to identify this service
 var resource = ResourceBuilder.CreateDefault()
@@ -96,9 +104,6 @@ Console.WriteLine("""
     Type your message and press Enter. Type 'exit' or empty message to quit.
     """);
 
-var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set.");
-var deploymentName = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
-
 // Log application startup
 appLogger.LogInformation("OpenTelemetry Aspire Demo application started");
 
@@ -109,29 +114,102 @@ static async Task<string> GetWeatherAsync([Description("The location to get the 
     return $"The weather in {location} is cloudy with a high of 15°C.";
 }
 
-// WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
-// In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
-// latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 appLogger.LogInformation("Creating Agent with OpenTelemetry instrumentation");
-// Create the agent with the instrumented chat client
-var agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
-    .AsAIAgent(
-        model: deploymentName,
-        instructions: "You are a helpful assistant that provides concise and informative responses.",
-        name: "OpenTelemetryDemoAgent",
-        tools: [AIFunctionFactory.Create(GetWeatherAsync)],
-        clientFactory: client => client
-            .AsBuilder()
-            .UseFunctionInvocation()
-            .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true) // enable telemetry at the chat client level
-            .Build())
-    .AsBuilder()
-    .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true) // enable telemetry at the agent level
-    .Build();
+
+// Auth/model selection precedence:
+//   A. Preferred (default): Microsoft Foundry via DefaultAzureCredential
+//      Requires: FOUNDRY_PROJECT_ENDPOINT. Run `az login` first.
+//      If FOUNDRY_MODEL is not set, defaults to gpt-5-mini.
+//   B. Fallback (local/dev): Azure OpenAI endpoint + API key — no az login required.
+//      Requires: AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY.
+//      If AZURE_OPENAI_DEPLOYMENT_NAME is not set, defaults to gpt-5-mini.
+//   When both are configured, Foundry takes precedence.
+
+const string DefaultModel = "gpt-5-mini";
+
+var foundryEndpoint = SystemEnvironment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
+var azureOpenAIEndpoint = SystemEnvironment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+var azureOpenAIApiKey = SystemEnvironment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+var azureOpenAIDeployment = SystemEnvironment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME");
+
+AIAgent agent;
+
+if (!string.IsNullOrWhiteSpace(foundryEndpoint))
+{
+    // Option A (Preferred): Microsoft Foundry with DefaultAzureCredential — requires az login
+    var foundryModel = SystemEnvironment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? DefaultModel;
+
+    appLogger.LogInformation("Mode: Foundry. Endpoint: {Endpoint}, Model: {Model}", foundryEndpoint, foundryModel);
+
+    // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
+    // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
+    // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
+    agent = new AIProjectClient(new Uri(foundryEndpoint), new DefaultAzureCredential())
+        .AsAIAgent(
+            model: foundryModel,
+            instructions: "You are a helpful assistant that provides concise and informative responses.",
+            name: "OpenTelemetryDemoAgent",
+            tools: [AIFunctionFactory.Create(GetWeatherAsync)],
+            clientFactory: client => client
+                .AsBuilder()
+                .UseFunctionInvocation()
+                .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true)
+                .Build())
+        .AsBuilder()
+        .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true)
+        .Build();
+}
+else if (!string.IsNullOrWhiteSpace(azureOpenAIEndpoint)
+    && !string.IsNullOrWhiteSpace(azureOpenAIApiKey))
+{
+    // Option B (Fallback): Azure OpenAI with API key — no az login required (local/dev convenience)
+    var deploymentName = azureOpenAIDeployment ?? DefaultModel;
+    appLogger.LogInformation("Mode: Azure OpenAI (API key). Endpoint: {Endpoint}, Deployment: {Deployment}", azureOpenAIEndpoint, deploymentName);
+
+    agent = new AzureOpenAIClient(new Uri(azureOpenAIEndpoint), new ApiKeyCredential(azureOpenAIApiKey))
+        .GetChatClient(deploymentName)
+        .AsAIAgent(
+            instructions: "You are a helpful assistant that provides concise and informative responses.",
+            name: "OpenTelemetryDemoAgent",
+            tools: [AIFunctionFactory.Create(GetWeatherAsync)],
+            clientFactory: client => client
+                .AsBuilder()
+                .UseFunctionInvocation()
+                .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true)
+                .Build())
+        .AsBuilder()
+        .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true)
+        .Build();
+}
+else
+{
+    throw new InvalidOperationException(
+        """
+        No valid configuration found. Set one of the following:
+
+        Option A — Microsoft Foundry (recommended):
+          FOUNDRY_PROJECT_ENDPOINT=https://<project>.services.ai.azure.com/api/projects/<project>
+          FOUNDRY_MODEL=<model-deployment-name>
+          Then run: az login
+
+        Option B — Azure OpenAI API key (local/dev fallback):
+          AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com/
+          AZURE_OPENAI_API_KEY=<your-api-key>
+          AZURE_OPENAI_DEPLOYMENT_NAME=<deployment-name>   # if not set, defaults to gpt-5-mini
+        """);
+}
 
 var session = await agent.CreateSessionAsync();
 
 appLogger.LogInformation("Agent created successfully with ID: {AgentId}", agent.Id);
+
+// When OTEL_DEMO_NEW_TRACE_PER_TURN=true, each interaction starts as a new root trace
+// (useful for demo readability in Aspire Dashboard or App Insights — each turn appears as a separate top-level trace while maintaining the overall session correlation).
+// Default (false): interactions are child spans of the session span, preserving correlation.
+var newTracePerTurn = string.Equals(
+    SystemEnvironment.GetEnvironmentVariable("OTEL_DEMO_NEW_TRACE_PER_TURN"),
+    "true",
+    StringComparison.OrdinalIgnoreCase);
 
 // Create a parent span for the entire agent session
 using var sessionActivity = activitySource.StartActivity("Agent Session");
@@ -162,11 +240,19 @@ using (appLogger.BeginScope(new Dictionary<string, object> { ["SessionId"] = ses
         interactionCount++;
         appLogger.LogInformation("Processing user interaction #{InteractionNumber}: {UserInput}", interactionCount, userInput);
 
-        // Create a child span for each individual interaction
+        // If OTEL_DEMO_NEW_TRACE_PER_TURN is enabled, break the parent-child link so each
+        // interaction appears as its own root trace in the dashboard. Otherwise, preserve
+        // the ambient context so all interaction spans correlate under the session trace.
+        if (newTracePerTurn)
+        {
+            Activity.Current = null;
+        }
+
         using var activity = activitySource.StartActivity("Agent Interaction");
         activity?
             .SetTag("user.input", userInput)
             .SetTag("agent.name", "OpenTelemetryDemoAgent")
+            .SetTag("session.id", sessionId)
             .SetTag("interaction.number", interactionCount);
 
         var stopwatch = Stopwatch.StartNew();

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
@@ -203,9 +203,10 @@ var session = await agent.CreateSessionAsync();
 
 appLogger.LogInformation("Agent created successfully with ID: {AgentId}", agent.Id);
 
-// When OTEL_DEMO_NEW_TRACE_PER_TURN=true, each interaction starts as a new root trace
-// (useful for demo readability in Aspire Dashboard or App Insights — each turn appears as a separate top-level trace while maintaining the overall session correlation).
-// Default (false): interactions are child spans of the session span, preserving correlation.
+// When OTEL_DEMO_NEW_TRACE_PER_TURN=true, each interaction starts a new root trace (new TraceId)
+// to make turns show up as standalone entries in dashboards. Session-level correlation is retained
+// via the shared session.id tag (not via parent/child trace relationships).
+// Default (false): interactions are child spans of the session span, preserving full trace correlation.
 var newTracePerTurn = string.Equals(
     SystemEnvironment.GetEnvironmentVariable("OTEL_DEMO_NEW_TRACE_PER_TURN"),
     "true",
@@ -240,15 +241,15 @@ using (appLogger.BeginScope(new Dictionary<string, object> { ["SessionId"] = ses
         interactionCount++;
         appLogger.LogInformation("Processing user interaction #{InteractionNumber}: {UserInput}", interactionCount, userInput);
 
-        // If OTEL_DEMO_NEW_TRACE_PER_TURN is enabled, break the parent-child link so each
-        // interaction appears as its own root trace in the dashboard. Otherwise, preserve
-        // the ambient context so all interaction spans correlate under the session trace.
-        if (newTracePerTurn)
-        {
-            Activity.Current = null;
-        }
-
-        using var activity = activitySource.StartActivity("Agent Interaction");
+        // If OTEL_DEMO_NEW_TRACE_PER_TURN is enabled, create a fresh ActivityContext with a new random
+        // TraceId so each interaction appears as an independent root trace in the dashboard.
+        // Passing `default` does NOT work — an empty ActivityContext causes the runtime to fall back
+        // to Activity.Current (the session span), so all turns would still share the same TraceId.
+        // Using a real random context guarantees a new TraceId without mutating Activity.Current.
+        using var activity = newTracePerTurn
+            ? activitySource.StartActivity("Agent Interaction", ActivityKind.Internal,
+                new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded))
+            : activitySource.StartActivity("Agent Interaction");
         activity?
             .SetTag("user.input", userInput)
             .SetTag("agent.name", "OpenTelemetryDemoAgent")

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
@@ -189,8 +189,8 @@ else
 
         Option A — Microsoft Foundry (recommended):
           FOUNDRY_PROJECT_ENDPOINT=https://<project>.services.ai.azure.com/api/projects/<project>
-          FOUNDRY_MODEL=<model-deployment-name>
-          Then run: az login
+          FOUNDRY_MODEL=<model-deployment-name>   # optional; defaults to gpt-5-mini
+          Then authenticate (e.g., az login)
 
         Option B — Azure OpenAI API key (local/dev fallback):
           AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com/

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
@@ -30,14 +30,54 @@ graph TD
 
 ## Configuration
 
-### Microsoft Foundry Setup
-Set the following environment variables:
+Two authentication paths are supported. **Foundry is the recommended default.** When both are configured, Foundry takes precedence.
+
+### Option A — Microsoft Foundry (Recommended)
+
+Uses `DefaultAzureCredential` (Azure CLI, managed identity, etc.). No API key required.
+
+| Variable | Required | Description |
+|---|---|---|
+| `FOUNDRY_PROJECT_ENDPOINT` | Yes | Your Foundry project endpoint URL |
+| `FOUNDRY_MODEL` | No | Model deployed in your Foundry project. If not set, defaults to `gpt-5-mini` |
+
 ```powershell
-$env:FOUNDRY_PROJECT_ENDPOINT="https://<your-project>.services.ai.azure.com/api/projects/<your-project>"
-$env:FOUNDRY_MODEL="gpt-5.4-mini"  # Optional, defaults to gpt-5.4-mini
+$env:FOUNDRY_PROJECT_ENDPOINT = "https://<your-project>.services.ai.azure.com/api/projects/<your-project>"
+$env:FOUNDRY_MODEL             = "gpt-5-mini"   # if not set, defaults to gpt-5-mini
+az login
 ```
 
-**Note**: This demo uses Azure CLI credentials for authentication. Make sure you're logged in with `az login` and have access to the Foundry project.
+**Note**: Option A uses Azure CLI credentials (`DefaultAzureCredential`). Make sure you are logged in with `az login` and have access to the Foundry project before running the demo.
+
+### Option B — Azure OpenAI API Key (Local/Dev Fallback)
+
+Useful when `az login` is not available. All three variables must be set.
+
+| Variable | Required | Description |
+|---|---|---|
+| `AZURE_OPENAI_ENDPOINT` | Yes | Your Azure OpenAI resource endpoint |
+| `AZURE_OPENAI_API_KEY` | Yes | API key for the resource |
+| `AZURE_OPENAI_DEPLOYMENT_NAME` | No | Deployment name. If not set, defaults to `gpt-5-mini` |
+
+```powershell
+$env:AZURE_OPENAI_ENDPOINT        = "https://<resource>.openai.azure.com/"
+$env:AZURE_OPENAI_API_KEY         = "<your-api-key>"
+$env:AZURE_OPENAI_DEPLOYMENT_NAME = "<deployment-name>"   # if not set, defaults to gpt-5-mini
+```
+
+### Observability Options
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | _(unset)_ | Enables Application Insights export |
+| `OTEL_DEMO_NEW_TRACE_PER_TURN` | `false` | See note below |
+
+**`OTEL_DEMO_NEW_TRACE_PER_TURN`**: By default, each interaction is a child span of the session span, preserving full correlation across the conversation. Set to `true` to make each turn start a new root trace — useful in demo walkthroughs where you want each interaction to appear as a standalone entry in the Aspire Dashboard.
+
+```powershell
+$env:OTEL_DEMO_NEW_TRACE_PER_TURN = "true"   # optional, per-turn root traces
+```
 
 ### [Optional] Application Insights Setup
 Set the following environment variables:
@@ -56,7 +96,7 @@ The easiest way to run the demo is using the provided PowerShell script:
 ```
 
 This script will automatically:
-- ✅ Check prerequisites (Docker, Foundry configuration)
+- ✅ Detect configuration (Foundry preferred; Azure OpenAI API key as fallback)
 - 🔨 Build the console application
 - 🐳 Start the Aspire Dashboard via Docker (with anonymous access)
 - ⏳ Wait for dashboard to be ready (polls port until listening)
@@ -182,7 +222,7 @@ Complete demo startup script that handles everything automatically.
 ```
 
 **Features:**
-- **Automatic configuration detection** - Checks for Foundry configuration
+- **Automatic configuration detection** - Checks for Foundry (preferred) then Azure OpenAI API key fallback
 - **Project building** - Automatically builds projects before running
 - **Error handling** - Provides clear error messages if something goes wrong
 - **Multi-window support** - Opens dashboard in separate window for better experience
@@ -204,7 +244,8 @@ If you encounter port binding errors, try:
 - Ensure your Foundry project endpoint is correctly configured
 - Check that the environment variables are set in the correct terminal session
 - Verify you're logged in with Azure CLI (`az login`) and have access to the Foundry project
-- Ensure the `FOUNDRY_MODEL` value matches an enabled model in your Foundry project
+- Ensure the `FOUNDRY_MODEL` value matches a model deployed in your Foundry project
+- If `az login` is not available (e.g. a dev machine without the Azure CLI), switch to Option B (Azure OpenAI API key) instead
 
 ### Build Issues
 - Ensure you're using .NET 10.0 SDK

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
@@ -47,11 +47,11 @@ $env:FOUNDRY_MODEL             = "gpt-5-mini"   # if not set, defaults to gpt-5-
 az login
 ```
 
-**Note**: Option A uses Azure CLI credentials (`DefaultAzureCredential`). Make sure you are logged in with `az login` and have access to the Foundry project before running the demo.
+ **Note**: Option A uses `DefaultAzureCredential`. For local runs, `az login` is usually the easiest way to authenticate; you can also use managed identity or other supported credential sources.
 
 ### Option B — Azure OpenAI API Key (Local/Dev Fallback)
 
-Useful when `az login` is not available. All three variables must be set.
+ Useful when `az login` is not available. `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_KEY` must be set (deployment name is optional).
 
 | Variable | Required | Description |
 |---|---|---|

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/start-demo.ps1
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/start-demo.ps1
@@ -35,7 +35,7 @@ if ($foundryEndpoint) {
     Write-Host "Configuration: Microsoft Foundry (recommended)" -ForegroundColor Green
     Write-Host "Endpoint   : $foundryEndpoint" -ForegroundColor Green
     Write-Host "Model      : $foundryModel$(if (!$env:FOUNDRY_MODEL) { ' (default)' })" -ForegroundColor Green
-    Write-Host "Note: Foundry uses DefaultAzureCredential. Ensure you have run 'az login'." -ForegroundColor Cyan
+    Write-Host "Note: Foundry uses DefaultAzureCredential. Authenticate (e.g., run 'az login')." -ForegroundColor Cyan
 } elseif ($azureOpenAIEndpoint -and $azureOpenAIApiKey) {
     # Option B: Azure OpenAI API key fallback — API key is intentionally not printed
     $deploymentName = if ($azureOpenAIDeployment) { $azureOpenAIDeployment } else { $defaultModel }

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/start-demo.ps1
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/start-demo.ps1
@@ -21,19 +21,48 @@ try {
     exit 1
 }
 
-# Check for Azure OpenAI configuration
-if ($env:AZURE_OPENAI_ENDPOINT) {
-    Write-Host "Found Azure OpenAI endpoint: $($env:AZURE_OPENAI_ENDPOINT)" -ForegroundColor Green
-    if ($env:AZURE_OPENAI_DEPLOYMENT_NAME) {
-        Write-Host "Using deployment: $($env:AZURE_OPENAI_DEPLOYMENT_NAME)" -ForegroundColor Green
-    } else {
-        Write-Host "Using default deployment: gpt-4o-mini" -ForegroundColor Cyan
-    }
+# Detect configuration — Foundry is preferred; Azure OpenAI API key is the fallback.
+$foundryEndpoint = $env:FOUNDRY_PROJECT_ENDPOINT
+$azureOpenAIEndpoint = $env:AZURE_OPENAI_ENDPOINT
+$azureOpenAIApiKey = $env:AZURE_OPENAI_API_KEY
+$azureOpenAIDeployment = $env:AZURE_OPENAI_DEPLOYMENT_NAME
+
+$defaultModel = "gpt-5-mini"
+
+if ($foundryEndpoint) {
+    # Option A: Foundry (recommended)
+    $foundryModel = if ($env:FOUNDRY_MODEL) { $env:FOUNDRY_MODEL } else { $defaultModel }
+    Write-Host "Configuration: Microsoft Foundry (recommended)" -ForegroundColor Green
+    Write-Host "Endpoint   : $foundryEndpoint" -ForegroundColor Green
+    Write-Host "Model      : $foundryModel$(if (!$env:FOUNDRY_MODEL) { ' (default)' })" -ForegroundColor Green
+    Write-Host "Note: Foundry uses DefaultAzureCredential. Ensure you have run 'az login'." -ForegroundColor Cyan
+} elseif ($azureOpenAIEndpoint -and $azureOpenAIApiKey) {
+    # Option B: Azure OpenAI API key fallback — API key is intentionally not printed
+    $deploymentName = if ($azureOpenAIDeployment) { $azureOpenAIDeployment } else { $defaultModel }
+    Write-Host "Configuration: Azure OpenAI API key (fallback mode)" -ForegroundColor Cyan
+    Write-Host "Endpoint   : $azureOpenAIEndpoint" -ForegroundColor Cyan
+    Write-Host "Deployment : $deploymentName$(if (!$azureOpenAIDeployment) { ' (default)' })" -ForegroundColor Cyan
 } else {
-    Write-Host "Warning: AZURE_OPENAI_ENDPOINT not found!" -ForegroundColor Yellow
-    Write-Host "Please set the AZURE_OPENAI_ENDPOINT environment variable" -ForegroundColor Yellow
-    Write-Host "Example: `$env:AZURE_OPENAI_ENDPOINT='https://your-resource.openai.azure.com/'" -ForegroundColor Yellow
+    Write-Host "Error: No valid configuration found." -ForegroundColor Red
     Write-Host ""
+    Write-Host "Option A — Microsoft Foundry (recommended):" -ForegroundColor Yellow
+    Write-Host "  `$env:FOUNDRY_PROJECT_ENDPOINT = 'https://<project>.services.ai.azure.com/api/projects/<project>'" -ForegroundColor Yellow
+    Write-Host "  `$env:FOUNDRY_MODEL            = '<model-name>'   # if not set, defaults to $defaultModel" -ForegroundColor Yellow
+    Write-Host "  az login" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Option B — Azure OpenAI API key (local/dev fallback):" -ForegroundColor Yellow
+    Write-Host "  `$env:AZURE_OPENAI_ENDPOINT        = 'https://<resource>.openai.azure.com/'" -ForegroundColor Yellow
+    Write-Host "  `$env:AZURE_OPENAI_API_KEY          = '<your-api-key>'" -ForegroundColor Yellow
+    Write-Host "  `$env:AZURE_OPENAI_DEPLOYMENT_NAME  = '<deployment-name>'   # if not set, defaults to $defaultModel" -ForegroundColor Yellow
+    Write-Host ""
+    exit 1
+}
+
+# Optional: per-turn root trace toggle
+if ($env:OTEL_DEMO_NEW_TRACE_PER_TURN -eq "true") {
+    Write-Host "Telemetry: Per-turn root traces enabled (OTEL_DEMO_NEW_TRACE_PER_TURN=true)" -ForegroundColor Cyan
+} else {
+    Write-Host "Telemetry: Correlated session traces (default). Set OTEL_DEMO_NEW_TRACE_PER_TURN=true for per-turn root traces." -ForegroundColor Gray
 }
 
 # Build console application


### PR DESCRIPTION
## Motivation & Context

While implementing observability for our own agents, I used this sample as a reference and found a startup inconsistency: `start-demo.ps1` prompted for Azure OpenAI API key configuration even when Foundry configuration was present, and the startup/manual guidance was not consistently supporting both paths.

In my local environment, `az login` was unavailable, but I had a valid Azure OpenAI endpoint/API key. The sample did not cleanly support that fallback path through either the script flow or the documented manual flow. I updated and tested the sample to support this scenario while keeping Foundry as the preferred default.

This PR aligns runtime/script/docs behavior: Foundry-first when configured, with Azure OpenAI API-key fallback for local/dev use.

## Description & Review Guide

### What are the major changes?

- **Program.cs**
  - Keeps **Foundry-first** configuration:
    - `FOUNDRY_PROJECT_ENDPOINT` (+ optional `FOUNDRY_MODEL`) -> `AIProjectClient` + `DefaultAzureCredential`
  - Adds **Azure OpenAI API-key fallback** for local/dev:
    - `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_API_KEY` (+ optional `AZURE_OPENAI_DEPLOYMENT_NAME`)
  - Enforces precedence: **Foundry wins when both are configured**
  - Improves invalid configuration guidance
  - Adds optional telemetry toggle:
    - `OTEL_DEMO_NEW_TRACE_PER_TURN=true` => per-turn root traces
    - default remains correlated session tracing

- **start-demo.ps1**
  - Detects Foundry first, Azure OpenAI fallback second
  - Prints selected mode and actionable setup guidance
  - Avoids printing secret values

- **README.md**
  - Documents both configuration paths with Foundry as recommended
  - Documents precedence and troubleshooting
  - Documents `OTEL_DEMO_NEW_TRACE_PER_TURN` behavior

### What is the impact of these changes?

- Scoped to `dotnet/samples/02-agents/AgentOpenTelemetry`
- Backward-compatible sample update
- Improves local developer experience without changing Foundry-first direction
- No public API changes

### What do you want reviewers to focus on?

- Config precedence and mode-selection behavior
- Consistency across Program.cs, start-demo.ps1, and README
- Optional per-turn trace toggle behavior vs default correlation path

## Validation

Changes are scoped to `dotnet/samples/02-agents/AgentOpenTelemetry/` only (no library/test code changes).

- **Build:** `dotnet build` - 0 errors, 0 warnings
- **Unit tests:** `dotnet test --filter-query "/*UnitTests*/*/*/*"` - 0 failures
- **Integration tests:** require live Azure/Foundry credentials not available locally - standard; CI will run these
- **`dotnet format`:** SDK version mismatch prevented local run (local: `10.0.300`, `global.json`: `10.0.301`) - CI will verify

## Related Issue

No dedicated issue was opened since this is a small sample consistency/usability follow-up.

## Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the Contribution Guidelines
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] This is not a breaking change. If it is a breaking change, add the breaking change label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.