### PR TITLE
.NET: Fix LocalCodeAct validation and package checks

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -163,6 +163,7 @@ jobs:
           # Change to project directory to ensure local nuget.config is used
           pushd consoleapp
           dotnet add packcheck.csproj package Microsoft.Agents.AI --prerelease
+          dotnet add packcheck.csproj package Microsoft.Agents.AI.LocalCodeAct --prerelease
           dotnet build -f ${{ matrix.targetFramework }} -c ${{ matrix.configuration }} packcheck.csproj
 
           # Clean up

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Resources/validator.py
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Resources/validator.py
@@ -271,6 +271,7 @@ class _CodeValidator(ast.NodeVisitor):
         self._allowed_builtins = allowed_builtins if allowed_builtins is not None else ALLOWED_BUILTINS
         self._blocked_builtins = blocked_builtins if blocked_builtins is not None else BLOCKED_BUILTINS
         self._allowed_os_attrs = allowed_os_attrs if allowed_os_attrs is not None else ALLOWED_OS_ATTRS
+        self._os_aliases: set[str] = {"os"}
 
     def validate(self, code: str) -> None:
         """Validate code and raise CodeValidationError if it violates policy."""
@@ -303,6 +304,10 @@ class _CodeValidator(ast.NodeVisitor):
                 self._errors.append(f"Import of '{alias_node.name}' is not allowed (blocked: {module_name})")
             elif module_name not in self._allowed_imports:
                 self._errors.append(f"Import of '{alias_node.name}' is not allowed (not in allow-list)")
+            if alias_node.name == "os":
+                self._os_aliases.add(alias_node.asname or "os")
+            elif alias_node.name.startswith("os.") and alias_node.asname is None:
+                self._os_aliases.add("os")
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
@@ -322,6 +327,24 @@ class _CodeValidator(ast.NodeVisitor):
             for alias_node in node.names:
                 if alias_node.name not in self._allowed_os_attrs:
                     self._errors.append(f"Import from 'os' of '{alias_node.name}' is not allowed")
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """Track re-bindings of the ``os`` module."""
+        if isinstance(node.value, ast.Name) and node.value.id in self._os_aliases:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    self._os_aliases.add(target.id)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        """Track annotated re-bindings of the ``os`` module."""
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id in self._os_aliases
+            and isinstance(node.target, ast.Name)
+        ):
+            self._os_aliases.add(node.target.id)
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -357,7 +380,7 @@ class _CodeValidator(ast.NodeVisitor):
         # Enforce the `os` attribute allow-list. Anything outside `ALLOWED_OS_ATTRS`
         # (file I/O, process control, mutating helpers, etc.) is rejected so the
         # validator matches the documented `os.environ` / `os.path`-only contract.
-        if isinstance(node.value, ast.Name) and node.value.id == "os" and node.attr not in self._allowed_os_attrs:
+        if isinstance(node.value, ast.Name) and node.value.id in self._os_aliases and node.attr not in self._allowed_os_attrs:
             self._errors.append(f"Access to os.{node.attr} is not allowed")
 
         # Block access to certain dangerous attributes

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Resources/validator.py
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Resources/validator.py
@@ -281,6 +281,7 @@ class _CodeValidator(ast.NodeVisitor):
             raise CodeValidationError(f"Syntax error in generated code: {exc}") from exc
 
         self._errors = []
+        self._os_aliases = {"os"}
         self.visit(tree)
 
         if self._errors:
@@ -331,10 +332,8 @@ class _CodeValidator(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         """Track re-bindings of the ``os`` module."""
-        if isinstance(node.value, ast.Name) and node.value.id in self._os_aliases:
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    self._os_aliases.add(target.id)
+        for target in node.targets:
+            self._track_os_alias_targets(target, node.value)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
@@ -346,6 +345,16 @@ class _CodeValidator(ast.NodeVisitor):
         ):
             self._os_aliases.add(node.target.id)
         self.generic_visit(node)
+
+    def _track_os_alias_targets(self, target: ast.AST, value: ast.AST) -> None:
+        if isinstance(target, ast.Starred):
+            target = target.value
+
+        if isinstance(target, ast.Name) and isinstance(value, ast.Name) and value.id in self._os_aliases:
+            self._os_aliases.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
+            for target_item, value_item in zip(target.elts, value.elts):
+                self._track_os_alias_targets(target_item, value_item)
 
     def visit_Call(self, node: ast.Call) -> None:
         """Validate function calls.

--- a/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
@@ -70,6 +70,9 @@ public sealed class LocalExecuteCodeFunctionIntegrationTests
     [InlineData("import os\n_o = os\n_o.system('id')")]
     [InlineData("import os as x\na = x\nb = a\nb.popen('id')")]
     [InlineData("import os.path\nos.system('id')")]
+    [InlineData("import os\na, _ = (os, 1)\na.system('id')")]
+    [InlineData("import os\n[a, _] = [os, 1]\na.system('id')")]
+    [InlineData("import os\nx: object = os\nx.system('id')")]
     public async Task ExecuteCode_ValidationBlocksDisallowedOsAccessAsync(string code)
     {
         SkipIfNoPython();

--- a/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
@@ -64,6 +64,47 @@ public sealed class LocalExecuteCodeFunctionIntegrationTests
             await function.InvokeAsync(args, CancellationToken.None));
     }
 
+    [Theory]
+    [InlineData("import os\nos.system('id')")]
+    [InlineData("import os as x\nx.system('id')")]
+    [InlineData("import os\n_o = os\n_o.system('id')")]
+    [InlineData("import os as x\na = x\nb = a\nb.popen('id')")]
+    [InlineData("import os.path\nos.system('id')")]
+    public async Task ExecuteCode_ValidationBlocksDisallowedOsAccessAsync(string code)
+    {
+        SkipIfNoPython();
+
+        var function = new LocalExecuteCodeFunction(s_python!);
+
+        var args = new AIFunctionArguments
+        {
+            ["code"] = code,
+        };
+
+        var ex = await Assert.ThrowsAsync<CodeValidationException>(async () =>
+            await function.InvokeAsync(args, CancellationToken.None));
+        Assert.Contains("os.", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("import os\nprint(os.environ.get('PATH') is not None)")]
+    [InlineData("import os as x\nprint(x.path.join('a', 'b'))")]
+    [InlineData("import os.path as p\nprint(p.join('a', 'b'))")]
+    public async Task ExecuteCode_AllowsPermittedOsAccessAsync(string code)
+    {
+        SkipIfNoPython();
+
+        var function = new LocalExecuteCodeFunction(s_python!);
+
+        var args = new AIFunctionArguments
+        {
+            ["code"] = code,
+        };
+
+        var result = await function.InvokeAsync(args, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
     [Fact]
     public async Task ExecuteCode_CapturesFilesInWritableMountAsync()
     {


### PR DESCRIPTION
### Motivation & Context

The LocalCodeAct validator currently enforces the `os.environ`/`os.path` policy only when the module is referenced by the literal name `os`, allowing aliases and simple re-bindings to reach disallowed APIs. In addition, the repository's package-install smoke test does not consume `Microsoft.Agents.AI.LocalCodeAct`, so a missing or unusable package artifact can go unnoticed. This change closes the validator bypass and adds package coverage for the LocalCodeAct distribution path.

### Description & Review Guide

- **What are the major changes?** Track names bound to the `os` module from direct and aliased imports plus simple assignments, enforce the allow-list for those names, add regression coverage for blocked and permitted access, and install `Microsoft.Agents.AI.LocalCodeAct` in the existing packed-artifact smoke test.
- **What is the impact of these changes?** Disallowed `os` APIs cannot bypass validation by changing the variable name. Existing `os.environ`, `os.path`, and `import os.path as p` usage remains allowed. CI now verifies that the LocalCodeAct package is emitted and consumable from local release artifacts.
- **What do you want reviewers to focus on?** Confirm the alias/import binding semantics, especially `import os.path` versus `import os.path as p`, and confirm the package smoke test uses the same local artifact source as the existing package check.

### Related Issue

Fixes #7068

Related to #6824 (the repository-side package smoke check is included; the actual NuGet publication is handled by an external release pipeline).

PR #7071 contained an overlapping implementation of the #7068 validator fix and was closed as superseded by this PR. Its submitter was thanked for the investigation and regression coverage.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after a language prefix) — a workflow keeps the label and title prefix in sync automatically.