### PR TITLE
Python: Bump Python package versions for 1.11.0 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-09
+
+### Added
+- **agent-framework-core**: Add message injection middleware so tools or host code can enqueue messages into an active run and drain them into the next model call within the same `AgentSession` ([#6998](https://github.com/microsoft/agent-framework/pull/6998))
+- **agent-framework-core**: Integrate message injection into `create_harness_agent` and the harness console sample so a running harness agent can be nudged mid-turn ([#7027](https://github.com/microsoft/agent-framework/pull/7027))
+- **agent-framework-core**: Add progressive MCP disclosure so agents can discover, load, and unload MCP tool schemas on demand while keeping the `allowed_tools` boundary intact ([#6850](https://github.com/microsoft/agent-framework/pull/6850))
+- **agent-framework-core**: Add `refresh_interval` (TTL) to `CachingSkillsSource` so cached skill lists expire and re-fetch on a configured interval ([#6977](https://github.com/microsoft/agent-framework/pull/6977))
+- **agent-framework-core**, **agent-framework-foundry-hosting**: Add `SkillsSourceContext` (invoking agent plus optional session) threaded through the skills source pipeline, enabling context-aware filtering and per-key cache isolation ([#6895](https://github.com/microsoft/agent-framework/pull/6895))
+- **agent-framework-core**: Allow disabling approval for `SkillsProvider` tools ([#6867](https://github.com/microsoft/agent-framework/pull/6867))
+- **agent-framework-core**: Allow opting out of `FileAccessProvider` tool approval ([#6879](https://github.com/microsoft/agent-framework/pull/6879))
+- **agent-framework-core**: Allow custom argument parsing for inline skill scripts so non-conforming tool-call argument shapes (for example, vLLM) can be handled ([#6817](https://github.com/microsoft/agent-framework/pull/6817))
+- **agent-framework-hosting**, **agent-framework-hosting-responses**: Add a hosting protocol helper surface (`AgentState`, `WorkflowState`, `SessionStore`, `AgentRunArgs`, `WorkflowRunArgs`) and Responses helpers (`create_response_id`, `responses_session_id`, `responses_to_run`, `responses_from_run`, `responses_from_streaming_run`) ([#6891](https://github.com/microsoft/agent-framework/pull/6891))
+- **agent-framework-ag-ui**: Add FastAPI SSE keepalive support for long, output-silent streams ([#6980](https://github.com/microsoft/agent-framework/pull/6980))
+- **agent-framework-github-copilot**: Forward `skill_directories` and `disabled_skills` to the Copilot session ([#6937](https://github.com/microsoft/agent-framework/pull/6937))
+- **agent-framework-openai**: Allow `tool_choice: required` when `allowed_tools` is set ([#7024](https://github.com/microsoft/agent-framework/pull/7024))
+- **agent-framework-anthropic**, **agent-framework-core**, **agent-framework-foundry-hosting**, **agent-framework-gemini**, **agent-framework-openai**: Mark hosted/provider-executed tool calls as informational-only via `Content.informational_only` so they remain visible in transcripts without local re-invocation ([#6997](https://github.com/microsoft/agent-framework/pull/6997))
+- **samples**: Add a deterministic action-boundary validation middleware sample ([#6528](https://github.com/microsoft/agent-framework/pull/6528))
+- **samples**: Add Agent Harness blog post accompanying samples, part 3 ([#6741](https://github.com/microsoft/agent-framework/pull/6741))
+- **samples**: Add a declarative Foundry Hosted Agent workflow sample ([#6897](https://github.com/microsoft/agent-framework/pull/6897))
+
+### Changed
+- **agent-framework-core**: [BREAKING — experimental] Extract caching from `SkillsProvider` into a `CachingSkillsSource` decorator ([#6847](https://github.com/microsoft/agent-framework/pull/6847))
+- **agent-framework-core**: [BREAKING — experimental] Treat nested `SKILL.md` content as part of the parent skill instead of discovering it as a separate skill root ([#6849](https://github.com/microsoft/agent-framework/pull/6849))
+- **agent-framework-core**: [BREAKING — experimental] `FileAccess`/`FileMemory` `replace_lines` now performs literal replacement (including line deletion) instead of always re-adding a line terminator ([#6859](https://github.com/microsoft/agent-framework/pull/6859))
+- **agent-framework-core**: Remove the experimental marker from the Skills API now that its surface is stable ([#6974](https://github.com/microsoft/agent-framework/pull/6974))
+- **agent-framework-core**: Lazy-load root `agent_framework` exports to reduce import cost for narrow-surface scenarios ([#6962](https://github.com/microsoft/agent-framework/pull/6962))
+- **agent-framework-a2a**, **agent-framework-claude**, **agent-framework-copilotstudio**, **agent-framework-core**, **agent-framework-durabletask**, **agent-framework-github-copilot**, **agent-framework-purview**: Implement ADR-0029 `service_session_id` lifecycle mapping, separating durable continuation state, per-run identity forwarding, and telemetry conversation-id extraction ([#6724](https://github.com/microsoft/agent-framework/pull/6724))
+- **agent-framework-azurefunctions**, **agent-framework-core**, **agent-framework-durabletask**: [BREAKING] Support multi-workflow hosting and sub-workflows on the Durable Task host, including per-workflow durable naming and nested human-in-the-loop request routing ([#6696](https://github.com/microsoft/agent-framework/pull/6696))
+- **agent-framework-ag-ui**: [BREAKING] Canonicalize AG-UI interrupt and resume handling around `RUN_FINISHED.outcome.interrupts` and canonical `ResumeEntry` payloads ([#6925](https://github.com/microsoft/agent-framework/pull/6925))
+- **agent-framework-mem0**: Support the mem0ai 2.x OSS search call shape ([#7004](https://github.com/microsoft/agent-framework/pull/7004))
+- **agent-framework-mistral**: Widen the `uv_build` backend requirement to allow newer `uv` releases ([#7033](https://github.com/microsoft/agent-framework/pull/7033))
+- **agent-framework-lab**: Raise the `agentlightning` dependency ceiling for the `lightning` extra ([#6984](https://github.com/microsoft/agent-framework/pull/6984))
+- **agent-framework-claude**, **agent-framework-durabletask**, **agent-framework-gemini**, **agent-framework-monty**, **agent-framework-openai**: Raise dependency floors to the first versions that provide the SDK APIs and typing consumed by these packages
+- **docs**: Clarify `AgentSession.service_session_id` scoping to document backing API key/project boundaries and hosted multi-tenant guidance ([#6993](https://github.com/microsoft/agent-framework/pull/6993))
+- **docs**: Add security guidance for external skill sources and script execution to harness feature docstrings ([#6936](https://github.com/microsoft/agent-framework/pull/6936))
+- **samples**: Bump `vite` and `@vitejs/plugin-react-swc` in the ChatKit integration sample frontend ([#6613](https://github.com/microsoft/agent-framework/pull/6613))
+- **samples**: Add a multi-tenant hosting security consideration note to the A2A sample ([#6983](https://github.com/microsoft/agent-framework/pull/6983))
+- **samples**: Update Foundry Hosted Agent samples for the v2 protocol changes ([#6841](https://github.com/microsoft/agent-framework/pull/6841))
+- **samples**: Use a writable runtime directory for the Foundry Skills sample ([#6606](https://github.com/microsoft/agent-framework/pull/6606))
+- **tests**: Add Agent typing smoke tests across chat clients ([#6950](https://github.com/microsoft/agent-framework/pull/6950))
+- **tests**: Skip NumPy stubs during mypy typing to unblock scheduled dependency-maintenance typing runs ([#6969](https://github.com/microsoft/agent-framework/pull/6969))
+- **tests**: Consolidate Dependabot dependency updates for dev tooling (`uv`, `ruff`, `pytest`, `mypy`, `pyright`, `mcp`, `opentelemetry-sdk`, `poethepoet`) across the workspace and package dev-dependency groups ([#6984](https://github.com/microsoft/agent-framework/pull/6984), [#7033](https://github.com/microsoft/agent-framework/pull/7033))
+- **tests**: Bump the transitive `js-yaml` dependency in the DevUI frontend lockfile ([#6813](https://github.com/microsoft/agent-framework/pull/6813))
+
+### Fixed
+- **agent-framework-core**: Parse the structured response value from the final message instead of concatenated text, avoiding spurious `ValidationError`/`JSONDecodeError` ([#6383](https://github.com/microsoft/agent-framework/pull/6383))
+- **agent-framework-core**: Fix `read_skill_resource` instruction dropping the `.md` extension ([#7031](https://github.com/microsoft/agent-framework/pull/7031))
+- **agent-framework-core**: Bind policy-enforcement approvals to a single tool invocation (call id, function, arguments, security label, and session) and consume them on first use ([#6966](https://github.com/microsoft/agent-framework/pull/6966))
+- **agent-framework-core**: Process messages to an executor serially within a superstep to prevent concurrent handler invocations for the same target executor ([#6776](https://github.com/microsoft/agent-framework/pull/6776))
+- **agent-framework-core**: Auto-inject local conversation history on stateless clients even when non-history context providers (for example, `SkillsProvider` and `FileAccessProvider`) are registered ([#6810](https://github.com/microsoft/agent-framework/pull/6810))
+- **agent-framework-core**: Improve the error message when a `TypeVar` is used in handler/executor registration ([#4553](https://github.com/microsoft/agent-framework/pull/4553))
+- **agent-framework-anthropic**, **agent-framework-core**: Fix Anthropic requests that mix tool calls and tool results in one assistant message, and return a deterministic result when the function-loop limit is reached with a blank final response ([#6794](https://github.com/microsoft/agent-framework/pull/6794))
+- **agent-framework-anthropic**, **agent-framework-core**, **agent-framework-foundry-hosting**, **agent-framework-openai**: Fix Foundry reasoning/MCP compaction so reasoning output keeps its provider id and reasoning plus MCP call pairs stay atomic ([#6907](https://github.com/microsoft/agent-framework/pull/6907))
+- **agent-framework-anthropic**: Normalize a single Anthropic tool value the same as a one-item sequence during request preparation ([#6903](https://github.com/microsoft/agent-framework/pull/6903))
+- **agent-framework-anthropic**: Migrate structured outputs to the stable `output_config.format` shape to avoid malformed/concatenated JSON when tools are also present ([#5884](https://github.com/microsoft/agent-framework/pull/5884))
+- **agent-framework-azure-ai-search**: Pass `include_reference_source_data` in agentic search requests so `source_data` is populated on returned references ([#5100](https://github.com/microsoft/agent-framework/pull/5100))
+- **agent-framework-bedrock**: Fix non-ASCII escaping in JSON content blocks returned by the Converse API ([#6628](https://github.com/microsoft/agent-framework/pull/6628))
+- **agent-framework-foundry**: Strip tools from the Foundry agent request on the preview path (`allow_preview=True`) to avoid `invalid_payload` errors ([#6644](https://github.com/microsoft/agent-framework/pull/6644))
+- **agent-framework-gemini**: Fix `GeminiChatClient` dropping image/file content on multimodal messages ([#6751](https://github.com/microsoft/agent-framework/pull/6751))
+- **agent-framework-claude**, **agent-framework-core**, **agent-framework-github-copilot**, **agent-framework-ollama**: Fix response metadata construction so usage, finish reason, raw response, continuation token, and structured value are propagated consistently across providers ([#6955](https://github.com/microsoft/agent-framework/pull/6955))
+- **agent-framework-a2a**: Accept A2A data URIs whose media type includes parameters before the `;base64` marker ([#6818](https://github.com/microsoft/agent-framework/pull/6818))
+- **agent-framework-ag-ui**: Prefer explicit AG-UI resume payloads over message-derived responses ([#6360](https://github.com/microsoft/agent-framework/pull/6360))
+- **agent-framework-ag-ui**: Clear queued approvals on cancel so cancelled flows do not leave stale prompts for later turns ([#6947](https://github.com/microsoft/agent-framework/pull/6947))
+- **agent-framework-ag-ui**: Preserve the streamed text message id in mixed snapshots with pending tool calls and streamed trailing text ([#6269](https://github.com/microsoft/agent-framework/pull/6269))
+- **agent-framework-devui**: Fix `list[Message]` input handling for declarative `ToolAgent` entries ([#6534](https://github.com/microsoft/agent-framework/pull/6534))
+- **agent-framework-devui**: Fix DevUI deployment Dockerfile auth args ([#6150](https://github.com/microsoft/agent-framework/pull/6150))
+- **agent-framework-hyperlight**: Harden workspace staging against symlinks and reparse points that could escape the sandbox workspace/mount root ([#6856](https://github.com/microsoft/agent-framework/pull/6856))
+- **agent-framework-openai**: Fix `web_search_options` sent to the Azure OpenAI Chat Completions API ([#6225](https://github.com/microsoft/agent-framework/pull/6225))
+- **docs**: Fix stale `ChatAgent` references in `_clients.py` docstrings and make tool-support examples copy/paste-safe ([#6924](https://github.com/microsoft/agent-framework/pull/6924))
+- **samples**: Fix an invalid `options` kwarg in the workflow shared-session sample ([#6294](https://github.com/microsoft/agent-framework/pull/6294))
+- **docs**: Add prerequisite command documentation for Python hosting samples ([#5935](https://github.com/microsoft/agent-framework/pull/5935))
+
+### Removed
+- **agent-framework-hosting-telegram**: [BREAKING] Remove the unreleased hosting-telegram package and the earlier host/channel surface from the workspace, superseded by the new hosting protocol helper surface ([#6891](https://github.com/microsoft/agent-framework/pull/6891))
+
 ## [1.10.0] - 2026-06-30
 
 ### Added
@@ -1259,7 +1334,8 @@ Release candidate for **agent-framework-core** and **agent-framework-azure-ai** 
 
 For more information, see the [announcement blog post](https://devblogs.microsoft.com/foundry/introducing-microsoft-agent-framework-the-open-source-engine-for-agentic-ai-apps/).
 
-[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.10.0...HEAD
+[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.11.0...HEAD
+[1.11.0]: https://github.com/microsoft/agent-framework/compare/python-1.10.0...python-1.11.0
 [1.10.0]: https://github.com/microsoft/agent-framework/compare/python-1.9.0...python-1.10.0
 [1.9.0]: https://github.com/microsoft/agent-framework/compare/python-1.8.1...python-1.9.0
 [1.8.1]: https://github.com/microsoft/agent-framework/compare/python-1.8.0...python-1.8.1

--- a/python/packages/a2a/pyproject.toml
+++ b/python/packages/a2a/pyproject.toml
@@ -4,7 +4,7 @@ description = "A2A integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260604"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.8.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "a2a-sdk>=1.0.0,<2",
 ]
 

--- a/python/packages/ag-ui/pyproject.toml
+++ b/python/packages/ag-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-framework-ag-ui"
-version = "1.0.0rc7"
+version = "1.0.0rc8"
 description = "AG-UI protocol integration for Agent Framework"
 readme = "README.md"
 license-files = ["LICENSE"]
@@ -22,7 +22,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "ag-ui-protocol>=0.1.19,<0.2",
     "fastapi>=0.121.0,<0.138.1",
     "sse-starlette>=3.4.5,<4",

--- a/python/packages/anthropic/pyproject.toml
+++ b/python/packages/anthropic/pyproject.toml
@@ -4,7 +4,7 @@ description = "Anthropic integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "anthropic>=0.80.0,<0.117.0",
 ]
 

--- a/python/packages/azure-ai-search/pyproject.toml
+++ b/python/packages/azure-ai-search/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure AI Search integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     # Stable/GA (12.0.0) targets Azure AI Search api-version 2026-04-01; the preview
     # line (e.g. 12.1.0b1, installed with --pre) targets api-version 2026-05-01-preview.
     "azure-search-documents>=12.0.0,<13",

--- a/python/packages/azurefunctions/pyproject.toml
+++ b/python/packages/azurefunctions/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure Functions integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,8 +22,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
-    "agent-framework-durabletask>=1.0.0b260630,<2",
+    "agent-framework-core>=1.11.0,<2",
+    "agent-framework-durabletask>=1.0.0b260709,<2",
     "azure-functions>=1.24.0,<2",
     "azure-functions-durable>=1.3.1,<2",
 ]

--- a/python/packages/bedrock/pyproject.toml
+++ b/python/packages/bedrock/pyproject.toml
@@ -4,7 +4,7 @@ description = "Amazon Bedrock integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "boto3>=1.35.0,<2.0.0",
     "botocore>=1.35.0,<2.0.0",
 ]

--- a/python/packages/claude/pyproject.toml
+++ b/python/packages/claude/pyproject.toml
@@ -4,7 +4,7 @@ description = "Claude Agent SDK integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260609"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,8 +23,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.8.1,<2",
-    "claude-agent-sdk>=0.1.36,<0.3",
+    "agent-framework-core>=1.11.0,<2",
+    "claude-agent-sdk>=0.1.46,<0.3",
 ]
 
 [tool.uv]

--- a/python/packages/copilotstudio/pyproject.toml
+++ b/python/packages/copilotstudio/pyproject.toml
@@ -4,7 +4,7 @@ description = "Copilot Studio integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260521"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.6.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "microsoft-agents-copilotstudio-client>=0.3.1,<0.3.2",
 ]
 

--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -3287,7 +3287,7 @@ class MCPWebsocketTool(MCPTool):
             An async context manager for the WebSocket client transport.
         """
         try:
-            from mcp.client.websocket import websocket_client  # pyright: ignore[reportDeprecated]
+            websocket_module = __import__("mcp.client.websocket", fromlist=["websocket_client"])
         except ModuleNotFoundError as ex:
             missing_name = ex.name or "mcp/websocket dependencies"
             if missing_name == "mcp" or missing_name.startswith("mcp."):
@@ -3301,9 +3301,11 @@ class MCPWebsocketTool(MCPTool):
                 "Please install `mcp[ws]` and update your dependencies."
             ) from ex
 
+        # Support MCP releases from before and after the transport gained its deprecation marker.
+        websocket_client = websocket_module.websocket_client
         args: dict[str, Any] = {
             "url": self.url,
         }
         if self._client_kwargs:
             args.update(self._client_kwargs)
-        return websocket_client(**args)  # pyright: ignore[reportDeprecated]
+        return websocket_client(**args)

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.10.0"
+version = "1.11.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -59,11 +59,12 @@ all = [
 ]
 
 [dependency-groups]
-# agent-framework-tools depends on agent-framework-core, so core cannot list it as a
-# runtime dependency. It is declared here (dev only) so the harness shell-tool integration
-# can be type-checked and tested in isolated environments without a circular runtime dependency.
+# These optional integrations depend on agent-framework-core, so core cannot list them as
+# runtime dependencies. They are declared here so isolated source checks can resolve their APIs.
 dev = [
+    "agent-framework-azure-contentunderstanding",
     "agent-framework-tools",
+    "azure-ai-agentserver-core>=2.0.0b7,<3",
 ]
 
 [tool.uv]

--- a/python/packages/devui/pyproject.toml
+++ b/python/packages/devui/pyproject.toml
@@ -4,7 +4,7 @@ description = "Debug UI for Microsoft Agent Framework with OpenAI-compatible API
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://github.com/microsoft/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
  dependencies = [
-     "agent-framework-core>=1.10.0,<2",
+     "agent-framework-core>=1.11.0,<2",
      "openai>=1.99.0,<3",
      "opentelemetry-sdk>=1.39.0,<2",
      "fastapi>=0.115.0,<0.138.1",

--- a/python/packages/devui/tests/devui/test_schema_generation.py
+++ b/python/packages/devui/tests/devui/test_schema_generation.py
@@ -170,9 +170,7 @@ def test_extract_response_type_from_executor():
         class TestDecision(BaseModel):
             """Test decision response."""
 
-            decision: Literal["approve", "reject"] = Field(
-                description="User's decision"
-            )
+            decision: Literal["approve", "reject"] = Field(description="User's decision")
             reason: str = Field(description="Reason for decision", default="")
 
         # Create test executor with @response_handler
@@ -201,17 +199,11 @@ def test_extract_response_type_from_executor():
 
         # Test extraction
         executor = TestExecutor()
-        extracted_type = extract_response_type_from_executor(
-            executor, TestApprovalRequest
-        )
+        extracted_type = extract_response_type_from_executor(executor, TestApprovalRequest)
 
         # Verify correct type was extracted
-        assert (
-            extracted_type is not None
-        ), "Should extract response type from @response_handler"
-        assert (
-            extracted_type == TestDecision
-        ), f"Expected TestDecision, got {extracted_type}"
+        assert extracted_type is not None, "Should extract response type from @response_handler"
+        assert extracted_type == TestDecision, f"Expected TestDecision, got {extracted_type}"
 
         # Test full schema generation pipeline
         schema = generate_input_schema(extracted_type)
@@ -251,9 +243,7 @@ def test_extract_response_type_no_match():
         executor = MinimalExecutor()
         extracted_type = extract_response_type_from_executor(executor, UnmatchedRequest)
 
-        assert (
-            extracted_type is None
-        ), "Should return None when no matching handler exists"
+        assert extracted_type is None, "Should return None when no matching handler exists"
 
     except ImportError as e:
         pytest.skip(f"Required dependencies not available: {e}")

--- a/python/packages/devui/tests/devui/test_server.py
+++ b/python/packages/devui/tests/devui/test_server.py
@@ -79,9 +79,7 @@ async def test_server_execution_sync(test_entities_dir):
     )
 
     response = await executor.execute_sync(request)
-    assert (
-        response.model == "devui"
-    )  # Response model defaults to 'devui' when not specified
+    assert response.model == "devui"  # Response model defaults to 'devui' when not specified
     assert len(response.output) > 0
 
 
@@ -111,9 +109,7 @@ async def test_server_execution_streaming(test_entities_dir):
 
 def test_configuration():
     """Test basic configuration."""
-    server = DevServer(
-        entities_dir="test", port=9000, host="localhost", auth_enabled=False
-    )
+    server = DevServer(entities_dir="test", port=9000, host="localhost", auth_enabled=False)
     assert server.port == 9000
     assert server.host == "localhost"
     assert server.entities_dir == "test"
@@ -314,9 +310,7 @@ async def test_credential_cleanup() -> None:
     await server._cleanup_entities()
 
     # Verify credential.close() was called
-    assert (
-        mock_credential.close.called
-    ), "Async credential close should have been called"
+    assert mock_credential.close.called, "Async credential close should have been called"
     assert mock_credential.close.call_count == 1
 
 
@@ -525,9 +519,7 @@ async def test_checkpoint_api_endpoints(test_entities_dir):
     executor = await server._ensure_executor()
 
     # Create a conversation
-    conversation = executor.conversation_store.create_conversation(
-        metadata={"name": "Test Session"}
-    )
+    conversation = executor.conversation_store.create_conversation(metadata={"name": "Test Session"})
     conv_id = conversation.id
 
     # Get checkpoint storage and add a checkpoint
@@ -590,9 +582,9 @@ def test_streaming_response_does_not_hardcode_acao_header():
             headers={"Authorization": "Bearer s3cret"},
         )
 
-        assert "access-control-allow-origin" not in {
-            k.lower() for k in response.headers
-        }, "Streaming response sets ACAO directly, bypassing CORSMiddleware"
+        assert "access-control-allow-origin" not in {k.lower() for k in response.headers}, (
+            "Streaming response sets ACAO directly, bypassing CORSMiddleware"
+        )
 
 
 def test_cors_default_does_not_allow_arbitrary_origin_even_on_localhost():
@@ -725,9 +717,7 @@ def test_serve_rejects_non_loopback_no_auth(monkeypatch):
     monkeypatch.delenv("DEVUI_AUTH_TOKEN", raising=False)
 
     with pytest.raises(ValueError, match="authentication cannot be disabled"):
-        agent_framework_devui.serve(
-            entities=[], host="0.0.0.0", auth_enabled=False, ui_enabled=False
-        )
+        agent_framework_devui.serve(entities=[], host="0.0.0.0", auth_enabled=False, ui_enabled=False)
 
 
 def test_serve_rejects_non_loopback_without_explicit_token(monkeypatch):
@@ -771,9 +761,7 @@ def test_devserver_accepts_request_with_valid_bearer_token(monkeypatch):
     app = server.get_app()
 
     with TestClient(app, base_url="http://127.0.0.1") as client:
-        response = client.get(
-            "/v1/entities", headers={"Authorization": "Bearer s3cret"}
-        )
+        response = client.get("/v1/entities", headers={"Authorization": "Bearer s3cret"})
 
     assert response.status_code == 200
 
@@ -823,9 +811,9 @@ def test_loopback_bind_rejects_non_allowlisted_host_header(monkeypatch):
 def test_serve_defaults_to_auth_enabled():
     """`serve()`'s public signature must default to auth_enabled=True."""
     sig = inspect.signature(agent_framework_devui.serve)
-    assert (
-        sig.parameters["auth_enabled"].default is True
-    ), "serve() must default to auth_enabled=True so `devui ./agents` is secure out of the box"
+    assert sig.parameters["auth_enabled"].default is True, (
+        "serve() must default to auth_enabled=True so `devui ./agents` is secure out of the box"
+    )
 
 
 def test_cli_enables_auth_by_default_and_supports_loopback_no_auth_optout():
@@ -845,9 +833,7 @@ def test_cli_enables_auth_by_default_and_supports_loopback_no_auth_optout():
     assert "Non-loopback hosts require auth" in help_text
 
 
-def _run_cli_with_fake_uvicorn(
-    monkeypatch, tmp_path: Path, *args: str
-) -> dict[str, Any]:
+def _run_cli_with_fake_uvicorn(monkeypatch, tmp_path: Path, *args: str) -> dict[str, Any]:
     """Run the DevUI CLI without binding a socket."""
     import uvicorn
 
@@ -860,9 +846,7 @@ def _run_cli_with_fake_uvicorn(
         run_args["port"] = port
 
     monkeypatch.setattr(uvicorn, "run", fake_run)
-    monkeypatch.setattr(
-        sys, "argv", ["devui", str(tmp_path), "--no-open", "--headless", *args]
-    )
+    monkeypatch.setattr(sys, "argv", ["devui", str(tmp_path), "--no-open", "--headless", *args])
 
     _cli.main()
 
@@ -878,24 +862,18 @@ def test_cli_allows_loopback_no_auth_without_binding_socket(monkeypatch, tmp_pat
     assert run_args == {"host": "127.0.0.1", "port": 8080}
 
 
-def test_cli_rejects_non_loopback_no_auth_before_binding_socket(
-    monkeypatch, tmp_path, capsys
-):
+def test_cli_rejects_non_loopback_no_auth_before_binding_socket(monkeypatch, tmp_path, capsys):
     """`devui --host 0.0.0.0 --no-auth` must fail through shared server validation."""
     monkeypatch.delenv("DEVUI_AUTH_TOKEN", raising=False)
 
     with pytest.raises(SystemExit) as exc_info:
-        _run_cli_with_fake_uvicorn(
-            monkeypatch, tmp_path, "--host", "0.0.0.0", "--no-auth"
-        )
+        _run_cli_with_fake_uvicorn(monkeypatch, tmp_path, "--host", "0.0.0.0", "--no-auth")
 
     assert exc_info.value.code == 1
     assert "authentication cannot be disabled" in capsys.readouterr().err
 
 
-def test_cli_rejects_non_loopback_without_explicit_token_before_binding_socket(
-    monkeypatch, tmp_path, capsys
-):
+def test_cli_rejects_non_loopback_without_explicit_token_before_binding_socket(monkeypatch, tmp_path, capsys):
     """`devui --host 0.0.0.0` must fail when neither --auth-token nor DEVUI_AUTH_TOKEN is set."""
     monkeypatch.delenv("DEVUI_AUTH_TOKEN", raising=False)
 
@@ -906,22 +884,16 @@ def test_cli_rejects_non_loopback_without_explicit_token_before_binding_socket(
     assert "DEVUI_AUTH_TOKEN or auth_token" in capsys.readouterr().err
 
 
-def test_cli_allows_non_loopback_with_auth_token_without_binding_socket(
-    monkeypatch, tmp_path
-):
+def test_cli_allows_non_loopback_with_auth_token_without_binding_socket(monkeypatch, tmp_path):
     """`devui --host 0.0.0.0 --auth-token ...` starts with token auth enabled."""
     monkeypatch.delenv("DEVUI_AUTH_TOKEN", raising=False)
 
-    run_args = _run_cli_with_fake_uvicorn(
-        monkeypatch, tmp_path, "--host", "0.0.0.0", "--auth-token", "s3cret"
-    )
+    run_args = _run_cli_with_fake_uvicorn(monkeypatch, tmp_path, "--host", "0.0.0.0", "--auth-token", "s3cret")
 
     assert run_args == {"host": "0.0.0.0", "port": 8080}
 
 
-def test_cli_allows_non_loopback_with_env_token_without_binding_socket(
-    monkeypatch, tmp_path
-):
+def test_cli_allows_non_loopback_with_env_token_without_binding_socket(monkeypatch, tmp_path):
     """`DEVUI_AUTH_TOKEN=... devui --host 0.0.0.0` starts with token auth enabled."""
     monkeypatch.setenv("DEVUI_AUTH_TOKEN", "env-s3cret")
 

--- a/python/packages/durabletask/pyproject.toml
+++ b/python/packages/durabletask/pyproject.toml
@@ -4,7 +4,7 @@ description = "Durable Task integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,8 +22,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
-    "durabletask>=1.4.0,!=1.4.1,!=1.4.2,!=1.4.3,<2",
+    "agent-framework-core>=1.11.0,<2",
+    "durabletask>=1.5.0,<2",
     "durabletask-azuremanaged>=1.4.0,<2",
     "python-dateutil>=2.8.0,<3",
 ]

--- a/python/packages/foundry/pyproject.toml
+++ b/python/packages/foundry/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Foundry integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.10.0"
+version = "1.10.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "agent-framework-openai>=1.10.0,<2",
     "aiohttp>=3.9,<4",
     "azure-ai-inference>=1.0.0b9,<1.0.0b10",

--- a/python/packages/foundry_hosting/pyproject.toml
+++ b/python/packages/foundry_hosting/pyproject.toml
@@ -4,7 +4,7 @@ description = "Foundry Hosting integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260630"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "azure-ai-agentserver-core>=2.0.0b7,<3",
     "azure-ai-agentserver-responses>=1.0.0b8,<2",
     "azure-ai-agentserver-invocations>=1.0.0b6,<2",

--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -538,9 +538,9 @@ class RawGeminiChatClient(
             async def _stream() -> AsyncIterable[ChatResponseUpdate]:
                 validated = await self._validate_options(options)
                 model, contents, config = self._prepare_request(messages, validated)
-                async for chunk in await self._genai_client.aio.models.generate_content_stream(  # pyright: ignore[reportUnknownMemberType]
+                async for chunk in await self._genai_client.aio.models.generate_content_stream(
                     model=model,
-                    contents=contents,
+                    contents=contents,  # pyright: ignore[reportArgumentType]
                     config=config,
                 ):
                     yield self._process_chunk(chunk)

--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -538,9 +538,9 @@ class RawGeminiChatClient(
             async def _stream() -> AsyncIterable[ChatResponseUpdate]:
                 validated = await self._validate_options(options)
                 model, contents, config = self._prepare_request(messages, validated)
-                async for chunk in await self._genai_client.aio.models.generate_content_stream(
+                async for chunk in await self._genai_client.aio.models.generate_content_stream(  # pyright: ignore[reportUnknownMemberType]
                     model=model,
-                    contents=contents,  # type: ignore[arg-type]
+                    contents=contents,
                     config=config,
                 ):
                     yield self._process_chunk(chunk)

--- a/python/packages/gemini/pyproject.toml
+++ b/python/packages/gemini/pyproject.toml
@@ -4,7 +4,7 @@ description = "Google Gemini integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260630"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -24,8 +24,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
-    "google-genai>=1.65.0,<3.0.0",
+    "agent-framework-core>=1.11.0,<2",
+    "google-genai>=1.68.0,<3.0.0",
 ]
 
 [tool.uv]

--- a/python/packages/github_copilot/pyproject.toml
+++ b/python/packages/github_copilot/pyproject.toml
@@ -4,7 +4,7 @@ description = "GitHub Copilot integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "github-copilot-sdk==1.0.2; python_version >= '3.11'",
 ]
 
@@ -102,4 +102,3 @@ interpreter = "posix"
 [build-system]
 requires = ["flit-core >= 3.11,<4.0"]
 build-backend = "flit_core.buildapi"
-

--- a/python/packages/hosting-responses/pyproject.toml
+++ b/python/packages/hosting-responses/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI Responses-shaped helpers for agent-framework-hosting."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260625"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,8 +23,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
-    "agent-framework-hosting==1.0.0a260625",
+    "agent-framework-core>=1.11.0,<2",
+    "agent-framework-hosting==1.0.0a260709",
     "openai>=1.99.0,<3",
 ]
 

--- a/python/packages/hosting/pyproject.toml
+++ b/python/packages/hosting/pyproject.toml
@@ -4,7 +4,7 @@ description = "Execution-state helpers for app-owned Agent Framework hosting rou
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260625"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
 ]
 
 [tool.uv]

--- a/python/packages/hyperlight/pyproject.toml
+++ b/python/packages/hyperlight/pyproject.toml
@@ -4,7 +4,7 @@ description = "Hyperlight CodeAct integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,7 +22,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "hyperlight-sandbox>=0.4.0,<0.5",
     "hyperlight-sandbox-backend-wasm>=0.4.0,<0.5 ; ((sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and platform_machine == 'AMD64')) and python_version < '3.14'",
     "hyperlight-sandbox-python-guest>=0.4.0,<0.6",

--- a/python/packages/lab/pyproject.toml
+++ b/python/packages/lab/pyproject.toml
@@ -4,7 +4,7 @@ description = "Experimental modules for Microsoft Agent Framework"
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260521"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "agent-framework-core>=1.6.0,<2",
+  "agent-framework-core>=1.11.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/python/packages/mem0/pyproject.toml
+++ b/python/packages/mem0/pyproject.toml
@@ -4,7 +4,7 @@ description = "Mem0 integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260609"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.8.1,<2",
+    "agent-framework-core>=1.11.0,<2",
     "mem0ai>=2.0.0,<3",
 ]
 

--- a/python/packages/mistral/pyproject.toml
+++ b/python/packages/mistral/pyproject.toml
@@ -4,7 +4,7 @@ description = "Mistral AI integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260604"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://learn.microsoft.com/en-us/agent-framework/"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.8.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "mistralai>=2.0.0,<3",
 ]
 

--- a/python/packages/monty/pyproject.toml
+++ b/python/packages/monty/pyproject.toml
@@ -4,7 +4,7 @@ description = "Monty CodeAct integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260521"
+version = "1.0.0a260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core>=1.6.0,<2",
-    "pydantic-monty>=0,<0.1",
+    "pydantic-monty>=0.0.1,<0.1",
 ]
 
 [tool.uv]

--- a/python/packages/monty/pyproject.toml
+++ b/python/packages/monty/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.6.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "pydantic-monty>=0.0.1,<0.1",
 ]
 

--- a/python/packages/ollama/pyproject.toml
+++ b/python/packages/ollama/pyproject.toml
@@ -4,7 +4,7 @@ description = "Ollama integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://learn.microsoft.com/en-us/agent-framework/"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "ollama>=0.5.3,<0.5.4",
 ]
 

--- a/python/packages/openai/pyproject.toml
+++ b/python/packages/openai/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.10.0"
+version = "1.10.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,8 +23,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
-    "openai>=1.99.0,<3",
+    "agent-framework-core>=1.11.0,<2",
+    "openai>=2.25.0,<3",
 ]
 
 [tool.uv]

--- a/python/packages/purview/pyproject.toml
+++ b/python/packages/purview/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Purview (Graph dataSecurityAndGovernance) integration f
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 license-files = ["LICENSE"]
 urls.homepage = "https://github.com/microsoft/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -24,7 +24,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.10.0,<2",
+    "agent-framework-core>=1.11.0,<2",
     "azure-core>=1.30.0,<2",
     "httpx>=0.27.0,<0.29",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.10.0"
+version = "1.11.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core[all]==1.10.0",
+    "agent-framework-core[all]==1.11.0",
 ]
 
 [dependency-groups]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.10.0"
+version = "1.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -179,7 +179,7 @@ dev = [
 
 [[package]]
 name = "agent-framework-a2a"
-version = "1.0.0b260604"
+version = "1.0.0b260709"
 source = { editable = "packages/a2a" }
 dependencies = [
     { name = "a2a-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -194,7 +194,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-ag-ui"
-version = "1.0.0rc7"
+version = "1.0.0rc8"
 source = { editable = "packages/ag-ui" }
 dependencies = [
     { name = "ag-ui-protocol", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -224,7 +224,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "agent-framework-anthropic"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/anthropic" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -239,7 +239,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azure-ai-search"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/azure-ai-search" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -290,7 +290,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azurefunctions"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/azurefunctions" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -312,7 +312,7 @@ dev = []
 
 [[package]]
 name = "agent-framework-bedrock"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/bedrock" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -344,7 +344,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-claude"
-version = "1.0.0b260609"
+version = "1.0.0b260709"
 source = { editable = "packages/claude" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -354,12 +354,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.36,<0.3" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.46,<0.3" },
 ]
 
 [[package]]
 name = "agent-framework-copilotstudio"
-version = "1.0.0b260521"
+version = "1.0.0b260709"
 source = { editable = "packages/copilotstudio" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -374,7 +374,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -414,7 +414,9 @@ all = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "agent-framework-azure-contentunderstanding", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "agent-framework-tools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-ai-agentserver-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -452,7 +454,11 @@ requires-dist = [
 provides-extras = ["all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "agent-framework-tools", editable = "packages/tools" }]
+dev = [
+    { name = "agent-framework-azure-contentunderstanding", editable = "packages/azure-contentunderstanding" },
+    { name = "agent-framework-tools", editable = "packages/tools" },
+    { name = "azure-ai-agentserver-core", specifier = ">=2.0.0b7,<3" },
+]
 
 [[package]]
 name = "agent-framework-declarative"
@@ -483,7 +489,7 @@ dev = [{ name = "types-pyyaml", specifier = "==6.0.12.20260518" }]
 
 [[package]]
 name = "agent-framework-devui"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/devui" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -521,7 +527,7 @@ provides-extras = ["dev", "all"]
 
 [[package]]
 name = "agent-framework-durabletask"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/durabletask" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -538,7 +544,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "durabletask", specifier = ">=1.4.0,!=1.4.1,!=1.4.2,!=1.4.3,<2" },
+    { name = "durabletask", specifier = ">=1.5.0,<2" },
     { name = "durabletask-azuremanaged", specifier = ">=1.4.0,<2" },
     { name = "python-dateutil", specifier = ">=2.8.0,<3" },
 ]
@@ -548,7 +554,7 @@ dev = [{ name = "types-python-dateutil", specifier = "==2.9.0.20260518" }]
 
 [[package]]
 name = "agent-framework-foundry"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "packages/foundry" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -569,7 +575,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-foundry-hosting"
-version = "1.0.0a260630"
+version = "1.0.0a260709"
 source = { editable = "packages/foundry_hosting" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -609,7 +615,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-gemini"
-version = "1.0.0a260630"
+version = "1.0.0a260709"
 source = { editable = "packages/gemini" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -619,12 +625,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "google-genai", specifier = ">=1.65.0,<3.0.0" },
+    { name = "google-genai", specifier = ">=1.68.0,<3.0.0" },
 ]
 
 [[package]]
 name = "agent-framework-github-copilot"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 source = { editable = "packages/github_copilot" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -639,7 +645,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-hosting"
-version = "1.0.0a260625"
+version = "1.0.0a260709"
 source = { editable = "packages/hosting" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -650,7 +656,7 @@ requires-dist = [{ name = "agent-framework-core", editable = "packages/core" }]
 
 [[package]]
 name = "agent-framework-hosting-responses"
-version = "1.0.0a260625"
+version = "1.0.0a260709"
 source = { editable = "packages/hosting-responses" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -679,7 +685,7 @@ dev = [
 
 [[package]]
 name = "agent-framework-hyperlight"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/hyperlight" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -698,7 +704,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-lab"
-version = "1.0.0b260521"
+version = "1.0.0b260709"
 source = { editable = "packages/lab" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -780,7 +786,7 @@ dev = [
 
 [[package]]
 name = "agent-framework-mem0"
-version = "1.0.0b260609"
+version = "1.0.0b260709"
 source = { editable = "packages/mem0" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -795,7 +801,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-mistral"
-version = "1.0.0a260604"
+version = "1.0.0a260709"
 source = { editable = "packages/mistral" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -810,7 +816,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-monty"
-version = "1.0.0a260521"
+version = "1.0.0a260709"
 source = { editable = "packages/monty" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -820,12 +826,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "pydantic-monty", specifier = ">=0,<0.1" },
+    { name = "pydantic-monty", specifier = ">=0.0.1,<0.1" },
 ]
 
 [[package]]
 name = "agent-framework-ollama"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/ollama" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -840,7 +846,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-openai"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -850,7 +856,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "openai", specifier = ">=1.99.0,<3" },
+    { name = "openai", specifier = ">=2.25.0,<3" },
 ]
 
 [[package]]
@@ -866,7 +872,7 @@ requires-dist = [{ name = "agent-framework-core", editable = "packages/core" }]
 
 [[package]]
 name = "agent-framework-purview"
-version = "1.0.0b260630"
+version = "1.0.0b260709"
 source = { editable = "packages/purview" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
Bump the CHANGELOG-selected packages for the 1.11.0 release: core and the root package move to 1.11.0 for the new stable APIs, Foundry and OpenAI receive patch bumps, changed prerelease packages receive the 260709 stamp or next RC counter, and Monty joins the bump set for corrected published dependency metadata. No beta cohort bump was applied. Raise core floors conservatively on every package publishing this cycle and correct dependency floors exposed by lower-bound validation.