### PR TITLE
.NET: [BREAKING] Graduate message injection out of experimental

### DIFF
--- a/dotnet/samples/02-agents/Agents/Agent_Step19_InFunctionLoopCheckpointing/Program.cs
+++ b/dotnet/samples/02-agents/Agents/Agent_Step19_InFunctionLoopCheckpointing/Program.cs
@@ -67,7 +67,7 @@ static string GetTime([Description("The city name.")] string city) =>
 // asking for alternative destinations. The model will process this injected message on the next
 // service call — even though the parent FunctionInvokingChatClient loop would otherwise stop.
 [Description("Check current travel advisories for a city.")]
-static string CheckTravelAdvisory([Description("The city name.")] string city)
+static async Task<string> CheckTravelAdvisory([Description("The city name.")] string city)
 {
     // Simulated travel advisory data.
     var advisory = city.ToUpperInvariant() switch
@@ -85,9 +85,13 @@ static string CheckTravelAdvisory([Description("The city name.")] string city)
     // When an advisory is found, inject a follow-up question so the model automatically
     // suggests alternatives without the user needing to ask.
     var runContext = AIAgent.CurrentRunContext!;
-    runContext.Agent.GetService<MessageInjectingChatClient>()?.EnqueueMessages(
-        runContext.Session!,
-        [new ChatMessage(ChatRole.User, $"Given the travel advisory for {city}, what alternative cities would you recommend instead?")]);
+    var injector = runContext.Agent.GetService<MessageInjectingChatClient>();
+    if (injector is not null)
+    {
+        await injector.EnqueueMessagesAsync(
+            runContext.Session!,
+            [new ChatMessage(ChatRole.User, $"Given the travel advisory for {city}, what alternative cities would you recommend instead?")]);
+    }
 
     return advisory;
 }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
@@ -111,16 +111,15 @@ public sealed class HarnessAgentRunner : IDisposable
     /// enqueued via the <see cref="MessageInjectingChatClient"/> so it can be picked up
     /// by the agent on its next opportunity.
     /// </summary>
-    internal Task OnStreamingInputAsync(string text)
+    internal async Task OnStreamingInputAsync(string text)
     {
         if (this._messageInjector is null)
         {
-            return Task.CompletedTask;
+            return;
         }
 
-        this._messageInjector.EnqueueMessages(this._session, [new ChatMessage(ChatRole.User, text)]);
-        this._ux.SetQueuedMessages(this._messageInjector.GetPendingMessages(this._session));
-        return Task.CompletedTask;
+        await this._messageInjector.EnqueueMessagesAsync(this._session, [new ChatMessage(ChatRole.User, text)]).ConfigureAwait(false);
+        this._ux.SetQueuedMessages(await this._messageInjector.GetPendingMessagesAsync(this._session).ConfigureAwait(false));
     }
 
     /// <summary>
@@ -151,7 +150,9 @@ public sealed class HarnessAgentRunner : IDisposable
     private async Task RunAgentLoopAsync(IList<ChatMessage> messages)
     {
         IList<ChatMessage>? nextMessages = messages;
-        IReadOnlyList<ChatMessage> lastPendingMessages = this._messageInjector?.GetPendingMessages(this._session) ?? [];
+        IReadOnlyList<ChatMessage> lastPendingMessages = this._messageInjector is not null
+            ? await this._messageInjector.GetPendingMessagesAsync(this._session).ConfigureAwait(false)
+            : [];
 
         while (nextMessages is not null)
         {
@@ -199,7 +200,7 @@ public sealed class HarnessAgentRunner : IDisposable
                         }
                     }
 
-                    this.SyncQueuedMessageDisplay(ref lastPendingMessages);
+                    lastPendingMessages = await this.SyncQueuedMessageDisplayAsync(lastPendingMessages).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -208,7 +209,7 @@ public sealed class HarnessAgentRunner : IDisposable
             }
 
             // Final sync after streaming.
-            this.SyncQueuedMessageDisplay(ref lastPendingMessages);
+            lastPendingMessages = await this.SyncQueuedMessageDisplayAsync(lastPendingMessages).ConfigureAwait(false);
 
             this._ux.StopSpinner();
             await this._ux.EndStreamingOutputAsync().ConfigureAwait(false);
@@ -275,14 +276,15 @@ public sealed class HarnessAgentRunner : IDisposable
     /// Messages that have been consumed (drained by the service) are echoed to the output
     /// area as regular user-input entries.
     /// </summary>
-    private void SyncQueuedMessageDisplay(ref IReadOnlyList<ChatMessage> lastPendingMessages)
+    /// <returns>The updated snapshot of pending messages.</returns>
+    private async Task<IReadOnlyList<ChatMessage>> SyncQueuedMessageDisplayAsync(IReadOnlyList<ChatMessage> lastPendingMessages)
     {
         if (this._messageInjector is null)
         {
-            return;
+            return lastPendingMessages;
         }
 
-        var pending = this._messageInjector.GetPendingMessages(this._session);
+        var pending = await this._messageInjector.GetPendingMessagesAsync(this._session).ConfigureAwait(false);
 
         int consumedCount = lastPendingMessages.Count - pending.Count;
         for (int i = 0; i < consumedCount && i < lastPendingMessages.Count; i++)
@@ -291,7 +293,7 @@ public sealed class HarnessAgentRunner : IDisposable
             this._ux.WriteUserInputEcho(text);
         }
 
-        lastPendingMessages = pending;
         this._ux.SetQueuedMessages(pending);
+        return pending;
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -177,7 +175,6 @@ public sealed class ChatClientAgentOptions
     /// <value>
     /// Default is <see langword="false"/>.
     /// </value>
-    [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
     public bool EnableMessageInjection { get; set; }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientBuilderExtensions.cs
@@ -2,11 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Extensions.AI;
@@ -143,7 +141,6 @@ public static class ChatClientBuilderExtensions
     /// </remarks>
     /// <param name="builder">The <see cref="ChatClientBuilder"/> to add the decorator to.</param>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
-    [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
     public static ChatClientBuilder UseMessageInjection(this ChatClientBuilder builder)
     {
         return builder.Use(innerClient => new MessageInjectingChatClient(innerClient));

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
@@ -2,13 +2,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -41,7 +39,6 @@ namespace Microsoft.Agents.AI;
 /// method is called.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class MessageInjectingChatClient : DelegatingChatClient
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/MessageInjectingChatClient.cs
@@ -47,6 +47,14 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
     internal const string PendingMessagesStateKey = "MessageInjectingChatClient.PendingInjectedMessages";
 
     /// <summary>
+    /// Per-session semaphore used to serialize all access to a session's pending messages queue,
+    /// including its creation. A single client instance is shared across sessions, so the lock is
+    /// keyed on the session and stored in a <see cref="ConditionalWeakTable{TKey, TValue}"/> so it
+    /// is released automatically when the session is collected.
+    /// </summary>
+    private readonly ConditionalWeakTable<AgentSession, SemaphoreSlim> _sessionLocks = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MessageInjectingChatClient"/> class.
     /// </summary>
     /// <param name="innerClient">The underlying chat client that will handle the core operations.</param>
@@ -62,9 +70,8 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
         CancellationToken cancellationToken = default)
     {
         var session = GetRequiredSession();
-        var queue = GetOrCreateQueue(session);
 
-        var newMessages = DrainInjectedMessages(queue, messages as IList<ChatMessage> ?? messages.ToList());
+        var newMessages = await this.DrainInjectedMessagesAsync(session, messages as IList<ChatMessage> ?? messages.ToList(), cancellationToken).ConfigureAwait(false);
 
         // Loop to process injected messages: after each service call, if no actionable function calls
         // are pending but new messages have been injected into the queue, we call the service again
@@ -83,13 +90,7 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
 
             // No actionable function calls. If there are pending injected messages, loop again
             // to send them to the service. Otherwise, we're done.
-            bool queueEmpty;
-            lock (queue)
-            {
-                queueEmpty = queue.Count == 0;
-            }
-
-            if (queueEmpty)
+            if (await this.IsQueueEmptyAsync(session, cancellationToken).ConfigureAwait(false))
             {
                 return response;
             }
@@ -98,7 +99,7 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
             // continue within the same conversation.
             UpdateOptionsForNextIteration(ref options, response.ConversationId);
 
-            newMessages = DrainInjectedMessages(queue, Array.Empty<ChatMessage>());
+            newMessages = await this.DrainInjectedMessagesAsync(session, Array.Empty<ChatMessage>(), cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -109,9 +110,8 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var session = GetRequiredSession();
-        var queue = GetOrCreateQueue(session);
 
-        var newMessages = DrainInjectedMessages(queue, messages as IList<ChatMessage> ?? messages.ToList());
+        var newMessages = await this.DrainInjectedMessagesAsync(session, messages as IList<ChatMessage> ?? messages.ToList(), cancellationToken).ConfigureAwait(false);
 
         // Loop to process injected messages: after each service call, if no actionable function calls
         // are pending but new messages have been injected into the queue, we call the service again
@@ -158,13 +158,7 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
 
             // No actionable function calls. If there are pending injected messages, loop again
             // to send them to the service. Otherwise, we're done.
-            bool queueEmpty;
-            lock (queue)
-            {
-                queueEmpty = queue.Count == 0;
-            }
-
-            if (queueEmpty)
+            if (await this.IsQueueEmptyAsync(session, cancellationToken).ConfigureAwait(false))
             {
                 yield break;
             }
@@ -173,7 +167,7 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
             // continue within the same conversation.
             UpdateOptionsForNextIteration(ref options, lastConversationId);
 
-            newMessages = DrainInjectedMessages(queue, Array.Empty<ChatMessage>());
+            newMessages = await this.DrainInjectedMessagesAsync(session, Array.Empty<ChatMessage>(), cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -187,19 +181,26 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
     /// </remarks>
     /// <param name="session">The agent session to enqueue messages for.</param>
     /// <param name="messages">The messages to enqueue.</param>
-    public void EnqueueMessages(AgentSession session, IEnumerable<ChatMessage> messages)
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    public async Task EnqueueMessagesAsync(AgentSession session, IEnumerable<ChatMessage> messages, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(session);
         Throw.IfNull(messages);
 
-        var queue = GetOrCreateQueue(session);
-
-        lock (queue)
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
+            var queue = GetOrCreateQueue(session);
             foreach (var message in messages)
             {
                 queue.Add(message);
             }
+        }
+        finally
+        {
+            sessionLock.Release();
         }
     }
 
@@ -212,30 +213,47 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
     /// list is a point-in-time snapshot; messages may be consumed between calls.
     /// </remarks>
     /// <param name="session">The agent session to check.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A read-only list of pending messages, or an empty list if none are pending.</returns>
-    public IReadOnlyList<ChatMessage> GetPendingMessages(AgentSession session)
+    public async Task<IReadOnlyList<ChatMessage>> GetPendingMessagesAsync(AgentSession session, CancellationToken cancellationToken = default)
     {
         Throw.IfNull(session);
 
-        if (!session.StateBag.TryGetValue<List<ChatMessage>>(PendingMessagesStateKey, out var queue) || queue is null)
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            return Array.Empty<ChatMessage>();
-        }
+            if (!session.StateBag.TryGetValue<List<ChatMessage>>(PendingMessagesStateKey, out var queue) || queue is null || queue.Count == 0)
+            {
+                return Array.Empty<ChatMessage>();
+            }
 
-        lock (queue)
+            return queue.ToList();
+        }
+        finally
         {
-            return queue.Count == 0 ? Array.Empty<ChatMessage>() : queue.ToList();
+            sessionLock.Release();
         }
     }
 
     /// <summary>
+    /// Returns the per-session semaphore used to serialize access to the session's pending messages queue.
+    /// </summary>
+    private SemaphoreSlim GetSessionLock(AgentSession session)
+        => this._sessionLocks.GetValue(session, static _ => new SemaphoreSlim(1, 1));
+
+    /// <summary>
     /// Gets or creates the pending injected messages queue from the session's <see cref="AgentSessionStateBag"/>.
     /// </summary>
+    /// <remarks>
+    /// Callers must hold the session lock (see <see cref="GetSessionLock"/>) while calling this method and
+    /// while operating on the returned queue, since the get-or-create is a non-atomic check-then-act.
+    /// </remarks>
     private static List<ChatMessage> GetOrCreateQueue(AgentSession session)
     {
-        if (session.StateBag.TryGetValue<List<ChatMessage>>(PendingMessagesStateKey, out var queue))
+        if (session.StateBag.TryGetValue<List<ChatMessage>>(PendingMessagesStateKey, out var queue) && queue is not null)
         {
-            return queue!;
+            return queue;
         }
 
         var newQueue = new List<ChatMessage>();
@@ -260,13 +278,34 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
     }
 
     /// <summary>
-    /// Drains all pending injected messages from the queue and returns a new list combining
-    /// the original messages with the drained messages. The original list is never modified.
+    /// Returns <see langword="true"/> if the session's pending messages queue is empty or has not been created.
     /// </summary>
-    private static IList<ChatMessage> DrainInjectedMessages(List<ChatMessage> queue, IList<ChatMessage> newMessages)
+    private async Task<bool> IsQueueEmptyAsync(AgentSession session, CancellationToken cancellationToken)
     {
-        lock (queue)
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
+            return !session.StateBag.TryGetValue<List<ChatMessage>>(PendingMessagesStateKey, out var queue) || queue is null || queue.Count == 0;
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Drains all pending injected messages from the session's queue and returns a new list combining
+    /// the original messages with the drained messages. The original <paramref name="newMessages"/> list
+    /// is never modified.
+    /// </summary>
+    private async Task<IList<ChatMessage>> DrainInjectedMessagesAsync(AgentSession session, IList<ChatMessage> newMessages, CancellationToken cancellationToken)
+    {
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var queue = GetOrCreateQueue(session);
             if (queue.Count == 0)
             {
                 return newMessages;
@@ -276,6 +315,10 @@ public sealed class MessageInjectingChatClient : DelegatingChatClient
             combined.AddRange(queue);
             queue.Clear();
             return combined;
+        }
+        finally
+        {
+            sessionLock.Release();
         }
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/MessageInjectingChatClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/MessageInjectingChatClientTests.cs
@@ -175,17 +175,17 @@ public class MessageInjectingChatClientTests
                 It.IsAny<IEnumerable<ChatMessage>>(),
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>()))
-            .Returns((IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken _) =>
+            .Returns(async (IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken ct) =>
             {
                 serviceCallCount++;
                 if (serviceCallCount == 1)
                 {
                     // First call — simulate that something enqueues a message (e.g., a provider or background task)
-                    injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected during first call")]);
+                    await injectorRef!.EnqueueMessagesAsync(sessionRef!, [new ChatMessage(ChatRole.User, "injected during first call")], ct);
                 }
 
                 // Return a plain text response (no FunctionCallContent) to trigger the internal loop
-                return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, $"response {serviceCallCount}")]));
+                return new ChatResponse([new(ChatRole.Assistant, $"response {serviceCallCount}")]);
             });
 
         Mock<ChatHistoryProvider> mockChatHistoryProvider = new(null, null, null);
@@ -236,20 +236,20 @@ public class MessageInjectingChatClientTests
                 It.IsAny<IEnumerable<ChatMessage>>(),
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>()))
-            .Returns((IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken _) =>
+            .Returns(async (IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken ct) =>
             {
                 serviceCallCount++;
                 if (serviceCallCount == 1)
                 {
                     // Enqueue a message during the first call
-                    injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected")]);
+                    await injectorRef!.EnqueueMessagesAsync(sessionRef!, [new ChatMessage(ChatRole.User, "injected")], ct);
                     // Return a response with an actionable FunctionCallContent
-                    return Task.FromResult(new ChatResponse([new(ChatRole.Assistant,
-                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>())])]));
+                    return new ChatResponse([new(ChatRole.Assistant,
+                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>())])]);
                 }
 
                 // Subsequent calls return plain text (the FCC loop will call back after tool execution)
-                return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, "final")]));
+                return new ChatResponse([new(ChatRole.Assistant, "final")]);
             });
 
         Mock<ChatHistoryProvider> mockChatHistoryProvider = new(null, null, null);
@@ -306,19 +306,19 @@ public class MessageInjectingChatClientTests
                 It.IsAny<IEnumerable<ChatMessage>>(),
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>()))
-            .Returns((IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken _) =>
+            .Returns(async (IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken ct) =>
             {
                 serviceCallCount++;
                 if (serviceCallCount == 1)
                 {
                     // Enqueue a message during the first call
-                    injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected")]);
+                    await injectorRef!.EnqueueMessagesAsync(sessionRef!, [new ChatMessage(ChatRole.User, "injected")], ct);
                     // Return a response with InformationalOnly FCC (not actionable)
-                    return Task.FromResult(new ChatResponse([new(ChatRole.Assistant,
-                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>()) { InformationalOnly = true }])]));
+                    return new ChatResponse([new(ChatRole.Assistant,
+                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>()) { InformationalOnly = true }])]);
                 }
 
-                return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, "final")]));
+                return new ChatResponse([new(ChatRole.Assistant, "final")]);
             });
 
         Mock<ChatHistoryProvider> mockChatHistoryProvider = new(null, null, null);
@@ -370,7 +370,7 @@ public class MessageInjectingChatClientTests
                 It.IsAny<IEnumerable<ChatMessage>>(),
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>()))
-            .Returns((IEnumerable<ChatMessage> _, ChatOptions? opts, CancellationToken _) =>
+            .Returns(async (IEnumerable<ChatMessage> _, ChatOptions? opts, CancellationToken ct) =>
             {
                 serviceCallCount++;
                 capturedConversationIds.Add(opts?.ConversationId);
@@ -378,15 +378,15 @@ public class MessageInjectingChatClientTests
                 if (serviceCallCount == 1)
                 {
                     // First call: inject a message and return a ConversationId
-                    injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected")]);
-                    return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, "first response")])
+                    await injectorRef!.EnqueueMessagesAsync(sessionRef!, [new ChatMessage(ChatRole.User, "injected")], ct);
+                    return new ChatResponse([new(ChatRole.Assistant, "first response")])
                     {
                         ConversationId = "conv-123",
-                    });
+                    };
                 }
 
                 // Second call (from loop): should have the propagated ConversationId
-                return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, "second response")]));
+                return new ChatResponse([new(ChatRole.Assistant, "second response")]);
             });
 
         ChatClientAgent agent = new(mockService.Object, options: new()
@@ -427,7 +427,7 @@ public class MessageInjectingChatClientTests
                 It.IsAny<IEnumerable<ChatMessage>>(),
                 It.IsAny<ChatOptions>(),
                 It.IsAny<CancellationToken>()))
-            .Returns((IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken _) =>
+            .Returns(async (IEnumerable<ChatMessage> msgs, ChatOptions? _, CancellationToken ct) =>
             {
                 if (runCount == 1)
                 {
@@ -435,16 +435,16 @@ public class MessageInjectingChatClientTests
 
                     // Inject a message during the first run — this will remain pending (not drained)
                     // because we return an actionable FCC that causes the parent loop to take over.
-                    injectorRef!.EnqueueMessages(sessionRef!, [new ChatMessage(ChatRole.User, "injected before serialization")]);
+                    await injectorRef!.EnqueueMessagesAsync(sessionRef!, [new ChatMessage(ChatRole.User, "injected before serialization")], ct);
 
                     // Return actionable FCC so the injection loop does NOT drain the message
-                    return Task.FromResult(new ChatResponse([new(ChatRole.Assistant,
-                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>())])]));
+                    return new ChatResponse([new(ChatRole.Assistant,
+                        [new FunctionCallContent("call1", "myTool", new Dictionary<string, object?>())])]);
                 }
 
                 // Second run (after deserialization) — capture what messages come through
                 capturedMessagesSecondRun.AddRange(msgs);
-                return Task.FromResult(new ChatResponse([new(ChatRole.Assistant, "final response")]));
+                return new ChatResponse([new(ChatRole.Assistant, "final response")]);
             });
 
         Mock<ChatHistoryProvider> mockChatHistoryProvider = new(null, null, null);
@@ -489,5 +489,52 @@ public class MessageInjectingChatClientTests
         // Assert — the second run should include the injected message from before serialization
         Assert.Contains(capturedMessagesSecondRun, m => m.Text == "injected before serialization");
         Assert.Contains(capturedMessagesSecondRun, m => m.Text == "second run message");
+    }
+
+    /// <summary>
+    /// Verifies that concurrent <see cref="MessageInjectingChatClient.EnqueueMessagesAsync"/> calls on the same
+    /// session do not lose messages. This guards against the queue-creation race where two callers could
+    /// each create a separate backing queue and one overwrites the other.
+    /// </summary>
+    [Fact]
+    public async Task EnqueueMessages_ConcurrentEnqueues_DoesNotLoseMessagesAsync()
+    {
+        // Arrange
+        Mock<IChatClient> mockService = new();
+        ChatClientAgent agent = new(mockService.Object, options: new()
+        {
+            EnableMessageInjection = true,
+        });
+
+        var injector = agent.ChatClient.GetService<MessageInjectingChatClient>();
+        Assert.NotNull(injector);
+
+        var session = await agent.CreateSessionAsync();
+
+        const int ThreadCount = 16;
+        const int MessagesPerThread = 100;
+
+        // Release all threads at once to maximize the chance of hitting the queue-creation race.
+        using var barrier = new Barrier(ThreadCount);
+        var tasks = new List<Task>(ThreadCount);
+        for (int t = 0; t < ThreadCount; t++)
+        {
+            int threadIndex = t;
+            tasks.Add(Task.Run(async () =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < MessagesPerThread; i++)
+                {
+                    await injector!.EnqueueMessagesAsync(session, [new ChatMessage(ChatRole.User, $"{threadIndex}-{i}")]);
+                }
+            }));
+        }
+
+        // Act
+        await Task.WhenAll(tasks);
+
+        // Assert — every enqueued message must be present (none lost to a creation race).
+        IReadOnlyList<ChatMessage> pending = await injector!.GetPendingMessagesAsync(session);
+        Assert.Equal(ThreadCount * MessagesPerThread, pending.Count);
     }
 }


### PR DESCRIPTION
### Motivation & Context

Part of releasing the `HarnessAgent`: several of the APIs it depends on are still marked
`[Experimental]`. The `HarnessAgent` adds message injection to its pipeline on-by-default, so this
dependency must be graduated to a released, non-experimental API before the harness can ship without
pulling users into experimental surface. This continues the work started in #6970 (which graduated
per-service-call persistence and approval-not-required function bypassing).

### Description & Review Guide

- **What are the major changes?**
  - Removed `[Experimental(MAAI001)]` from the three message-injection APIs (no behavior change):
    - `MessageInjectingChatClient` (remains **public** — it is the entry point callers use to enqueue
      messages via `agent.GetService<MessageInjectingChatClient>()`).
    - `ChatClientBuilderExtensions.UseMessageInjection()`.
    - `ChatClientAgentOptions.EnableMessageInjection`.
  - Dropped the now-unused `System.Diagnostics.CodeAnalysis` and `Microsoft.Shared.DiagnosticIds`
    usings from the three edited files.

- **What is the impact of these changes?**
  - Message injection is now a released, non-experimental API, unblocking it as an on-by-default
    harness dependency. This is **not a breaking change**: nothing is renamed, no defaults change, and
    existing (experimental) callers keep compiling — their `MAAI001` suppressions simply become
    unnecessary.
  - Validated with `Microsoft.Agents.AI`, `Microsoft.Agents.AI.Harness`, and
    `Microsoft.Agents.AI.UnitTests` building clean (0 warnings / 0 errors) plus `dotnet format`
    verification. Samples and tests suppress `MAAI001` globally (still required for other
    experimental types), so no sample/test changes are needed.

- **What do you want reviewers to focus on?**
  - Confirmation that keeping `MessageInjectingChatClient` public is the right call, since it is the
    only way to enqueue messages (`EnqueueMessages` / `GetPendingMessages`).

### Related Issue

Related #6964

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
