### PR TITLE
.NET: Cover source-type-agnostic toolbox consent parsing (a2a_preview)

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ToolboxConsentParserTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ToolboxConsentParserTests.cs
@@ -24,6 +24,32 @@ public class ToolboxConsentParserTests
         Assert.Equal("https://login.example.com/consent?data=abc", consent.ConsentUrl);
     }
 
+    [Theory]
+    [InlineData("mcp")]
+    [InlineData("a2a_preview")]
+    [InlineData("some_future_source")]
+    public void TryParseConsentRequired_IsSourceTypeAgnostic_ReturnsTrue(string sourceType)
+    {
+        // Arrange: consent detection keys off the nested CONSENT_REQUIRED error code, not the
+        // tool source "type". Work IQ emits "a2a_preview" (issue #7227) rather than "mcp"; the
+        // parser must surface consent for any source type so hosting does not fail like the
+        // Python parser that hard-coded type == "mcp".
+        string message =
+            "Request failed (remote): tools/list failed for 1 tool source(s), succeeded for 0 tool source(s) " +
+            "{\"errors\":[{\"name\":\"work-iq-connection\",\"type\":\"" + sourceType + "\"," +
+            "\"error\":{\"code\":\"CONSENT_REQUIRED\",\"message\":\"https://consent.example/login?data=xyz\"}}]}";
+
+        // Act
+        var parsed = ToolboxConsentParser.TryParseConsentRequired("work-iq-toolbox", message, out var consents);
+
+        // Assert
+        Assert.True(parsed);
+        var consent = Assert.Single(consents);
+        Assert.Equal("work-iq-toolbox", consent.ToolboxName);
+        Assert.Equal("work-iq-connection", consent.ToolName);
+        Assert.Equal("https://consent.example/login?data=xyz", consent.ConsentUrl);
+    }
+
     [Fact]
     public void TryParseConsentRequired_MultipleConsentErrors_ReturnsAll()
     {


### PR DESCRIPTION
### Motivation & Context

Issue #7227 reports that the Python Foundry hosting consent parser only recognizes a
consent requirement when the toolbox source `type` is `mcp`. Work IQ identifies its
source as `a2a_preview`, so the Python parser returns `None` and the hosted agent never
surfaces the `oauth_consent_request` to the client.

The .NET `Microsoft.Agents.AI.Foundry.Hosting` package already avoids that trap: consent
detection keys off the JSON-RPC error semantics only, never the tool source `type`.
`ToolboxConsentParser.TryParseConsentRequired` walks the embedded `errors[]` array and
matches on the nested `error.code == "CONSENT_REQUIRED"`, and the per-tool-call path in
`ConsentAwareMcpClientAIFunction` intercepts on JSON-RPC code `-32006` alone. Both are
source-type agnostic, so the Work IQ `a2a_preview` scenario works on .NET today.

The existing unit tests all happened to use `type: mcp`, so nothing actually pinned the
source-agnostic guarantee. This PR adds coverage so the behavior cannot silently regress.

### Description & Review Guide

**What are the major changes?**
- Added a `[Theory]` to `ToolboxConsentParserTests` that asserts consent is surfaced for
  `mcp`, `a2a_preview` (the Work IQ case from #7227), and an arbitrary future source type.

**What is the impact of these changes?**
- Test-only. No production code changes. Locks in the source-type-agnostic consent
  parsing that already exists in .NET so a future edit cannot reintroduce a `type == "mcp"`
  restriction like the one Python hit.

**What do you want reviewers to focus on?**
- Confirm the added theory cases reflect the real proxy payload shape from #7227.

### Related Issue

Contributes to #7227 (the .NET side; the Python parser fix is tracked separately in the
same issue).

### Contribution Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md) and my code adheres to them
- [x] The code builds clean without any errors or warnings
- [x] I didn't break anyone. All existing tests pass
- [x] This is not a breaking change.
