### PR TITLE
.NET: Fix CompactionMessageIndex.IsSummaryMessage

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageIndex.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageIndex.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.ML.Tokenizers;
 using Microsoft.Shared.DiagnosticIds;
@@ -525,5 +526,10 @@ public sealed class CompactionMessageIndex
 
     private static bool IsSummaryMessage(ChatMessage message) =>
         message.AdditionalProperties?.TryGetValue(CompactionMessageGroup.SummaryPropertyKey, out object? value) is true
-            && value is true;
+            && value switch
+            {
+                bool b => b,
+                JsonElement j => j.GetBoolean(),
+                _ => false,
+            };
 }

--- a/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageIndex.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionMessageIndex.cs
@@ -529,7 +529,7 @@ public sealed class CompactionMessageIndex
             && value switch
             {
                 bool b => b,
-                JsonElement j => j.GetBoolean(),
+                JsonElement j => j.ValueKind == JsonValueKind.True,
                 _ => false,
             };
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionMessageIndexTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionMessageIndexTests.cs
@@ -1480,6 +1480,8 @@ public class CompactionMessageIndexTests
     [InlineData(null, CompactionGroupKind.AssistantText)]
     [InlineData(false, CompactionGroupKind.AssistantText)]
     [InlineData("false", CompactionGroupKind.AssistantText)]
+    [InlineData("null", CompactionGroupKind.AssistantText)]
+    [InlineData("\"Unexpected string\"", CompactionGroupKind.AssistantText)]
     [InlineData(true, CompactionGroupKind.Summary)]
     [InlineData("true", CompactionGroupKind.Summary)]
     public void SummaryPropertyKeyIsRespected(object? summaryPropertyValue, CompactionGroupKind expectedCompactionGroupKind)

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionMessageIndexTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionMessageIndexTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Text.Json;
 using Microsoft.Agents.AI.Compaction;
 using Microsoft.Extensions.AI;
 using Microsoft.ML.Tokenizers;
@@ -1473,5 +1474,33 @@ public class CompactionMessageIndexTests
         Assert.Equal(CompactionGroupKind.AssistantText, index.Groups[1].Kind);
         Assert.Equal(CompactionGroupKind.ToolCall, index.Groups[2].Kind);
         Assert.Equal(3, index.Groups[2].MessageCount); // reasoning + toolCall + toolResult
+    }
+
+    [Theory]
+    [InlineData(null, CompactionGroupKind.AssistantText)]
+    [InlineData(false, CompactionGroupKind.AssistantText)]
+    [InlineData("false", CompactionGroupKind.AssistantText)]
+    [InlineData(true, CompactionGroupKind.Summary)]
+    [InlineData("true", CompactionGroupKind.Summary)]
+    public void SummaryPropertyKeyIsRespected(object? summaryPropertyValue, CompactionGroupKind expectedCompactionGroupKind)
+    {
+        ChatMessage message = new(ChatRole.Assistant, "Hello");
+        message.AdditionalProperties ??= [];
+
+        // Convert string to JsonElement for the deserialized case
+        if (summaryPropertyValue != null)
+        {
+            message.AdditionalProperties[CompactionMessageGroup.SummaryPropertyKey] = summaryPropertyValue switch
+            {
+                string s => JsonDocument.Parse(s).RootElement,
+                _ => summaryPropertyValue
+            };
+        }
+
+        CompactionMessageIndex index = CompactionMessageIndex.Create([message]);
+
+        // Assert — the message is recognized as a summary message
+        Assert.Single(index.Groups);
+        Assert.Equal(expectedCompactionGroupKind, index.Groups[0].Kind);
     }
 }


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve? 
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Deserialized chat messages do not group summary chat messages appropriately because IsSummaryMessage will always return false when the additional property type is JsonElement. 

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** No major changes
- **What is the impact of these changes?** Supports deserialized ChatMessage.AdditionalProperties, which may be JsonElement instead of bool
- **What do you want reviewers to focus on?** Should IsSummaryMessage handle “bools and JsonElement” or JsonElement only?
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #7003 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
