### PR TITLE
.NET: [BREAKING] Graduate FileMemoryProvider

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileListEntry.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileListEntry.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -10,7 +8,6 @@ namespace Microsoft.Agents.AI;
 /// Represents a file entry returned by the <see cref="FileMemoryProvider"/> list (ls) tool,
 /// containing the file name, its entry type, and an optional description.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FileListEntry
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProvider.cs
@@ -3,12 +3,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.DiagnosticIds;
 using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
@@ -41,7 +39,6 @@ namespace Microsoft.Agents.AI;
 /// </list>
 /// </para>
 /// </remarks>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FileMemoryProvider : AIContextProvider, IDisposable
 {
     /// <summary>The name of the tool that writes a memory file.</summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProviderOptions.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Shared.DiagnosticIds;
-
 namespace Microsoft.Agents.AI;
 
 /// <summary>
 /// Options controlling the behavior of <see cref="FileMemoryProvider"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FileMemoryProviderOptions
 {
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryState.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using Microsoft.Shared.DiagnosticIds;
 
 namespace Microsoft.Agents.AI;
 
@@ -10,7 +8,6 @@ namespace Microsoft.Agents.AI;
 /// Represents the state of the <see cref="FileMemoryProvider"/>,
 /// stored in the session's <see cref="AgentSessionStateBag"/>.
 /// </summary>
-[Experimental(DiagnosticIds.Experiments.AgentsAIExperiments)]
 public sealed class FileMemoryState
 {
     /// <summary>


### PR DESCRIPTION
### Motivation & Context

The .NET `HarnessAgent` and its supporting building blocks are being graduated out of experimental/preview status so the harness can ship GA (tracked by #6964). `FileMemoryProvider` — the harness's durable, owner-keyed file-memory building block — was still marked `[Experimental(MAAI001)]`, which prevented it (and anything built on it) from being consumed without opting into experimental diagnostics. This PR graduates that provider and its directly related public types.

### Description & Review Guide

- **What are the major changes?**
  Removed the `[Experimental(MAAI001)]` attribute (and the now-orphaned `using System.Diagnostics.CodeAnalysis;` / `using Microsoft.Shared.DiagnosticIds;` usings) from the four `FileMemory` public types:
  - `FileMemoryProvider`
  - `FileMemoryProviderOptions`
  - `FileMemoryState`
  - `FileListEntry`

- **What is the impact of these changes?**
  These four types become part of the stable public API surface — callers no longer need `#pragma warning disable MAAI001` (or an equivalent `NoWarn`) to use them. Graduating public API out of experimental is a **breaking change** for existing experimental consumers, hence the `[BREAKING]` prefix.

  Note: `FileMemoryProvider`'s public constructor still takes an `AgentFileStore`, which remains `[Experimental]` (out of scope for this PR). Constructing the provider therefore still touches an experimental type until `AgentFileStore` is graduated separately.

- **What do you want reviewers to focus on?**
  That the graduation scope is limited to exactly these four `FileMemory` types and that no behavior changed — this is an attribute/using-only diff (4 files, 13 deletions).

### Related Issue

Related to #6964 (umbrella tracking issue — intentionally left open, this PR graduates only the `FileMemoryProvider` types).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
