### PR TITLE
Python: Fix duplicate function call on approval round-trip (#7267)

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -2119,12 +2119,19 @@ def _replace_approval_contents_with_results(
     # Track which call_ids had their placeholders replaced
     placeholders_replaced: set[str] = set()
 
-    for msg in messages:
-        # First pass - collect existing function call IDs to avoid duplicates
-        existing_call_ids = {
-            content.call_id for content in msg.contents if content.type == "function_call" and content.call_id
-        }
+    # Collect existing function call IDs across *all* messages to avoid duplicates. The
+    # function call and its approval request are frequently carried in separate messages
+    # (e.g. when a hosting layer replays them as separate items on an approval round
+    # trip), so scoping this per-message would let the same call_id be restored twice and
+    # leave the copy without a result unanswered.
+    existing_call_ids = {
+        content.call_id
+        for msg in messages
+        for content in msg.contents
+        if content.type == "function_call" and content.call_id
+    }
 
+    for msg in messages:
         # Track approval requests that should be removed (duplicates)
         contents_to_remove: list[int] = []
 
@@ -2140,6 +2147,8 @@ def _replace_approval_contents_with_results(
                 elif content.function_call is not None:
                     # Put back the function call content only if it doesn't exist
                     msg.contents[content_idx] = content.function_call
+                    if content.function_call.call_id:
+                        existing_call_ids.add(content.function_call.call_id)
             elif content.type == "function_approval_response":
                 # Skip hosted tool approvals — they must pass through to the API unchanged
                 if _is_hosted_tool_approval(content):

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -2096,6 +2096,12 @@ def _collect_approval_responses(
     return fcc_todo
 
 
+def _is_approval_placeholder_result(content: Content) -> bool:
+    """Whether a function_result is the stand-in emitted while approval is pending."""
+    result = getattr(content, "result", None)
+    return isinstance(result, str) and "[APPROVAL_PENDING]" in result
+
+
 def _replace_approval_contents_with_results(
     messages: list[Message],
     fcc_todo: dict[str, Content],
@@ -2119,16 +2125,27 @@ def _replace_approval_contents_with_results(
     # Track which call_ids had their placeholders replaced
     placeholders_replaced: set[str] = set()
 
-    # Collect existing function call IDs across *all* messages to avoid duplicates. The
+    # Collect *pending* function call IDs across all messages to avoid duplicates. The
     # function call and its approval request are frequently carried in separate messages
-    # (e.g. when a hosting layer replays them as separate items on an approval round
-    # trip), so scoping this per-message would let the same call_id be restored twice and
-    # leave the copy without a result unanswered.
+    # (e.g. when a hosting layer replays them as separate items on an approval round trip),
+    # so scoping this per-message would let the same call_id be restored twice and leave
+    # the copy without a result unanswered.
+    #
+    # Calls that already carry a real result are excluded: reusing a call_id for a later
+    # invocation is supported, and a completed pair must not suppress the fresh request —
+    # that would drop the new call and attach its result to the old one. Placeholder
+    # results still count as pending, since the call they answer is the one being restored.
+    answered_call_ids = {
+        content.call_id
+        for msg in messages
+        for content in msg.contents
+        if content.type == "function_result" and content.call_id and not _is_approval_placeholder_result(content)
+    }
     existing_call_ids = {
         content.call_id
         for msg in messages
         for content in msg.contents
-        if content.type == "function_call" and content.call_id
+        if content.type == "function_call" and content.call_id and content.call_id not in answered_call_ids
     }
 
     for msg in messages:
@@ -2178,12 +2195,7 @@ def _replace_approval_contents_with_results(
                     msg.role = "tool"
             elif content.type == "function_result":
                 # Check if this is a placeholder result that should be replaced
-                if (
-                    hasattr(content, "result")
-                    and isinstance(content.result, str)
-                    and "[APPROVAL_PENDING]" in content.result
-                    and content.call_id in result_by_call_id
-                ):
+                if _is_approval_placeholder_result(content) and content.call_id in result_by_call_id:
                     # Replace placeholder with actual result
                     msg.contents[content_idx] = result_by_call_id[content.call_id]
                     placeholders_replaced.add(content.call_id)

--- a/python/packages/core/tests/core/test_function_invocation_logic.py
+++ b/python/packages/core/tests/core/test_function_invocation_logic.py
@@ -2338,23 +2338,24 @@ def test_replace_approval_contents_with_results_uses_result_call_ids_without_pla
     ]
 
 
-def test_replace_approval_contents_with_results_dedupes_call_across_messages() -> None:
-    """A function call and its approval request may arrive in separate messages.
+def test_replace_approval_contents_with_results_allows_reused_call_id_after_completion() -> None:
+    """A completed call must not suppress a later approval request that reuses its id.
 
-    Hosting layers replay a stored ``function_call`` item and its
-    ``mcp_approval_request`` item as two assistant messages. The approval request
-    must not restore a second copy of the call, or that copy is left without a
-    result and the service rejects the turn with "No tool output found for
-    function call".
+    Re-approving the same ``(call_id, function)`` is supported behaviour. If the dedupe
+    matched every occurrence of the id, the fresh request would be dropped and its result
+    attached to the already-answered call, leaving one call with two results.
     """
     from agent_framework._tools import _collect_approval_responses, _replace_approval_contents_with_results
 
-    call, request, response = _build_approved_tool_roundtrip(
-        call_id="call_1", approval_id="approval_1", tool_name="run_skill_script"
+    completed_call = Content.from_function_call(call_id="call_reused", name="run_skill_script", arguments="{}")
+    completed_result = Content.from_function_result(call_id="call_reused", result="first output")
+    _, request, response = _build_approved_tool_roundtrip(
+        call_id="call_reused", approval_id="approval_2", tool_name="run_skill_script"
     )
 
     messages = [
-        Message(role="assistant", contents=[call]),
+        Message(role="assistant", contents=[completed_call]),
+        Message(role="tool", contents=[completed_result]),
         Message(role="assistant", contents=[request]),
         Message(role="user", contents=[response]),
     ]
@@ -2362,14 +2363,16 @@ def test_replace_approval_contents_with_results_dedupes_call_across_messages() -
     _replace_approval_contents_with_results(
         messages,
         _collect_approval_responses(messages),
-        [Content.from_function_result(call_id="call_1", result="script output")],
+        [Content.from_function_result(call_id="call_reused", result="second output")],
     )
 
     function_calls = [c for m in messages for c in m.contents if c.type == "function_call"]
-    assert [c.call_id for c in function_calls] == ["call_1"]
+    assert [c.call_id for c in function_calls] == ["call_reused", "call_reused"]
     results = [c for m in messages for c in m.contents if c.type == "function_result"]
-    assert [(c.call_id, c.result) for c in results] == [("call_1", "script output")]
-
+    assert [(c.call_id, c.result) for c in results] == [
+        ("call_reused", "first output"),
+        ("call_reused", "second output"),
+    ]
 
 def test_replace_approval_contents_with_results_uses_result_call_ids_for_placeholders() -> None:
     from agent_framework._tools import _collect_approval_responses, _replace_approval_contents_with_results

--- a/python/packages/core/tests/core/test_function_invocation_logic.py
+++ b/python/packages/core/tests/core/test_function_invocation_logic.py
@@ -2338,6 +2338,39 @@ def test_replace_approval_contents_with_results_uses_result_call_ids_without_pla
     ]
 
 
+def test_replace_approval_contents_with_results_dedupes_call_across_messages() -> None:
+    """A function call and its approval request may arrive in separate messages.
+
+    Hosting layers replay a stored ``function_call`` item and its
+    ``mcp_approval_request`` item as two assistant messages. The approval request
+    must not restore a second copy of the call, or that copy is left without a
+    result and the service rejects the turn with "No tool output found for
+    function call".
+    """
+    from agent_framework._tools import _collect_approval_responses, _replace_approval_contents_with_results
+
+    call, request, response = _build_approved_tool_roundtrip(
+        call_id="call_1", approval_id="approval_1", tool_name="run_skill_script"
+    )
+
+    messages = [
+        Message(role="assistant", contents=[call]),
+        Message(role="assistant", contents=[request]),
+        Message(role="user", contents=[response]),
+    ]
+
+    _replace_approval_contents_with_results(
+        messages,
+        _collect_approval_responses(messages),
+        [Content.from_function_result(call_id="call_1", result="script output")],
+    )
+
+    function_calls = [c for m in messages for c in m.contents if c.type == "function_call"]
+    assert [c.call_id for c in function_calls] == ["call_1"]
+    results = [c for m in messages for c in m.contents if c.type == "function_result"]
+    assert [(c.call_id, c.result) for c in results] == [("call_1", "script output")]
+
+
 def test_replace_approval_contents_with_results_uses_result_call_ids_for_placeholders() -> None:
     from agent_framework._tools import _collect_approval_responses, _replace_approval_contents_with_results
 


### PR DESCRIPTION
### Motivation & Context

Approving a `run_skill_script` tool call in the Agent Inspector left the function
call unanswered: the tool block showed a red ✗ and the next conversation turn was
rejected by the Responses API with
`400 - No tool output found for function call call_<id>`.

The same defect affects any approval round-trip served through a hosting layer,
not just skills — `SkillsProvider` is simply the configuration that surfaces it,
because it puts an approval-gated tool on the default path.

### Description & Review Guide

- **What are the major changes?**

  One scoping fix in `_replace_approval_contents_with_results`
  (`python/packages/core/agent_framework/_tools.py`).

  The function restores a `function_call` from its `function_approval_request`
  wrapper, deduping against calls already present so it does not add a second
  copy. That dedupe set was rebuilt inside the per-message loop, so it only ever
  saw the message currently being scanned. On an approval round-trip the hosting
  layer replays the stored `function_call` item and its `mcp_approval_request`
  item as **two separate assistant messages** — so the check never fired and the
  approval request restored a duplicate of the call.

  Only one copy was matched to the function result. The orphaned copy went back
  to the service unanswered, which is exactly what the 400 reports.

  The fix collects existing call ids across all messages, and adds a restored
  call to that set so two approval requests for the same call cannot both expand.

- **What is the impact of these changes?**

  Not a breaking change; no public API or signature changes. Conversation history
  sent on an approval round-trip now contains each `function_call` exactly once,
  paired with its result.

  Verified with a full-stack `ResponsesHostServer` + `SkillsProvider` repro
  (`load_skill` approval, then `run_skill_script` approval). Outgoing history on
  the final turn, before and after:

  ```
  before                                after
  ------------------------------------  ------------------------------------
  user      [text]                      user      [text]
  assistant [function_call   call_1]    assistant [function_call   call_1]
  assistant [function_call   call_1]    tool      [function_result call_1]
  tool      [function_result call_1]    assistant [function_call   call_2]
  assistant [function_call   call_2]    tool      [function_result call_2]
  assistant [function_call   call_2]
  tool      [function_result call_2]
  ```

  Regression test added in
  `python/packages/core/tests/core/test_function_invocation_logic.py`; it fails on
  `main` with `['call_1', 'call_1'] == ['call_1']`. Core suites and all 192
  `agent-framework-foundry-hosting` tests pass.

- **What do you want reviewers to focus on?**

  Two things I could not close out locally, both worth a second opinion:

  1. I could not reproduce the reported Inspector **hang** — against a mock chat
     client the registered `script_runner` was invoked on both the pre-fix and
     post-fix paths. This change fixes the duplication that produces the 400;
     whether the hang is entirely downstream of it is unconfirmed without the
     live Foundry API.
  2. The duplication also affects `load_skill`'s call, so on a strict reading the
     reported flow should have failed one turn earlier than the issue describes.
     That may mean the service tolerates some duplicate shapes, or that a second
     factor is involved.

### Related Issue

Fixes #7267

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow automatically keeps the label and title prefix in sync.
