### PR TITLE
Python: fix compaction token count inflating non-ASCII text

### DIFF
--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -515,7 +515,9 @@ def _serialize_message(message: Message) -> str:
         "message_id": message.message_id,
         "contents": serialized_contents,
     }
-    return json.dumps(payload, ensure_ascii=True, sort_keys=True, default=str)
+    # ensure_ascii=False so non-ASCII text (e.g. CJK) is token-counted as the
+    # actual characters the model sees, not as inflated ``\uXXXX`` escapes.
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
 
 
 def annotate_token_counts(

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -35,6 +35,7 @@ from agent_framework import (
     included_token_count,
 )
 from agent_framework._compaction import (
+    _serialize_message,
     append_compaction_message,
     extend_compaction_messages,
 )
@@ -1293,3 +1294,19 @@ def test_context_window_strategy_validates_thresholds() -> None:
             tool_eviction_threshold=0.8,
             truncation_threshold=0.5,
         )
+
+
+def test_serialize_message_preserves_non_ascii_for_token_count() -> None:
+    """Non-ASCII text is token-counted as the characters the model sees, not as
+    inflated ``\\uXXXX`` escapes, so the token estimate isn't skewed (#7022)."""
+    text = "こんにちは、元気ですか"
+    message = Message(role="user", contents=[text])
+    tokenizer = CharacterEstimatorTokenizer()
+
+    serialized = _serialize_message(message)
+    # the same payload as it would serialize with ensure_ascii=True
+    escaped = serialized.encode("ascii", "backslashreplace").decode("ascii")
+
+    assert text in serialized
+    assert "\\u3053" not in serialized
+    assert tokenizer.count_tokens(serialized) < tokenizer.count_tokens(escaped)


### PR DESCRIPTION
## Motivation and Context

`TokenBudgetComposedStrategy` estimates a message's token count by feeding its JSON serialization to the tokenizer. `_serialize_message()` built that JSON with `ensure_ascii=True`, which escapes non-ASCII text into `\uXXXX` sequences. The tokenizer then counts the escape sequences instead of the characters the model actually tokenizes — e.g. `こんにちは` is counted as `こんにちは`. For non-Latin content this inflates the estimate (~1.6x for a mixed Japanese message with the built-in `CharacterEstimatorTokenizer`, and more for pure CJK), so compaction and token-budget decisions fire on numbers that diverge from real LLM usage.

## Description

Serialize with `ensure_ascii=False` so non-ASCII text is token-counted as the characters the model sees. This matches the `ensure_ascii=False` already used elsewhere in the same module, and it only affects token estimation — the serialized string is never stored or transmitted. Added a regression test that asserts the serialized payload keeps the real characters (no `\uXXXX`) and that its token count is lower than the escaped form's.

### Related Issue

Fixes #7022

## Contribution Checklist

- [x] The code builds and tests pass locally (`pytest tests/core/test_compaction.py`, ruff format + check clean)
- [x] I have added a test that proves the fix is effective
- [x] The PR is linked to an issue with a closing keyword
- [x] The change is focused and does not touch unrelated code
