### PR TITLE
.NET: Fix expensive logging

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
@@ -362,11 +362,16 @@ public sealed class HostedWorkflowState
     }
 
     private void WarnOnNoProgress(string sessionId)
+    {
         // The resumed turn drove no work: the checkpoint may be stale or the input may not match the workflow's
         // expected type, so the session's state may not have progressed.
-        => this._logger.LogWarning(
-            "Resuming workflow session '{SessionId}' produced no events; the checkpoint may be stale or the input may not match the workflow's expected input type. Session state may not have progressed.",
-            sessionId);
+        if (this._logger.IsEnabled(LogLevel.Warning))
+        {
+            this._logger.LogWarning(
+                "Resuming workflow session '{SessionId}' produced no events; the checkpoint may be stale or the input may not match the workflow's expected input type. Session state may not have progressed.",
+                sessionId);
+        }
+    }
 
     /// <summary>
     /// Gets the recorded head checkpoint for <paramref name="sessionId"/>, if any.

--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
@@ -362,16 +362,9 @@ public sealed class HostedWorkflowState
     }
 
     private void WarnOnNoProgress(string sessionId)
-    {
         // The resumed turn drove no work: the checkpoint may be stale or the input may not match the workflow's
         // expected type, so the session's state may not have progressed.
-        if (this._logger.IsEnabled(LogLevel.Warning))
-        {
-            this._logger.LogWarning(
-                "Resuming workflow session '{SessionId}' produced no events; the checkpoint may be stale or the input may not match the workflow's expected input type. Session state may not have progressed.",
-                sessionId);
-        }
-    }
+        => this._logger.LogWorkflowResumeMadeNoProgress(sessionId);
 
     /// <summary>
     /// Gets the recorded head checkpoint for <paramref name="sessionId"/>, if any.
@@ -387,4 +380,12 @@ public sealed class HostedWorkflowState
         _ = Throw.IfNullOrEmpty(sessionId);
         return this._cursor.TryGetValue(sessionId, out checkpoint);
     }
+}
+
+internal static partial class HostedWorkflowStateLogMessages
+{
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Resuming workflow session '{SessionId}' produced no events; the checkpoint may be stale or the input may not match the workflow's expected input type. Session state may not have progressed.")]
+    public static partial void LogWorkflowResumeMadeNoProgress(this ILogger logger, string sessionId);
 }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowState.cs
@@ -382,6 +382,7 @@ public sealed class HostedWorkflowState
     }
 }
 
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static partial class HostedWorkflowStateLogMessages
 {
     [LoggerMessage(


### PR DESCRIPTION
This pull request refactors how warning logs are generated when a workflow session resumes but makes no progress. The main change is moving the logging logic from an inline message to a strongly-typed logging method using source generators, which improves maintainability and consistency.

**Logging improvements:**

* Replaced the inline warning log in `UpdateCursor` with a call to a new strongly-typed logging method, `LogWorkflowResumeMadeNoProgress`, in `HostedWorkflowState.cs`.
* Introduced the `HostedWorkflowStateLogMessages` static partial class, defining the `LogWorkflowResumeMadeNoProgress` method using the `[LoggerMessage]` attribute for efficient and consistent logging.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
- **What is the impact of these changes?**
- **What do you want reviewers to focus on?**
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
