### PR TITLE
Python: Bump agent-framework-hosting-a2a to 1.0.0a260723

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [hosting-a2a-1.0.0a260723] - 2026-07-23
+
+### Added
+- **agent-framework-hosting-a2a**: Add progressive agent and workflow A2A adapters with native card generation, skill discovery, typed conversion, and mode-aware validation ([#7258](https://github.com/microsoft/agent-framework/pull/7258))
+
+### Changed
+- **samples**: Update the app-owned A2A hosting sample to use the progressive adapter surface ([#7258](https://github.com/microsoft/agent-framework/pull/7258))
+
 ## [1.12.1] - 2026-07-22
 
 ### Added

--- a/python/packages/hosting-a2a/pyproject.toml
+++ b/python/packages/hosting-a2a/pyproject.toml
@@ -4,7 +4,7 @@ description = "A2A conversion helpers for app-owned Agent Framework hosting."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260721"
+version = "1.0.0a260723"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -694,7 +694,7 @@ requires-dist = [{ name = "agent-framework-core", editable = "packages/core" }]
 
 [[package]]
 name = "agent-framework-hosting-a2a"
-version = "1.0.0a260721"
+version = "1.0.0a260723"
 source = { editable = "packages/hosting-a2a" }
 dependencies = [
     { name = "a2a-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
### Motivation & Context

Publish the progressive A2A hosting adapters introduced in #7258 as a focused alpha update without bumping unrelated Python packages.

### Description & Review Guide

- **What are the major changes?** Adds a package-qualified CHANGELOG section, bumps `agent-framework-hosting-a2a` from `1.0.0a260721` to `1.0.0a260723`, and refreshes its workspace version in `uv.lock`.
- **What is the impact of these changes?** Only `agent-framework-hosting-a2a` receives a new version; internal dependency bounds and all other package versions remain unchanged.
- **What do you want reviewers to focus on?** The focused package scope, target alpha version, and CHANGELOG wording for #7258.

### Related Issue

Follow-up to #7258. There is no separate issue for this release bump.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after a language prefix) — workflows keep the label and the title prefix in sync automatically.