### PR TITLE
Python: [BREAKING]: Emit TOOL_CALL events for workflow participant tool calls in AG-UI

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
@@ -62,6 +62,7 @@ _WORKFLOW_EVENT_BASE_FIELDS: set[str] = {
 }
 
 _INTERRUPT_CARD_EVENT_NAME = "WorkflowInterruptEvent"
+_FUNCTION_CONTENT_TYPES = {"function_call", "function_result", "function_approval_request"}
 
 
 def _json_schema_for_response_type(response_type: Any) -> dict[str, Any] | None:
@@ -675,16 +676,16 @@ def _workflow_payload_to_contents(payload: Any) -> list[Content] | None:
             return None
         return list(payload.contents or [])
     if isinstance(payload, AgentResponseUpdate):
+        contents = list(payload.contents or [])
         role_field = payload.role
-        if role_field is None:
-            return None
         if isinstance(role_field, str):
             role = role_field
         else:
             role = str(getattr(role_field, "value", role_field))
-        if role != "assistant":
-            return None
-        return list(payload.contents or [])
+        if role == "assistant":
+            return contents
+        function_contents = [content for content in contents if content.type in _FUNCTION_CONTENT_TYPES]
+        return function_contents or None
     if isinstance(payload, AgentResponse):
         return _latest_assistant_contents(list(payload.messages or []))
     if isinstance(payload, list):

--- a/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_workflow_run.py
@@ -62,7 +62,10 @@ _WORKFLOW_EVENT_BASE_FIELDS: set[str] = {
 }
 
 _INTERRUPT_CARD_EVENT_NAME = "WorkflowInterruptEvent"
-_FUNCTION_CONTENT_TYPES = {"function_call", "function_result", "function_approval_request"}
+# Tool content admitted from streaming updates regardless of role. Approval requests are
+# deliberately excluded: workflow approvals resume through request_info pending state, and an
+# approval interrupt emitted from streamed content would have no pending request to resume against.
+_TOOL_CONTENT_TYPES = {"function_call", "function_result", "mcp_server_tool_call", "mcp_server_tool_result"}
 
 
 def _json_schema_for_response_type(response_type: Any) -> dict[str, Any] | None:
@@ -684,8 +687,8 @@ def _workflow_payload_to_contents(payload: Any) -> list[Content] | None:
             role = str(getattr(role_field, "value", role_field))
         if role == "assistant":
             return contents
-        function_contents = [content for content in contents if content.type in _FUNCTION_CONTENT_TYPES]
-        return function_contents or None
+        tool_contents = [content for content in contents if content.type in _TOOL_CONTENT_TYPES]
+        return tool_contents or None
     if isinstance(payload, AgentResponse):
         return _latest_assistant_contents(list(payload.messages or []))
     if isinstance(payload, list):

--- a/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
@@ -460,6 +460,44 @@ async def test_workflow_participant_tool_call_emits_standard_tool_events() -> No
     ]
 
 
+async def test_workflow_stream_does_not_repeat_tool_call_from_final_response() -> None:
+    """A final response containing streamed history should not repeat its tool call."""
+    function_call = Content.from_function_call(
+        call_id="weather-call",
+        name="get_weather",
+        arguments={"city": "Seattle"},
+    )
+
+    @executor(id="participant")
+    async def participant(message: Any, ctx: WorkflowContext[Any, AgentResponse | AgentResponseUpdate]) -> None:
+        del message
+        await ctx.yield_output(AgentResponseUpdate(contents=[function_call], role=None))
+        await ctx.yield_output(
+            AgentResponse(
+                messages=[
+                    Message(role="assistant", contents=[function_call]),
+                    Message(
+                        role="tool",
+                        contents=[Content.from_function_result(call_id="weather-call", result="Sunny in Seattle")],
+                    ),
+                    Message(role="assistant", contents=[Content.from_text("The weather is sunny.")]),
+                ]
+            )
+        )
+
+    workflow = WorkflowBuilder(start_executor=participant, output_from="all").build()
+    events = [
+        event
+        async for event in run_workflow_stream(
+            {"messages": [{"role": "user", "content": "What is the weather in Seattle?"}]},
+            workflow,
+        )
+    ]
+
+    tool_call_starts = [event for event in events if event.type == "TOOL_CALL_START"]
+    assert [event.tool_call_id for event in tool_call_starts] == ["weather-call"]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+
 async def test_workflow_run_passthroughs_ag_ui_base_events():
     """Workflow outputs that are AG-UI BaseEvent instances should be emitted directly."""
 

--- a/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
@@ -1250,12 +1250,38 @@ class TestWorkflowPayloadToContents:
         assert _workflow_payload_to_contents(update) == [function_result]
 
     def test_agent_response_update_approval_request_without_role(self) -> None:
-        """Approval request content passes through without role metadata."""
+        """Approval request content is excluded from the role bypass.
+
+        Workflow approvals resume through request_info pending state; an approval interrupt
+        emitted from streamed content would have no pending request to resume against.
+        """
         function_call = Content.from_function_call(call_id="call-1", name="search", arguments={"query": "weather"})
         approval_request = Content.from_function_approval_request(id="approval-1", function_call=function_call)
         update = AgentResponseUpdate(contents=[approval_request], role=None)
 
-        assert _workflow_payload_to_contents(update) == [approval_request]
+        assert _workflow_payload_to_contents(update) is None
+
+    def test_agent_response_update_mcp_tool_call_without_role(self) -> None:
+        """MCP server tool call content passes through without role metadata."""
+        mcp_call = Content.from_mcp_server_tool_call(call_id="mcp-1", tool_name="search", arguments={"q": "weather"})
+        update = AgentResponseUpdate(contents=[mcp_call], role=None)
+
+        assert _workflow_payload_to_contents(update) == [mcp_call]
+
+    def test_agent_response_update_mcp_tool_result_without_role(self) -> None:
+        """MCP server tool result content passes through without role metadata."""
+        mcp_result = Content.from_mcp_server_tool_result(call_id="mcp-1", output={"temperature": 72})
+        update = AgentResponseUpdate(contents=[mcp_result], role=None)
+
+        assert _workflow_payload_to_contents(update) == [mcp_result]
+
+    def test_agent_response_update_mixed_content_without_role(self) -> None:
+        """Non-assistant updates keep tool content and drop text content."""
+        text = Content.from_text(text="calling the tool")
+        function_call = Content.from_function_call(call_id="call-1", name="search", arguments={"query": "weather"})
+        update = AgentResponseUpdate(contents=[text, function_call], role=None)
+
+        assert _workflow_payload_to_contents(update) == [function_call]
 
     def test_agent_response_update_assistant_text(self) -> None:
         """Assistant text content continues to pass through."""

--- a/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_workflow_run.py
@@ -3,14 +3,17 @@
 """Tests for native workflow AG-UI runner."""
 
 import json
+from collections.abc import AsyncIterator
 from enum import Enum
 from types import SimpleNamespace
 from typing import Any, cast
 
 from ag_ui.core import EventType, StateSnapshotEvent
 from agent_framework import (
+    Agent,
     AgentResponse,
     AgentResponseUpdate,
+    ChatResponseUpdate,
     Content,
     Executor,
     Message,
@@ -20,7 +23,9 @@ from agent_framework import (
     executor,
     handler,
     response_handler,
+    tool,
 )
+from conftest import StreamingChatClientStub  # pyrefly: ignore[missing-import] # pyright: ignore[reportMissingImports]
 
 from agent_framework_ag_ui._workflow_run import (
     _coerce_content,
@@ -393,6 +398,66 @@ async def test_workflow_run_non_chat_output_maps_to_custom_output_event():
     output_custom = [event for event in events if event.type == "CUSTOM" and event.name == "workflow_output"]  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     assert len(output_custom) == 1
     assert output_custom[0].value == {"count": 3}  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+
+async def test_workflow_participant_tool_call_emits_standard_tool_events() -> None:
+    """Participant tool calls should use the standard AG-UI tool event lifecycle."""
+
+    @tool
+    def get_weather(city: str) -> str:
+        return f"Sunny in {city}"
+
+    invocation = 0
+
+    async def scripted_stream(messages: Any, options: Any, **kwargs: Any) -> AsyncIterator[ChatResponseUpdate]:
+        nonlocal invocation
+        del messages, options, kwargs
+        if invocation == 0:
+            yield ChatResponseUpdate(
+                contents=[
+                    Content.from_function_call(
+                        call_id="weather-call",
+                        name="get_weather",
+                        arguments={"city": "Seattle"},
+                    )
+                ],
+                role=None,
+            )
+        else:
+            yield ChatResponseUpdate(contents=[Content.from_text("The weather is sunny.")], role="assistant")
+        invocation += 1
+
+    participant = Agent(
+        client=StreamingChatClientStub(scripted_stream),
+        name="weather-agent",
+        tools=[get_weather],
+    )
+    workflow = WorkflowBuilder(start_executor=participant, output_from="all").build()
+
+    events = [
+        event
+        async for event in run_workflow_stream(
+            {"messages": [{"role": "user", "content": "What is the weather in Seattle?"}]},
+            workflow,
+        )
+    ]
+
+    tool_events = [
+        event
+        for event in events
+        if event.type in {"TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_RESULT", "TOOL_CALL_END"}
+    ]
+    assert [event.type for event in tool_events] == [
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+    ]
+    assert tool_events[0].tool_call_name == "get_weather"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    assert all(event.tool_call_id == "weather-call" for event in tool_events)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    assert not [
+        event for event in events if event.type == "CUSTOM" and getattr(event, "name", None) == "workflow_output"
+    ]
 
 
 async def test_workflow_run_passthroughs_ag_ui_base_events():
@@ -1131,6 +1196,35 @@ class TestWorkflowPayloadToContents:
         """AgentResponseUpdate with None role returns None."""
         update = AgentResponseUpdate(contents=[Content.from_text(text="hi")], role=None)
         assert _workflow_payload_to_contents(update) is None
+
+    def test_agent_response_update_function_call_without_role(self) -> None:
+        """Function call content passes through without role metadata."""
+        function_call = Content.from_function_call(call_id="call-1", name="search", arguments={"query": "weather"})
+        update = AgentResponseUpdate(contents=[function_call], role=None)
+
+        assert _workflow_payload_to_contents(update) == [function_call]
+
+    def test_agent_response_update_function_result_with_tool_role(self) -> None:
+        """Function result content passes through with the tool role."""
+        function_result = Content.from_function_result(call_id="call-1", result={"temperature": 72})
+        update = AgentResponseUpdate(contents=[function_result], role="tool")
+
+        assert _workflow_payload_to_contents(update) == [function_result]
+
+    def test_agent_response_update_approval_request_without_role(self) -> None:
+        """Approval request content passes through without role metadata."""
+        function_call = Content.from_function_call(call_id="call-1", name="search", arguments={"query": "weather"})
+        approval_request = Content.from_function_approval_request(id="approval-1", function_call=function_call)
+        update = AgentResponseUpdate(contents=[approval_request], role=None)
+
+        assert _workflow_payload_to_contents(update) == [approval_request]
+
+    def test_agent_response_update_assistant_text(self) -> None:
+        """Assistant text content continues to pass through."""
+        text = Content.from_text(text="hi")
+        update = AgentResponseUpdate(contents=[text], role="assistant")
+
+        assert _workflow_payload_to_contents(update) == [text]
 
     def test_list_with_none_item(self):
         """List containing None causes None return."""


### PR DESCRIPTION
### Motivation & Context

The Workflows with AG-UI docs list TOOL_CALL_START/TOOL_CALL_ARGS/TOOL_CALL_END as standard events emitted when an agent invokes a tool inside a workflow, and the worked example shows a handoff participant emitting them. In practice the workflow code path never emitted them for participant tool calls: the only TOOL_CALL events came from the request_info interrupt mechanism, and every participant tool call was wrapped in an informational `CustomEvent(name="workflow_output")` instead. The single-agent path emits the documented events for the identical tool, so anything downstream that observes tool calls by name (for example tool-call-interception middleware) could see calls from a standalone agent but structurally could not see the same call made by a workflow participant.

Root cause: `_workflow_payload_to_contents` only converted a streaming `AgentResponseUpdate` into chat content when the update carried an assistant role. Providers stream function-call chunks with no role and function-result chunks with the tool role, so both were rejected and fell through to the custom event. Because the shared emitters only produce TOOL_CALL_END when the function result flows through them, the rejected result also explains the missing END: one gate, all three missing event kinds.

### Description & Review Guide

- **What are the major changes?**
  - `_workflow_payload_to_contents` is now content-aware for streaming updates: function_call, function_result, and function_approval_request content passes through to the shared AG-UI content emitters regardless of the update's role. Text content keeps the existing assistant-role requirement unchanged.
  - Unit tests cover the gate matrix (role-less function call passes, tool-role function result passes, role-less approval request passes, non-assistant text still rejected, assistant text still passes).
  - An integration test drives the workflow run stream with a scripted participant tool call and asserts the full TOOL_CALL_START -> TOOL_CALL_ARGS -> TOOL_CALL_RESULT -> TOOL_CALL_END sequence with the correct tool call name.
  - A regression test asserts exactly one TOOL_CALL_START per call id when a workflow emits both streaming updates and a final response containing the same conversation; no production guard was needed because the final-response conversion takes only the latest assistant message's contents.
- **What is the impact of these changes?**
  - Workflow participant tool calls (including handoff function calls) now emit the documented TOOL_CALL events through the same shared emitters as the single-agent path. Those function-content updates no longer appear as `workflow_output` custom events, so a tool call is represented exactly once in the stream. request_info interrupt events, text emission, and non-chat workflow outputs are unchanged; existing workflow golden scenarios do not exercise participant tool calls, so no snapshots changed.
  - Breaking for consumers of the previous (undocumented) stream shape: clients that detect participant tool calls by parsing `CustomEvent(name="workflow_output")` payloads must migrate to the standard TOOL_CALL events, which is the shape the docs have described all along.
- **What do you want reviewers to focus on?**
  - The role-gate semantics in `_workflow_payload_to_contents`: function-typed content intentionally bypasses the role check while text intentionally does not, to keep this fix scoped to the reported behavior.

### Related Issue

Fixes #6994

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically. _This is a breaking change: the `[BREAKING]` title prefix and label are applied._
