### PR TITLE
.NET: [BREAKING] Graduate ToolApprovalAgent and add ToolAutoApprovalRuleContext

### DIFF
--- a/dotnet/samples/02-agents/Harness/Harness_Step05_Loop/Program.cs
+++ b/dotnet/samples/02-agents/Harness/Harness_Step05_Loop/Program.cs
@@ -174,9 +174,9 @@ async Task ApprovalLoopAsync()
         {
             AutoApprovalRules =
             [
-                functionCall =>
+                context =>
                 {
-                    Console.WriteLine($"  Auto-approving: {functionCall.Name}");
+                    Console.WriteLine($"  Auto-approving: {context.FunctionCallContent.Name}");
                     return ValueTask.FromResult(true);
                 },
             ],

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
@@ -189,8 +189,8 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// human approval boundary. Ensure no other tool collides with these reserved names.
     /// </para>
     /// </remarks>
-    public static Func<FunctionCallContent, ValueTask<bool>> ReadOnlyToolsAutoApprovalRule { get; } =
-        functionCall => new ValueTask<bool>(s_readOnlyToolNames.Contains(functionCall.Name));
+    public static Func<ToolAutoApprovalRuleContext, ValueTask<bool>> ReadOnlyToolsAutoApprovalRule { get; } =
+        context => new ValueTask<bool>(s_readOnlyToolNames.Contains(context.FunctionCallContent.Name));
 
     /// <summary>
     /// Gets an auto-approval rule that approves all file access tools, including the tools that modify the
@@ -226,8 +226,8 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// human approval boundary. Ensure no other tool collides with these reserved names.
     /// </para>
     /// </remarks>
-    public static Func<FunctionCallContent, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
-        functionCall => new ValueTask<bool>(s_allToolNames.Contains(functionCall.Name));
+    public static Func<ToolAutoApprovalRuleContext, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
+        context => new ValueTask<bool>(s_allToolNames.Contains(context.FunctionCallContent.Name));
 
     /// <inheritdoc />
     public override IReadOnlyList<string> StateKeys => [];

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/AlwaysApproveToolApprovalResponseContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/AlwaysApproveToolApprovalResponseContent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -25,7 +23,6 @@ namespace Microsoft.Agents.AI;
 /// entries in the session state.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class AlwaysApproveToolApprovalResponseContent : AIContent
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
@@ -2,14 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -46,12 +44,11 @@ namespace Microsoft.Agents.AI;
 /// <item><b>Tool+arguments:</b> Approve all calls to a specific tool with exactly matching arguments.</item>
 /// </list>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class ToolApprovalAgent : DelegatingAIAgent
 {
     private readonly ProviderSessionState<ToolApprovalState> _sessionState;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
-    private readonly Func<FunctionCallContent, ValueTask<bool>>[]? _autoApprovalRules;
+    private readonly Func<ToolAutoApprovalRuleContext, ValueTask<bool>>[]? _autoApprovalRules;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolApprovalAgent"/> class.
@@ -96,7 +93,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     /// of the tool name (<see cref="FunctionCallContent.Name"/>) or arguments. Only use this rule in a fully trusted context.
     /// </para>
     /// </remarks>
-    public static Func<FunctionCallContent, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
+    public static Func<ToolAutoApprovalRuleContext, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
         _ => new ValueTask<bool>(true);
 
     /// <inheritdoc />
@@ -106,8 +103,10 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
         AgentRunOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        var requestMessages = messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+
         // Steps 1–2: Unwrap AlwaysApprove wrappers, process any queued approval requests.
-        var (state, callerMessages, nextQueuedItem) = await this.PrepareInboundMessagesAsync(messages, session).ConfigureAwait(false);
+        var (state, callerMessages, nextQueuedItem) = await this.PrepareInboundMessagesAsync(requestMessages, session, options).ConfigureAwait(false);
 
         if (nextQueuedItem is not null)
         {
@@ -126,7 +125,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
             var response = await this.InnerAgent.RunAsync(processedMessages, session, options, cancellationToken).ConfigureAwait(false);
 
             // Classify approval requests: auto-approve matching, queue excess, keep first unapproved.
-            bool allAutoApproved = await this.ProcessAndQueueOutboundApprovalRequestsAsync(response.Messages, state, session).ConfigureAwait(false);
+            bool allAutoApproved = await this.ProcessAndQueueOutboundApprovalRequestsAsync(response.Messages, state, session, options, requestMessages).ConfigureAwait(false);
 
             if (!allAutoApproved)
             {
@@ -146,8 +145,10 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
         AgentRunOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        var requestMessages = messages as IReadOnlyCollection<ChatMessage> ?? messages.ToList();
+
         // Steps 1–2: Unwrap AlwaysApprove wrappers, process any queued approval requests.
-        var (state, callerMessages, nextQueuedItem) = await this.PrepareInboundMessagesAsync(messages, session).ConfigureAwait(false);
+        var (state, callerMessages, nextQueuedItem) = await this.PrepareInboundMessagesAsync(requestMessages, session, options).ConfigureAwait(false);
 
         if (nextQueuedItem is not null)
         {
@@ -234,7 +235,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
                     state.CollectedApprovalResponses.Add(
                         tarc.CreateResponse(approved: true, reason: "Auto-approved by standing rule"));
                 }
-                else if (await this.MatchesAutoApprovalRuleAsync(tarc).ConfigureAwait(false))
+                else if (await this.MatchesAutoApprovalRuleAsync(tarc, session, options, requestMessages).ConfigureAwait(false))
                 {
                     state.CollectedApprovalResponses.Add(
                         tarc.CreateResponse(approved: true, reason: "Auto-approved by auto-approval rule"));
@@ -326,7 +327,11 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     /// <summary>
     /// Re-evaluates queued approval requests against current rules and auto-approval rules, and auto-approves any that now match.
     /// </summary>
-    private async ValueTask DrainAutoApprovableFromQueueAsync(ToolApprovalState state)
+    private async ValueTask DrainAutoApprovableFromQueueAsync(
+        ToolApprovalState state,
+        AgentSession? session,
+        AgentRunOptions? options,
+        IReadOnlyCollection<ChatMessage> requestMessages)
     {
         for (int i = state.QueuedApprovalRequests.Count - 1; i >= 0; i--)
         {
@@ -336,7 +341,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
                     state.QueuedApprovalRequests[i].CreateResponse(approved: true, reason: "Auto-approved by standing rule"));
                 state.QueuedApprovalRequests.RemoveAt(i);
             }
-            else if (await this.MatchesAutoApprovalRuleAsync(state.QueuedApprovalRequests[i]).ConfigureAwait(false))
+            else if (await this.MatchesAutoApprovalRuleAsync(state.QueuedApprovalRequests[i], session, options, requestMessages).ConfigureAwait(false))
             {
                 state.CollectedApprovalResponses.Add(
                     state.QueuedApprovalRequests[i].CreateResponse(approved: true, reason: "Auto-approved by auto-approval rule"));
@@ -358,7 +363,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     /// When the returned item is non-null, the caller should return/yield it without calling the inner agent.
     /// </returns>
     private async ValueTask<(ToolApprovalState State, List<ChatMessage> CallerMessages, ToolApprovalRequestContent? NextQueuedItem)>
-        PrepareInboundMessagesAsync(IEnumerable<ChatMessage> messages, AgentSession? session)
+        PrepareInboundMessagesAsync(IReadOnlyCollection<ChatMessage> messages, AgentSession? session, AgentRunOptions? options)
     {
         var state = this._sessionState.GetOrInitializeState(session);
 
@@ -376,7 +381,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
 
             // Re-evaluate remaining queued items — the caller may have added new rules
             // (e.g., "always approve this tool") that resolve additional items.
-            await this.DrainAutoApprovableFromQueueAsync(state).ConfigureAwait(false);
+            await this.DrainAutoApprovableFromQueueAsync(state, session, options, messages).ConfigureAwait(false);
 
             if (state.QueuedApprovalRequests.Count > 0)
             {
@@ -428,7 +433,9 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     private async ValueTask<bool> ProcessAndQueueOutboundApprovalRequestsAsync(
         IList<ChatMessage> responseMessages,
         ToolApprovalState state,
-        AgentSession? session)
+        AgentSession? session,
+        AgentRunOptions? options,
+        IReadOnlyCollection<ChatMessage> requestMessages)
     {
         // Pass 1: Scan all response messages and classify each approval request.
         //         Auto-approved requests (matching a standing rule or auto-approval rule) have their
@@ -451,7 +458,7 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
                         toRemove.Add(tarc);
                         autoApprovedCount++;
                     }
-                    else if (await this.MatchesAutoApprovalRuleAsync(tarc).ConfigureAwait(false))
+                    else if (await this.MatchesAutoApprovalRuleAsync(tarc, session, options, requestMessages).ConfigureAwait(false))
                     {
                         state.CollectedApprovalResponses.Add(
                             tarc.CreateResponse(approved: true, reason: "Auto-approved by auto-approval rule"));
@@ -712,7 +719,11 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     /// <see langword="true"/> if any auto-approval rule returns <see langword="true"/> for the function call;
     /// <see langword="false"/> if no rules are configured, the request is not a function call, or no rule approves it.
     /// </returns>
-    private async ValueTask<bool> MatchesAutoApprovalRuleAsync(ToolApprovalRequestContent request)
+    private async ValueTask<bool> MatchesAutoApprovalRuleAsync(
+        ToolApprovalRequestContent request,
+        AgentSession? session,
+        AgentRunOptions? options,
+        IReadOnlyCollection<ChatMessage> requestMessages)
     {
         if (this._autoApprovalRules is not { Length: > 0 })
         {
@@ -724,9 +735,11 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
             return false;
         }
 
+        var context = new ToolAutoApprovalRuleContext(functionCall, this, session, requestMessages, options);
+
         foreach (var rule in this._autoApprovalRules)
         {
-            if (await rule(functionCall).ConfigureAwait(false))
+            if (await rule(context).ConfigureAwait(false))
             {
                 return true;
             }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentBuilderExtensions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -9,7 +7,6 @@ namespace Microsoft.Agents.AI;
 /// <summary>
 /// Provides extension methods for adding tool approval middleware to <see cref="AIAgentBuilder"/> instances.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class ToolApprovalAgentBuilderExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
@@ -2,18 +2,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Options for configuring the <see cref="ToolApprovalAgent"/> middleware.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public class ToolApprovalAgentOptions
 {
     /// <summary>
@@ -31,8 +27,9 @@ public class ToolApprovalAgentOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Each function receives a <see cref="FunctionCallContent"/> representing the tool call that requires approval
-    /// and returns a <see cref="ValueTask{Boolean}"/> that resolves to <see langword="true"/> to auto-approve
+    /// Each function receives a <see cref="ToolAutoApprovalRuleContext"/> describing the tool call that requires
+    /// approval (via <see cref="ToolAutoApprovalRuleContext.FunctionCallContent"/>) along with the surrounding run
+    /// context, and returns a <see cref="ValueTask{Boolean}"/> that resolves to <see langword="true"/> to auto-approve
     /// the call, or <see langword="false"/> to continue evaluating the next rule.
     /// </para>
     /// <para>
@@ -48,5 +45,5 @@ public class ToolApprovalAgentOptions
     /// otherwise that tool will be auto-approved without a human prompt, bypassing the approval boundary.
     /// </para>
     /// </remarks>
-    public IEnumerable<Func<FunctionCallContent, ValueTask<bool>>>? AutoApprovalRules { get; set; }
+    public IEnumerable<Func<ToolAutoApprovalRuleContext, ValueTask<bool>>>? AutoApprovalRules { get; set; }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalRequestContentExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalRequestContentExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -12,7 +10,6 @@ namespace Microsoft.Agents.AI;
 /// <see cref="AlwaysApproveToolApprovalResponseContent"/> instances that instruct the
 /// <see cref="ToolApprovalAgent"/> middleware to record standing approval rules.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public static class ToolApprovalRequestContentExtensions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalRule.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalRule.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -29,7 +27,6 @@ namespace Microsoft.Agents.AI;
 /// as a non-null dictionary so it cannot be silently broadened to all invocations of the tool.
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class ToolApprovalRule
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalState.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -12,7 +10,6 @@ namespace Microsoft.Agents.AI;
 /// Represents the persisted state of standing tool approval rules,
 /// stored in the session's <see cref="AgentSessionStateBag"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 internal sealed class ToolApprovalState
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolAutoApprovalRuleContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolAutoApprovalRuleContext.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// Provides context for a tool auto-approval rule evaluated by the <see cref="ToolApprovalAgent"/>.
+/// </summary>
+/// <remarks>
+/// This type wraps the <see cref="FunctionCallContent"/> that requires approval together with the
+/// surrounding run context (agent, session, request messages, and run options).
+/// </remarks>
+public sealed class ToolAutoApprovalRuleContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolAutoApprovalRuleContext"/> class.
+    /// </summary>
+    /// <param name="functionCallContent">The <see cref="FunctionCallContent"/> representing the tool call that requires approval.</param>
+    /// <param name="agent">The <see cref="AIAgent"/> that is evaluating the tool call.</param>
+    /// <param name="session">The <see cref="AgentSession"/> that is associated with the current run, if any.</param>
+    /// <param name="requestMessages">The request messages passed into the current run.</param>
+    /// <param name="agentRunOptions">The <see cref="AgentRunOptions"/> that was passed to the current run, if any.</param>
+    public ToolAutoApprovalRuleContext(
+        FunctionCallContent functionCallContent,
+        AIAgent agent,
+        AgentSession? session,
+        IReadOnlyCollection<ChatMessage> requestMessages,
+        AgentRunOptions? agentRunOptions)
+    {
+        this.FunctionCallContent = Throw.IfNull(functionCallContent);
+        this.Agent = Throw.IfNull(agent);
+        this.Session = session;
+        this.RequestMessages = Throw.IfNull(requestMessages);
+        this.RunOptions = agentRunOptions;
+    }
+
+    /// <summary>Gets the <see cref="FunctionCallContent"/> representing the tool call that requires approval.</summary>
+    public FunctionCallContent FunctionCallContent { get; }
+
+    /// <summary>Gets the <see cref="AIAgent"/> that is evaluating the tool call.</summary>
+    public AIAgent Agent { get; }
+
+    /// <summary>Gets the <see cref="AgentSession"/> that is associated with the current run.</summary>
+    public AgentSession? Session { get; }
+
+    /// <summary>Gets the request messages passed into the current run.</summary>
+    public IReadOnlyCollection<ChatMessage> RequestMessages { get; }
+
+    /// <summary>Gets the <see cref="AgentRunOptions"/> that was passed to the current run.</summary>
+    public AgentRunOptions? RunOptions { get; }
+}

--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -105,8 +105,8 @@ public sealed partial class AgentSkillsProvider : AIContextProvider, IDisposable
     /// human approval boundary. Ensure no other tool collides with these reserved names.
     /// </para>
     /// </remarks>
-    public static Func<FunctionCallContent, ValueTask<bool>> ReadOnlyToolsAutoApprovalRule { get; } =
-        functionCall => new ValueTask<bool>(s_readOnlyToolNames.Contains(functionCall.Name));
+    public static Func<ToolAutoApprovalRuleContext, ValueTask<bool>> ReadOnlyToolsAutoApprovalRule { get; } =
+        context => new ValueTask<bool>(s_readOnlyToolNames.Contains(context.FunctionCallContent.Name));
 
     /// <summary>
     /// Gets an auto-approval rule that approves all skill tools, including the script execution tool
@@ -138,8 +138,8 @@ public sealed partial class AgentSkillsProvider : AIContextProvider, IDisposable
     /// human approval boundary. Ensure no other tool collides with these reserved names.
     /// </para>
     /// </remarks>
-    public static Func<FunctionCallContent, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
-        functionCall => new ValueTask<bool>(s_allToolNames.Contains(functionCall.Name));
+    public static Func<ToolAutoApprovalRuleContext, ValueTask<bool>> AllToolsAutoApprovalRule { get; } =
+        context => new ValueTask<bool>(s_allToolNames.Contains(context.FunctionCallContent.Name));
 
     /// <summary>
     /// Placeholder token for the generated skills list in the prompt template.

--- a/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Harness.UnitTests/HarnessAgentTests.cs
@@ -683,7 +683,7 @@ public class HarnessAgentTests
         options.DisableToolAutoApproval = false;
         options.ToolApprovalAgentOptions = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => new ValueTask<bool>(fcc.Name == "ReadTool")]
+            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]
         };
 
         var agent = new HarnessAgent(mockClient.Object, options);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -20,6 +20,9 @@ public sealed class AgentSkillsProviderTests : IDisposable
     private readonly string _testRoot;
     private readonly TestAIAgent _agent = new();
 
+    private static ToolAutoApprovalRuleContext CreateRuleContext(FunctionCallContent functionCall) =>
+        new(functionCall, new TestAIAgent(), session: null, requestMessages: [], agentRunOptions: null);
+
     public AgentSkillsProviderTests()
     {
         this._testRoot = Path.Combine(Path.GetTempPath(), "skills-provider-tests-" + Guid.NewGuid().ToString("N"));
@@ -1155,12 +1158,12 @@ public sealed class AgentSkillsProviderTests : IDisposable
         var unrelatedCall = new FunctionCallContent("call4", "some_other_tool", null);
 
         // Act & Assert — read-only tools should be approved
-        Assert.True(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(loadSkillCall));
-        Assert.True(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(readResourceCall));
+        Assert.True(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(CreateRuleContext(loadSkillCall)));
+        Assert.True(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(CreateRuleContext(readResourceCall)));
 
         // Act & Assert — script tool and unrelated tools should not be approved
-        Assert.False(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(runScriptCall));
-        Assert.False(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(unrelatedCall));
+        Assert.False(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(CreateRuleContext(runScriptCall)));
+        Assert.False(await AgentSkillsProvider.ReadOnlyToolsAutoApprovalRule(CreateRuleContext(unrelatedCall)));
     }
 
     [Fact]
@@ -1173,12 +1176,12 @@ public sealed class AgentSkillsProviderTests : IDisposable
         var unrelatedCall = new FunctionCallContent("call4", "some_other_tool", null);
 
         // Act & Assert — all skill tools should be approved
-        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(loadSkillCall));
-        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(readResourceCall));
-        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(runScriptCall));
+        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(CreateRuleContext(loadSkillCall)));
+        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(CreateRuleContext(readResourceCall)));
+        Assert.True(await AgentSkillsProvider.AllToolsAutoApprovalRule(CreateRuleContext(runScriptCall)));
 
         // Act & Assert — unrelated tools should not be approved
-        Assert.False(await AgentSkillsProvider.AllToolsAutoApprovalRule(unrelatedCall));
+        Assert.False(await AgentSkillsProvider.AllToolsAutoApprovalRule(CreateRuleContext(unrelatedCall)));
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessProviderTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Agents.AI.UnitTests.Harness.FileAccess;
 
 public class FileAccessProviderTests
 {
+    private static ToolAutoApprovalRuleContext CreateRuleContext(FunctionCallContent functionCall) =>
+        new(functionCall, new Mock<AIAgent>().Object, session: null, requestMessages: [], agentRunOptions: null);
+
     #region Constructor Validation
 
     [Fact]
@@ -127,7 +130,7 @@ public class FileAccessProviderTests
         var functionCall = new FunctionCallContent("call1", toolName);
 
         // Act
-        bool approved = await FileAccessProvider.ReadOnlyToolsAutoApprovalRule(functionCall);
+        bool approved = await FileAccessProvider.ReadOnlyToolsAutoApprovalRule(CreateRuleContext(functionCall));
 
         // Assert
         Assert.Equal(expected, approved);
@@ -148,7 +151,7 @@ public class FileAccessProviderTests
         var functionCall = new FunctionCallContent("call1", toolName);
 
         // Act
-        bool approved = await FileAccessProvider.AllToolsAutoApprovalRule(functionCall);
+        bool approved = await FileAccessProvider.AllToolsAutoApprovalRule(CreateRuleContext(functionCall));
 
         // Assert
         Assert.Equal(expected, approved);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
@@ -1779,20 +1779,38 @@ public class ToolApprovalAgentTests
                 return new AgentResponse([new ChatMessage(ChatRole.Assistant, "Done")]);
             });
 
+        ToolAutoApprovalRuleContext? capturedContext = null;
+        var runOptions = new AgentRunOptions();
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]
+            AutoApprovalRules =
+            [
+                context =>
+                {
+                    capturedContext = context;
+                    return new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool");
+                }
+            ]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
         // Act
         var response = await agent.RunAsync(
             [new ChatMessage(ChatRole.User, "Hi")],
-            session);
+            session,
+            runOptions);
 
         // Assert — the approval request was auto-approved, inner agent called twice
         Assert.Equal(2, callCount);
         Assert.Equal("Done", response.Text);
+
+        // Assert — the auto-approval rule received a fully populated context (non-streaming path).
+        Assert.NotNull(capturedContext);
+        Assert.Same(agent, capturedContext!.Agent);
+        Assert.Same(session, capturedContext.Session);
+        Assert.Same(runOptions, capturedContext.RunOptions);
+        Assert.Equal("ReadTool", capturedContext.FunctionCallContent.Name);
+        Assert.Contains(capturedContext.RequestMessages, m => m.Text == "Hi");
     }
 
     /// <summary>
@@ -2032,15 +2050,24 @@ public class ToolApprovalAgentTests
                 return ToAsyncEnumerableAsync([new AgentResponseUpdate(ChatRole.Assistant, "Done")]);
             });
 
+        ToolAutoApprovalRuleContext? capturedContext = null;
+        var runOptions = new AgentRunOptions();
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]
+            AutoApprovalRules =
+            [
+                context =>
+                {
+                    capturedContext = context;
+                    return new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool");
+                }
+            ]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
         // Act
         var updates = new List<AgentResponseUpdate>();
-        await foreach (var update in agent.RunStreamingAsync([new ChatMessage(ChatRole.User, "Hi")], session))
+        await foreach (var update in agent.RunStreamingAsync([new ChatMessage(ChatRole.User, "Hi")], session, runOptions))
         {
             updates.Add(update);
         }
@@ -2049,6 +2076,14 @@ public class ToolApprovalAgentTests
         Assert.Equal(2, callCount);
         Assert.Single(updates);
         Assert.Equal("Done", updates[0].Text);
+
+        // Assert — the auto-approval rule received a fully populated context (streaming path).
+        Assert.NotNull(capturedContext);
+        Assert.Same(agent, capturedContext!.Agent);
+        Assert.Same(session, capturedContext.Session);
+        Assert.Same(runOptions, capturedContext.RunOptions);
+        Assert.Equal("ReadTool", capturedContext.FunctionCallContent.Name);
+        Assert.Contains(capturedContext.RequestMessages, m => m.Text == "Hi");
     }
 
     #endregion

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Agents.AI.UnitTests;
 /// </summary>
 public class ToolApprovalAgentTests
 {
+    private static ToolAutoApprovalRuleContext CreateRuleContext(FunctionCallContent functionCall) =>
+        new(functionCall, new Mock<AIAgent>().Object, session: null, requestMessages: [], agentRunOptions: null);
+
     #region Constructor
 
     /// <summary>
@@ -1690,7 +1693,7 @@ public class ToolApprovalAgentTests
         var functionCall = new FunctionCallContent("call1", toolName);
 
         // Act
-        bool approved = await ToolApprovalAgent.AllToolsAutoApprovalRule(functionCall);
+        bool approved = await ToolApprovalAgent.AllToolsAutoApprovalRule(CreateRuleContext(functionCall));
 
         // Assert
         Assert.True(approved);
@@ -1778,7 +1781,7 @@ public class ToolApprovalAgentTests
 
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => new ValueTask<bool>(fcc.Name == "ReadTool")]
+            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
@@ -1806,7 +1809,7 @@ public class ToolApprovalAgentTests
 
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => new ValueTask<bool>(fcc.Name == "ReadTool")]  // Only approves ReadTool
+            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]  // Only approves ReadTool
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
@@ -1857,8 +1860,8 @@ public class ToolApprovalAgentTests
         {
             AutoApprovalRules =
             [
-                fcc => { rule1Called = true; return new ValueTask<bool>(fcc.Name == "SpecialTool"); },
-                fcc => { rule2Called = true; return new ValueTask<bool>(true); }  // Should not be reached
+                context => { rule1Called = true; return new ValueTask<bool>(context.FunctionCallContent.Name == "SpecialTool"); },
+                context => { rule2Called = true; return new ValueTask<bool>(true); }  // Should not be reached
             ]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
@@ -1904,7 +1907,7 @@ public class ToolApprovalAgentTests
         var heuristicCalled = false;
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => { heuristicCalled = true; return new ValueTask<bool>(true); }]
+            AutoApprovalRules = [context => { heuristicCalled = true; return new ValueTask<bool>(true); }]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
@@ -1969,7 +1972,7 @@ public class ToolApprovalAgentTests
 
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => new ValueTask<bool>(fcc.Name == "HeuristicTool")]
+            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "HeuristicTool")]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 
@@ -2031,7 +2034,7 @@ public class ToolApprovalAgentTests
 
         var options = new ToolApprovalAgentOptions
         {
-            AutoApprovalRules = [fcc => new ValueTask<bool>(fcc.Name == "ReadTool")]
+            AutoApprovalRules = [context => new ValueTask<bool>(context.FunctionCallContent.Name == "ReadTool")]
         };
         var agent = new ToolApprovalAgent(innerAgent.Object, options);
 


### PR DESCRIPTION
### Motivation & Context

The Harness agent (`HarnessAgent`) is being prepared for release, but it depends on the
tool-approval feature which was still marked experimental. This PR graduates
`ToolApprovalAgent` and its related public types out of experimental status so they can ship
as part of the supported surface.

It also makes the auto-approval extension point future-proof. Auto-approval rules previously
received only a `FunctionCallContent`, which cannot gain additional inputs without breaking
every rule. Wrapping the input in a context object lets us add fields over time without
further breaking changes.

Part of the harness dependency graduation tracked by #6964.

### Description & Review Guide

- **What are the major changes?**
  - Removed the `[Experimental]` attribute (and now-unused usings) from the ToolApproval
    public types: `ToolApprovalAgent`, `ToolApprovalAgentOptions`,
    `ToolApprovalAgentBuilderExtensions`, `ToolApprovalRule`,
    `AlwaysApproveToolApprovalResponseContent`, `ToolApprovalRequestContentExtensions`,
    `ToolApprovalState`.
  - Added a new public `ToolAutoApprovalRuleContext` that wraps the `FunctionCallContent`
    together with the surrounding run context (`Agent`, `Session`, `RequestMessages`,
    `RunOptions`), mirroring `AgentRunContext`.
  - Changed the auto-approval rule delegate from
    `Func<FunctionCallContent, ValueTask<bool>>` to
    `Func<ToolAutoApprovalRuleContext, ValueTask<bool>>` on
    `ToolApprovalAgentOptions.AutoApprovalRules` and the built-in rules
    (`ToolApprovalAgent.AllToolsAutoApprovalRule`, and the `ReadOnly`/`AllTools` rules on
    `FileAccessProvider` and `AgentSkillsProvider`).
  - Threaded the run context (session, run options, request messages) through the
    `ToolApprovalAgent` run/streaming/queue-drain paths so it can be supplied to rules.

- **What is the impact of these changes?**
  - Breaking: the auto-approval rule delegate signature changed and the previously
    experimental types are now GA. Custom rules that used the `FunctionCallContent` parameter
    must now read `context.FunctionCallContent`.
  - The new context type allows additional fields to be added later without further breaking
    changes.

- **What do you want reviewers to focus on?**
  - The context plumbing in `ToolApprovalAgent` — that `Agent`/`Session`/`RequestMessages`/
    `RunOptions` are correctly populated on every code path (non-streaming, streaming, and the
    queued-request drain).

### Related Issue

Related to #6964

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
