### PR TITLE
Python: [BREAKING] Graduate file memory provider out of experimental

### DIFF
--- a/python/packages/core/agent_framework/_harness/_file_memory.py
+++ b/python/packages/core/agent_framework/_harness/_file_memory.py
@@ -40,7 +40,6 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
-from .._feature_stage import ExperimentalFeature, experimental
 from .._sessions import AgentSession, ContextProvider, SessionContext
 from .._tools import tool
 from .._types import Message
@@ -218,7 +217,6 @@ class _SearchFilesInput(BaseModel):
     ] = None
 
 
-@experimental(feature_id=ExperimentalFeature.HARNESS)
 class FileMemoryProvider(ContextProvider):
     """Context provider that gives an agent session-scoped, file-based memory.
 

--- a/python/packages/core/tests/core/test_harness_file_memory.py
+++ b/python/packages/core/tests/core/test_harness_file_memory.py
@@ -288,9 +288,10 @@ async def test_provider_accepts_custom_instructions() -> None:
     assert all(DEFAULT_FILE_MEMORY_INSTRUCTIONS not in chunk for chunk in context.instructions)
 
 
-def test_file_memory_provider_is_experimental() -> None:
-    """The provider should be marked experimental under the harness feature."""
-    assert getattr(FileMemoryProvider, "__feature_stage__", None) == "experimental"
+def test_file_memory_provider_is_not_experimental() -> None:
+    """The provider is graduated and should no longer carry experimental metadata."""
+    assert getattr(FileMemoryProvider, "__feature_stage__", None) is None
+    assert getattr(FileMemoryProvider, "__feature_id__", None) is None
 
 
 async def test_tools_reject_nested_paths() -> None:


### PR DESCRIPTION
### Motivation & Context

The Microsoft Agent Framework harness depends on several building-block features
that are still marked experimental. As part of releasing those dependencies (see
#6964), the **file memory** provider is now stable enough to graduate out of
experimental status so downstream users can rely on it without opting into
experimental warnings.

### Description & Review Guide

- **What are the major changes?**
  - Removed the `@experimental(feature_id=ExperimentalFeature.HARNESS)` decorator
    from `FileMemoryProvider` in `_harness/_file_memory.py`, along with the
    now-unused `_feature_stage` import.
  - Inverted the corresponding unit test into a graduation guard
    (`test_file_memory_provider_is_not_experimental`) asserting the provider no
    longer carries `__feature_stage__` / `__feature_id__` metadata.

- **What is the impact of these changes?**
  - `FileMemoryProvider` no longer emits experimental warnings.
  - **Breaking (experimental surface only):** graduating a preview API is marked
    breaking so preview users of the experimental harness are notified; no
    released API is broken.
  - The shared `ExperimentalFeature.HARNESS` id is intentionally retained (still
    referenced by other harness symbols that remain experimental).
  - The shared file-store types in `_file_access.py` (`AgentFileStore`,
    `InMemoryAgentFileStore`, `FileSystemAgentFileStore`, and the file DTOs)
    remain experimental and are intentionally out of scope here.

- **What do you want reviewers to focus on?**
  - That `FileMemoryProvider` (and its already-undecorated
    `DEFAULT_FILE_MEMORY_SOURCE_ID` / `DEFAULT_FILE_MEMORY_INSTRUCTIONS`
    constants) is the intended graduation scope, while the shared file-store
    types remain experimental.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Related to #6964

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
