### PR TITLE
Python: [BREAKING] Graduate tool approval middleware out of experimental

### DIFF
--- a/python/packages/core/AGENTS.md
+++ b/python/packages/core/AGENTS.md
@@ -129,7 +129,7 @@ agent_framework/
 
 ### Tool Approval Harness (`_harness/_tool_approval.py`)
 
-- **`ToolApprovalMiddleware`** - Experimental opt-in agent middleware that coordinates session-backed approval
+- **`ToolApprovalMiddleware`** - Opt-in agent middleware that coordinates session-backed approval
   rules, heuristic `auto_approval_rules`, queued approval requests, collected approval responses, and
   streaming/non-streaming approval prompts. Heuristic callbacks receive the underlying `function_call` content.
 - **`ToolApprovalRule`** / **`ToolApprovalState`** - Serializable state models for standing approvals and queued

--- a/python/packages/core/agent_framework/_harness/_tool_approval.py
+++ b/python/packages/core/agent_framework/_harness/_tool_approval.py
@@ -9,7 +9,6 @@ from asyncio import sleep
 from collections.abc import AsyncIterable, Awaitable, Callable, Iterable, Mapping, MutableMapping, Sequence
 from typing import Any, Literal, cast
 
-from .._feature_stage import ExperimentalFeature, experimental
 from .._middleware import AgentContext, AgentMiddleware
 from .._serialization import SerializationMixin
 from .._sessions import AgentSession
@@ -83,7 +82,6 @@ def _content_to_state(content: Content) -> dict[str, Any]:
     return content.to_dict()
 
 
-@experimental(feature_id=ExperimentalFeature.HARNESS)
 class ToolApprovalRule(SerializationMixin):
     """A standing rule for approving future matching tool calls."""
 
@@ -156,7 +154,6 @@ class ToolApprovalRule(SerializationMixin):
         return payload
 
 
-@experimental(feature_id=ExperimentalFeature.HARNESS)
 class ToolApprovalState(SerializationMixin):
     """Session-backed state used by :class:`ToolApprovalMiddleware`."""
 
@@ -342,7 +339,6 @@ def _clone_without_always_approve_metadata(response: Content) -> Content:
     return cloned
 
 
-@experimental(feature_id=ExperimentalFeature.HARNESS)
 class ToolApprovalMiddleware(AgentMiddleware):
     """Coordinate standing tool approvals and queued approval prompts for an agent.
 


### PR DESCRIPTION
### Motivation & Context

The Microsoft Agent Framework harness depends on several building-block features
that are still marked experimental. As part of releasing those dependencies (see
#6964), the **tool approval** middleware and its supporting types are now stable
enough to graduate out of experimental status so downstream users can rely on
them without opting into experimental warnings.

### Description & Review Guide

- **What are the major changes?**
  - Removed the `@experimental(feature_id=ExperimentalFeature.HARNESS)` decorators
    from the graduated tool-approval types (`ToolApprovalRule`,
    `ToolApprovalState`, `ToolApprovalMiddleware`) in
    `_harness/_tool_approval.py`, along with the now-unused `_feature_stage`
    import.
  - Updated the "Tool Approval Harness" section of `packages/core/AGENTS.md` to
    drop the "Experimental" qualifier from `ToolApprovalMiddleware`.

- **What is the impact of these changes?**
  - The tool-approval middleware and its state/rule types no longer emit
    experimental warnings.
  - **Breaking (experimental surface only):** graduating a preview API is marked
    breaking so preview users of the experimental harness are notified; no
    released API is broken.
  - The shared `ExperimentalFeature.HARNESS` id is intentionally retained (still
    referenced by other harness symbols that remain experimental).

- **What do you want reviewers to focus on?**
  - That the tool-approval surface (`ToolApprovalRule`, `ToolApprovalState`,
    `ToolApprovalMiddleware`, and the already-undecorated helper functions and
    `ToolApprovalRuleCallback` alias) is the intended graduation scope.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Related to #6964

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
