### PR TITLE
Python: Clarify service session ID scoping

### DIFF
--- a/python/packages/core/agent_framework/_sessions.py
+++ b/python/packages/core/agent_framework/_sessions.py
@@ -166,7 +166,8 @@ class SessionContext:
 
     Attributes:
         session_id: The ID of the current session.
-        service_session_id: Service-managed session ID (if present, service handles storage).
+        service_session_id: Service-managed session identifier
+            (if present, the service stores history).
         input_messages: The new messages being sent to the agent (set by caller).
         context_messages: Dict mapping source_id -> messages added by that provider.
             Maintains insertion order (provider execution order).
@@ -196,7 +197,7 @@ class SessionContext:
 
         Args:
             session_id: The ID of the current session.
-            service_session_id: Service-managed session ID.
+            service_session_id: Service-managed session identifier.
             input_messages: The new messages being sent to the agent.
             context_messages: Pre-populated context messages by source.
             instructions: Pre-populated instructions.
@@ -756,9 +757,16 @@ class AgentSession:
     Lightweight state container. Provider instances are owned by the agent,
     not the session. The session only holds session IDs and a mutable state dict.
 
+    ``service_session_id`` can contain a provider-issued service session
+    identifier, such as a service conversation ID or response ID. Treat this
+    value as trusted application state: it is scoped by the backing API key,
+    service account, or project, but it is not an end-user authorization
+    boundary by itself.
+
     Attributes:
         session_id: Unique identifier for this session.
-        service_session_id: Service-managed session ID (if using service-side storage).
+        service_session_id: Service-managed session identifier
+            (if using service-side storage).
         state: Mutable state dict shared with all providers.
     """
 
@@ -772,7 +780,7 @@ class AgentSession:
 
         Args:
             session_id: Optional session ID (generated if not provided).
-            service_session_id: Optional service-managed session ID.
+            service_session_id: Optional service-managed session identifier.
         """
         self._session_id = session_id or str(uuid.uuid4())
         self.service_session_id = service_session_id

--- a/python/samples/02-agents/providers/openai/client_with_session.py
+++ b/python/samples/02-agents/providers/openai/client_with_session.py
@@ -123,6 +123,9 @@ async def example_with_existing_session_id() -> None:
     if existing_session_id:
         print("\n--- Continuing with the same session ID in a new agent instance ---")
 
+        # In a hosted multi-user app, do not echo this service session ID to clients
+        # and accept it back unscoped. OpenAI scopes it to the API key/project, so
+        # store it server-side and verify it belongs to the authenticated user or tenant.
         agent = Agent(
             client=OpenAIChatClient(),
             instructions="You are a helpful weather agent.",


### PR DESCRIPTION
### Motivation & Context

Clarifies user-facing guidance around `AgentSession.service_session_id` when service-managed history is used. The current docs describe it as a lightweight state field, but do not make the OpenAI API key/project scoping behavior or hosted multi-user responsibility explicit.

This helps library users understand that OpenAI `resp_*` response IDs and `conv_*` conversation IDs are scoped to the backing API key/project by default, and that hosted agents using one backing key/project for multiple users should bind stored service-side IDs to authenticated users or tenants before resuming.

### Description & Review Guide

- **What are the major changes?**
  - Expanded `AgentSession` and `SessionContext` docstrings to describe `service_session_id` as a service-managed session identifier.
  - Added OpenAI session sample guidance to avoid echoing raw service session IDs to clients and accepting them back unscoped in hosted multi-user apps.
- **What is the impact of these changes?**
  - Documentation-only clarification; no runtime behavior, API surface, tests, or serialization changes.
- **What do you want reviewers to focus on?**
  - Whether the terminology avoids confusing `service_session_id` with background response continuation tokens.
  - Whether the hosted multi-user OpenAI scoping guidance is accurate and appropriately placed in user-facing docs/sample guidance.

### Related Issue

N/A — documentation-only clarification; no linked issue.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.