### PR TITLE
Python: Support async credentials in `FoundryToolbox`

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -20,11 +21,12 @@ from agent_framework import (
 from azure.ai.agentserver.core import get_request_context
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import AsyncGenerator, Generator
     from datetime import timedelta
 
     from agent_framework import Skill
-    from azure.core.credentials import TokenCredential
+    from azure.core.credentials import AccessToken, TokenCredential
+    from azure.core.credentials_async import AsyncTokenCredential
     from mcp.client.session import ClientSession
 
 logger = logging.getLogger(__name__)
@@ -74,24 +76,50 @@ def _toolbox_name_from_endpoint(endpoint: str) -> str:
 class _ToolboxAuth(httpx.Auth):
     """Injects a fresh bearer token and the platform call-id on every request.
 
-    ``auth_flow`` runs for *every* outbound request (connection handshake as well
-    as tool calls), so the bearer token is always present. The per-request
-    ``x-agent-foundry-call-id`` is read from the request-scoped context populated
-    by the hosting endpoint; it resolves to a fresh value on each request and is
-    absent (no header) for protocol ``1.0.0`` or local development.
+    Both the synchronous (``sync_auth_flow``) and asynchronous (``async_auth_flow``)
+    httpx auth hooks are implemented, so the same auth works regardless of which
+    transport the toolbox client uses. Each runs for *every* outbound request
+    (connection handshake as well as tool calls), so the bearer token is always
+    present. Both synchronous :class:`~azure.core.credentials.TokenCredential` and
+    asynchronous :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    credentials are supported: the async flow awaits an async credential's
+    ``get_token``, while the sync flow requires a synchronous credential. The
+    per-request ``x-agent-foundry-call-id`` is read from the request-scoped context
+    populated by the hosting endpoint; it resolves to a fresh value on each request
+    and is absent (no header) for protocol ``1.0.0`` or local development.
     """
 
-    def __init__(self, credential: TokenCredential, scope: str) -> None:
+    def __init__(self, credential: TokenCredential | AsyncTokenCredential, scope: str) -> None:
         self._credential = credential
         self._scope = scope
 
-    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
-        # azure-core credentials cache the token internally and only refresh near
-        # expiry, so calling get_token per request is cheap.
-        token = self._credential.get_token(self._scope).token
-        request.headers["Authorization"] = f"Bearer {token}"
+    def _apply_headers(self, request: httpx.Request, token: AccessToken) -> None:
+        request.headers["Authorization"] = f"Bearer {token.token}"
         for key, value in get_request_context().platform_headers().items():
             request.headers[key] = value
+
+    def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        # azure-core credentials cache the token internally and only refresh near
+        # expiry, so calling get_token per request is cheap.
+        token = self._credential.get_token(self._scope)
+        if inspect.isawaitable(token):
+            close = getattr(token, "close", None)
+            if callable(close):
+                close()
+            raise RuntimeError(
+                "An async credential cannot be used with the synchronous auth flow; "
+                "use a synchronous TokenCredential or drive the toolbox with an httpx.AsyncClient."
+            )
+        self._apply_headers(request, token)
+        yield request
+
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        # Sync credentials return the token directly; async credentials return an
+        # awaitable to await.
+        token = self._credential.get_token(self._scope)
+        if inspect.isawaitable(token):
+            token = await token
+        self._apply_headers(request, token)
         yield request
 
 
@@ -138,7 +166,7 @@ class FoundryToolbox(MCPStreamableHTTPTool):
 
     def __init__(
         self,
-        credential: TokenCredential,
+        credential: TokenCredential | AsyncTokenCredential,
         *,
         url: str | None = None,
         name: str | None = None,
@@ -150,9 +178,9 @@ class FoundryToolbox(MCPStreamableHTTPTool):
         """Initialize a Foundry toolbox tool.
 
         Args:
-            credential: A Microsoft Entra credential used to obtain bearer tokens for
-                the toolbox endpoint. Tokens are requested per outbound request and
-                cached by the credential.
+            credential: A synchronous or asynchronous Microsoft Entra credential used
+                to obtain bearer tokens for the toolbox endpoint. Tokens are requested
+                per outbound request and cached by the credential.
 
         Keyword Args:
             url: The toolbox MCP endpoint URL. When ``None``, it is resolved from

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
     from mcp.client.session import ClientSession
 
+    AzureCredentialTypes = TokenCredential | AsyncTokenCredential
+
 logger = logging.getLogger(__name__)
 
 # Default Microsoft Entra scope for Foundry data-plane access.
@@ -89,7 +91,7 @@ class _ToolboxAuth(httpx.Auth):
     and is absent (no header) for protocol ``1.0.0`` or local development.
     """
 
-    def __init__(self, credential: TokenCredential | AsyncTokenCredential, scope: str) -> None:
+    def __init__(self, credential: AzureCredentialTypes, scope: str) -> None:
         self._credential = credential
         self._scope = scope
 
@@ -169,7 +171,7 @@ class FoundryToolbox(MCPStreamableHTTPTool):
 
     def __init__(
         self,
-        credential: TokenCredential | AsyncTokenCredential,
+        credential: AzureCredentialTypes,
         *,
         url: str | None = None,
         name: str | None = None,
@@ -181,9 +183,9 @@ class FoundryToolbox(MCPStreamableHTTPTool):
         """Initialize a Foundry toolbox tool.
 
         Args:
-            credential: A synchronous or asynchronous Microsoft Entra credential used
-                to obtain bearer tokens for the toolbox endpoint. Tokens are requested
-                per outbound request and cached by the credential.
+            credential: A Microsoft Entra credential used to obtain bearer tokens for
+                the toolbox endpoint. Tokens are requested per outbound request and
+                cached by the credential.
 
         Keyword Args:
             url: The toolbox MCP endpoint URL. When ``None``, it is resolved from

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -98,6 +98,9 @@ class _ToolboxAuth(httpx.Auth):
         for key, value in get_request_context().platform_headers().items():
             request.headers[key] = value
 
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        yield from self.sync_auth_flow(request)
+
     def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
         # azure-core credentials cache the token internally and only refresh near
         # expiry, so calling get_token per request is cheap.

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -100,9 +100,6 @@ class _ToolboxAuth(httpx.Auth):
         for key, value in get_request_context().platform_headers().items():
             request.headers[key] = value
 
-    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
-        yield from self.sync_auth_flow(request)
-
     def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
         # azure-core credentials cache the token internally and only refresh near
         # expiry, so calling get_token per request is cheap.

--- a/python/packages/foundry_hosting/tests/test_toolbox.py
+++ b/python/packages/foundry_hosting/tests/test_toolbox.py
@@ -57,6 +57,18 @@ class _FakeCredential:
         return _FakeAccessToken(self._token)
 
 
+class _FakeAsyncCredential:
+    """Minimal stand-in for azure.core.credentials_async.AsyncTokenCredential."""
+
+    def __init__(self, token: str = "fake-token") -> None:
+        self._token = token
+        self.scopes: list[str] = []
+
+    async def get_token(self, *scopes: str, **kwargs: object) -> _FakeAccessToken:
+        self.scopes.extend(scopes)
+        return _FakeAccessToken(self._token)
+
+
 def test_resolve_endpoint_prefers_explicit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TOOLBOX_ENDPOINT", "https://host/toolboxes/tb/mcp?api-version=v1")
     assert _resolve_toolbox_endpoint() == "https://host/toolboxes/tb/mcp?api-version=v1"
@@ -106,36 +118,65 @@ def test_init_derives_name_and_defaults() -> None:
     assert toolbox.load_prompts_flag is False
 
 
-def test_auth_flow_injects_bearer_token() -> None:
+async def test_auth_flow_injects_bearer_token() -> None:
     cred = _FakeCredential("abc123")
     auth = _ToolboxAuth(cred, "https://ai.azure.com/.default")  # type: ignore
     request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
 
-    flow = auth.auth_flow(request)
-    prepared = next(flow)
+    prepared = await anext(auth.async_auth_flow(request))
 
     assert prepared.headers["Authorization"] == "Bearer abc123"
     assert cred.scopes == ["https://ai.azure.com/.default"]
 
 
-def test_auth_flow_forwards_call_id_when_present() -> None:
+async def test_auth_flow_injects_bearer_token_async_credential() -> None:
+    cred = _FakeAsyncCredential("async123")
+    auth = _ToolboxAuth(cred, "https://ai.azure.com/.default")  # type: ignore
+    request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
+
+    prepared = await anext(auth.async_auth_flow(request))
+
+    assert prepared.headers["Authorization"] == "Bearer async123"
+    assert cred.scopes == ["https://ai.azure.com/.default"]
+
+
+def test_sync_auth_flow_injects_bearer_token() -> None:
+    cred = _FakeCredential("sync123")
+    auth = _ToolboxAuth(cred, "https://ai.azure.com/.default")  # type: ignore
+    request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
+
+    prepared = next(auth.sync_auth_flow(request))
+
+    assert prepared.headers["Authorization"] == "Bearer sync123"
+    assert cred.scopes == ["https://ai.azure.com/.default"]
+
+
+def test_sync_auth_flow_rejects_async_credential() -> None:
+    auth = _ToolboxAuth(_FakeAsyncCredential(), "scope")  # type: ignore
+    request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
+
+    with pytest.raises(RuntimeError, match="async credential"):
+        next(auth.sync_auth_flow(request))
+
+
+async def test_auth_flow_forwards_call_id_when_present() -> None:
     auth = _ToolboxAuth(_FakeCredential(), "scope")  # type: ignore
     request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
 
     token = set_request_context(FoundryAgentRequestContext(call_id="call-xyz"))
     try:
-        prepared = next(auth.auth_flow(request))
+        prepared = await anext(auth.async_auth_flow(request))
     finally:
         reset_request_context(token)
 
     assert prepared.headers["x-agent-foundry-call-id"] == "call-xyz"
 
 
-def test_auth_flow_omits_call_id_when_absent() -> None:
+async def test_auth_flow_omits_call_id_when_absent() -> None:
     auth = _ToolboxAuth(_FakeCredential(), "scope")  # type: ignore
     request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
 
-    prepared = next(auth.auth_flow(request))
+    prepared = await anext(auth.async_auth_flow(request))
 
     assert "x-agent-foundry-call-id" not in prepared.headers
 


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
- **What is the impact of these changes?**
- **What do you want reviewers to focus on?**
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

Adds support for async credentials to FoundryToolbox.

### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #7207

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
