### PR TITLE
Restore dedicated DevFlow authentication

### DIFF
--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -121,7 +121,6 @@ jobs:
     if: ${{ needs.team_check.outputs.is_team_member == 'true' }}
     permissions:
       contents: read
-      copilot-requests: write
       issues: write
       pull-requests: write
     timeout-minutes: 60
@@ -171,7 +170,7 @@ jobs:
         working-directory: ${{ env.DEVFLOW_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_COPILOT_TOKEN: ${{ github.token }}
+          GH_COPILOT_TOKEN: ${{ secrets.GH_COPILOT_TOKEN }}
           SK_REPO_PATH: ${{ env.TARGET_REPO_PATH }}
           AGENT_REPO_PATH: ${{ env.TARGET_REPO_PATH }}
           PR_URL: ${{ needs.team_check.outputs.pr_url }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -126,7 +126,6 @@ jobs:
     environment: integration
     permissions:
       contents: read
-      copilot-requests: write
       id-token: write
       issues: write
     timeout-minutes: 60
@@ -203,7 +202,7 @@ jobs:
         working-directory: ${{ env.DEVFLOW_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_COPILOT_TOKEN: ${{ github.token }}
+          GH_COPILOT_TOKEN: ${{ secrets.GH_COPILOT_TOKEN }}
           # Not seen by the agent prompt; used only to push a paper-trail
           # branch back to maf-dashboard at run end.
           DEVFLOW_TOKEN: ${{ secrets.DEVFLOW_TOKEN }}


### PR DESCRIPTION
### Motivation & Context

DevFlow PR review and issue reproduction cannot currently authenticate through the run-scoped workflow credential in the organization configuration. Restore the previously supported dedicated credential path so these automations can run while the durable organization-billed path is investigated.

### Description & Review Guide

- **What are the major changes?** Restore `GH_COPILOT_TOKEN` secret usage in the two DevFlow execution jobs and remove their unused Copilot request permission.
- **What is the impact of these changes?** DevFlow returns to user-backed Copilot authentication. Repository automation continues to use the existing App-based credential path.
- **What do you want reviewers to focus on?** Confirm the rollback is limited to Copilot inference authentication and does not affect GitHub App repository operations.


### Related Issue

Fixes #7275

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.