### PR TITLE
Fix message ordering in workflow-hosted agents

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs
@@ -4,157 +4,121 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Workflows;
 
 internal sealed class MessageMerger
 {
-    private sealed class ResponseMergeState(string? responseId)
+    private sealed class MessageMergeState(string? messageId)
     {
-        public string? ResponseId { get; } = responseId;
+        public string? MessageId { get; } = messageId;
 
-        public Dictionary<string, List<AgentResponseUpdate>> UpdatesByMessageId { get; } = [];
-        public List<AgentResponseUpdate> DanglingUpdates { get; } = [];
+        public List<AgentResponseUpdate> Updates { get; } = [];
 
-        public void AddUpdate(AgentResponseUpdate update)
+        public AgentResponse ComputeMerged(string? responseId)
         {
-            if (update.MessageId is null)
+            if (this.Updates.Count == 0)
             {
-                this.DanglingUpdates.Add(update);
-            }
-            else
-            {
-                if (!this.UpdatesByMessageId.TryGetValue(update.MessageId, out List<AgentResponseUpdate>? updates))
-                {
-                    this.UpdatesByMessageId[update.MessageId] = updates = [];
-                }
-
-                updates.Add(update);
-            }
-        }
-
-        public AgentResponse ComputeMerged(string messageId)
-        {
-            if (this.UpdatesByMessageId.TryGetValue(Throw.IfNull(messageId), out List<AgentResponseUpdate>? updates))
-            {
-                return updates.ToAgentResponse();
+                throw new InvalidOperationException($"No updates found for message ID '{this.MessageId}' in response '{responseId}'.");
             }
 
-            throw new KeyNotFoundException($"No updates found for message ID '{messageId}' in response '{this.ResponseId}'.");
-        }
-
-        public AgentResponse ComputeDangling()
-        {
-            if (this.DanglingUpdates.Count == 0)
-            {
-                throw new InvalidOperationException("No dangling updates to compute a response from.");
-            }
-
-            return this.DanglingUpdates.ToAgentResponse();
-        }
-
-        public List<ChatMessage> ComputeFlattened()
-        {
-            List<ChatMessage> result = this.UpdatesByMessageId.Keys.SelectMany(AggregateUpdatesToMessage).ToList();
-            if (this.DanglingUpdates.Count > 0)
-            {
-                result.AddRange(this.ComputeDangling().Messages);
-            }
-
-            return result;
-
-            IList<ChatMessage> AggregateUpdatesToMessage(string messageId)
-            {
-                List<AgentResponseUpdate> updates = this.UpdatesByMessageId[messageId];
-                if (updates.Count == 0)
-                {
-                    throw new InvalidOperationException($"No updates found for message ID '{messageId}' in response '{this.ResponseId}'.");
-                }
-
-                return updates.Select(oldUpdate => oldUpdate.AsChatResponseUpdate()).ToChatResponse().Messages;
-            }
+            return this.Updates.ToAgentResponse();
         }
     }
 
+    private sealed class ResponseMergeState(string? responseId)
+    {
+        private readonly Dictionary<string, MessageMergeState> _messageStates = [];
+        private readonly List<MessageMergeState> _messageStatesInOrder = [];
+        private MessageMergeState? _lastObservedState;
+
+        public string? ResponseId { get; } = responseId;
+
+        public void AddUpdate(AgentResponseUpdate update)
+        {
+            MessageMergeState state = this.GetOrCreateMessageState(update.MessageId);
+            state.Updates.Add(update);
+            this._lastObservedState = state;
+        }
+
+        private MessageMergeState GetOrCreateMessageState(string? messageId)
+        {
+            if (messageId is null)
+            {
+                if (this._lastObservedState is { MessageId: null })
+                {
+                    return this._lastObservedState;
+                }
+
+                MessageMergeState state = new(null);
+                this._messageStatesInOrder.Add(state);
+                return state;
+            }
+
+            if (!this._messageStates.TryGetValue(messageId, out MessageMergeState? existingState))
+            {
+                existingState = new(messageId);
+                this._messageStates[messageId] = existingState;
+                this._messageStatesInOrder.Add(existingState);
+            }
+
+            return existingState;
+        }
+
+        public List<AgentResponse> ComputeMerged()
+            => this._messageStatesInOrder.ConvertAll(state => state.ComputeMerged(this.ResponseId));
+
+        public List<ChatMessage> ComputeFlattened()
+            => this.ComputeMerged().SelectMany(response => response.Messages).ToList();
+    }
+
     private readonly Dictionary<string, ResponseMergeState> _mergeStates = [];
+    private readonly List<string> _responseIdsInOrder = [];
     private readonly ResponseMergeState _danglingState = new(null);
 
     public void AddUpdate(AgentResponseUpdate update)
     {
         if (update.ResponseId is null)
         {
-            this._danglingState.DanglingUpdates.Add(update);
+            this._danglingState.AddUpdate(update);
         }
         else
         {
             if (!this._mergeStates.TryGetValue(update.ResponseId, out ResponseMergeState? state))
             {
                 this._mergeStates[update.ResponseId] = state = new ResponseMergeState(update.ResponseId);
+                this._responseIdsInOrder.Add(update.ResponseId);
             }
 
             state.AddUpdate(update);
         }
     }
 
-    private int CompareByDateTimeOffset(AgentResponse left, AgentResponse right)
-    {
-        const int LESS = -1, EQ = 0, GREATER = 1;
-
-        if (left.CreatedAt == right.CreatedAt)
-        {
-            return EQ;
-        }
-
-        if (!left.CreatedAt.HasValue)
-        {
-            return GREATER;
-        }
-
-        if (!right.CreatedAt.HasValue)
-        {
-            return LESS;
-        }
-
-        return left.CreatedAt.Value.CompareTo(right.CreatedAt.Value);
-    }
-
     public AgentResponse ComputeMerged(string primaryResponseId, string? primaryAgentId = null, string? primaryAgentName = null)
     {
         List<ChatMessage> messages = [];
-        Dictionary<string, AgentResponse> responses = [];
+        List<AgentResponse> responses = [];
         HashSet<string> agentIds = [];
         HashSet<ChatFinishReason> finishReasons = [];
 
-        foreach (string responseId in this._mergeStates.Keys)
+        foreach (string responseId in this._responseIdsInOrder)
         {
             ResponseMergeState mergeState = this._mergeStates[responseId];
 
-            List<AgentResponse> responseList = mergeState.UpdatesByMessageId.Keys.Select(mergeState.ComputeMerged).ToList();
-            if (mergeState.DanglingUpdates.Count > 0)
-            {
-                responseList.Add(mergeState.ComputeDangling());
-            }
-
-            responseList.Sort(this.CompareByDateTimeOffset);
-            responses[responseId] = responseList.Aggregate(MergeResponses);
-            messages.AddRange(GetMessagesWithCreatedAt(responses[responseId]));
+            List<AgentResponse> responseList = mergeState.ComputeMerged();
+            AgentResponse response = responseList.Aggregate(MergeResponses);
+            responses.Add(response);
+            messages.AddRange(GetMessagesWithCreatedAt(response));
         }
 
         UsageDetails? usage = null;
         AdditionalPropertiesDictionary? additionalProperties = null;
-        HashSet<DateTimeOffset> createdTimes = [];
 
-        foreach (AgentResponse response in responses.Values)
+        foreach (AgentResponse response in responses)
         {
             if (response.AgentId is not null)
             {
                 agentIds.Add(response.AgentId);
-            }
-
-            if (response.CreatedAt.HasValue)
-            {
-                createdTimes.Add(response.CreatedAt.Value);
             }
 
             if (response.FinishReason.HasValue)
@@ -242,8 +206,9 @@ internal sealed class MessageMerger
                     AuthorName = message.AuthorName,
                     Contents = message.Contents,
                     MessageId = message.MessageId,
-                    CreatedAt = createdAt,
-                    RawRepresentation = message.RawRepresentation
+                    CreatedAt = message.CreatedAt ?? createdAt,
+                    RawRepresentation = message.RawRepresentation,
+                    AdditionalProperties = message.AdditionalProperties
                 });
         }
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Specialized/HandoffAgentExecutor.cs
@@ -427,10 +427,9 @@ internal sealed class HandoffAgentExecutor :
         AgentResponse response;
 
         AIAgentUnservicedRequestsCollector collector = new(this._userInputHandler, this._functionCallHandler);
-
         string? requestedHandoff = null;
         List<AgentResponseUpdate> updates = [];
-        List<FunctionCallContent> candidateRequests = [];
+        List<(FunctionCallContent Request, string? ResponseId)> candidateRequests = [];
 
         this._session ??= await this._agent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
 
@@ -448,7 +447,7 @@ internal sealed class HandoffAgentExecutor :
                 bool isHandoffRequest = this._handoffFunctionNames.Contains(candidateHandoffRequest.Name);
                 if (isHandoffRequest)
                 {
-                    candidateRequests.Add(candidateHandoffRequest);
+                    candidateRequests.Add((candidateHandoffRequest, update.ResponseId));
                 }
 
                 return !isHandoffRequest;
@@ -457,13 +456,13 @@ internal sealed class HandoffAgentExecutor :
 
         if (candidateRequests.Count > 1)
         {
-            string message = $"Duplicate handoff requests in single turn ([{string.Join(", ", candidateRequests.Select(request => request.Name))}]). Using last ({candidateRequests.Last().Name})";
+            string message = $"Duplicate handoff requests in single turn ([{string.Join(", ", candidateRequests.Select(candidate => candidate.Request.Name))}]). Using last ({candidateRequests.Last().Request.Name})";
             await context.AddEventAsync(new WorkflowWarningEvent(message), cancellationToken).ConfigureAwait(false);
         }
 
         if (candidateRequests.Count > 0)
         {
-            FunctionCallContent handoffRequest = candidateRequests[candidateRequests.Count - 1];
+            (FunctionCallContent handoffRequest, string? handoffResponseId) = candidateRequests[candidateRequests.Count - 1];
             requestedHandoff = handoffRequest.Name;
 
             await AddUpdateAsync(
@@ -474,6 +473,7 @@ internal sealed class HandoffAgentExecutor :
                         Contents = [CreateHandoffResult(handoffRequest.CallId)],
                         CreatedAt = DateTimeOffset.UtcNow,
                         MessageId = Guid.NewGuid().ToString("N"),
+                        ResponseId = handoffResponseId,
                         Role = ChatRole.Tool,
                     },
                     cancellationToken

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/HandoffOrchestrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/HandoffOrchestrationTests.cs
@@ -322,6 +322,96 @@ public class HandoffOrchestrationTests
     }
 
     [Fact]
+    public async Task Handoffs_MultipleTransfers_AsAgentPreservesCallResultOrderAsync()
+    {
+        // Arrange
+        string[] expected = ["call:call1", "result:call1", "call:call2", "result:call2", "text:Hello from agent3"];
+
+        AIAgent nonStreamingAgent = CreateThreeAgentHandoffWorkflow().AsAIAgent(name: "HandoffWorkflow");
+        AgentSession nonStreamingSession = await nonStreamingAgent.CreateSessionAsync();
+
+        AIAgent streamingAgent = CreateThreeAgentHandoffWorkflow().AsAIAgent(name: "StreamingHandoffWorkflow");
+        AgentSession streamingSession = await streamingAgent.CreateSessionAsync();
+
+        // Act
+        AgentResponse nonStreamingResponse = await nonStreamingAgent.RunAsync("abc", nonStreamingSession);
+
+        List<AgentResponseUpdate> streamingUpdates = [];
+        await foreach (AgentResponseUpdate update in streamingAgent.RunStreamingAsync("abc", streamingSession))
+        {
+            if (update.Contents.Count > 0)
+            {
+                streamingUpdates.Add(update);
+            }
+        }
+        AgentResponse streamingResponse = streamingUpdates.ToAgentResponse();
+
+        // Assert
+        GetMessageSequence(nonStreamingResponse.Messages).Should().Equal(expected);
+        GetMessageSequence(streamingResponse.Messages).Should().Equal(expected);
+
+        WorkflowSession nonStreamingWorkflowSession = Assert.IsType<WorkflowSession>(nonStreamingSession);
+        WorkflowSession streamingWorkflowSession = Assert.IsType<WorkflowSession>(streamingSession);
+
+        GetMessageSequence(nonStreamingWorkflowSession.ChatHistoryProvider.GetAllMessages(nonStreamingWorkflowSession).Skip(1)).Should().Equal(expected);
+        GetMessageSequence(streamingWorkflowSession.ChatHistoryProvider.GetAllMessages(streamingWorkflowSession).Skip(1)).Should().Equal(expected);
+    }
+
+    [Fact]
+    public async Task Handoffs_ReturnToInitialAgent_AsAgentKeepsInvocationsSeparateAsync()
+    {
+        // Arrange
+        int initialAgentInvocationCount = 0;
+
+        var initialAgent = new ChatClientAgent(new MockChatClient((messages, options) =>
+        {
+            initialAgentInvocationCount++;
+            if (initialAgentInvocationCount == 1)
+            {
+                string? transferFuncName = options?.Tools?.FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+                Assert.NotNull(transferFuncName);
+                return new(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("call1", transferFuncName)]) { MessageId = "message-initial-1" })
+                {
+                    ResponseId = "response-initial-1",
+                };
+            }
+
+            return new(new ChatMessage(ChatRole.Assistant, "Final response") { MessageId = "message-initial-2" })
+            {
+                ResponseId = "response-initial-2",
+            };
+        }), name: "initialAgent");
+
+        var secondAgent = new ChatClientAgent(new MockChatClient((messages, options) =>
+        {
+            string? transferFuncName = options?.Tools?.FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+            Assert.NotNull(transferFuncName);
+            return new(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("call2", transferFuncName)]) { MessageId = "message-second" })
+            {
+                ResponseId = "response-second",
+            };
+        }), name: "secondAgent", description: "The second agent");
+
+        Workflow workflow = AgentWorkflowBuilder.CreateHandoffBuilderWith(initialAgent)
+            .WithHandoff(initialAgent, secondAgent)
+            .WithHandoff(secondAgent, initialAgent)
+            .Build();
+        AIAgent hostAgent = workflow.AsAIAgent(name: "PingPongHandoffWorkflow");
+
+        // Act
+        AgentResponse response = await hostAgent.RunAsync("abc");
+
+        // Assert
+        initialAgentInvocationCount.Should().Be(2);
+        GetMessageSequence(response.Messages).Should().Equal(
+            "call:call1",
+            "result:call1",
+            "call:call2",
+            "result:call2",
+            "text:Final response");
+    }
+
+    [Fact]
     public async Task Handoffs_FilteringNone_HandoffTargetReceivesAllMessagesIncludingToolCallsAsync()
     {
         // With filtering set to None, the target agent should see everything including
@@ -1537,6 +1627,57 @@ public class HandoffOrchestrationTests
     private static Task<WorkflowRunResult> RunWorkflowAsync(
         Workflow workflow, List<ChatMessage> input, ExecutionEnvironment executionEnvironment = ExecutionEnvironment.InProcess_Lockstep)
         => RunWorkflowCheckpointedAsync(workflow, input, executionEnvironment.ToWorkflowExecutionEnvironment());
+
+    private static Workflow CreateThreeAgentHandoffWorkflow()
+    {
+        var initialAgent = new ChatClientAgent(new MockChatClient((messages, options) =>
+        {
+            string? transferFuncName = options?.Tools?.FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+            Assert.NotNull(transferFuncName);
+            return new(new ChatMessage(ChatRole.Assistant, [new TextContent("Routing to second agent"), new FunctionCallContent("call1", transferFuncName)]))
+            {
+                ResponseId = "response-initial",
+            };
+        }), name: "initialAgent");
+
+        var secondAgent = new ChatClientAgent(new MockChatClient((messages, options) =>
+        {
+            string? transferFuncName = options?.Tools?.FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+            Assert.NotNull(transferFuncName);
+            return new(new ChatMessage(ChatRole.Assistant, [new TextContent("Routing to third agent"), new FunctionCallContent("call2", transferFuncName)]))
+            {
+                ResponseId = "response-second",
+            };
+        }), name: "secondAgent", description: "The second agent");
+
+        var thirdAgent = new ChatClientAgent(new MockChatClient((messages, options) =>
+            new(new ChatMessage(ChatRole.Assistant, "Hello from agent3") { MessageId = "message-third" })
+            {
+                ResponseId = "response-third",
+            }),
+            name: "thirdAgent",
+            description: "The third agent");
+
+        return AgentWorkflowBuilder.CreateHandoffBuilderWith(initialAgent)
+            .WithHandoff(initialAgent, secondAgent)
+            .WithHandoff(secondAgent, thirdAgent)
+            .Build();
+    }
+
+    private static string[] GetMessageSequence(IEnumerable<ChatMessage> messages)
+    {
+        return messages.Select(message =>
+        {
+            FunctionCallContent? call = message.Contents.OfType<FunctionCallContent>().FirstOrDefault();
+            if (call is not null)
+            {
+                return $"call:{call.CallId}";
+            }
+
+            FunctionResultContent? result = message.Contents.OfType<FunctionResultContent>().FirstOrDefault();
+            return result is not null ? $"result:{result.CallId}" : $"text:{message.Text}";
+        }).ToArray();
+    }
 
     private sealed class CapturingAgent(string name, string description, string textToCapture) : AIAgent
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MessageMergerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MessageMergerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
 
@@ -70,5 +71,146 @@ public class MessageMergerTests
 
         // Assert - FinishReason from the update should propagate through
         response.FinishReason.Should().Be(ChatFinishReason.ContentFilter);
+    }
+
+    [Fact]
+    public void Test_MessageMerger_PreservesFirstSeenMessageOrder()
+    {
+        // Arrange
+        string responseId = Guid.NewGuid().ToString("N");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        MessageMerger merger = new();
+
+        AddTextMessage(merger, responseId, "first", now.AddMinutes(1));
+        AddTextMessage(merger, responseId, "second", null);
+        AddTextMessage(merger, responseId, "third", now.AddMinutes(-1));
+        AddTextMessage(merger, responseId, "fourth", now.AddMinutes(-1));
+
+        // Act
+        AgentResponse response = merger.ComputeMerged(responseId);
+
+        // Assert
+        response.Messages.Select(message => message.Text).Should().Equal("first", "second", "third", "fourth");
+        response.Messages[0].CreatedAt.Should().Be(now.AddMinutes(1));
+        response.Messages[2].CreatedAt.Should().Be(now.AddMinutes(-1));
+    }
+
+    [Fact]
+    public void Test_MessageMerger_KeepsResponsesContiguousInFirstSeenOrder()
+    {
+        // Arrange
+        const string ResponseId1 = "response-1";
+        const string ResponseId2 = "response-2";
+        MessageMerger merger = new();
+
+        AddTextMessage(merger, ResponseId1, "A1");
+        AddTextMessage(merger, ResponseId2, "B1");
+        AddTextMessage(merger, ResponseId1, "A2");
+        AddTextMessage(merger, ResponseId2, "B2");
+
+        // Act
+        AgentResponse response = merger.ComputeMerged(ResponseId1);
+
+        // Assert
+        response.Messages.Select(message => message.Text).Should().Equal("A1", "A2", "B1", "B2");
+    }
+
+    [Fact]
+    public void Test_MessageMerger_PreservesFunctionCallResultOrder()
+    {
+        // Arrange
+        const string ResponseId = "response";
+        const string CallId = "call";
+        MessageMerger merger = new();
+
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            ResponseId = ResponseId,
+            MessageId = "call-message",
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent(CallId, "handoff")],
+        });
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            ResponseId = ResponseId,
+            MessageId = "result-message",
+            Role = ChatRole.Tool,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [new FunctionResultContent(CallId, "Transferred.")],
+        });
+
+        // Act
+        AgentResponse response = merger.ComputeMerged(ResponseId);
+
+        // Assert
+        response.Messages.Should().HaveCount(2);
+        Assert.Equal(CallId, Assert.IsType<FunctionCallContent>(Assert.Single(response.Messages[0].Contents)).CallId);
+        Assert.Equal(CallId, Assert.IsType<FunctionResultContent>(Assert.Single(response.Messages[1].Contents)).CallId);
+    }
+
+    [Fact]
+    public void Test_MessageMerger_PreservesIdentifierlessMessageOrder()
+    {
+        // Arrange
+        const string ResponseId = "response";
+        const string CallId = "call";
+        MessageMerger merger = new();
+
+        AddTextMessage(merger, ResponseId, "before");
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            ResponseId = ResponseId,
+            Role = ChatRole.Assistant,
+            Contents = [new FunctionCallContent(CallId, "handoff")],
+        });
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            ResponseId = ResponseId,
+            MessageId = "result-message",
+            Role = ChatRole.Tool,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [new FunctionResultContent(CallId, "Transferred.")],
+        });
+
+        // Act
+        AgentResponse response = merger.ComputeMerged(ResponseId);
+
+        // Assert
+        response.Messages.Should().HaveCount(3);
+        response.Messages[0].Text.Should().Be("before");
+        Assert.IsType<FunctionCallContent>(Assert.Single(response.Messages[1].Contents));
+        Assert.IsType<FunctionResultContent>(Assert.Single(response.Messages[2].Contents));
+    }
+
+    [Fact]
+    public void Test_MessageMerger_SeparatesIdentifierlessSegments()
+    {
+        // Arrange
+        const string ResponseId = "response";
+        const string MessageId = "message";
+        MessageMerger merger = new();
+
+        merger.AddUpdate(new AgentResponseUpdate(ChatRole.Assistant, "A") { ResponseId = ResponseId, MessageId = MessageId });
+        merger.AddUpdate(new AgentResponseUpdate(ChatRole.Tool, "X") { ResponseId = ResponseId });
+        merger.AddUpdate(new AgentResponseUpdate(ChatRole.Assistant, "B") { ResponseId = ResponseId, MessageId = MessageId });
+        merger.AddUpdate(new AgentResponseUpdate(ChatRole.Tool, "Y") { ResponseId = ResponseId });
+
+        // Act
+        AgentResponse response = merger.ComputeMerged(ResponseId);
+
+        // Assert
+        response.Messages.Select(message => message.Text).Should().Equal("AB", "X", "Y");
+    }
+
+    private static void AddTextMessage(MessageMerger merger, string responseId, string text, DateTimeOffset? createdAt = null)
+    {
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            ResponseId = responseId,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Role = ChatRole.Assistant,
+            CreatedAt = createdAt,
+            Contents = [new TextContent(text)],
+        });
     }
 }


### PR DESCRIPTION
### Motivation & Context

When a handoff workflow was used as an agent, non-streaming responses and saved history could move a tool result away from its matching tool call. This produced invalid conversation history, potentially causing provider errors on later turns, while streaming output appeared correct and hid the problem.

### Description & Review Guide

Fixes handoff tool results being separated from their matching tool calls. Messages now preserve their produced order within each agent response while keeping concurrent responses grouped correctly.

Fixes #5720 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
