### PR TITLE
Python: Fix read_skill_resource instruction dropping .md extension

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1803,7 +1803,7 @@ Only load what is needed, when it is needed."""
 
 RESOURCE_INSTRUCTIONS: Final[str] = (
     "- Use `read_skill_resource` to read any referenced resources, using the name exactly as listed\n"
-    '   (e.g. `"style-guide"` not `"style-guide.md"`, `"references/FAQ"` not `"FAQ.md"`).\n'
+    '   (e.g. `"style-guide"` not `"style-guide.md"`, `"references/FAQ.md"` not `"FAQ.md"`).\n'
 )
 
 SCRIPT_RUNNER_INSTRUCTIONS: Final[str] = (


### PR DESCRIPTION
### Motivation & Context

Microsoft Agent Framework Skills expose a `read_skill_resource` tool that resolves resources by their exact listed name. For file-based skills, resource names include their relative path **and** file extension (e.g. `references/output-schema.md`), and the `<available_resources>` block advertises them that way. Lookup (`get_resource`) matches on that exact name.

However, the generated `RESOURCE_INSTRUCTIONS` prompt contained a misleading example that told the model to strip the extension:

> Use `read_skill_resource` ... (e.g. `"style-guide"` not `"style-guide.md"`, `"references/FAQ"` not `"FAQ.md"`).

The second example (`references/FAQ` instead of `references/FAQ.md`) demonstrates dropping the `.md` extension, which directly contradicts the exact-match behavior. This nudges the model into calling `read_skill_resource(resource_name="references/output-schema")`, which then fails with `Resource '...' not found in skill '...'`.

This is a Python-only transcription defect: the .NET original (`AgentSkillsProvider.cs`) correctly reads `"references/FAQ.md"` not `"FAQ.md"`.

### Description & Review Guide

- **What are the major changes?** A one-line fix to the `RESOURCE_INSTRUCTIONS` example in `python/packages/core/agent_framework/_skills.py`: `"references/FAQ"` -> `"references/FAQ.md"`, restoring exact parity with the .NET prompt. The unifying rule ("use the name exactly as listed") is unchanged; the file-resource example now keeps its extension.
- **What is the impact of these changes?** Agents following the instruction now call `read_skill_resource` with the full listed name (including `.md`), so resource loading no longer fails. Prompt-text only; no API or behavioral code changes.
- **What do you want reviewers to focus on?** Confirm the corrected example matches how file resources are named/advertised and looked up.

### Related Issue

Fixes #7008

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.