### PR TITLE
.NET: Fix CosmosChatHistoryProvider: omit ttl when MessageTtlSeconds is nul…

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.CosmosNoSql/CosmosChatHistoryProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.CosmosNoSql/CosmosChatHistoryProvider.cs
@@ -607,7 +607,10 @@ public sealed class CosmosChatHistoryProvider : ChatHistoryProvider, IDisposable
         [Newtonsoft.Json.JsonProperty("type")]
         public string Type { get; set; } = string.Empty;
 
-        [Newtonsoft.Json.JsonProperty("ttl")]
+        // Omit "ttl" from the document when null so Cosmos DB leaves TTL unset (disabled) instead of
+        // rejecting the write. Cosmos requires ttl to be a positive integer or -1; a literal null is
+        // invalid, so serializing MessageTtlSeconds = null must drop the property entirely.
+        [Newtonsoft.Json.JsonProperty("ttl", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Ttl { get; set; }
 
         /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.CosmosNoSql.UnitTests/CosmosChatHistoryProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.CosmosNoSql.UnitTests/CosmosChatHistoryProviderTests.cs
@@ -290,6 +290,52 @@ public sealed class CosmosChatHistoryProviderTests : IAsyncLifetime, IDisposable
 
     [Fact]
     [Trait("Category", "CosmosDB")]
+    public async Task InvokedAsync_WithNullMessageTtl_ShouldPersistWithoutTtlPropertyAsync()
+    {
+        // Arrange
+        this.SkipIfEmulatorNotAvailable();
+        var session = CreateMockSession();
+        var conversationId = Guid.NewGuid().ToString();
+        using var provider = new CosmosChatHistoryProvider(this._connectionString, s_testDatabaseId, TestContainerId,
+            _ => new CosmosChatHistoryProvider.State(conversationId))
+        {
+            MessageTtlSeconds = null // Disable TTL. Previously this serialized ttl=null and Cosmos rejected the write.
+        };
+        var message = new ChatMessage(ChatRole.User, "No TTL message");
+        var context = new ChatHistoryProvider.InvokedContext(s_mockAgent, session, [message], []);
+
+        // Act - must not throw "The input ttl 'null' is invalid ..."
+        await provider.InvokedAsync(context);
+
+        // Wait a moment for eventual consistency
+        await Task.Delay(100);
+
+        // Assert - message persisted and the stored document omits the "ttl" property entirely.
+        var invokingContext = new ChatHistoryProvider.InvokingContext(s_mockAgent, session, []);
+        var messageList = (await provider.InvokingAsync(invokingContext)).ToList();
+        Assert.Single(messageList);
+        Assert.Equal("No TTL message", messageList[0].Text);
+
+        var rawQuery = new QueryDefinition("SELECT * FROM c WHERE c.conversationId = @conversationId")
+            .WithParameter("@conversationId", conversationId);
+        var rawIterator = this._setupClient!.GetDatabase(s_testDatabaseId).GetContainer(TestContainerId)
+            .GetItemQueryIterator<Newtonsoft.Json.Linq.JObject>(rawQuery, requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(conversationId)
+            });
+
+        List<Newtonsoft.Json.Linq.JObject> rawDocs = [];
+        while (rawIterator.HasMoreResults)
+        {
+            rawDocs.AddRange(await rawIterator.ReadNextAsync());
+        }
+
+        Assert.Single(rawDocs);
+        Assert.False(rawDocs[0].ContainsKey("ttl"), "The 'ttl' property must be omitted when MessageTtlSeconds is null.");
+    }
+
+    [Fact]
+    [Trait("Category", "CosmosDB")]
     public async Task InvokedAsync_WithMultipleMessages_ShouldAddAllMessagesAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation & Context

`CosmosChatHistoryProvider.MessageTtlSeconds` is documented as *"Set to null to disable TTL."*, but setting it to `null` broke persistence. The provider's internal `CosmosMessageDocument.Ttl` property was annotated with a plain `[Newtonsoft.Json.JsonProperty("ttl")]`, so a `null` value serialized to `ttl: null` in the document. Cosmos DB rejects that:

> The input ttl 'null' is invalid. Ensure to provide a nonzero positive integer less than or equal to '2147483647', or '-1' which means never expire.

So the documented "disable TTL" behavior was impossible — any write with `MessageTtlSeconds = null` failed.

### Description & Review Guide

- **What are the major changes?**
  - Added `NullValueHandling = NullValueHandling.Ignore` to the `ttl` JSON property on `CosmosMessageDocument`, so the field is omitted from the document entirely when `MessageTtlSeconds` is `null`. Cosmos then leaves TTL unset (disabled), which is the documented behavior. Cosmos still receives a valid positive integer (or `-1`) when a TTL is configured.
  - Added an emulator-backed unit test (`InvokedAsync_WithNullMessageTtl_ShouldPersistWithoutTtlPropertyAsync`) that sets `MessageTtlSeconds = null`, persists a message, and asserts the write succeeds and the stored document contains no `ttl` key.

- **What is the impact of these changes?**
  - `MessageTtlSeconds = null` now works as documented and no longer throws. No behavior change when a TTL value is set. No public API change.

### Related Issue

Fixes #6992

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**