### PR TITLE
Python: quiet A2AExecutor logging for unmapped content types

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_a2a_executor.py
+++ b/python/packages/a2a/agent_framework_a2a/_a2a_executor.py
@@ -273,8 +273,10 @@ class A2AExecutor(AgentExecutor):
             elif content.type == "uri" and content.uri:
                 parts.append(Part(url=content.uri, media_type=content.media_type or ""))
             else:
-                # Silently skip unsupported content types
-                logger.warning("A2AExecutor does not yet support content type: %s. Omitted.", content.type)
+                # Content that doesn't map to an A2A part (e.g. intermediate function_call /
+                # function_result from tool use) is skipped; only final user-facing output
+                # (text/data/uri) is surfaced.
+                logger.debug("Skipping unsupported content type for A2A: %s", content.type)
 
         if parts:
             if isinstance(item, AgentResponseUpdate):

--- a/python/packages/a2a/tests/test_a2a_executor.py
+++ b/python/packages/a2a/tests/test_a2a_executor.py
@@ -855,14 +855,14 @@ class TestA2AExecutorHandleEvents:
 
         # Assert
         mock_logger.warning.assert_not_called()
-        mock_logger.debug.assert_called_once()
+        mock_logger.debug.assert_called_once_with("Skipping unsupported content type for A2A: %s", "unknown")
         mock_updater.update_status.assert_not_called()
 
     async def test_handle_intermediate_content_type(self, executor: A2AExecutor, mock_updater: MagicMock) -> None:
         """Test that intermediate tool content (e.g. function_call) is skipped quietly (debug, not warning)."""
         # Arrange
         message = Message(
-            contents=[Content(type=cast(Any, "function_call"))],  # type: ignore[arg-type]
+            contents=[Content(type="function_call")],
             role="assistant",
         )
 
@@ -872,7 +872,7 @@ class TestA2AExecutorHandleEvents:
 
         # Assert
         mock_logger.warning.assert_not_called()
-        mock_logger.debug.assert_called_once()
+        mock_logger.debug.assert_called_once_with("Skipping unsupported content type for A2A: %s", "function_call")
         mock_updater.update_status.assert_not_called()
 
 

--- a/python/packages/a2a/tests/test_a2a_executor.py
+++ b/python/packages/a2a/tests/test_a2a_executor.py
@@ -842,7 +842,7 @@ class TestA2AExecutorHandleEvents:
         assert call_kwargs["append"] is True
 
     async def test_handle_unsupported_content_type(self, executor: A2AExecutor, mock_updater: MagicMock) -> None:
-        """Test handling messages with unsupported content types."""
+        """Test that unsupported content types are skipped quietly (debug, not warning)."""
         # Arrange
         message = Message(
             contents=[Content(type=cast(Any, "unknown"), text="Some text")],  # type: ignore[arg-type]
@@ -854,7 +854,25 @@ class TestA2AExecutorHandleEvents:
             await executor.handle_events(message, mock_updater)
 
         # Assert
-        mock_logger.warning.assert_called_once()
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_called_once()
+        mock_updater.update_status.assert_not_called()
+
+    async def test_handle_intermediate_content_type(self, executor: A2AExecutor, mock_updater: MagicMock) -> None:
+        """Test that intermediate tool content (e.g. function_call) is skipped quietly (debug, not warning)."""
+        # Arrange
+        message = Message(
+            contents=[Content(type=cast(Any, "function_call"))],  # type: ignore[arg-type]
+            role="assistant",
+        )
+
+        # Act
+        with patch("agent_framework_a2a._a2a_executor.logger") as mock_logger:
+            await executor.handle_events(message, mock_updater)
+
+        # Assert
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_called_once()
         mock_updater.update_status.assert_not_called()
 
 


### PR DESCRIPTION
### Motivation & Context

When an Agent Framework agent that uses tools (e.g. an MCP tool) is served via the A2A protocol, its response messages contain intermediate `function_call` and `function_result` content parts. The `A2AExecutor` only surfaces final user-facing output (text/data/uri), so these intermediate parts are correctly omitted — but it logged each omission at **WARNING** level with a misleading *"does not yet support content type: … Omitted."* message. This fires on every tool call, producing noisy, alarming output even though nothing is wrong and the final answer still reaches the client.

### Description & Review Guide

- **What are the major changes?**
  - In `A2AExecutor.handle_events`, the fall-through for unmapped content types now logs at `DEBUG` (`"Skipping unsupported content type for A2A: %s"`) and skips, instead of emitting a `WARNING`. This matches the outbound content-conversion convention already used across the Python chat clients (Gemini, Anthropic, Bedrock, OpenAI, AG-UI), which uniformly `logger.debug(...)` and skip unmapped content.
  - Updated the corresponding unit tests to assert the omission is logged at `DEBUG` and not `WARNING`, and added a test covering intermediate tool content (`function_call`).

- **What is the impact of these changes?**
  - Serving a tool-using agent over A2A no longer spams `WARNING`s on every tool call. Content-conversion behavior is unchanged (the same content is still omitted); only the log level and message change. No public API changes.

- **What do you want reviewers to focus on?**
  - Whether `DEBUG` + skip is the right consistency target (it aligns with the other Python chat clients' outbound conversion paths).

### Related Issue

Fixes #6982

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
