### PR TITLE
Python: Fix stale agent.json reference in A2A sample docstring

### DIFF
--- a/python/samples/04-hosting/a2a/a2a_server.http
+++ b/python/samples/04-hosting/a2a/a2a_server.http
@@ -4,7 +4,7 @@
 @hostLogistics = http://localhost:5002
 
 ### Query agent card for the invoice agent
-GET {{hostInvoice}}/.well-known/agent.json
+GET {{hostInvoice}}/.well-known/agent-card.json
 
 ### Send a message to the invoice agent
 POST {{hostInvoice}}
@@ -30,7 +30,7 @@ Content-Type: application/json
 }
 
 ### Query agent card for the policy agent
-GET {{hostPolicy}}/.well-known/agent.json
+GET {{hostPolicy}}/.well-known/agent-card.json
 
 ### Send a message to the policy agent
 POST {{hostPolicy}}
@@ -56,7 +56,7 @@ Content-Type: application/json
 }
 
 ### Query agent card for the logistics agent
-GET {{hostLogistics}}/.well-known/agent.json
+GET {{hostLogistics}}/.well-known/agent-card.json
 
 ### Send a message to the logistics agent
 POST {{hostLogistics}}

--- a/python/samples/04-hosting/a2a/a2a_server.py
+++ b/python/samples/04-hosting/a2a/a2a_server.py
@@ -36,7 +36,7 @@ A2A Server Sample — Host an Agent Framework agent as an A2A endpoint
 
 This sample creates a Python-based A2A-compliant server that wraps an Agent
 Framework agent.  The server uses the a2a-sdk's Starlette application to handle
-JSON-RPC requests and serves the AgentCard at /.well-known/agent.json.
+JSON-RPC requests and serves the AgentCard at /.well-known/agent-card.json.
 
 Three agent types are available:
   - invoice   — Answers invoice queries using mock data and function tools.
@@ -194,7 +194,7 @@ def main() -> None:
     print(f"Starting A2A server: {agent_card.name}")
     print(f"  Agent type : {args.agent_type}")
     print(f"  Listening  : {url}")
-    print(f"  Agent card : {url}.well-known/agent.json")
+    print(f"  Agent card : {url}.well-known/agent-card.json")
     print()
 
     uvicorn.run(


### PR DESCRIPTION
### Motivation & Context

The A2A hosting sample used `/.well-known/agent.json` in three places, but the
correct A2A specification path is `/.well-known/agent-card.json`. These stale
references made the sample broken and misleading out of the box.

### Description & Review Guide

- **What are the major changes?**
  - `python/samples/04-hosting/a2a/a2a_server.http`: corrected the agent card
    `GET` endpoint for all three agents (`hostInvoice`, `hostPolicy`,
    `hostLogistics`) from `/.well-known/agent.json` to
    `/.well-known/agent-card.json`.
  - `python/samples/04-hosting/a2a/a2a_server.py`: corrected the module
    docstring and the startup `print` statement that both referenced the old
    `/.well-known/agent.json` path.
- **What is the impact of these changes?**
  Running the A2A sample now works end-to-end: agent card discovery `GET`
  requests succeed, and the URL printed to the console on startup matches the
  actual endpoint.
- **What do you want reviewers to focus on?**
  Confirm no other files in the sample still reference the old `agent.json` path.

### Related Issue

Fixes https://github.com/microsoft/agent-framework/issues/7286

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.