### PR TITLE
Reduce workflow credential exposure

### DIFF
--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -81,13 +81,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -119,6 +119,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: team_check
     if: ${{ needs.team_check.outputs.is_team_member == 'true' }}
+    permissions:
+      contents: read
+      copilot-requests: write
+      issues: write
+      pull-requests: write
     timeout-minutes: 60
     # Advisory check: failures here should not block the PR. The reviewer
     # posts comments as a best-effort signal; if the pipeline breaks, the
@@ -166,7 +171,7 @@ jobs:
         working-directory: ${{ env.DEVFLOW_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_COPILOT_TOKEN: ${{ secrets.GH_COPILOT_TOKEN }}
+          GH_COPILOT_TOKEN: ${{ github.token }}
           SK_REPO_PATH: ${{ env.TARGET_REPO_PATH }}
           AGENT_REPO_PATH: ${{ env.TARGET_REPO_PATH }}
           PR_URL: ${{ needs.team_check.outputs.pr_url }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -80,13 +80,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -124,6 +124,11 @@ jobs:
         || needs.team_check.outputs.is_team_member == 'false'
       }}
     environment: integration
+    permissions:
+      contents: read
+      copilot-requests: write
+      id-token: write
+      issues: write
     timeout-minutes: 60
 
     steps:
@@ -198,7 +203,7 @@ jobs:
         working-directory: ${{ env.DEVFLOW_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_COPILOT_TOKEN: ${{ secrets.GH_COPILOT_TOKEN }}
+          GH_COPILOT_TOKEN: ${{ github.token }}
           # Not seen by the agent prompt; used only to push a paper-trail
           # branch back to maf-dashboard at run end.
           DEVFLOW_TOKEN: ${{ secrets.DEVFLOW_TOKEN }}

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -30,13 +30,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -36,13 +36,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 

--- a/.github/workflows/limit-community-prs.yml
+++ b/.github/workflows/limit-community-prs.yml
@@ -41,13 +41,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
@@ -96,13 +96,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 

--- a/.github/workflows/stale-issue-pr-ping.yml
+++ b/.github/workflows/stale-issue-pr-ping.yml
@@ -40,13 +40,13 @@ jobs:
         uses: ./.github/actions/github-app-token
         with:
           mode: ${{ vars.GH_APP_AUTH_MODE }}
-          azure-client-id: ${{ vars.GH_APP_AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ vars.GH_APP_AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ vars.GH_APP_AZURE_SUBSCRIPTION_ID }}
-          key-vault-name: ${{ vars.GH_APP_KEY_VAULT_NAME }}
-          key-name: ${{ vars.GH_APP_KEY_NAME }}
-          github-app-client-id: ${{ vars.GH_APP_CLIENT_ID }}
-          github-app-installation-id: ${{ vars.GH_APP_INSTALLATION_ID }}
+          azure-client-id: ${{ secrets.GH_APP_AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.GH_APP_AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.GH_APP_AZURE_SUBSCRIPTION_ID }}
+          key-vault-name: ${{ secrets.GH_APP_KEY_VAULT_NAME }}
+          key-name: ${{ secrets.GH_APP_KEY_NAME }}
+          github-app-client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 


### PR DESCRIPTION
### Motivation & Context

Workflow run logs currently expose configuration metadata that does not need to be public, and DevFlow depends on a separately managed user credential for Copilot requests. These values and credentials should be minimized while preserving the established authentication behavior and rollout controls.

### Description & Review Guide

- **What are the major changes?** Read non-mode authentication configuration from environment secrets in all six affected workflows. Grant only the two DevFlow execution jobs `copilot-requests: write` and use their run-scoped GitHub token for Copilot authentication.
- **What is the impact of these changes?** GitHub masks the configuration inputs in workflow logs, and DevFlow no longer requires a separately rotated Copilot credential. The authentication rollout mode remains an environment variable.
- **What do you want reviewers to focus on?** Confirm that every affected workflow consistently uses the masked configuration context and that the Copilot permission is limited to the jobs that make Copilot requests.


### Related Issue

Fixes #7269

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.