### PR TITLE
Python: feat: add agent-framework-tenki (Tenki-backed CodeAct provider)

### DIFF
--- a/python/packages/tenki/LICENSE
+++ b/python/packages/tenki/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/python/packages/tenki/README.md
+++ b/python/packages/tenki/README.md
@@ -1,0 +1,147 @@
+# agent-framework-tenki
+
+[Tenki Sandbox](https://tenki.cloud) integration for Microsoft Agent Framework.
+
+## Installation
+
+```bash
+pip install agent-framework-tenki --pre
+```
+
+You also need a Tenki API key. Follow the [Tenki Sandbox quick start](https://tenki.cloud/docs/sandbox/quick-start-sandbox)
+to create a workspace and generate a key, then export it before running your agent:
+
+```bash
+export TENKI_API_KEY="tk_..."
+```
+
+## Quick start
+
+### Context provider (recommended)
+
+Use `TenkiCodeActProvider` to inject an `execute_code` tool into every agent run. Each
+run shares the same underlying Tenki sandbox until the provider is closed.
+
+```python
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatClient
+from agent_framework_tenki import TenkiCodeActProvider
+
+async with TenkiCodeActProvider() as codeact:
+    agent = Agent(
+        client=OpenAIChatClient(),
+        context_providers=[codeact],
+    )
+    result = await agent.run("Compute the 42nd Fibonacci number.")
+```
+
+### Standalone tool
+
+Use `TenkiExecuteCodeTool` directly when you want full control over how the tool is
+attached to the agent.
+
+```python
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatClient
+from agent_framework_tenki import TenkiExecuteCodeTool
+
+async with TenkiExecuteCodeTool() as execute_code:
+    agent = Agent(
+        client=OpenAIChatClient(),
+        tools=[execute_code],
+    )
+    result = await agent.run("Print the SHA-256 of 'hello world'.")
+```
+
+Remember to `close()` (or use `async with`) so the sandbox is terminated when you're
+done — otherwise it lives until your Tenki workspace timeout expires.
+
+## Configuration
+
+| Kwarg | Default | Description |
+|---|---|---|
+| `sandbox_name` | `agent-framework-<8-hex>` | Sandbox identifier used when creating the sandbox on Tenki. |
+| `api_key` | `os.environ["TENKI_API_KEY"]` | Overrides the environment variable. |
+| `image` | Tenki default | Custom base image identifier. |
+| `project_id` / `workspace_id` | `os.environ["TENKI_PROJECT_ID"]` / `os.environ["TENKI_WORKSPACE_ID"]` | Required when your API key has access to multiple projects. Constructor args override the env vars. |
+| `cpu_cores` / `memory_mb` / `disk_size_gb` | Tenki defaults | Optional resource overrides. |
+| `max_duration_seconds` | `None` | Server-side cost kill-switch. Recommended for production agent loops. |
+| `exec_timeout_seconds` | `60` | Per-`execute_code` invocation timeout in seconds. |
+| `extra_create_kwargs` | `{}` | Passed straight to `tenki_sandbox.Sandbox.create` for Tenki-specific options — see the section below. |
+
+### Tenki-specific options via `extra_create_kwargs`
+
+The Tenki SDK exposes platform features beyond the ones surfaced directly on
+`TenkiExecuteCodeTool`. Anything you pass through `extra_create_kwargs` is
+forwarded verbatim to `tenki_sandbox.Sandbox.create`. Common ones:
+
+| Kwarg | Type | Purpose |
+|---|---|---|
+| `snapshot_id` | `str` | Restore the sandbox from a previously created Tenki snapshot instead of provisioning a fresh image — preserves filesystem state across sessions. |
+| `clone_repo_url` | `str` | Git-clone the URL into the sandbox on create. Pair with `github_token` for private repos. |
+| `github_token` | `str` | Auth token consumed by `clone_repo_url`. |
+| `env` | `dict[str, str]` | Environment variables passed into the sandbox at creation time (agent secrets, config, etc.). |
+| `allow_inbound` / `allow_outbound` | `bool` | Sandbox network policy. Enable `allow_inbound` for inbound exposure workflows; disable `allow_outbound` for stricter isolation. Both default to `True`. |
+| `metadata` | `dict[str, str]` | Attach arbitrary key-value tags for filtering, billing attribution, or upstream job-ID tracking. |
+| `tags` | `list[str]` | Attach labels for organization/filtering in the Tenki dashboard. |
+| `volumes` | `list[dict]` | Attach persistent [Tenki volumes](https://tenki.cloud/docs/sandbox/volumes) that survive sandbox termination. Each entry: `{"volume_id": str, "mount_path": str, "read_only": bool (optional)}`. Volumes are workspace-scoped and must be reattached explicitly on future sandboxes. |
+
+Example:
+
+```python
+async with TenkiExecuteCodeTool(
+    extra_create_kwargs={
+        "clone_repo_url": "https://github.com/myorg/myrepo",
+        "github_token": os.environ["GITHUB_TOKEN"],
+        "env": {"OPENAI_API_KEY": os.environ["OPENAI_API_KEY"]},
+    },
+) as tool:
+    ...
+```
+
+See the [Tenki sandbox sessions](https://tenki.cloud/docs/sandbox/sessions#create-a-session)
+and [Tenki volumes](https://tenki.cloud/docs/sandbox/volumes) reference for the
+complete option list and semantics.
+
+## Lifecycle
+
+The sandbox is provisioned lazily on the first `execute_code` call and reused for every
+subsequent call on the same tool or provider instance. Before each call the tool
+reconciles remote sandbox state, so callers never need to track pause/terminate
+transitions manually. Each call runs `python3 -c <code>` inside the sandbox, which
+means:
+
+- **Sandbox filesystem persists** across calls — files written to `/tmp` or the user
+  home in one call are visible in the next.
+- **Installed packages persist** — packages installed via pip or apt in one call are
+  available in subsequent calls (subject to the sandbox's outbound network policy).
+  See [Tenki's sandbox quick start](https://tenki.cloud/docs/sandbox/quick-start-sandbox)
+  for the recommended installation workflow (the default image ships `python3-venv`).
+- **Python interpreter state does not persist** — each call is a fresh `python3`
+  process, so variables defined in one call are not reachable in the next. Persist
+  intermediate state through files or environment variables when a later call needs
+  it.
+- **Paused sandboxes auto-resume** — if the sandbox transitions to `PAUSED` between
+  calls (Tenki's server-side idle policies, `idle_timeout_minutes` supplied via
+  `extra_create_kwargs`, or an external `tenki sandbox pause`), the next
+  `execute_code` call transparently resumes it before running. Filesystem and
+  installed packages carry across the pause unchanged.
+- **Terminated sandboxes are replaced** — if the sandbox transitions to
+  `TERMINATING`/`TERMINATED` (workspace timeout, `max_duration_seconds`, or an
+  external `tenki sandbox terminate`), the next call provisions a fresh sandbox.
+  Filesystem and installed packages from the previous sandbox are **not** carried
+  over — snapshot the sandbox (via `extra_create_kwargs={"snapshot_id": ...}` on a
+  new tool) if you need to preserve state across a termination.
+
+Call `close()` on the tool or provider (or use `async with`) to terminate the sandbox
+and release the underlying microVM. Different agents that share a single
+`TenkiCodeActProvider` share the same sandbox — create a separate provider per agent
+when isolation matters.
+
+## Notes
+
+- In-sandbox tool callbacks are not supported — code executing inside the sandbox
+  cannot invoke host-side tools (Tenki's SDK does not expose a callback bridge).
+- File mounts and outbound network allow-lists are not modeled by this package. Bake
+  dependencies into a custom Tenki image, or pass extra configuration through
+  `extra_create_kwargs`.

--- a/python/packages/tenki/agent_framework_tenki/__init__.py
+++ b/python/packages/tenki/agent_framework_tenki/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import importlib.metadata
+
+from ._execute_code_tool import TenkiExecuteCodeTool
+from ._provider import TenkiCodeActProvider
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = [
+    "TenkiCodeActProvider",
+    "TenkiExecuteCodeTool",
+    "__version__",
+]

--- a/python/packages/tenki/agent_framework_tenki/_execute_code_tool.py
+++ b/python/packages/tenki/agent_framework_tenki/_execute_code_tool.py
@@ -1,0 +1,348 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import threading
+import uuid
+from typing import Any, ClassVar, Optional
+
+logger = logging.getLogger(__name__)
+
+from agent_framework import Content, FunctionTool
+from agent_framework._tools import ApprovalMode
+
+try:
+    from tenki_sandbox import Sandbox
+except ImportError as _import_err:  # pragma: no cover - environment-dependent
+    raise RuntimeError(
+        "Missing dependencies for TenkiExecuteCodeTool. "
+        "Install the Tenki SDK with `pip install tenki-sandbox` "
+        "(or via `pip install agent-framework-tenki`)."
+    ) from _import_err
+
+
+EXECUTE_CODE_TOOL_DESCRIPTION = (
+    "Execute Python in an isolated Tenki microVM sandbox. Each call runs the "
+    "code as `python3 -c <code>`; only stdout and stderr are captured, so wrap "
+    "any values you want to see in `print(...)` — bare expressions are not "
+    "auto-printed like in a REPL."
+)
+
+EXECUTE_CODE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "title": "_ExecuteCodeInput",
+    "properties": {
+        "code": {
+            "type": "string",
+            "title": "Code",
+            "description": (
+                "Python code to execute in an isolated Tenki sandbox. The code "
+                "runs as `python3 -c <code>` — only stdout/stderr are captured, "
+                "so use `print(...)` to return any values."
+            ),
+        },
+    },
+    "required": ["code"],
+}
+
+
+def _default_sandbox_name() -> str:
+    """Return a unique, source-attributable sandbox name.
+
+    The ``agent-framework-`` prefix lets operators inspecting the Tenki dashboard or the
+    ``tenki sandbox list`` CLI attribute the sandbox back to Agent Framework — matching
+    the client-attributable naming already used elsewhere in the workspace (for example
+    ``WorkflowBuilder-<uuid>`` in ``agent-framework-durabletask``).
+    """
+    return f"agent-framework-{uuid.uuid4().hex[:8]}"
+
+
+class TenkiExecuteCodeTool(FunctionTool):
+    r"""Execute Python code inside a `Tenki <https://tenki.cloud>`_ managed microVM sandbox.
+
+    Requires the ``tenki-sandbox`` Python SDK (installed as a dependency of
+    ``agent-framework-tenki``) and a Tenki API key. Follow the
+    `Tenki Sandbox quick start <https://tenki.cloud/docs/sandbox/quick-start-sandbox>`_
+    to create a workspace and generate a key, then export it as ``TENKI_API_KEY``.
+
+    Lifecycle: the tool lazily provisions a sandbox on the first ``_run_code`` invocation
+    and reuses the same sandbox for every subsequent call within the tool's lifetime.
+    Before each call the tool reconciles remote sandbox state — a sandbox that has
+    transitioned to ``PAUSED`` (Tenki server-side idle policy, ``idle_timeout_minutes``
+    from ``extra_create_kwargs``, or an external ``tenki sandbox pause``) is
+    transparently resumed, and a sandbox that has transitioned to ``TERMINATING`` or
+    ``TERMINATED`` (workspace timeout, ``max_duration_seconds``, or an external
+    ``tenki sandbox terminate``) is replaced by a fresh provision. Callers therefore
+    never have to track pause/terminate transitions manually. Each call runs
+    ``python3 -c <code>`` inside the sandbox, so the sandbox filesystem and installed
+    packages persist across calls but the Python interpreter state does not —
+    variables defined in one call are not reachable in the next. Filesystem and
+    installed packages are also lost when the sandbox is re-provisioned after a
+    termination; use ``extra_create_kwargs={"snapshot_id": ...}`` on a new tool if you
+    need to preserve state across that boundary. Persist intermediate state through
+    files or environment variables when a later call needs it. Call :meth:`close` (or
+    use the tool via ``async with``) to terminate the sandbox and release the
+    underlying microVM. A new sandbox is created on the next call if the tool is
+    reused after being closed.
+
+    Args:
+        approval_mode (Optional[ApprovalMode]): Approval policy passed through to
+            :class:`agent_framework.FunctionTool`. Defaults to ``"never_require"``.
+        api_key (Optional[str]): Optional Tenki API key. When ``None`` the SDK reads
+            :envvar:`TENKI_API_KEY` from the environment.
+        sandbox_name (Optional[str]): Optional sandbox identifier. When ``None`` the tool
+            generates ``agent-framework-<8-hex>`` — matching the naming convention already
+            used by other Agent Framework packages that create externally visible
+            resources.
+        image (Optional[str]): Optional Tenki base-image identifier. When ``None`` the
+            Tenki service picks its default sandbox image (which ships ``python3``).
+        project_id (Optional[str]): Optional Tenki project ID scoping the sandbox.
+            Required when the API key has access to more than one project.
+        workspace_id (Optional[str]): Optional Tenki workspace ID.
+        cpu_cores (Optional[int]): Optional CPU-core count. When ``None`` the Tenki
+            service default applies.
+        memory_mb (Optional[int]): Optional memory (MB). ``None`` uses the service default.
+        disk_size_gb (Optional[int]): Optional ephemeral disk (GB). ``None`` uses the
+            service default.
+        max_duration_seconds (Optional[int]): Optional cost-safety cap on sandbox
+            lifetime, enforced server-side. When ``None`` the sandbox lives until
+            explicitly terminated (or the workspace timeout applies). Recommended for
+            production use to avoid runaway sandboxes in agent loops.
+        exec_timeout_seconds (int): Per-``_run_code`` timeout in seconds. Defaults to 60.
+        extra_create_kwargs (Optional[dict[str, Any]]): Optional keyword arguments passed
+            straight to :meth:`tenki_sandbox.Sandbox.create` — for advanced knobs not
+            surfaced individually (e.g. ``snapshot_id``, ``allow_inbound``,
+            ``allow_outbound``).
+
+    Notes:
+        * In-sandbox tool callbacks are not supported — code executing inside the sandbox
+          cannot invoke host-side :class:`~agent_framework.FunctionTool` instances (the
+          Tenki SDK does not expose a callback bridge).
+        * File mounts and outbound network allow-lists are not modeled by this package.
+          Bake dependencies and files into a custom Tenki image, or configure them
+          through ``extra_create_kwargs``.
+        * The sandbox lifecycle is *reuse-per-tool*, not per-agent-run. If the tool is
+          shared across many agent runs, filesystem state from run N is visible to run
+          N+1 (same sandbox), though each individual ``execute_code`` invocation is a
+          fresh Python process. Create a fresh :class:`TenkiExecuteCodeTool` per agent
+          instance if isolation between agents matters.
+    """
+
+    SUPPORTED_LANGUAGES: ClassVar[list[str]] = ["python"]
+
+    def __init__(
+        self,
+        *,
+        approval_mode: Optional[ApprovalMode] = None,
+        api_key: Optional[str] = None,
+        sandbox_name: Optional[str] = None,
+        image: Optional[str] = None,
+        project_id: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        cpu_cores: Optional[int] = None,
+        memory_mb: Optional[int] = None,
+        disk_size_gb: Optional[int] = None,
+        max_duration_seconds: Optional[int] = None,
+        exec_timeout_seconds: int = 60,
+        extra_create_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if exec_timeout_seconds < 1:
+            raise ValueError("exec_timeout_seconds must be greater than or equal to 1.")
+
+        super().__init__(
+            name="execute_code",
+            description=EXECUTE_CODE_TOOL_DESCRIPTION,
+            approval_mode=approval_mode or "never_require",
+            func=self._run_code,
+            input_model=EXECUTE_CODE_INPUT_SCHEMA,
+        )
+
+        self._api_key = api_key
+        self._sandbox_name = sandbox_name or _default_sandbox_name()
+        self._image = image
+        self._project_id = project_id
+        self._workspace_id = workspace_id
+        self._cpu_cores = cpu_cores
+        self._memory_mb = memory_mb
+        self._disk_size_gb = disk_size_gb
+        self._max_duration_seconds = max_duration_seconds
+        self._exec_timeout_seconds = exec_timeout_seconds
+        self._extra_create_kwargs: dict[str, Any] = dict(extra_create_kwargs) if extra_create_kwargs else {}
+
+        # A single sandbox is created lazily on first use and reused across calls.
+        # A lock guards the create/close race between concurrent ``_run_code`` invocations.
+        self._sandbox_lock = threading.Lock()
+        self._sandbox: Optional[Sandbox] = None
+
+    @property
+    def sandbox_name(self) -> str:
+        """The name of the underlying Tenki sandbox."""
+        return self._sandbox_name
+
+    @property
+    def exec_timeout_seconds(self) -> int:
+        """Per-invocation execution timeout in seconds."""
+        return self._exec_timeout_seconds
+
+    def _build_create_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"name": self._sandbox_name}
+        # Only forward optional values the caller explicitly set; the Tenki SDK applies
+        # its own defaults when we omit a field, and it may reject ``field=None``.
+        api_key = self._api_key or os.environ.get("TENKI_API_KEY")
+        if api_key is not None:
+            kwargs["auth_token"] = api_key
+        if self._image is not None:
+            kwargs["image"] = self._image
+        # Explicit constructor args take precedence over env vars, matching the
+        # api_key path above and OpenAI/Anthropic sibling packages' behavior.
+        project_id = self._project_id or os.environ.get("TENKI_PROJECT_ID")
+        if project_id is not None:
+            kwargs["project_id"] = project_id
+        workspace_id = self._workspace_id or os.environ.get("TENKI_WORKSPACE_ID")
+        if workspace_id is not None:
+            kwargs["workspace_id"] = workspace_id
+        if self._cpu_cores is not None:
+            kwargs["cpu_cores"] = self._cpu_cores
+        if self._memory_mb is not None:
+            kwargs["memory_mb"] = self._memory_mb
+        if self._disk_size_gb is not None:
+            kwargs["disk_size_gb"] = self._disk_size_gb
+        if self._max_duration_seconds is not None:
+            kwargs["max_duration"] = self._max_duration_seconds
+        # Caller-supplied extras win last so they can override anything above.
+        kwargs.update(self._extra_create_kwargs)
+        return kwargs
+
+    def _ensure_sandbox_sync(self) -> Sandbox:
+        """Return a usable sandbox — provision on first use, resume if paused, re-provision if gone.
+
+        Tenki sandboxes can transition to ``PAUSED`` between calls (server-side idle
+        policies, external ``tenki sandbox pause``) and to ``TERMINATED`` if the
+        workspace timeout or ``max_duration`` elapsed. This method reconciles the
+        remote state on every call so ``_run_code`` never hands the SDK a
+        ``sandbox.exec`` that would fail with ``sandbox is not RUNNING``.
+
+        Called inside ``asyncio.to_thread``.
+        """
+        with self._sandbox_lock:
+            sandbox = self._sandbox
+            if sandbox is None:
+                return self._create_sandbox_locked()
+
+            try:
+                sandbox.refresh()
+            except Exception as exc:
+                # Remote state is unknowable — drop the stale handle and re-provision.
+                logger.debug("Dropping Tenki sandbox handle after refresh failure: %s", exc)
+                self._sandbox = None
+                return self._create_sandbox_locked()
+
+            state = getattr(sandbox, "state", None)
+            if state == "PAUSED":
+                try:
+                    sandbox.resume()
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to resume paused Tenki sandbox: {exc}") from exc
+                return sandbox
+            if state in {"TERMINATING", "TERMINATED"}:
+                logger.debug("Dropping Tenki sandbox handle after remote state=%s", state)
+                self._sandbox = None
+                return self._create_sandbox_locked()
+            return sandbox
+
+    def _create_sandbox_locked(self) -> Sandbox:
+        """Provision a fresh sandbox. The sandbox lock must be held by the caller."""
+        create_kwargs = self._build_create_kwargs()
+        try:
+            sandbox = Sandbox.create(**create_kwargs)  # pyright: ignore[reportUnknownMemberType]
+        except Exception as exc:
+            raise RuntimeError(f"Failed to create Tenki sandbox: {exc}") from exc
+        self._sandbox = sandbox
+        return sandbox
+
+    async def _run_code(self, *, code: str) -> list[Content]:
+        """Execute a single block of Python code inside the sandbox."""
+        try:
+            sandbox = await asyncio.to_thread(self._ensure_sandbox_sync)
+        except RuntimeError as exc:
+            return [Content.from_error(message="Failed to provision Tenki sandbox", error_details=str(exc))]
+
+        try:
+            result = await asyncio.to_thread(sandbox.exec, "python3", "-c", code, timeout=self._exec_timeout_seconds)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation-dependent
+            return [Content.from_error(message="Code execution was cancelled")]
+        except Exception as exc:
+            return [Content.from_error(message="Sandbox execution failed", error_details=str(exc))]
+
+        return self._build_contents(result)
+
+    _ERROR_MESSAGE_STDERR_LIMIT: ClassVar[int] = 500
+
+    # Recovery hint appended when the sandbox reports a Python SyntaxError. Only
+    # fires for that specific error class to keep the hint from misleading
+    # stronger models on unrelated failures.
+    _SYNTAX_ERROR_HINT: ClassVar[str] = (
+        " [Common causes: (1) a compound statement (with/for/if/try/while) "
+        "following a semicolon at the outer level; put it on its own line "
+        "instead. (2) `\\n` literals in the JSON payload where actual newline "
+        "characters were intended.]"
+    )
+
+    def _build_contents(self, result: Any) -> list[Content]:
+        """Convert a Tenki exec result into a list of :class:`Content` values."""
+        stdout = getattr(result, "stdout_text", "") or ""
+        stderr = getattr(result, "stderr_text", "") or ""
+        exit_code = int(getattr(result, "exit_code", 1))
+
+        contents: list[Content] = []
+        if stdout:
+            contents.append(Content.from_text(stdout))
+        if exit_code != 0:
+            # Inline a truncated stderr into the message so downstream LLM
+            # consumers see the traceback in the primary field, not just in
+            # error_details — small models tend to under-weight secondary fields.
+            stderr_snippet = stderr.strip()[: self._ERROR_MESSAGE_STDERR_LIMIT] if stderr else ""
+            message = f"Code exited with status {exit_code}"
+            if stderr_snippet:
+                message = f"{message}. stderr: {stderr_snippet}"
+            if stderr and "SyntaxError" in stderr:
+                message = f"{message}{self._SYNTAX_ERROR_HINT}"
+            contents.append(
+                Content.from_error(
+                    message=message,
+                    error_details=stderr or None,
+                )
+            )
+        elif stderr:
+            # Non-fatal stderr (e.g. warnings) — surface it as ordinary text so the model
+            # sees it, matching Hyperlight's behaviour.
+            contents.append(Content.from_text(stderr))
+        if not contents:
+            contents.append(Content.from_text("Code executed successfully without output."))
+        return contents
+
+    async def close(self) -> None:
+        """Terminate the underlying Tenki sandbox and release its resources.
+
+        Safe to call multiple times; a no-op if the sandbox was never created. After
+        close, a subsequent ``_run_code`` invocation lazily provisions a new sandbox.
+        """
+        with self._sandbox_lock:
+            sandbox = self._sandbox
+            self._sandbox = None
+        if sandbox is None:
+            return
+        # SDK errors on shutdown are ignored — the sandbox is server-side managed and will
+        # be reaped by Tenki's own idle timeout even if our terminate call fails.
+        with contextlib.suppress(Exception):  # pragma: no cover - defensive
+            await asyncio.to_thread(sandbox.close_if_open)
+
+    async def __aenter__(self) -> TenkiExecuteCodeTool:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.close()

--- a/python/packages/tenki/agent_framework_tenki/_provider.py
+++ b/python/packages/tenki/agent_framework_tenki/_provider.py
@@ -1,0 +1,108 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from agent_framework import AgentSession, ContextProvider, SessionContext
+from agent_framework._tools import ApprovalMode
+
+from ._execute_code_tool import TenkiExecuteCodeTool
+
+TENKI_CODEACT_INSTRUCTIONS = (
+    "You have access to `execute_code`, which runs Python inside a Tenki microVM "
+    "sandbox. Each call runs the code as `python3 -c <code>` — only stdout and "
+    "stderr are captured, so wrap results in `print(...)`; bare expressions are "
+    "not auto-printed like in a REPL. The sandbox filesystem persists across "
+    "calls (files under `/home/tenki` and `/tmp` are visible in later calls), but "
+    "Python interpreter state does not — every call starts a fresh Python process, "
+    "so persist intermediate state through files or environment variables when a "
+    "later call needs it. Do not use Jupyter/IPython magic syntax (`!command`, "
+    "`%magic`, `{var}` interpolation) — those do not work in plain `python3 -c` "
+    "and will raise `SyntaxError`. Use newlines (not semicolons) to introduce "
+    "compound statements like `if`, `for`, `while`, `with`, or `try`: Python's "
+    "grammar does not permit compound statements after `;` and `import x; with "
+    "open(...) as f: ...` raises `SyntaxError`. Valid single-line form: "
+    "`with open('/tmp/x.txt') as f: print(f.read())` — semicolons ARE allowed "
+    "between simple statements inside the block body (e.g. `with open(...) as "
+    "f: x = f.read(); print(x)`); what's forbidden is a compound statement "
+    "following a semicolon. For shell commands, use "
+    "`subprocess`; for example, to install a Python package: `import subprocess, "
+    "sys; subprocess.check_call([sys.executable, '-m', 'pip', 'install', "
+    "'--break-system-packages', '<package>'])`."
+)
+
+
+class TenkiCodeActProvider(ContextProvider):
+    """Inject a Tenki-backed CodeAct surface using a provider-owned execute_code tool.
+
+    On every agent run, the provider exposes its underlying :class:`TenkiExecuteCodeTool`
+    to the context so the model can run Python inside a Tenki sandbox.
+
+    The sandbox is reused across runs of the same provider — its filesystem and installed
+    packages persist across calls, though each individual ``execute_code`` invocation is
+    a fresh Python process. Instantiate a new provider per agent instance when you need
+    isolation between agents.
+    """
+
+    DEFAULT_SOURCE_ID = "tenki_codeact"
+
+    def __init__(
+        self,
+        source_id: str = DEFAULT_SOURCE_ID,
+        *,
+        approval_mode: Optional[ApprovalMode] = None,
+        api_key: Optional[str] = None,
+        sandbox_name: Optional[str] = None,
+        image: Optional[str] = None,
+        project_id: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        cpu_cores: Optional[int] = None,
+        memory_mb: Optional[int] = None,
+        disk_size_gb: Optional[int] = None,
+        max_duration_seconds: Optional[int] = None,
+        exec_timeout_seconds: int = 60,
+        extra_create_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(source_id)
+        self._execute_code_tool = TenkiExecuteCodeTool(
+            approval_mode=approval_mode,
+            api_key=api_key,
+            sandbox_name=sandbox_name,
+            image=image,
+            project_id=project_id,
+            workspace_id=workspace_id,
+            cpu_cores=cpu_cores,
+            memory_mb=memory_mb,
+            disk_size_gb=disk_size_gb,
+            max_duration_seconds=max_duration_seconds,
+            exec_timeout_seconds=exec_timeout_seconds,
+            extra_create_kwargs=extra_create_kwargs,
+        )
+
+    @property
+    def execute_code_tool(self) -> TenkiExecuteCodeTool:
+        """The underlying execute_code tool. Exposed for advanced integration."""
+        return self._execute_code_tool
+
+    async def close(self) -> None:
+        """Terminate the underlying Tenki sandbox and release its resources."""
+        await self._execute_code_tool.close()
+
+    async def __aenter__(self) -> TenkiCodeActProvider:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.close()
+
+    async def before_run(
+        self,
+        *,
+        agent: Any,
+        session: AgentSession | None,
+        context: SessionContext,
+        state: dict[str, Any],
+    ) -> None:
+        """Inject the execute_code tool and its usage instructions for this run."""
+        context.extend_instructions(self.source_id, TENKI_CODEACT_INSTRUCTIONS)
+        context.extend_tools(self.source_id, [self._execute_code_tool])

--- a/python/packages/tenki/pyproject.toml
+++ b/python/packages/tenki/pyproject.toml
@@ -1,0 +1,94 @@
+[project]
+name = "agent-framework-tenki"
+description = "Tenki Sandbox CodeAct integrations for Microsoft Agent Framework."
+authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
+readme = "README.md"
+requires-python = ">=3.10"
+version = "0.1.0b260716"
+license-files = ["LICENSE"]
+urls.homepage = "https://aka.ms/agent-framework"
+urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
+urls.release_notes = "https://github.com/microsoft/agent-framework/releases?q=tag%3Apython-1&expanded=true"
+urls.issues = "https://github.com/microsoft/agent-framework/issues"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
+]
+dependencies = [
+    "agent-framework-core>=1.11.0,<2",
+    "tenki-sandbox>=0.1.0,<1",
+]
+
+[tool.uv]
+prerelease = "if-necessary-or-explicit"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.0"
+
+[tool.pytest.ini_options]
+testpaths = 'tests'
+addopts = "-ra -q -r fEX"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+filterwarnings = []
+timeout = 120
+markers = [
+    "integration: marks tests as integration tests that require external services",
+]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D", "INP", "TD", "ERA001", "RUF", "S"]
+
+[tool.coverage.run]
+omit = [
+    "**/__init__.py"
+]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["agent_framework_tenki"]
+exclude = ['tests']
+
+[tool.mypy]
+plugins = ['pydantic.mypy']
+strict = true
+python_version = "3.10"
+ignore_missing_imports = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+check_untyped_defs = true
+warn_return_any = true
+show_error_codes = true
+warn_unused_ignores = false
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+
+[tool.bandit]
+targets = ["agent_framework_tenki"]
+exclude_dirs = ["tests"]
+
+[tool.poe]
+executor.type = "uv"
+include = "../../shared_tasks.toml"
+
+[tool.poe.tasks.mypy]
+help = "Run MyPy for this package."
+cmd = "mypy --config-file $POE_ROOT/pyproject.toml agent_framework_tenki"
+
+[tool.poe.tasks.test]
+help = "Run the default unit test suite for this package."
+cmd = 'pytest -m "not integration" --cov=agent_framework_tenki --cov-report=term-missing:skip-covered tests'
+
+[build-system]
+requires = ["flit-core >= 3.11,<4.0"]
+build-backend = "flit_core.buildapi"

--- a/python/packages/tenki/tests/tenki/test_tenki_codeact.py
+++ b/python/packages/tenki/tests/tenki/test_tenki_codeact.py
@@ -1,0 +1,625 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+if sys.platform == "win32":  # pragma: no cover - platform-dependent
+    # The integration test relies on POSIX-style commands inside the sandbox. Skip the
+    # whole module on Windows to match the sibling ``agent-framework-hyperlight`` tests.
+    pytest.skip("Tenki tests use POSIX-style shell invocations.", allow_module_level=True)
+
+# The executor module raises ``RuntimeError`` at import time when ``tenki_sandbox`` is
+# missing. In that case there's nothing meaningful to test here — skip the whole module.
+try:
+    from agent_framework_tenki import TenkiCodeActProvider, TenkiExecuteCodeTool
+    from agent_framework_tenki import _execute_code_tool as _tenki_module
+except RuntimeError as _import_err:  # pragma: no cover - environment-dependent
+    pytest.skip(
+        f"tenki-sandbox SDK is not importable ({_import_err}); skipping Tenki tests.",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fake Tenki SDK — deterministic, in-memory replacement for ``tenki_sandbox.Sandbox``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeExecResult(SimpleNamespace):
+    def __init__(self, *, stdout_text: str = "", stderr_text: str = "", exit_code: int = 0) -> None:
+        super().__init__(stdout_text=stdout_text, stderr_text=stderr_text, exit_code=exit_code)
+
+
+class _FakeSandbox:
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+        self.closed: bool = False
+        self.exec_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.script_result: _FakeExecResult = _FakeExecResult(stdout_text="ok\n")
+        self.script_handler: Any = None
+        # Lifecycle state — mirrors the real SDK's ``sandbox.state`` string values.
+        self.state: str = "RUNNING"
+        self.refresh_calls: int = 0
+        self.resume_calls: int = 0
+        # When set, ``refresh()`` transitions ``state`` to this value on the next call.
+        self.refresh_transitions_to: str | None = None
+        # When set, ``refresh()`` raises this exception on the next call.
+        self.refresh_raises: BaseException | None = None
+        # When set, ``resume()`` raises this exception on the next call.
+        self.resume_raises: BaseException | None = None
+
+    def exec(self, *args: Any, **kwargs: Any) -> _FakeExecResult:
+        self.exec_calls.append((args, kwargs))
+        if self.script_handler is not None:
+            return self.script_handler(args, kwargs)  # type: ignore[no-any-return]
+        return self.script_result
+
+    def refresh(self) -> None:
+        self.refresh_calls += 1
+        if self.refresh_raises is not None:
+            exc, self.refresh_raises = self.refresh_raises, None
+            raise exc
+        if self.refresh_transitions_to is not None:
+            self.state = self.refresh_transitions_to
+            self.refresh_transitions_to = None
+
+    def resume(self) -> None:
+        self.resume_calls += 1
+        if self.resume_raises is not None:
+            exc, self.resume_raises = self.resume_raises, None
+            raise exc
+        self.state = "RUNNING"
+
+    def close_if_open(self) -> None:
+        self.closed = True
+
+
+class _FakeSandboxFactory:
+    """Stand-in for :class:`tenki_sandbox.Sandbox`. Records ``create`` calls."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.sandboxes: list[_FakeSandbox] = []
+        self.raise_on_create: BaseException | None = None
+
+    @property
+    def last_sandbox(self) -> _FakeSandbox | None:
+        return self.sandboxes[-1] if self.sandboxes else None
+
+    def create(self, **kwargs: Any) -> _FakeSandbox:
+        if self.raise_on_create is not None:
+            raise self.raise_on_create
+        self.create_calls.append(kwargs)
+        sandbox = _FakeSandbox(name=kwargs.get("name", "sb-fake"))
+        self.sandboxes.append(sandbox)
+        return sandbox
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> _FakeSandboxFactory:
+    """Replace the Tenki ``Sandbox`` class in the executor module with an in-memory fake."""
+    factory = _FakeSandboxFactory()
+    monkeypatch.setattr(_tenki_module, "Sandbox", factory)
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no network / no real Tenki service.
+# ---------------------------------------------------------------------------
+
+
+def test_default_sandbox_name_carries_agent_framework_prefix() -> None:
+    tool = TenkiExecuteCodeTool()
+    assert tool.sandbox_name.startswith("agent-framework-")
+    # 8-char hex suffix, per _default_sandbox_name.
+    suffix = tool.sandbox_name.rsplit("-", 1)[-1]
+    assert len(suffix) == 8
+    int(suffix, 16)  # raises if the suffix is not hex.
+
+
+def test_explicit_sandbox_name_is_preserved() -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="my-name")
+    assert tool.sandbox_name == "my-name"
+
+
+def test_exec_timeout_below_one_is_rejected() -> None:
+    with pytest.raises(ValueError, match="exec_timeout_seconds"):
+        TenkiExecuteCodeTool(exec_timeout_seconds=0)
+
+
+async def test_run_code_lazily_creates_sandbox(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="lazy")
+    # No sandbox yet just from construction.
+    assert fake_sdk.create_calls == []
+
+    await tool._run_code(code="print('hello')")
+    assert len(fake_sdk.create_calls) == 1
+    assert fake_sdk.create_calls[0]["name"] == "lazy"
+
+
+async def test_run_code_reuses_the_same_sandbox_across_calls(fake_sdk: _FakeSandboxFactory) -> None:
+    """Reuse-per-session: subsequent calls do NOT create a new sandbox."""
+    tool = TenkiExecuteCodeTool(sandbox_name="reuse")
+    await tool._run_code(code="x = 1")
+    await tool._run_code(code="print(x)")
+    await tool._run_code(code="print(x + 1)")
+    assert len(fake_sdk.create_calls) == 1
+    # All exec calls landed on the single created sandbox.
+    assert fake_sdk.last_sandbox is not None
+    assert len(fake_sdk.last_sandbox.exec_calls) == 3
+
+
+async def test_close_terminates_sandbox_and_next_call_creates_new_one(
+    fake_sdk: _FakeSandboxFactory,
+) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="cycle")
+    await tool._run_code(code="print('a')")
+    first_sandbox = fake_sdk.last_sandbox
+    assert first_sandbox is not None
+    await tool.close()
+    assert first_sandbox.closed is True
+
+    await tool._run_code(code="print('b')")
+    assert len(fake_sdk.create_calls) == 2
+    assert fake_sdk.last_sandbox is not first_sandbox
+
+
+async def test_paused_sandbox_is_auto_resumed_between_calls(fake_sdk: _FakeSandboxFactory) -> None:
+    """A sandbox paused between calls must be transparently resumed before the next exec."""
+    tool = TenkiExecuteCodeTool(sandbox_name="paused")
+    await tool._run_code(code="print('a')")
+    sandbox = fake_sdk.last_sandbox
+    assert sandbox is not None
+
+    # Simulate a server-side pause discovered on the next ``refresh()``.
+    sandbox.refresh_transitions_to = "PAUSED"
+
+    await tool._run_code(code="print('b')")
+
+    # Same sandbox reused (no re-provision).
+    assert len(fake_sdk.create_calls) == 1
+    assert fake_sdk.last_sandbox is sandbox
+    # refresh + resume were called, and state landed back on RUNNING.
+    assert sandbox.refresh_calls == 1
+    assert sandbox.resume_calls == 1
+    assert sandbox.state == "RUNNING"
+    # The second exec landed on the same sandbox.
+    assert len(sandbox.exec_calls) == 2
+
+
+async def test_terminated_sandbox_is_replaced_by_fresh_provision(fake_sdk: _FakeSandboxFactory) -> None:
+    """A sandbox that terminated between calls must be dropped and replaced."""
+    tool = TenkiExecuteCodeTool(sandbox_name="gone")
+    await tool._run_code(code="print('a')")
+    first = fake_sdk.last_sandbox
+    assert first is not None
+
+    first.refresh_transitions_to = "TERMINATED"
+
+    await tool._run_code(code="print('b')")
+
+    # A brand new sandbox was provisioned; the terminated one was not resumed.
+    assert len(fake_sdk.create_calls) == 2
+    assert fake_sdk.last_sandbox is not first
+    assert first.resume_calls == 0
+    assert fake_sdk.last_sandbox is not None
+    assert len(fake_sdk.last_sandbox.exec_calls) == 1
+
+
+async def test_resume_failure_surfaces_as_error_content(fake_sdk: _FakeSandboxFactory) -> None:
+    """If ``resume()`` raises, the failure surfaces to the caller as error content.
+
+    The stale handle is deliberately kept so that a subsequent call (once the underlying
+    condition clears, e.g. quota released) can retry ``resume()`` on the same sandbox
+    without losing filesystem state to an unnecessary re-provision.
+    """
+    tool = TenkiExecuteCodeTool(sandbox_name="resume-fail")
+    await tool._run_code(code="print('a')")
+    sandbox = fake_sdk.last_sandbox
+    assert sandbox is not None
+
+    sandbox.refresh_transitions_to = "PAUSED"
+    sandbox.resume_raises = RuntimeError("quota_exceeded: resume denied")
+
+    contents = await tool._run_code(code="print('b')")
+
+    # RuntimeError from _ensure_sandbox_sync is caught in _run_code and returned as
+    # error content — the caller sees a structured failure, not an unhandled exception.
+    assert len(contents) == 1
+    assert contents[0].type == "error"
+    assert "Failed to provision Tenki sandbox" in (contents[0].message or "")
+    assert "quota_exceeded" in (contents[0].error_details or "")
+
+    # Resume was attempted exactly once; no re-provision happened.
+    assert sandbox.resume_calls == 1
+    assert len(fake_sdk.create_calls) == 1
+
+
+async def test_refresh_failure_falls_back_to_fresh_provision(fake_sdk: _FakeSandboxFactory) -> None:
+    """If ``refresh()`` raises, the stale handle is dropped and a fresh sandbox is provisioned."""
+    tool = TenkiExecuteCodeTool(sandbox_name="stale")
+    await tool._run_code(code="print('a')")
+    first = fake_sdk.last_sandbox
+    assert first is not None
+
+    first.refresh_raises = RuntimeError("connection reset")
+
+    await tool._run_code(code="print('b')")
+
+    assert len(fake_sdk.create_calls) == 2
+    assert fake_sdk.last_sandbox is not first
+    # We did not attempt to resume a sandbox whose state we couldn't confirm.
+    assert first.resume_calls == 0
+
+
+async def test_close_is_idempotent(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="idempotent")
+    await tool.close()  # no sandbox yet — no-op.
+    await tool._run_code(code="print('x')")
+    await tool.close()
+    await tool.close()  # second close — no-op.
+    assert fake_sdk.last_sandbox is not None
+    assert fake_sdk.last_sandbox.closed is True
+
+
+async def test_async_context_manager_closes_sandbox(fake_sdk: _FakeSandboxFactory) -> None:
+    async with TenkiExecuteCodeTool(sandbox_name="cm") as tool:
+        await tool._run_code(code="print('inside')")
+    assert fake_sdk.last_sandbox is not None
+    assert fake_sdk.last_sandbox.closed is True
+
+
+async def test_create_kwargs_only_forward_set_optionals(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(
+        sandbox_name="kwargs",
+        api_key="tk_TEST",
+        image="my-image",
+        project_id="proj-1",
+        workspace_id="ws-1",
+        cpu_cores=4,
+        memory_mb=2048,
+        disk_size_gb=10,
+        max_duration_seconds=300,
+        extra_create_kwargs={"allow_inbound": True},
+    )
+    await tool._run_code(code="pass")
+
+    call = fake_sdk.create_calls[0]
+    assert call["name"] == "kwargs"
+    assert call["auth_token"] == "tk_TEST"
+    assert call["image"] == "my-image"
+    assert call["project_id"] == "proj-1"
+    assert call["workspace_id"] == "ws-1"
+    assert call["cpu_cores"] == 4
+    assert call["memory_mb"] == 2048
+    assert call["disk_size_gb"] == 10
+    assert call["max_duration"] == 300
+    assert call["allow_inbound"] is True
+
+
+async def test_create_kwargs_omit_unset_optionals(
+    fake_sdk: _FakeSandboxFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Every Tenki env var the tool consults must be scrubbed so this test doesn't
+    # inherit a real developer/CI value and start asserting against it.
+    monkeypatch.delenv("TENKI_API_KEY", raising=False)
+    monkeypatch.delenv("TENKI_PROJECT_ID", raising=False)
+    monkeypatch.delenv("TENKI_WORKSPACE_ID", raising=False)
+    tool = TenkiExecuteCodeTool(sandbox_name="bare")
+    await tool._run_code(code="pass")
+
+    call = fake_sdk.create_calls[0]
+    for absent in (
+        "auth_token",
+        "image",
+        "project_id",
+        "workspace_id",
+        "cpu_cores",
+        "memory_mb",
+        "disk_size_gb",
+        "max_duration",
+    ):
+        assert absent not in call, f"expected {absent!r} to be omitted from create kwargs"
+
+
+async def test_env_api_key_is_forwarded_as_auth_token(
+    fake_sdk: _FakeSandboxFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TENKI_API_KEY", "tk_FROM_ENV")
+    tool = TenkiExecuteCodeTool(sandbox_name="env-key")
+    await tool._run_code(code="pass")
+    assert fake_sdk.create_calls[0]["auth_token"] == "tk_FROM_ENV"
+
+
+async def test_env_project_id_is_forwarded_when_unset(
+    fake_sdk: _FakeSandboxFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TENKI_PROJECT_ID env var populates project_id when the constructor arg is None."""
+    monkeypatch.setenv("TENKI_PROJECT_ID", "proj-from-env")
+    tool = TenkiExecuteCodeTool(sandbox_name="env-proj")
+    await tool._run_code(code="pass")
+    assert fake_sdk.create_calls[0]["project_id"] == "proj-from-env"
+
+
+async def test_env_workspace_id_is_forwarded_when_unset(
+    fake_sdk: _FakeSandboxFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TENKI_WORKSPACE_ID env var populates workspace_id when the constructor arg is None."""
+    monkeypatch.setenv("TENKI_WORKSPACE_ID", "ws-from-env")
+    tool = TenkiExecuteCodeTool(sandbox_name="env-ws")
+    await tool._run_code(code="pass")
+    assert fake_sdk.create_calls[0]["workspace_id"] == "ws-from-env"
+
+
+async def test_constructor_project_id_wins_over_env(
+    fake_sdk: _FakeSandboxFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit constructor project_id takes precedence over TENKI_PROJECT_ID env."""
+    monkeypatch.setenv("TENKI_PROJECT_ID", "proj-from-env")
+    monkeypatch.setenv("TENKI_WORKSPACE_ID", "ws-from-env")
+    tool = TenkiExecuteCodeTool(
+        sandbox_name="explicit-wins",
+        project_id="proj-explicit",
+        workspace_id="ws-explicit",
+    )
+    await tool._run_code(code="pass")
+    call = fake_sdk.create_calls[0]
+    assert call["project_id"] == "proj-explicit"
+    assert call["workspace_id"] == "ws-explicit"
+
+
+async def test_create_failure_returns_error_content(fake_sdk: _FakeSandboxFactory) -> None:
+    fake_sdk.raise_on_create = RuntimeError("resource_exhausted: no live node-agent")
+    tool = TenkiExecuteCodeTool(sandbox_name="fails")
+    contents = await tool._run_code(code="print('never runs')")
+    assert len(contents) == 1
+    assert contents[0].type == "error"
+    assert "Failed to provision Tenki sandbox" in (contents[0].message or "")
+    assert "resource_exhausted" in (contents[0].error_details or "")
+
+
+async def test_run_code_uses_python3_dash_c_with_timeout(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="argshape", exec_timeout_seconds=45)
+    await tool._run_code(code="print(1 + 1)")
+
+    assert fake_sdk.last_sandbox is not None
+    args, kwargs = fake_sdk.last_sandbox.exec_calls[0]
+    assert args == ("python3", "-c", "print(1 + 1)")
+    assert kwargs == {"timeout": 45}
+
+
+async def test_stdout_only_produces_single_text_content(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="stdout")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(stdout_text="hello\n", exit_code=0)
+    contents = await tool._run_code(code="print('hello')")
+    assert len(contents) == 1
+    assert contents[0].type == "text"
+    assert contents[0].text == "hello\n"
+
+
+async def test_non_zero_exit_produces_error_content_with_stderr(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="failing")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(stdout_text="", stderr_text="Traceback...\n", exit_code=1)
+    contents = await tool._run_code(code="raise ValueError('boom')")
+    error_contents = [c for c in contents if c.type == "error"]
+    assert len(error_contents) == 1
+    message = error_contents[0].message or ""
+    assert "status 1" in message
+    # stderr must be inlined into the message so LLMs that under-weight
+    # `error_details` still see the traceback in the primary field.
+    assert "Traceback" in message
+    assert "Traceback" in (error_contents[0].error_details or "")
+
+
+async def test_syntaxerror_appends_recovery_hint(fake_sdk: _FakeSandboxFactory) -> None:
+    """SyntaxError stderr must trigger the recovery hint in the message field."""
+    tool = TenkiExecuteCodeTool(sandbox_name="syntax")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(
+        stdout_text="",
+        stderr_text=(
+            'File "<string>", line 1\n'
+            "    import os; with open('/tmp/x') as f: pass\n"
+            "               ^^^^\n"
+            "SyntaxError: invalid syntax"
+        ),
+        exit_code=1,
+    )
+    contents = await tool._run_code(code="import os; with open('/tmp/x') as f: pass")
+    error_content = next(c for c in contents if c.type == "error")
+    message = error_content.message or ""
+    # Hint should mention both known failure modes.
+    assert "Common causes" in message
+    assert "compound statement" in message
+    assert "\\n" in message  # literal-newline pitfall reference
+
+
+async def test_non_syntax_error_does_not_append_hint(fake_sdk: _FakeSandboxFactory) -> None:
+    """Non-SyntaxError stderr must NOT trigger the recovery hint (no misleading advice)."""
+    tool = TenkiExecuteCodeTool(sandbox_name="runtime")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(
+        stdout_text="",
+        stderr_text=(
+            'Traceback (most recent call last):\n  File "<string>", line 1, in <module>\nValueError: bad value'
+        ),
+        exit_code=1,
+    )
+    contents = await tool._run_code(code="raise ValueError('bad value')")
+    error_content = next(c for c in contents if c.type == "error")
+    message = error_content.message or ""
+    assert "ValueError" in message
+    assert "Common causes" not in message
+
+
+async def test_error_message_truncates_long_stderr(fake_sdk: _FakeSandboxFactory) -> None:
+    """Very long stderr must be truncated in the message so it doesn't blow the field."""
+    tool = TenkiExecuteCodeTool(sandbox_name="failing-long")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    long_stderr = "err " * 500  # 2000 chars total
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(stdout_text="", stderr_text=long_stderr, exit_code=1)
+    contents = await tool._run_code(code="raise Exception('x')")
+    error_contents = [c for c in contents if c.type == "error"]
+    assert len(error_contents) == 1
+    message = error_contents[0].message or ""
+    # message field capped: status prefix + up to 500 chars of stderr + minor formatting.
+    # Verify total is well below the full stderr length so the LLM's context isn't flooded.
+    assert len(message) < 700
+    # Full stderr still available via error_details for callers that want it.
+    assert len(error_contents[0].error_details or "") == len(long_stderr)
+
+
+async def test_stderr_without_error_becomes_text_content(fake_sdk: _FakeSandboxFactory) -> None:
+    """Warnings to stderr should still surface to the model, matching Hyperlight."""
+    tool = TenkiExecuteCodeTool(sandbox_name="warn")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(
+        stdout_text="", stderr_text="DeprecationWarning: foo\n", exit_code=0
+    )
+    contents = await tool._run_code(code="import warnings; warnings.warn('foo')")
+    assert any(c.type == "text" and "DeprecationWarning" in (c.text or "") for c in contents)
+    assert not any(c.type == "error" for c in contents)
+
+
+async def test_empty_output_produces_placeholder_text(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="silent")
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_result = _FakeExecResult(stdout_text="", stderr_text="", exit_code=0)
+    contents = await tool._run_code(code="x = 1")
+    assert len(contents) == 1
+    assert contents[0].type == "text"
+    assert "without output" in (contents[0].text or "")
+
+
+async def test_exec_exception_returns_error_content(fake_sdk: _FakeSandboxFactory) -> None:
+    tool = TenkiExecuteCodeTool(sandbox_name="exec-err")
+
+    def handler(_args: tuple[Any, ...], _kwargs: dict[str, Any]) -> _FakeExecResult:
+        raise RuntimeError("SDK exec transport error")
+
+    await tool._run_code(code="init")
+    assert fake_sdk.last_sandbox is not None
+    fake_sdk.last_sandbox.script_handler = handler
+
+    contents = await tool._run_code(code="print('x')")
+    assert len(contents) == 1
+    assert contents[0].type == "error"
+    assert "Sandbox execution failed" in (contents[0].message or "")
+
+
+async def test_tool_name_and_description() -> None:
+    tool = TenkiExecuteCodeTool()
+    assert tool.name == "execute_code"
+    assert "Tenki" in tool.description
+
+
+async def test_provider_close_terminates_underlying_sandbox(fake_sdk: _FakeSandboxFactory) -> None:
+    provider = TenkiCodeActProvider(sandbox_name="prov")
+    await provider.execute_code_tool._run_code(code="print('x')")
+    assert fake_sdk.last_sandbox is not None
+    await provider.close()
+    assert fake_sdk.last_sandbox.closed is True
+
+
+async def test_provider_async_context_manager_closes_sandbox(fake_sdk: _FakeSandboxFactory) -> None:
+    async with TenkiCodeActProvider(sandbox_name="prov-cm") as provider:
+        await provider.execute_code_tool._run_code(code="print('x')")
+        assert fake_sdk.last_sandbox is not None
+        assert fake_sdk.last_sandbox.closed is False
+    assert fake_sdk.last_sandbox is not None
+    assert fake_sdk.last_sandbox.closed is True
+
+
+async def test_provider_exposes_execute_code_tool_before_run(fake_sdk: _FakeSandboxFactory) -> None:
+    provider = TenkiCodeActProvider(sandbox_name="ctx")
+    recorded: dict[str, Any] = {"tools_calls": [], "instructions_calls": []}
+
+    class _StubContext:
+        def extend_tools(self, source_id: str, tools: list[Any]) -> None:
+            recorded["tools_calls"].append((source_id, tools))
+
+        def extend_instructions(self, source_id: str, instructions: str) -> None:
+            recorded["instructions_calls"].append((source_id, instructions))
+
+    # ``_StubContext`` is structurally compatible with ``SessionContext`` (implements
+    # extend_tools + extend_instructions) but isn't a nominal subclass. Cast to Any
+    # so strict type checkers accept the deliberate stub injection.
+    await provider.before_run(agent=None, session=None, context=cast(Any, _StubContext()), state={})
+
+    assert len(recorded["tools_calls"]) == 1
+    tools_source_id, tools = recorded["tools_calls"][0]
+    assert tools_source_id == TenkiCodeActProvider.DEFAULT_SOURCE_ID
+    assert tools == [provider.execute_code_tool]
+
+    assert len(recorded["instructions_calls"]) == 1
+    instr_source_id, instructions = recorded["instructions_calls"][0]
+    assert instr_source_id == TenkiCodeActProvider.DEFAULT_SOURCE_ID
+    # The instructions must reinforce the print() requirement, the persistence
+    # rules, the "no Jupyter magic" rule, and the "newlines for compound
+    # statements" rule so that small models tool-call correctly against a
+    # fresh interpreter.
+    assert "print(" in instructions
+    assert "python3 -c" in instructions
+    assert "filesystem persists" in instructions
+    assert "subprocess" in instructions
+    # Match on '!command' to catch the specific Jupyter-magic footgun we hit
+    # in the field (small models emitted `!{sys.executable} -m pip install ...`).
+    assert "!command" in instructions
+    # Match on 'compound statements' to catch the semicolon-in-compound-stmt
+    # footgun (small models emitted `import os; with open(...) as f: ...`).
+    assert "compound statements" in instructions
+    # A concrete valid single-line `with` example nudges small models toward
+    # the shape that actually worked in the field.
+    assert "with open('/tmp/x.txt') as f: print(f.read())" in instructions
+
+
+# ---------------------------------------------------------------------------
+# Integration test — real Tenki service. Requires TENKI_API_KEY. Marked as
+# integration so ``pytest -m "not integration"`` (the default suite) skips it.
+# ---------------------------------------------------------------------------
+
+
+def _tenki_integration_skip_reason() -> str | None:
+    if os.environ.get("SKIP_TENKI", "").lower() == "true":
+        return "SKIP_TENKI=true is set."
+    if importlib.util.find_spec("tenki_sandbox") is None:
+        return "tenki-sandbox is not installed."
+    if not os.environ.get("TENKI_API_KEY"):
+        return "TENKI_API_KEY is not set."
+    return None
+
+
+skip_if_tenki_integration_disabled = pytest.mark.skipif(
+    _tenki_integration_skip_reason() is not None,
+    reason=_tenki_integration_skip_reason() or "unknown",
+)
+
+
+@pytest.mark.integration
+@skip_if_tenki_integration_disabled
+async def test_integration_execute_hello_world() -> None:
+    project_id = os.environ.get("TENKI_PROJECT_ID")
+    async with TenkiExecuteCodeTool(
+        sandbox_name=f"agent-framework-ci-{os.getpid()}",
+        project_id=project_id,
+        max_duration_seconds=300,
+    ) as tool:
+        contents = await tool._run_code(code="print('hello from tenki')")
+    text_contents = [c for c in contents if c.type == "text"]
+    assert any("hello from tenki" in (c.text or "") for c in text_contents)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -105,6 +105,7 @@ agent-framework-orchestrations = { workspace = true }
 agent-framework-purview = { workspace = true }
 agent-framework-redis = { workspace = true }
 agent-framework-azure-contentunderstanding = { workspace = true }
+agent-framework-tenki = { workspace = true }
 agent-framework-tools = { workspace = true }
 
 [tool.ruff]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -63,6 +63,7 @@ members = [
     "agent-framework-orchestrations",
     "agent-framework-purview",
     "agent-framework-redis",
+    "agent-framework-tenki",
     "agent-framework-tools",
 ]
 constraints = [
@@ -924,6 +925,15 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.6,<3" },
     { name = "redis", specifier = ">=6.4.0,<7.2.1" },
     { name = "redisvl", specifier = ">=0.11.0,<0.16" },
+]
+
+[[package]]
+name = "agent-framework-tenki"
+version = "0.1.0b260716"
+source = { editable = "packages/tenki" }
+dependencies = [
+    { name = "agent-framework-core" },
+    { name = "tenki-sandbox" },
 ]
 
 [[package]]
@@ -7978,6 +7988,20 @@ wheels = [
 ]
 
 [[package]]
+name = "tenki-sandbox"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/3e/319d553fb6bd266aed3f5e0ec5d9b1865ee7cb45388c9dc6dac1ee30a51f/tenki_sandbox-0.3.6.tar.gz", hash = "sha256:f4a6e0b7329a7fd42138d5eb582adb1356c084e6f6b3fe046530cbbcd426ffe2", size = 144662, upload-time = "2026-07-10T08:28:16.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/860d1ba154200904b493ed4353e1994aa14627f407144d975b21e4cf51be/tenki_sandbox-0.3.6-py3-none-any.whl", hash = "sha256:324fe804a0b561ffa129e6b1b1874e0d7747ebcb566d976e8485c9dd45ef6853", size = 128658, upload-time = "2026-07-10T08:28:14.925Z" },
+]
+
+[[package]]
 name = "termcolor"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8524,6 +8548,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation and Context

CodeAct currently has two backends in the Python repo: `agent-framework-hyperlight`
(WASM micro-VM) and `agent-framework-monty` (in-process Rust interpreter). Both are
great for fast, low-overhead code exec, but neither offers full Linux userland
isolation — you can't `apt install`, run arbitrary subprocesses, or keep long-lived
state on a real filesystem across calls.

This PR adds a third backend — `agent-framework-tenki` — that wraps
[Tenki Sandbox](https://tenki.cloud) (managed Linux micro-VMs with a Python SDK)
behind the same `*CodeActProvider` / `*ExecuteCodeTool` shape as the existing
backends, so users can swap providers with minimal churn. Tenki fills the "I need
a real Linux box for the agent" niche: apt/pip installs persist, subprocesses run
natively, `/tmp` and the user home carry state across calls, and paused sandboxes
are auto-resumed by the tool.

### Description

**New alpha package `agent-framework-tenki`** (`python/packages/tenki/`).

Public API (mirrors Hyperlight / Monty naming):

- `TenkiCodeActProvider` — `ContextProvider` that injects an `execute_code` tool
  plus CodeAct usage instructions into every agent run.
- `TenkiExecuteCodeTool` — standalone `FunctionTool` for mixed-tool agents or
  manual wiring.

Constructor kwargs: `approval_mode`, `api_key`, `sandbox_name`, `image`,
`project_id`, `workspace_id`, `cpu_cores`, `memory_mb`, `disk_size_gb`,
`max_duration_seconds`, `exec_timeout_seconds`, `extra_create_kwargs`. Env
fallbacks (`TENKI_API_KEY`, `TENKI_PROJECT_ID`, `TENKI_WORKSPACE_ID`) match
the pattern used by other cloud-backed packages; explicit constructor args win.

**Sandbox lifecycle** (reuse-per-tool, reconciled per call):

- Lazy provision on the first `execute_code` invocation, reused for every later
  call on the same tool / provider instance.
- Before each call the tool refreshes remote state and:
  - `PAUSED` → transparently `resume()` and continue on the same sandbox
    (filesystem + installed packages carry across the pause);
  - `TERMINATING`/`TERMINATED` → drop the handle, provision a fresh sandbox;
  - `refresh()` failure → drop the handle, provision a fresh sandbox.
- `close()` (or `async with`) terminates the sandbox server-side.

**Injected CodeAct instructions** cover footguns observed in the field with
smaller models: `print(...)` requirement (only stdout/stderr are captured),
no Jupyter magic (`!command`, `%magic`), no compound statement after `;`, use
`subprocess` for pip installs. Non-zero exit surfaces stderr inlined into the
error `message` field (small models under-weight secondary fields); a
SyntaxError-specific recovery hint is appended only for that error class.

**Internals:**

- Sync Tenki SDK bridged to async agent-framework via `asyncio.to_thread` +
  a `threading.Lock` around sandbox create/reconcile/close.
- `_build_create_kwargs` only forwards optionals that were explicitly set —
  the Tenki SDK applies its own defaults, and rejects some `field=None` inputs.
- Sandbox naming defaults to `agent-framework-<8-hex>`, matching the
  client-attributable naming already used in `agent-framework-durabletask`.

**Alpha-policy compliance** (per `python-package-management`):

- Added `agent-framework-tenki = { workspace = true }` to root
  `python/pyproject.toml`.
- **Not** added to `agent-framework[all]`; **no** `agent_framework.tenki`
  lazy-loading shim — both deferred until beta promotion.

**Tests:**

- **32 hermetic unit tests** stubbing `tenki_sandbox.Sandbox` for speed and to
  keep CI green without the SDK. Coverage includes lazy provisioning, sandbox
  reuse, kwargs forwarding + omission, env-var fallbacks, `python3 -c` arg
  shape + timeout, stdout/stderr handling, error content shape, long-stderr
  truncation, empty-output placeholder, close/idempotency, async-cm cleanup,
  provider `before_run` injection, and the full reconcile path (pause →
  auto-resume, terminate → re-provision, refresh failure → re-provision,
  resume failure → structured error content).
- **1 opt-in integration test** marked `@pytest.mark.integration`, guarded on
  `TENKI_API_KEY` — round-trips `print('hello from tenki')` against the real
  Tenki service.

### Out of scope (deliberately, for the alpha)

- **In-sandbox host tool callbacks** — the Tenki SDK does not expose a callback
  bridge, so code running inside the sandbox cannot invoke host-side
  `FunctionTool` instances. Documented in the README and class docstrings.
- **Explicit file mounts / outbound network allow-lists** — Tenki surfaces
  these via SDK kwargs (`clone_repo_url`, `allow_inbound`, `allow_outbound`,
  `volumes`, …) rather than a modeled API on our side. Users pass them
  through `extra_create_kwargs`. A README section enumerates the common ones.
- **Snapshots for cross-termination state** — the SDK's `snapshot_id` /
  volumes surface is likewise reachable through `extra_create_kwargs`;
  we don't model it as first-class.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] All unit tests pass, and I have added new tests where possible
- [ ] **Is this a breaking change?** No — additive only (new package).