### PR TITLE
Python: Fix PropertySchema.to_json_schema() not recursing into nested array items / object properties

### DIFF
--- a/python/packages/declarative/agent_framework_declarative/_models.py
+++ b/python/packages/declarative/agent_framework_declarative/_models.py
@@ -203,6 +203,49 @@ class ObjectProperty(Property):
         self.properties = converted_properties
 
 
+def _normalize_nested_schemas(node: dict[str, Any]) -> None:
+    """Recursively convert a node's nested schemas to JSON Schema form.
+
+    Nested schemas (array ``items``, object ``properties``) keep the declarative
+    shape after serialization: ``kind`` instead of ``type``, empty ``enum``
+    placeholders, and object properties as a list of ``{"name": ..., ...}``
+    entries. OpenAI rejects schemas whose nested nodes lack a ``type`` key, so
+    apply the same conversion the top-level properties loop performs.
+    """
+    items = node.get("items")
+    if isinstance(items, dict):
+        _normalize_schema_node(items)
+    props = node.get("properties")
+    if isinstance(props, list):
+        # Serialized PropertySchema shape: [{"name": ..., "kind": ..., ...}, ...]
+        new_props: dict[str, Any] = {}
+        required_fields: list[str] = []
+        for prop in props:
+            if not isinstance(prop, dict) or "name" not in prop:
+                return  # unexpected shape; leave untouched
+            prop_name = prop.pop("name")
+            if prop.pop("required", False):
+                required_fields.append(prop_name)
+            _normalize_schema_node(prop)
+            new_props[prop_name] = prop
+        node["properties"] = new_props
+        if required_fields:
+            node["required"] = required_fields
+    elif isinstance(props, dict):
+        for child in props.values():
+            if isinstance(child, dict):
+                _normalize_schema_node(child)
+
+
+def _normalize_schema_node(node: dict[str, Any]) -> None:
+    """Rename ``kind`` -> ``type``, drop empty ``enum``, and recurse into children."""
+    if "kind" in node:
+        node["type"] = node.pop("kind")
+    if not node.get("enum"):
+        node.pop("enum", None)
+    _normalize_nested_schemas(node)
+
+
 class PropertySchema(SerializationMixin):
     """Object representing a property schema."""
 
@@ -251,6 +294,7 @@ class PropertySchema(SerializationMixin):
             # Remove empty enum arrays
             if not prop.get("enum"):
                 prop.pop("enum", None)
+            _normalize_nested_schemas(prop)
             new_props[prop_name] = prop
         json_schema["type"] = "object"
         json_schema["properties"] = new_props

--- a/python/packages/declarative/agent_framework_declarative/_models.py
+++ b/python/packages/declarative/agent_framework_declarative/_models.py
@@ -217,12 +217,14 @@ def _normalize_nested_schemas(node: dict[str, Any]) -> None:
         _normalize_schema_node(items)
     props = node.get("properties")
     if isinstance(props, list):
-        # Serialized PropertySchema shape: [{"name": ..., "kind": ..., ...}, ...]
+        # Serialized PropertySchema shape: [{"name": ..., "kind": ..., ...}, ...].
+        # Validate every element BEFORE mutating any, so an unexpected shape
+        # leaves the node fully untouched rather than half-converted.
+        if not all(isinstance(prop, dict) and "name" in prop for prop in props):
+            return
         new_props: dict[str, Any] = {}
         required_fields: list[str] = []
         for prop in props:
-            if not isinstance(prop, dict) or "name" not in prop:
-                return  # unexpected shape; leave untouched
             prop_name = prop.pop("name")
             if prop.pop("required", False):
                 required_fields.append(prop_name)

--- a/python/packages/declarative/agent_framework_declarative/_models.py
+++ b/python/packages/declarative/agent_framework_declarative/_models.py
@@ -242,6 +242,10 @@ def _normalize_schema_node(node: dict[str, Any]) -> None:
         node["type"] = node.pop("kind")
     if not node.get("enum"):
         node.pop("enum", None)
+    if node.get("type") == "object":
+        # OpenAI strict structured outputs require additionalProperties: false on
+        # every object node; chat clients only inject it at the schema root.
+        node.setdefault("additionalProperties", False)
     _normalize_nested_schemas(node)
 
 
@@ -286,14 +290,10 @@ class PropertySchema(SerializationMixin):
         required_fields: list[str] = []
         for prop in json_schema.get("properties", []):
             prop_name = prop.pop("name")
-            prop["type"] = prop.pop("kind", None)
             # Convert property-level 'required' boolean to a top-level 'required' array
             if prop.pop("required", False):
                 required_fields.append(prop_name)
-            # Remove empty enum arrays
-            if not prop.get("enum"):
-                prop.pop("enum", None)
-            _normalize_nested_schemas(prop)
+            _normalize_schema_node(prop)
             new_props[prop_name] = prop
         json_schema["type"] = "object"
         json_schema["properties"] = new_props

--- a/python/packages/declarative/agent_framework_declarative/_models.py
+++ b/python/packages/declarative/agent_framework_declarative/_models.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections.abc import MutableMapping
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast, overload
 
 from agent_framework._serialization import SerializationMixin
 
@@ -214,29 +214,26 @@ def _normalize_nested_schemas(node: dict[str, Any]) -> None:
     """
     items = node.get("items")
     if isinstance(items, dict):
-        _normalize_schema_node(items)
+        _normalize_schema_node(cast("dict[str, Any]", items))
     props = node.get("properties")
-    if isinstance(props, list):
-        # Serialized PropertySchema shape: [{"name": ..., "kind": ..., ...}, ...].
-        # Validate every element BEFORE mutating any, so an unexpected shape
-        # leaves the node fully untouched rather than half-converted.
-        if not all(isinstance(prop, dict) and "name" in prop for prop in props):
-            return
-        new_props: dict[str, Any] = {}
-        required_fields: list[str] = []
-        for prop in props:
-            prop_name = prop.pop("name")
-            if prop.pop("required", False):
-                required_fields.append(prop_name)
-            _normalize_schema_node(prop)
-            new_props[prop_name] = prop
-        node["properties"] = new_props
-        if required_fields:
-            node["required"] = required_fields
-    elif isinstance(props, dict):
-        for child in props.values():
-            if isinstance(child, dict):
-                _normalize_schema_node(child)
+    if not isinstance(props, list):
+        return
+    # Serialized PropertySchema shape: [{"name": ..., "kind": ..., ...}, ...].
+    # Validate every element BEFORE mutating any, so an unexpected shape
+    # leaves the node fully untouched rather than half-converted.
+    if not all(isinstance(prop, dict) and "name" in prop for prop in cast("list[Any]", props)):
+        return
+    new_props: dict[str, Any] = {}
+    required_fields: list[str] = []
+    for prop in cast("list[dict[str, Any]]", props):
+        prop_name = prop.pop("name")
+        if prop.pop("required", False):
+            required_fields.append(prop_name)
+        _normalize_schema_node(prop)
+        new_props[prop_name] = prop
+    node["properties"] = new_props
+    if required_fields:
+        node["required"] = required_fields
 
 
 def _normalize_schema_node(node: dict[str, Any]) -> None:

--- a/python/packages/declarative/tests/test_declarative_models.py
+++ b/python/packages/declarative/tests/test_declarative_models.py
@@ -334,6 +334,30 @@ class TestPropertySchema:
         items = json_schema["properties"]["picks"]["items"]
         assert items["type"] == "object"
         assert items["properties"]["ref"] == {"type": "number"}
+        assert items["additionalProperties"] is False
+
+    def test_property_schema_object_nodes_get_additional_properties_false(self):
+        """Every object node below the root carries additionalProperties: false.
+
+        OpenAI strict structured outputs reject object nodes without it; chat
+        clients only inject it at the schema root.
+        """
+        schema = PropertySchema.from_dict({
+            "properties": {
+                "meta": {
+                    "kind": "object",
+                    "properties": {
+                        "inner": {"kind": "object", "properties": {"leaf": {"kind": "string"}}},
+                    },
+                },
+            },
+        })
+
+        json_schema = schema.to_json_schema()
+
+        meta = json_schema["properties"]["meta"]
+        assert meta["additionalProperties"] is False
+        assert meta["properties"]["inner"]["additionalProperties"] is False
 
     def test_property_schema_unexpected_nested_properties_left_untouched(self):
         """A nested properties list with an unexpected element is left fully unmodified."""

--- a/python/packages/declarative/tests/test_declarative_models.py
+++ b/python/packages/declarative/tests/test_declarative_models.py
@@ -302,6 +302,39 @@ class TestPropertySchema:
         assert "required" not in json_schema["properties"]["language"]
         assert "required" not in json_schema["properties"]["answer"]
 
+    def test_property_schema_array_items_kind_renamed_recursively(self):
+        """Nested array 'items' schemas get kind -> type renamed and empty enums dropped."""
+        schema = PropertySchema.from_dict({
+            "properties": {
+                "issues": {"kind": "array", "items": {"kind": "string"}},
+            },
+        })
+
+        json_schema = schema.to_json_schema()
+
+        assert json_schema["properties"]["issues"]["type"] == "array"
+        assert json_schema["properties"]["issues"]["items"] == {"type": "string"}
+
+    def test_property_schema_nested_object_properties_kind_renamed_recursively(self):
+        """Nested object 'properties' (including arrays of objects) are converted at every depth."""
+        schema = PropertySchema.from_dict({
+            "properties": {
+                "picks": {
+                    "kind": "array",
+                    "items": {
+                        "kind": "object",
+                        "properties": {"ref": {"kind": "number"}},
+                    },
+                },
+            },
+        })
+
+        json_schema = schema.to_json_schema()
+
+        items = json_schema["properties"]["picks"]["items"]
+        assert items["type"] == "object"
+        assert items["properties"]["ref"] == {"type": "number"}
+
 
 class TestConnection:
     """Tests for Connection base class."""

--- a/python/packages/declarative/tests/test_declarative_models.py
+++ b/python/packages/declarative/tests/test_declarative_models.py
@@ -335,6 +335,23 @@ class TestPropertySchema:
         assert items["type"] == "object"
         assert items["properties"]["ref"] == {"type": "number"}
 
+    def test_property_schema_unexpected_nested_properties_left_untouched(self):
+        """A nested properties list with an unexpected element is left fully unmodified."""
+        from agent_framework_declarative._models import _normalize_nested_schemas
+
+        node = {
+            "type": "object",
+            "properties": [
+                {"name": "ok", "kind": "string"},
+                "not-a-dict",
+            ],
+        }
+
+        _normalize_nested_schemas(node)
+
+        # No partial mutation: the well-formed first element keeps its original shape too.
+        assert node["properties"] == [{"name": "ok", "kind": "string"}, "not-a-dict"]
+
 
 class TestConnection:
     """Tests for Connection base class."""

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -5632,6 +5632,54 @@ async def test_integration_options(
                 assert "seattle" in response.value["location"].lower()
 
 
+@pytest.mark.flaky
+@pytest.mark.integration
+@skip_if_openai_integration_tests_disabled
+async def test_integration_response_format_nested_object_schema() -> None:
+    """A raw response_format dict with array-of-object items must round-trip in strict mode.
+
+    The schema literal mirrors what agent_framework_declarative's
+    PropertySchema.to_json_schema() emits for an array-of-objects output schema,
+    so this package needs no declarative dependency. OpenAI strict mode requires
+    additionalProperties: false on every object node, not just the root.
+    """
+    response_format: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "issues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "severity": {"type": "string"},
+                    },
+                    "required": ["title", "severity"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["issues"],
+    }
+    client = OpenAIChatClient()
+    messages = [
+        Message(
+            role="user",
+            contents=["List two code issues: a null pointer in parser.py (high) and a typo in README.md (low)."],
+        )
+    ]
+    response = await client.get_response(messages=messages, options={"response_format": response_format})
+
+    assert response.value is not None
+    assert isinstance(response.value, dict)
+    issues = response.value["issues"]
+    assert isinstance(issues, list)
+    assert issues
+    for issue in issues:
+        assert "title" in issue
+        assert "severity" in issue
+
+
 @pytest.mark.timeout(300)
 @pytest.mark.flaky
 @pytest.mark.integration


### PR DESCRIPTION
### Motivation and Context

`PropertySchema.to_json_schema()` renames `kind` → `type` (and drops empty `enum` placeholders) only in its top-level properties loop. Nested schemas — array `items`, nested object `properties` (which serialize in the named-list shape) — keep `kind` and empty `enum`, producing JSON Schema that OpenAI rejects ("schema must have a 'type' key"). Reproduced on 1.0.0rc2.

### Description

- Fixes #7198
- Adds `_normalize_nested_schemas` / `_normalize_schema_node`: recursively applies the same conversion the top-level loop performs — `kind` → `type`, empty-`enum` removal, named-list `properties` → dict with a `required` array — at every depth.
- Minimal repro from the issue now produces `"items": {"type": "string"}` instead of `"items": {"kind": "string", "enum": []}`.
- New tests: array-of-strings items, array-of-objects with nested properties.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible (`test_declarative_models.py`: 98 passed)
- [ ] **Is this a breaking change?** No — previously-invalid output becomes valid; schemas without nesting are byte-identical.