### PR TITLE
Update issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -3,6 +3,12 @@ name: Issue Triage
 on:
   issues:
     types: [opened, typed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +18,8 @@ permissions:
 concurrency:
   group: >-
     issue-triage-${{ github.repository }}-${{
-      github.event.issue.type.name == 'Bug' && github.event.issue.number
+      github.event_name == 'workflow_dispatch' && inputs.issue_number
+      || github.event.issue.type.name == 'Bug' && github.event.issue.number
       || github.run_id
     }}
   cancel-in-progress: true
@@ -26,7 +33,11 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.type.name == 'Bug' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        || github.event.issue.type.name == 'Bug'
+      }}
     outputs:
       is_team_member: ${{ steps.check.outputs.is_team_member }}
       issue_number: ${{ steps.issue.outputs.issue_number }}
@@ -36,14 +47,18 @@ jobs:
         id: issue
         shell: bash
         env:
-          ISSUE_NUMBER_EVENT: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: >-
+            ${{
+              github.event_name == 'workflow_dispatch' && inputs.issue_number
+              || github.event.issue.number
+            }}
         run: |
           set -euo pipefail
 
-          issue_number="${ISSUE_NUMBER_EVENT}"
+          issue_number="${ISSUE_NUMBER}"
 
           if [[ ! "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Could not determine issue number from event payload." >&2
+            echo "Could not determine issue number from event payload or manual input." >&2
             exit 1
           fi
 
@@ -58,6 +73,7 @@ jobs:
           persist-credentials: false
 
       - name: Check issue author team membership
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: check
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
@@ -84,7 +100,11 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     needs: team_check
-    if: ${{ needs.team_check.outputs.is_team_member == 'false' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        || needs.team_check.outputs.is_team_member == 'false'
+      }}
     environment: integration
     timeout-minutes: 60
 


### PR DESCRIPTION
### Motivation & Context

Updating the issue triage workflow.

### Description & Review Guide

- **What are the major changes?** Adds a manual `workflow_dispatch` trigger with a required issue number, resolves that input through the existing issue metadata step, and bypasses the author membership lookup only for manual runs. The concurrency key also uses the manually supplied issue number.
- **What is the impact of these changes?** Maintainers with repository write access can manually triage a specific issue. Automatically triggered runs continue to require the Bug issue type and continue to skip issues authored by team members.
- **What do you want reviewers to focus on?** Confirm that the manual path bypasses only the membership lookup while preserving issue-number validation and the existing automatic-run behavior.

### Related Issue

Related to #6981. This workflow change enables triage of that issue but does not resolve the underlying AG-UI bug.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
