### PR TITLE
Harden workflow credential selection

### DIFF
--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -1,0 +1,112 @@
+name: Get GitHub automation token
+description: Creates a GitHub App installation token with a temporary PAT fallback
+
+inputs:
+  mode:
+    description: Authentication mode (app, app-with-fallback, or pat)
+    required: false
+    default: app-with-fallback
+  azure-client-id:
+    description: Client ID of the Azure workload identity
+    required: true
+  azure-tenant-id:
+    description: Azure tenant ID
+    required: true
+  azure-subscription-id:
+    description: Azure subscription containing the Key Vault
+    required: true
+  key-vault-name:
+    description: Azure Key Vault name
+    required: true
+  key-name:
+    description: Key Vault key used to sign the GitHub App JWT
+    required: true
+  github-app-client-id:
+    description: GitHub App client ID
+    required: true
+  github-app-installation-id:
+    description: GitHub App installation ID
+    required: true
+  repository:
+    description: Repository to include in the installation token
+    required: true
+  fallback-token:
+    description: PAT used temporarily when app authentication is unavailable
+    required: false
+
+outputs:
+  token:
+    description: GitHub App installation token or fallback PAT
+    value: ${{ steps.select-token.outputs.token }}
+  source:
+    description: Selected authentication source
+    value: ${{ steps.select-token.outputs.source }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate authentication mode
+      shell: bash
+      env:
+        AUTH_MODE: ${{ inputs.mode || 'app-with-fallback' }}
+      run: |
+        if [[ "$AUTH_MODE" != "app" && "$AUTH_MODE" != "app-with-fallback" && "$AUTH_MODE" != "pat" ]]; then
+          echo "::error::Unsupported GitHub authentication mode."
+          exit 1
+        fi
+
+    - name: Sign in to Azure
+      id: azure-login
+      if: ${{ (inputs.mode || 'app-with-fallback') != 'pat' }}
+      continue-on-error: true
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
+
+    - name: Create GitHub App installation token
+      id: app-token
+      if: ${{ (inputs.mode || 'app-with-fallback') != 'pat' && steps.azure-login.outcome == 'success' }}
+      continue-on-error: true
+      shell: bash
+      env:
+        AZURE_SUBSCRIPTION_ID: ${{ inputs.azure-subscription-id }}
+        KEY_VAULT_NAME: ${{ inputs.key-vault-name }}
+        KEY_NAME: ${{ inputs.key-name }}
+        GITHUB_APP_CLIENT_ID: ${{ inputs.github-app-client-id }}
+        GITHUB_APP_INSTALLATION_ID: ${{ inputs.github-app-installation-id }}
+        TARGET_REPOSITORY: ${{ inputs.repository }}
+      run: |
+        token="$(node "$GITHUB_ACTION_PATH/create-token.js")"
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"
+
+    - name: Select authentication token
+      id: select-token
+      shell: bash
+      env:
+        AUTH_MODE: ${{ inputs.mode || 'app-with-fallback' }}
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        FALLBACK_TOKEN: ${{ inputs.fallback-token }}
+      run: |
+        if [[ "$AUTH_MODE" != "pat" && -n "$APP_TOKEN" ]]; then
+          token="$APP_TOKEN"
+          source="app"
+          echo "::notice::GitHub authentication source: app"
+        elif [[ "$AUTH_MODE" == "app-with-fallback" && -n "$FALLBACK_TOKEN" ]]; then
+          token="$FALLBACK_TOKEN"
+          source="pat-fallback"
+          echo "::warning::GitHub authentication source: PAT fallback"
+        elif [[ "$AUTH_MODE" == "pat" && -n "$FALLBACK_TOKEN" ]]; then
+          token="$FALLBACK_TOKEN"
+          source="pat-forced"
+          echo "::warning::GitHub authentication source: PAT (forced rollout mode)"
+        else
+          echo "::error::GitHub App authentication is unavailable and no fallback PAT was provided."
+          exit 1
+        fi
+
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"
+        echo "source=$source" >> "$GITHUB_OUTPUT"

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -8,28 +8,28 @@ inputs:
     default: app-with-fallback
   azure-client-id:
     description: Client ID of the Azure workload identity
-    required: true
+    required: false
   azure-tenant-id:
     description: Azure tenant ID
-    required: true
+    required: false
   azure-subscription-id:
     description: Azure subscription containing the Key Vault
-    required: true
+    required: false
   key-vault-name:
     description: Azure Key Vault name
-    required: true
+    required: false
   key-name:
     description: Key Vault key used to sign the GitHub App JWT
-    required: true
+    required: false
   github-app-client-id:
     description: GitHub App client ID
-    required: true
+    required: false
   github-app-installation-id:
     description: GitHub App installation ID
-    required: true
+    required: false
   repository:
     description: Repository to include in the installation token
-    required: true
+    required: false
   fallback-token:
     description: PAT used temporarily when app authentication is unavailable
     required: false

--- a/.github/actions/github-app-token/create-token.js
+++ b/.github/actions/github-app-token/create-token.js
@@ -50,13 +50,15 @@ async function createInstallationToken(config, dependencies = {}) {
   const execute = dependencies.execute ?? execFileSync;
   const request = dependencies.fetch ?? fetch;
   const nowSeconds = dependencies.nowSeconds ?? Math.floor(Date.now() / 1000);
-  const signingInput = createJwtSigningInput(config.githubAppClientId, nowSeconds);
-  const jwt = signJwt(signingInput, config, execute);
-  const [owner, repository] = config.targetRepository.split('/');
+  const repositoryParts = config.targetRepository.split('/');
 
-  if (!owner || !repository) {
+  if (repositoryParts.length !== 2 || repositoryParts.some((part) => part.length === 0)) {
     throw new Error('TARGET_REPOSITORY must use the owner/repository format.');
   }
+
+  const [, repository] = repositoryParts;
+  const signingInput = createJwtSigningInput(config.githubAppClientId, nowSeconds);
+  const jwt = signJwt(signingInput, config, execute);
 
   const response = await request(
     `https://api.github.com/app/installations/${config.githubAppInstallationId}/access_tokens`,

--- a/.github/actions/github-app-token/create-token.js
+++ b/.github/actions/github-app-token/create-token.js
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+
+function base64Url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function base64ToBase64Url(value) {
+  return Buffer.from(value, 'base64').toString('base64url');
+}
+
+function createJwtSigningInput(clientId, nowSeconds) {
+  const header = base64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64Url(JSON.stringify({
+    iat: nowSeconds - 60,
+    exp: nowSeconds + 540,
+    iss: clientId,
+  }));
+  return `${header}.${payload}`;
+}
+
+function signJwt(signingInput, config, execute = execFileSync) {
+  const digest = crypto.createHash('sha256').update(signingInput).digest('base64');
+  const signature = execute(
+    'az',
+    [
+      'keyvault', 'key', 'sign',
+      '--subscription', config.azureSubscriptionId,
+      '--vault-name', config.keyVaultName,
+      '--name', config.keyName,
+      '--algorithm', 'RS256',
+      '--digest', digest,
+      '--query', 'signature',
+      '--output', 'tsv',
+      '--only-show-errors',
+    ],
+    { encoding: 'utf8' },
+  ).trim();
+
+  if (!signature) {
+    throw new Error('Key Vault returned an empty signature.');
+  }
+
+  return `${signingInput}.${base64ToBase64Url(signature)}`;
+}
+
+async function createInstallationToken(config, dependencies = {}) {
+  const execute = dependencies.execute ?? execFileSync;
+  const request = dependencies.fetch ?? fetch;
+  const nowSeconds = dependencies.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const signingInput = createJwtSigningInput(config.githubAppClientId, nowSeconds);
+  const jwt = signJwt(signingInput, config, execute);
+  const [owner, repository] = config.targetRepository.split('/');
+
+  if (!owner || !repository) {
+    throw new Error('TARGET_REPOSITORY must use the owner/repository format.');
+  }
+
+  const response = await request(
+    `https://api.github.com/app/installations/${config.githubAppInstallationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${jwt}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({
+        repositories: [repository],
+        permissions: {
+          contents: 'read',
+          issues: 'write',
+          members: 'read',
+          pull_requests: 'write',
+        },
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub installation token request failed with HTTP ${response.status}.`);
+  }
+
+  const result = await response.json();
+  if (typeof result.token !== 'string' || result.token.length === 0) {
+    throw new Error('GitHub returned an empty installation token.');
+  }
+
+  return result.token;
+}
+
+function readConfig(environment) {
+  const config = {
+    azureSubscriptionId: environment.AZURE_SUBSCRIPTION_ID,
+    keyVaultName: environment.KEY_VAULT_NAME,
+    keyName: environment.KEY_NAME,
+    githubAppClientId: environment.GITHUB_APP_CLIENT_ID,
+    githubAppInstallationId: environment.GITHUB_APP_INSTALLATION_ID,
+    targetRepository: environment.TARGET_REPOSITORY,
+  };
+
+  if (Object.values(config).some((value) => !value)) {
+    throw new Error('Required GitHub App authentication configuration is missing.');
+  }
+
+  return config;
+}
+
+async function main() {
+  try {
+    const token = await createInstallationToken(readConfig(process.env));
+    process.stdout.write(token);
+  } catch {
+    console.error('GitHub App token generation failed.');
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  void main();
+}
+
+module.exports = {
+  base64ToBase64Url,
+  createInstallationToken,
+  createJwtSigningInput,
+  readConfig,
+  signJwt,
+};

--- a/.github/tests/test_create_github_app_token.js
+++ b/.github/tests/test_create_github_app_token.js
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  base64ToBase64Url,
+  createInstallationToken,
+  createJwtSigningInput,
+  readConfig,
+} = require('../actions/github-app-token/create-token.js');
+
+const CONFIG = {
+  azureSubscriptionId: 'subscription-id',
+  keyVaultName: 'vault-name',
+  keyName: 'key-name',
+  githubAppClientId: 'client-id',
+  githubAppInstallationId: '12345',
+  targetRepository: 'microsoft/agent-framework',
+};
+
+describe('GitHub App token creation', () => {
+  it('creates a short-lived GitHub App JWT', () => {
+    const signingInput = createJwtSigningInput('client-id', 1_000);
+    const [encodedHeader, encodedPayload] = signingInput.split('.');
+    const header = JSON.parse(Buffer.from(encodedHeader, 'base64url').toString());
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString());
+
+    assert.deepEqual(header, { alg: 'RS256', typ: 'JWT' });
+    assert.deepEqual(payload, { iat: 940, exp: 1_540, iss: 'client-id' });
+  });
+
+  it('converts Key Vault signatures to unpadded base64url', () => {
+    assert.equal(base64ToBase64Url('+/8='), '-_8');
+  });
+
+  it('requests a repository-scoped installation token', async () => {
+    let request;
+    const token = await createInstallationToken(CONFIG, {
+      nowSeconds: 1_000,
+      execute: (command, args) => {
+        assert.equal(command, 'az');
+        assert.ok(args.includes('RS256'));
+        return '+/8=\n';
+      },
+      fetch: async (url, options) => {
+        request = { url, options };
+        return {
+          ok: true,
+          json: async () => ({ token: 'installation-token' }),
+        };
+      },
+    });
+
+    assert.equal(token, 'installation-token');
+    assert.equal(request.url, 'https://api.github.com/app/installations/12345/access_tokens');
+    assert.match(request.options.headers.Authorization, /^Bearer [^.]+\.[^.]+\.-_8$/);
+    assert.deepEqual(JSON.parse(request.options.body), {
+      repositories: ['agent-framework'],
+      permissions: {
+        contents: 'read',
+        issues: 'write',
+        members: 'read',
+        pull_requests: 'write',
+      },
+    });
+  });
+
+  it('rejects incomplete configuration', () => {
+    assert.throws(
+      () => readConfig({}),
+      /Required GitHub App authentication configuration is missing/,
+    );
+  });
+});

--- a/.github/tests/test_create_github_app_token.js
+++ b/.github/tests/test_create_github_app_token.js
@@ -72,4 +72,22 @@ describe('GitHub App token creation', () => {
       /Required GitHub App authentication configuration is missing/,
     );
   });
+
+  it('rejects repository values with extra path segments before signing', async () => {
+    let signed = false;
+
+    await assert.rejects(
+      createInstallationToken(
+        { ...CONFIG, targetRepository: 'microsoft/agent-framework/extra' },
+        {
+          execute: () => {
+            signed = true;
+            return '+/8=\n';
+          },
+        },
+      ),
+      /TARGET_REPOSITORY must use the owner\/repository format/,
+    );
+    assert.equal(signed, false);
+  });
 });

--- a/.github/tests/test_create_github_app_token.js
+++ b/.github/tests/test_create_github_app_token.js
@@ -90,4 +90,36 @@ describe('GitHub App token creation', () => {
     );
     assert.equal(signed, false);
   });
+
+  it('rejects an empty Key Vault signature', async () => {
+    await assert.rejects(
+      createInstallationToken(CONFIG, {
+        execute: () => '\n',
+      }),
+      /Key Vault returned an empty signature/,
+    );
+  });
+
+  it('rejects a failed GitHub token request', async () => {
+    await assert.rejects(
+      createInstallationToken(CONFIG, {
+        execute: () => '+/8=\n',
+        fetch: async () => ({ ok: false, status: 403 }),
+      }),
+      /GitHub installation token request failed with HTTP 403/,
+    );
+  });
+
+  it('rejects an empty GitHub installation token', async () => {
+    await assert.rejects(
+      createInstallationToken(CONFIG, {
+        execute: () => '+/8=\n',
+        fetch: async () => ({
+          ok: true,
+          json: async () => ({ token: '' }),
+        }),
+      }),
+      /GitHub returned an empty installation token/,
+    );
+  });
 });

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Checkout GitHub token action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           sparse-checkout: .github/actions/github-app-token
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -66,11 +66,13 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "repo=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout GitHub token action
+      - name: Checkout GitHub automation
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
-          sparse-checkout: .github/actions/github-app-token
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts/check_team_membership.js
           fetch-depth: 1
           persist-credentials: false
 
@@ -98,29 +100,14 @@ jobs:
         with:
           github-token: ${{ steps.github-auth.outputs.token }}
           script: |
-            let author = context.payload.pull_request?.user?.login;
-            if (!author) {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: Number(process.env.PR_NUMBER),
-              });
-              author = pr.user.login;
-            }
-
-            let isTeamMember = false;
-            try {
-              const teamMembership = await github.rest.teams.getMembershipForUserInOrg({
-                org: context.repo.owner,
-                team_slug: process.env.TEAM_NAME,
-                username: author,
-              });
-              isTeamMember = teamMembership.data.state === 'active';
-            } catch (error) {
-              console.log(`Team membership lookup failed for ${author}: ${error.message}`);
-              isTeamMember = false;
-            }
-
+            const checkTeamMembership = require('./.github/scripts/check_team_membership.js');
+            const { author, isTeamMember } = await checkTeamMembership({
+              github,
+              context,
+              core,
+              teamSlug: process.env.TEAM_NAME,
+              issueNumber: process.env.PR_NUMBER,
+            });
             core.setOutput('is_team_member', isTeamMember ? 'true' : 'false');
             if (isTeamMember) {
               core.info(`Author ${author} is a team member; proceeding with review.`);

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -31,6 +32,7 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
+    environment: github-app-auth
     outputs:
       is_team_member: ${{ steps.check.outputs.is_team_member }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
@@ -64,6 +66,28 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "repo=${GITHUB_REPOSITORY}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout GitHub token action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/actions/github-app-token
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
       - name: Check PR author team membership
         id: check
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -71,7 +95,7 @@ jobs:
           TEAM_NAME: ${{ secrets.DEVELOPER_TEAM }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             let author = context.payload.pull_request?.user?.login;
             if (!author) {

--- a/.github/workflows/github-automation-tests.yml
+++ b/.github/workflows/github-automation-tests.yml
@@ -1,0 +1,33 @@
+name: GitHub automation tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/tests/**"
+      - ".github/workflows/github-automation-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/tests/**"
+      - ".github/workflows/github-automation-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
+      - name: Run tests
+        run: node --test .github/tests/*.js

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
+    environment: github-app-auth
     if: >-
       ${{
         github.event_name == 'workflow_dispatch'
@@ -68,9 +69,26 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
       - name: Check issue author team membership
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -80,7 +98,7 @@ jobs:
           TEAM_NAME: ${{ secrets.DEVELOPER_TEAM }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             const checkTeamMembership = require('./.github/scripts/check_team_membership.js');
             const { author, isTeamMember } = await checkTeamMembership({

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -16,10 +16,12 @@ jobs:
       id-token: write
       issues: write
     steps:
-      - name: Checkout GitHub token action
+      - name: Checkout GitHub automation
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: .github/actions/github-app-token
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts/check_team_membership.js
           fetch-depth: 1
           persist-credentials: false
 
@@ -49,21 +51,14 @@ jobs:
             // Define the labels array
             let labels = []
 
-            // Check if the issue author is in the agentframework-developers team
-            let isTeamMember = false
-            try {
-              const teamMembership = await github.rest.teams.getMembershipForUserInOrg({
-                org: context.repo.owner,
-                team_slug: process.env.TEAM_NAME,
-                username: context.payload.issue.user.login
-              })
-              console.log("Team Membership Data:", teamMembership);
-              isTeamMember = teamMembership.data.state === 'active'
-            } catch (error) {
-              // User is not in the team or team doesn't exist
-              console.error("Error fetching team membership:", error);
-              isTeamMember = false
-            }
+            const checkTeamMembership = require('./.github/scripts/check_team_membership.js')
+            const { isTeamMember } = await checkTeamMembership({
+              github,
+              context,
+              core,
+              teamSlug: process.env.TEAM_NAME,
+              issueNumber: context.issue.number,
+            })
 
             // Only add triage label if the author is not in the team
             if (!isTeamMember) {

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -10,12 +10,37 @@ jobs:
     name: "Issue: add labels"
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
     runs-on: ubuntu-latest
+    environment: github-app-auth
     permissions:
+      contents: read
+      id-token: write
       issues: write
     steps:
+      - name: Checkout GitHub token action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/actions/github-app-token
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             // Get the issue body and title
             const body = context.payload.issue.body

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             .github/actions/github-app-token
             .github/scripts

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -13,27 +13,46 @@ on:
 jobs:
   add_label:
     runs-on: ubuntu-latest
+    environment: github-app-auth
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
-        with:
-          repo-token: "${{ secrets.GH_ACTIONS_PR_WRITE }}"
-
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
+        with:
+          repo-token: ${{ steps.github-auth.outputs.token }}
 
       - name: "PR: add breaking change label from title"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             const { syncBreakingChangeLabelFromTitle } = require('./.github/scripts/title_prefix.js');
             await syncBreakingChangeLabelFromTitle({ github, context, core });

--- a/.github/workflows/limit-community-prs.yml
+++ b/.github/workflows/limit-community-prs.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             .github/actions/github-app-token
             .github/scripts
@@ -83,6 +84,7 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             .github/actions/github-app-token
             .github/scripts

--- a/.github/workflows/limit-community-prs.yml
+++ b/.github/workflows/limit-community-prs.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -21,15 +22,33 @@ env:
 jobs:
   team_check:
     runs-on: ubuntu-latest
+    environment: github-app-auth
     outputs:
       is_team_member: ${{ steps.check.outputs.is_team_member }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
       - name: Check PR author team membership
         id: check
@@ -38,7 +57,7 @@ jobs:
           TEAM_NAME: ${{ secrets.DEVELOPER_TEAM }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             const checkTeamMembership = require('./.github/scripts/check_team_membership.js');
             const { author, isTeamMember } = await checkTeamMembership({
@@ -57,20 +76,38 @@ jobs:
 
   limit_open_prs:
     runs-on: ubuntu-latest
+    environment: github-app-auth
     needs: team_check
     if: ${{ needs.team_check.outputs.is_team_member == 'false' }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/actions/github-app-token
+            .github/scripts
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
       - name: Enforce open PR limit
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          github-token: ${{ steps.github-auth.outputs.token }}
           script: |
             const { enforcePrLimit } = require('./.github/scripts/pr_limit_moderation.js');
             await enforcePrLimit({

--- a/.github/workflows/stale-issue-pr-ping.yml
+++ b/.github/workflows/stale-issue-pr-ping.yml
@@ -26,12 +26,29 @@ jobs:
   ping_stale:
     name: "Ping stale issues and PRs"
     runs-on: ubuntu-latest
+    environment: github-app-auth
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Get GitHub automation token
+        id: github-auth
+        uses: ./.github/actions/github-app-token
+        with:
+          mode: ${{ vars.GH_APP_AUTH_MODE }}
+          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ vars.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          repository: ${{ github.repository }}
+          fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -43,7 +60,7 @@ jobs:
       - name: Run stale issue/PR ping
         run: python .github/scripts/stale_issue_pr_ping.py
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          GITHUB_TOKEN: ${{ steps.github-auth.outputs.token }}
           TEAM_SLUG: ${{ secrets.DEVELOPER_TEAM }}
           DAYS_THRESHOLD: ${{ github.event.inputs.days_threshold || '4' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}


### PR DESCRIPTION
### Motivation & Context

Several repository automation workflows depend on a single credential acquisition path. This adds a staged selection mechanism with compatibility fallback so the updated path can be verified without interrupting issue and pull-request automation.

### Description & Review Guide

- **What are the major changes?** Adds a reusable credential-selection action, configurable rollout modes, source-only workflow logging, and coverage for the token construction logic. Updates the affected automation workflows to consume the selected token.
- **What is the impact of these changes?** Existing behavior remains available as a temporary fallback while the preferred path is exercised. Credentials and intermediate authentication material are not written to logs or repository artifacts.
- **What do you want reviewers to focus on?** The fallback state machine, workflow permission boundaries, and whether the rollout controls fail safely.

### Related Issue

Fixes #7248

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and the title prefix in sync automatically.