### PR TITLE
.NET: [BREAKING] Graduate todo and agent mode providers out of experimental

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Commands/ModeCommandHandler.cs
@@ -43,7 +43,7 @@ public sealed class ModeCommandHandler : CommandHandler
         string[] parts = input.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (parts.Length < 2)
         {
-            string current = this._modeProvider.GetMode(session);
+            string current = await this._modeProvider.GetModeAsync(session).ConfigureAwait(false);
             await ux.WriteInfoLineAsync($"Current mode: {current}").ConfigureAwait(false);
             return true;
         }
@@ -52,7 +52,7 @@ public sealed class ModeCommandHandler : CommandHandler
 
         try
         {
-            this._modeProvider.SetMode(session, newMode);
+            await this._modeProvider.SetModeAsync(session, newMode).ConfigureAwait(false);
             ux.CurrentMode = newMode;
             await ux.WriteInfoLineAsync($"Switched to {newMode} mode.", ModeColors.Get(newMode, this._modeColors)).ConfigureAwait(false);
         }

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessAgentRunner.cs
@@ -93,7 +93,7 @@ public sealed class HarnessAgentRunner : IDisposable
             {
                 if (await handler.TryHandleAsync(text, this._session, this._ux).ConfigureAwait(false))
                 {
-                    this._ux.CurrentMode = this._modeProvider?.GetMode(this._session);
+                    this._ux.CurrentMode = this._modeProvider is null ? null : await this._modeProvider.GetModeAsync(this._session).ConfigureAwait(false);
                     return;
                 }
             }
@@ -136,7 +136,7 @@ public sealed class HarnessAgentRunner : IDisposable
         {
             if (messages.Count == 0)
             {
-                this.CompleteTurn();
+                await this.CompleteTurnAsync().ConfigureAwait(false);
                 return;
             }
 
@@ -158,10 +158,10 @@ public sealed class HarnessAgentRunner : IDisposable
             var runOptions = new AgentRunOptions();
             foreach (var observer in this._observers)
             {
-                observer.ConfigureRunOptions(runOptions, this._agent, this._session);
+                await observer.ConfigureRunOptionsAsync(runOptions, this._agent, this._session).ConfigureAwait(false);
             }
 
-            this._ux.CurrentMode = this._modeProvider?.GetMode(this._session);
+            this._ux.CurrentMode = this._modeProvider is null ? null : await this._modeProvider.GetModeAsync(this._session).ConfigureAwait(false);
             this._ux.BeginStreaming();
             this._ux.BeginStreamingOutput();
 
@@ -171,7 +171,7 @@ public sealed class HarnessAgentRunner : IDisposable
                 {
                     if (this._modeProvider is not null)
                     {
-                        string currentMode = this._modeProvider.GetMode(this._session);
+                        string currentMode = await this._modeProvider.GetModeAsync(this._session).ConfigureAwait(false);
                         if (currentMode != this._ux.CurrentMode)
                         {
                             this._ux.CurrentMode = currentMode;
@@ -261,13 +261,13 @@ public sealed class HarnessAgentRunner : IDisposable
             nextMessages = drained.Count > 0 ? [.. drained] : null;
         }
 
-        this.CompleteTurn();
+        await this.CompleteTurnAsync().ConfigureAwait(false);
     }
 
-    private void CompleteTurn()
+    private async Task CompleteTurnAsync()
     {
         this._ux.EndStreaming();
-        this._ux.CurrentMode = this._modeProvider?.GetMode(this._session);
+        this._ux.CurrentMode = this._modeProvider is null ? null : await this._modeProvider.GetModeAsync(this._session).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/HarnessConsole.cs
@@ -40,9 +40,11 @@ public static class HarnessConsole
             ? await options.SessionFactory(agent)
             : await agent.CreateSessionAsync();
 
+        string? initialMode = modeProvider is null ? null : await modeProvider.GetModeAsync(session);
+
         using var component = new HarnessAppComponent(
             placeholder: userPrompt,
-            initialMode: modeProvider?.GetMode(session),
+            initialMode: initialMode,
             inputEnabled: messageInjector is not null,
             runnerFactory: ux => new HarnessAgentRunner(
                 agent: agent,

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/ConsoleObserver.cs
@@ -20,9 +20,7 @@ public abstract class ConsoleObserver
     /// <param name="options">The run options to configure.</param>
     /// <param name="agent">The agent being interacted with.</param>
     /// <param name="session">The current agent session.</param>
-    public virtual void ConfigureRunOptions(AgentRunOptions options, AIAgent agent, AgentSession session)
-    {
-    }
+    public virtual ValueTask ConfigureRunOptionsAsync(AgentRunOptions options, AIAgent agent, AgentSession session) => default;
 
     /// <summary>
     /// Called for each <see cref="AgentResponseUpdate"/> in the response stream, regardless of

--- a/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Shared_Console/Observers/PlanningOutputObserver.cs
@@ -40,9 +40,9 @@ public sealed class PlanningOutputObserver : ConsoleObserver
     }
 
     /// <inheritdoc/>
-    public override void ConfigureRunOptions(AgentRunOptions options, AIAgent agent, AgentSession session)
+    public override async ValueTask ConfigureRunOptionsAsync(AgentRunOptions options, AIAgent agent, AgentSession session)
     {
-        if (this.IsPlanningMode(this._modeProvider.GetMode(session)))
+        if (this.IsPlanningMode(await this._modeProvider.GetModeAsync(session).ConfigureAwait(false)))
         {
             options.ResponseFormat = ChatResponseFormat.ForJsonSchema<PlanningResponse>();
         }
@@ -205,7 +205,7 @@ public sealed class PlanningOutputObserver : ConsoleObserver
 
                 if (selection == ApproveOption)
                 {
-                    this._modeProvider.SetMode(session, this._executionModeName);
+                    await this._modeProvider.SetModeAsync(session, this._executionModeName).ConfigureAwait(false);
                     await ux.WriteInfoLineAsync(
                         $"✅ Switched to {this._executionModeName} mode.",
                         ModeColors.Get(this._executionModeName, this._modeColors)).ConfigureAwait(false);

--- a/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProvider.cs
@@ -2,12 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
 
@@ -34,12 +34,15 @@ namespace Microsoft.Agents.AI;
 /// </list>
 /// </para>
 /// <para>
-/// Public helper methods <see cref="GetMode"/> and <see cref="SetMode"/> allow external code
+/// Public helper methods <see cref="GetModeAsync"/> and <see cref="SetModeAsync"/> allow external code
 /// to programmatically read and change the mode.
 /// </para>
+/// <para>
+/// All operations are thread-safe; concurrent reads and mutations on the same session are serialized
+/// using a per-session lock to prevent lost updates or inconsistent reads.
+/// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
-public sealed class AgentModeProvider : AIContextProvider
+public sealed class AgentModeProvider : AIContextProvider, IDisposable
 {
     private const string DefaultInstructions =
         """
@@ -102,6 +105,8 @@ public sealed class AgentModeProvider : AIContextProvider
     private readonly string? _instructions;
     private readonly HashSet<string> _validModeNames;
     private readonly string _modeNamesDisplay;
+    private readonly ConditionalWeakTable<AgentSession, SemaphoreSlim> _sessionLocks = new();
+    private readonly SemaphoreSlim _nullSessionLock = new(1, 1);
     private IReadOnlyList<string>? _stateKeys;
 
     /// <summary>
@@ -159,14 +164,33 @@ public sealed class AgentModeProvider : AIContextProvider
     /// <inheritdoc />
     public override IReadOnlyList<string> StateKeys => this._stateKeys ??= [this._sessionState.StateKey];
 
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this._nullSessionLock.Dispose();
+    }
+
     /// <summary>
     /// Gets the current operating mode from the session state.
     /// </summary>
     /// <param name="session">The agent session to read the mode from.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>The current mode string.</returns>
-    public string GetMode(AgentSession? session)
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    public async Task<string> GetModeAsync(AgentSession session, CancellationToken cancellationToken = default)
     {
-        return this._sessionState.GetOrInitializeState(session).CurrentMode;
+        _ = Throw.IfNull(session);
+
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return this._sessionState.GetOrInitializeState(session).CurrentMode;
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
     }
 
     /// <summary>
@@ -174,50 +198,81 @@ public sealed class AgentModeProvider : AIContextProvider
     /// </summary>
     /// <param name="session">The agent session to update the mode in.</param>
     /// <param name="mode">The new mode to set.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="mode"/> is not a configured mode.</exception>
-    public void SetMode(AgentSession? session, string mode)
+    public async Task SetModeAsync(AgentSession session, string mode, CancellationToken cancellationToken = default)
     {
+        _ = Throw.IfNull(session);
+
         this.ValidateMode(mode);
 
-        AgentModeState state = this._sessionState.GetOrInitializeState(session);
-        string previousMode = state.CurrentMode;
-        state.CurrentMode = mode;
-
-        if (!string.Equals(previousMode, mode, StringComparison.Ordinal))
+        SemaphoreSlim sessionLock = this.GetSessionLock(session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            state.PreviousModeForNotification = previousMode;
-        }
+            AgentModeState state = this._sessionState.GetOrInitializeState(session);
+            string previousMode = state.CurrentMode;
+            state.CurrentMode = mode;
 
-        this._sessionState.SaveState(session, state);
+            if (!string.Equals(previousMode, mode, StringComparison.Ordinal))
+            {
+                state.PreviousModeForNotification = previousMode;
+            }
+
+            this._sessionState.SaveState(session, state);
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
     }
 
     /// <inheritdoc />
-    protected override ValueTask<AIContext> ProvideAIContextAsync(InvokingContext context, CancellationToken cancellationToken = default)
+    protected override async ValueTask<AIContext> ProvideAIContextAsync(InvokingContext context, CancellationToken cancellationToken = default)
     {
-        AgentModeState state = this._sessionState.GetOrInitializeState(context.Session);
+        string currentMode;
+        string? previousModeForNotification;
 
-        string instructions = this.BuildInstructions(state.CurrentMode);
+        SemaphoreSlim sessionLock = this.GetSessionLock(context.Session);
+        await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            AgentModeState state = this._sessionState.GetOrInitializeState(context.Session);
+            currentMode = state.CurrentMode;
+            previousModeForNotification = state.PreviousModeForNotification;
+
+            // If the mode was changed externally (e.g., via /mode command), clear the pending
+            // notification flag now that we are about to surface it to the agent.
+            if (previousModeForNotification != null)
+            {
+                state.PreviousModeForNotification = null;
+                this._sessionState.SaveState(context.Session, state);
+            }
+        }
+        finally
+        {
+            sessionLock.Release();
+        }
 
         var aiContext = new AIContext
         {
-            Instructions = instructions,
-            Tools = this.CreateTools(state, context.Session),
+            Instructions = this.BuildInstructions(currentMode),
+            Tools = this.CreateTools(context.Session),
         };
 
         // If the mode was changed externally (e.g., via /mode command), inject a notification message
         // so the agent clearly sees the change rather than relying solely on the system instructions.
-        if (state.PreviousModeForNotification != null)
+        if (previousModeForNotification != null)
         {
-            string previousMode = state.PreviousModeForNotification;
-            state.PreviousModeForNotification = null;
-
             aiContext.Messages =
             [
-                new ChatMessage(ChatRole.User, $"[Mode changed: The operating mode has been switched from \"{previousMode}\" to \"{state.CurrentMode}\". You must now adjust your behavior to match the \"{state.CurrentMode}\" mode.]"),
+                new ChatMessage(ChatRole.User, $"[Mode changed: The operating mode has been switched from \"{previousModeForNotification}\" to \"{currentMode}\". You must now adjust your behavior to match the \"{currentMode}\" mode.]"),
             ];
         }
 
-        return new ValueTask<AIContext>(aiContext);
+        return aiContext;
     }
 
     private string BuildInstructions(string currentMode)
@@ -227,7 +282,7 @@ public sealed class AgentModeProvider : AIContextProvider
         {
             modesListBuilder.AppendLine($"#### {mode.Name}");
             modesListBuilder.AppendLine();
-            modesListBuilder.AppendLine(mode.Description.TrimEnd());
+            modesListBuilder.AppendLine(mode.Instructions.TrimEnd());
             modesListBuilder.AppendLine();
         }
 
@@ -247,19 +302,43 @@ public sealed class AgentModeProvider : AIContextProvider
         }
     }
 
-    private AITool[] CreateTools(AgentModeState state, AgentSession? session)
+    /// <summary>
+    /// Returns the per-session semaphore used to serialize all mode operations.
+    /// </summary>
+    private SemaphoreSlim GetSessionLock(AgentSession? session)
+    {
+        if (session is null)
+        {
+            return this._nullSessionLock;
+        }
+
+        return this._sessionLocks.GetValue(session, _ => new SemaphoreSlim(1, 1));
+    }
+
+    private AITool[] CreateTools(AgentSession? session)
     {
         var serializerOptions = AgentJsonUtilities.DefaultOptions;
 
         return
         [
             AIFunctionFactory.Create(
-                (string mode) =>
+                async (string mode) =>
                 {
                     this.ValidateMode(mode);
 
-                    state.CurrentMode = mode;
-                    this._sessionState.SaveState(session, state);
+                    SemaphoreSlim sessionLock = this.GetSessionLock(session);
+                    await sessionLock.WaitAsync().ConfigureAwait(false);
+                    try
+                    {
+                        AgentModeState state = this._sessionState.GetOrInitializeState(session);
+                        state.CurrentMode = mode;
+                        this._sessionState.SaveState(session, state);
+                    }
+                    finally
+                    {
+                        sessionLock.Release();
+                    }
+
                     return $"Mode changed to \"{mode}\".";
                 },
                 new AIFunctionFactoryOptions
@@ -270,7 +349,19 @@ public sealed class AgentModeProvider : AIContextProvider
                 }),
 
             AIFunctionFactory.Create(
-                () => state.CurrentMode,
+                async () =>
+                {
+                    SemaphoreSlim sessionLock = this.GetSessionLock(session);
+                    await sessionLock.WaitAsync().ConfigureAwait(false);
+                    try
+                    {
+                        return this._sessionState.GetOrInitializeState(session).CurrentMode;
+                    }
+                    finally
+                    {
+                        sessionLock.Release();
+                    }
+                },
                 new AIFunctionFactoryOptions
                 {
                     Name = "mode_get",

--- a/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeProviderOptions.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -11,7 +9,6 @@ namespace Microsoft.Agents.AI;
 /// <summary>
 /// Options controlling the behavior of <see cref="AgentModeProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class AgentModeProviderOptions
 {
     /// <summary>
@@ -46,22 +43,21 @@ public sealed class AgentModeProviderOptions
     public string? DefaultMode { get; set; }
 
     /// <summary>
-    /// Represents an agent operating mode with a name and description.
+    /// Represents an agent operating mode with a name and instructions.
     /// </summary>
-    [Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
     public sealed class AgentMode
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AgentMode"/> class.
         /// </summary>
         /// <param name="name">The name of the mode.</param>
-        /// <param name="description">A description of when and how to use this mode.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="description"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="name"/> or <paramref name="description"/> is empty or whitespace.</exception>
-        public AgentMode(string name, string description)
+        /// <param name="instructions">Instructions for the agent describing when and how to operate in this mode.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="instructions"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> or <paramref name="instructions"/> is empty or whitespace.</exception>
+        public AgentMode(string name, string instructions)
         {
             this.Name = Throw.IfNullOrWhitespace(name);
-            this.Description = Throw.IfNullOrWhitespace(description);
+            this.Instructions = Throw.IfNullOrWhitespace(instructions);
         }
 
         /// <summary>
@@ -70,8 +66,8 @@ public sealed class AgentModeProviderOptions
         public string Name { get; }
 
         /// <summary>
-        /// Gets a description of when and how to use this mode.
+        /// Gets the instructions for the agent describing when and how to operate in this mode.
         /// </summary>
-        public string Description { get; }
+        public string Instructions { get; }
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/AgentMode/AgentModeState.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Represents the state of the agent's operating mode, stored in the session's <see cref="AgentSessionStateBag"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class AgentModeState
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Loop/TodoCompletionLoopEvaluator.cs
@@ -109,7 +109,7 @@ public sealed class TodoCompletionLoopEvaluator : LoopEvaluator
                 ?? throw new InvalidOperationException(
                     $"{nameof(TodoCompletionLoopEvaluator)} was configured with modes but no {nameof(AgentModeProvider)} could be resolved from the agent via GetService.");
 
-            string currentMode = modeProvider.GetMode(context.Session);
+            string currentMode = await modeProvider.GetModeAsync(context.Session, cancellationToken).ConfigureAwait(false);
             if (!this._modes.Contains(currentMode))
             {
                 return LoopEvaluation.Stop();

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoCompleteInput.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoCompleteInput.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Represents the input for completing a single todo item via the <see cref="TodoProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class TodoCompleteInput
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoItem.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoItem.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Represents a single todo item managed by the <see cref="TodoProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class TodoItem
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoItemInput.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoItemInput.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Represents the input for creating a new todo item via the <see cref="TodoProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class TodoItemInput
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProvider.cs
@@ -2,14 +2,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
 
@@ -38,7 +37,6 @@ namespace Microsoft.Agents.AI;
 /// using a per-session lock to prevent duplicate IDs, lost updates, or inconsistent reads.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class TodoProvider : AIContextProvider, IDisposable
 {
     private const string DefaultInstructions =
@@ -107,8 +105,11 @@ public sealed class TodoProvider : AIContextProvider, IDisposable
     /// <param name="session">The agent session to read todos from.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A list of all todo items. The items are live references to internal state.</returns>
-    public async Task<IReadOnlyList<TodoItem>> GetAllTodosAsync(AgentSession? session, CancellationToken cancellationToken = default)
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    public async Task<IReadOnlyList<TodoItem>> GetAllTodosAsync(AgentSession session, CancellationToken cancellationToken = default)
     {
+        _ = Throw.IfNull(session);
+
         SemaphoreSlim sessionLock = this.GetSessionLock(session);
         await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -132,8 +133,11 @@ public sealed class TodoProvider : AIContextProvider, IDisposable
     /// <param name="session">The agent session to read todos from.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests.</param>
     /// <returns>A list of incomplete todo items. The items are live references to internal state.</returns>
-    public async Task<List<TodoItem>> GetRemainingTodosAsync(AgentSession? session, CancellationToken cancellationToken = default)
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    public async Task<List<TodoItem>> GetRemainingTodosAsync(AgentSession session, CancellationToken cancellationToken = default)
     {
+        _ = Throw.IfNull(session);
+
         SemaphoreSlim sessionLock = this.GetSessionLock(session);
         await sessionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoProviderOptions.cs
@@ -2,15 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Options controlling the behavior of <see cref="TodoProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class TodoProviderOptions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/Todo/TodoState.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -11,7 +9,6 @@ namespace Microsoft.Agents.AI;
 /// Represents the state of the todo list managed by the <see cref="TodoProvider"/>,
 /// stored in the session's <see cref="AgentSessionStateBag"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class TodoState
 {
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/AgentMode/AgentModeProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/AgentMode/AgentModeProviderTests.cs
@@ -167,14 +167,14 @@ public class AgentModeProviderTests
     /// Verify that the public GetMode helper returns the default mode.
     /// </summary>
     [Fact]
-    public void PublicGetMode_ReturnsDefaultMode()
+    public async Task PublicGetMode_ReturnsDefaultModeAsync()
     {
         // Arrange
         var provider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
 
         // Act
-        string mode = provider.GetMode(session);
+        string mode = await provider.GetModeAsync(session);
 
         // Assert
         Assert.Equal("plan", mode);
@@ -184,15 +184,15 @@ public class AgentModeProviderTests
     /// Verify that the public SetMode helper changes the mode.
     /// </summary>
     [Fact]
-    public void PublicSetMode_ChangesMode()
+    public async Task PublicSetMode_ChangesModeAsync()
     {
         // Arrange
         var provider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
 
         // Act
-        provider.SetMode(session, "execute");
-        string mode = provider.GetMode(session);
+        await provider.SetModeAsync(session, "execute");
+        string mode = await provider.GetModeAsync(session);
 
         // Assert
         Assert.Equal("execute", mode);
@@ -202,17 +202,17 @@ public class AgentModeProviderTests
     /// Verify that the public SetMode helper throws for an unsupported value and does not persist the mode.
     /// </summary>
     [Fact]
-    public void PublicSetMode_InvalidMode_Throws()
+    public async Task PublicSetMode_InvalidMode_ThrowsAsync()
     {
         // Arrange
         var provider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => provider.SetMode(session, "foo"));
+        await Assert.ThrowsAsync<ArgumentException>(() => provider.SetModeAsync(session, "foo"));
 
         // Verify mode was not changed from default
-        string mode = provider.GetMode(session);
+        string mode = await provider.GetModeAsync(session);
         Assert.Equal("plan", mode);
     }
 
@@ -228,7 +228,7 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Set mode via public helper
-        provider.SetMode(session, "execute");
+        await provider.SetModeAsync(session, "execute");
 
 #pragma warning disable MAAI001
         var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());
@@ -307,7 +307,7 @@ public class AgentModeProviderTests
     /// Verify that custom modes are used.
     /// </summary>
     [Fact]
-    public void Options_CustomModes_AreUsed()
+    public async Task Options_CustomModes_AreUsedAsync()
     {
         // Arrange
         var options = new AgentModeProviderOptions
@@ -322,7 +322,7 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Act
-        string mode = provider.GetMode(session);
+        string mode = await provider.GetModeAsync(session);
 
         // Assert — default mode is first in list
         Assert.Equal("draft", mode);
@@ -332,7 +332,7 @@ public class AgentModeProviderTests
     /// Verify that SetMode validates against custom modes.
     /// </summary>
     [Fact]
-    public void Options_CustomModes_SetModeValidatesAgainstList()
+    public async Task Options_CustomModes_SetModeValidatesAgainstListAsync()
     {
         // Arrange
         var options = new AgentModeProviderOptions
@@ -347,20 +347,20 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Act — valid mode
-        provider.SetMode(session, "review");
+        await provider.SetModeAsync(session, "review");
 
         // Assert
-        Assert.Equal("review", provider.GetMode(session));
+        Assert.Equal("review", await provider.GetModeAsync(session));
 
         // Act & Assert — invalid mode (plan is no longer valid)
-        Assert.Throws<ArgumentException>(() => provider.SetMode(session, "plan"));
+        await Assert.ThrowsAsync<ArgumentException>(() => provider.SetModeAsync(session, "plan"));
     }
 
     /// <summary>
     /// Verify that a custom default mode is used.
     /// </summary>
     [Fact]
-    public void Options_CustomDefaultMode_IsUsed()
+    public async Task Options_CustomDefaultMode_IsUsedAsync()
     {
         // Arrange
         var options = new AgentModeProviderOptions
@@ -376,7 +376,7 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Act
-        string mode = provider.GetMode(session);
+        string mode = await provider.GetModeAsync(session);
 
         // Assert
         Assert.Equal("review", mode);
@@ -517,7 +517,7 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Change mode externally (simulating /mode command)
-        provider.SetMode(session, "execute");
+        await provider.SetModeAsync(session, "execute");
 
 #pragma warning disable MAAI001
         var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());
@@ -545,7 +545,7 @@ public class AgentModeProviderTests
         var provider = new AgentModeProvider();
         var agent = new Mock<AIAgent>().Object;
         var session = new ChatClientAgentSession();
-        provider.SetMode(session, "execute");
+        await provider.SetModeAsync(session, "execute");
 
 #pragma warning disable MAAI001
         var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());
@@ -603,7 +603,7 @@ public class AgentModeProviderTests
         var session = new ChatClientAgentSession();
 
         // Set to same default mode
-        provider.SetMode(session, "plan");
+        await provider.SetModeAsync(session, "plan");
 
 #pragma warning disable MAAI001
         var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/Loop/TodoCompletionLoopEvaluatorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/Loop/TodoCompletionLoopEvaluatorTests.cs
@@ -139,7 +139,7 @@ public class TodoCompletionLoopEvaluatorTests
         var todoProvider = new TodoProvider();
         var modeProvider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
-        modeProvider.SetMode(session, "execute");
+        await modeProvider.SetModeAsync(session, "execute");
         SeedTodos(session, (1, "Work item", null, false));
         AIAgent agent = CreateAgent(todoProvider, modeProvider);
         var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
@@ -163,7 +163,7 @@ public class TodoCompletionLoopEvaluatorTests
         var todoProvider = new TodoProvider();
         var modeProvider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
-        modeProvider.SetMode(session, "execute");
+        await modeProvider.SetModeAsync(session, "execute");
         SeedTodos(session, (1, "Already done", null, true));
         AIAgent agent = CreateAgent(todoProvider, modeProvider);
         var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });
@@ -187,7 +187,7 @@ public class TodoCompletionLoopEvaluatorTests
         var todoProvider = new TodoProvider();
         var modeProvider = new AgentModeProvider();
         var session = new ChatClientAgentSession();
-        modeProvider.SetMode(session, "plan");
+        await modeProvider.SetModeAsync(session, "plan");
         SeedTodos(session, (1, "Still open", null, false));
         AIAgent agent = CreateAgent(todoProvider, modeProvider);
         var evaluator = new TodoCompletionLoopEvaluator(new TodoCompletionLoopEvaluatorOptions { Modes = ["execute"] });


### PR DESCRIPTION
### Motivation & Context

The `HarnessAgent` is being prepared for release, but several of the features it
depends on are still marked experimental. This PR graduates the **Todo** and
**Agent Mode** providers (and their related types) out of experimental so they
can ship as part of the harness. These are features that are on by default when
using the harness, so they must be released rather than left behind an
experimental opt-in.

Part of the broader effort to release the harness dependencies.

### Description & Review Guide

- **What are the major changes?**
  - Removed `[Experimental(MAAI001)]` from `TodoProvider`, `AgentModeProvider`,
    and their related todo/mode types. `TodoCompletionLoopEvaluator` remains
    experimental because it ships with the still-experimental Loop feature.
  - Renamed `AgentMode.Description` → `AgentMode.Instructions`, since the value is
    LLM instructions for the mode rather than a human-facing description.
  - Made the `AgentSession` parameters non-nullable (with `Throw.IfNull`) on
    `TodoProvider.GetAllTodosAsync`/`GetRemainingTodosAsync` and the mode helpers —
    a null session was effectively a no-op and only invited misuse.
  - Added per-session locking to `AgentModeProvider` (mirroring `TodoProvider`) so
    concurrent reads/mutations of the mode state on the same session are serialized.
    This made the public helpers async: `GetMode`/`SetMode` are now
    `GetModeAsync`/`SetModeAsync`.
  - Propagated the async change through the internal consumer
    (`TodoCompletionLoopEvaluator`) and the Harness console samples, and updated the
    affected unit tests.

- **What is the impact of these changes?**
  - The Todo and Agent Mode providers are now part of the stable (non-experimental)
    surface.
  - **Breaking (experimental surface):** `AgentModeProvider.GetMode`/`SetMode` are
    renamed to async `GetModeAsync`/`SetModeAsync`, and `AgentMode.Description` is
    renamed to `Instructions`. These types were experimental, but the change is
    flagged as breaking so preview users are notified.

- **What do you want reviewers to focus on?**
  - The per-session locking pattern on `AgentModeProvider` matches `TodoProvider`.

### Related Issue

Related to #6964

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
