### PR TITLE
Python: Promote agent-framework-github-copilot to 1.0.0 (released)

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [github-copilot-1.0.0] - 2026-07-23
+
+### Added
+- **agent-framework-github-copilot**: Forward input attachments (images, documents, and other inline binary content) to GitHub Copilot as inline blobs ([#7300](https://github.com/microsoft/agent-framework/pull/7300))
+
+### Changed
+- **agent-framework-github-copilot**: Promote the package from release candidate to stable
+
 ## [hosting-a2a-1.0.0a260723] - 2026-07-23
 
 ### Added

--- a/python/PACKAGE_STATUS.md
+++ b/python/PACKAGE_STATUS.md
@@ -35,7 +35,7 @@ Status is grouped into these buckets:
 | `agent-framework-foundry-hosting` | `python/packages/foundry_hosting` | `beta` |
 | `agent-framework-foundry-local` | `python/packages/foundry_local` | `beta` |
 | `agent-framework-gemini` | `python/packages/gemini` | `beta` |
-| `agent-framework-github-copilot` | `python/packages/github_copilot` | `rc` |
+| `agent-framework-github-copilot` | `python/packages/github_copilot` | `released` |
 | `agent-framework-hosting` | `python/packages/hosting` | `alpha` |
 | `agent-framework-hosting-a2a` | `python/packages/hosting-a2a` | `alpha` |
 | `agent-framework-hosting-mcp` | `python/packages/hosting-mcp` | `alpha` |

--- a/python/packages/github_copilot/README.md
+++ b/python/packages/github_copilot/README.md
@@ -3,7 +3,7 @@
 Please install this package via pip:
 
 ```bash
-pip install agent-framework-github-copilot --pre
+pip install agent-framework-github-copilot
 ```
 
 ## GitHub Copilot Agent

--- a/python/packages/github_copilot/pyproject.toml
+++ b/python/packages/github_copilot/pyproject.toml
@@ -4,7 +4,7 @@ description = "GitHub Copilot integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0rc4"
+version = "1.0.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -12,7 +12,7 @@ urls.release_notes = "https://github.com/microsoft/agent-framework/releases?q=ta
 urls.issues = "https://github.com/microsoft/agent-framework/issues"
 classifiers = [
   "License :: OSI Approved :: MIT License",
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",

--- a/python/samples/02-agents/providers/github_copilot/README.md
+++ b/python/samples/02-agents/providers/github_copilot/README.md
@@ -10,7 +10,7 @@ This directory contains examples demonstrating how to use the `GitHubCopilotAgen
 2. **GitHub Copilot Subscription**: An active GitHub Copilot subscription
 3. **Install the package**:
    ```bash
-   pip install agent-framework-github-copilot --pre
+   pip install agent-framework-github-copilot
    ```
 
 ## Environment Variables

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -668,7 +668,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-github-copilot"
-version = "1.0.0rc4"
+version = "1.0.0"
 source = { editable = "packages/github_copilot" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
### Motivation & Context

The `agent-framework-github-copilot` package has been maturing through the release-candidate stage (currently `1.0.0rc4`) and its public API is now stable. This promotes it to `released` (`1.0.0`) so consumers can install it without the `--pre` flag and rely on a stable, semantically versioned surface.

### Description & Review Guide

- **What are the major changes?**
  - Bump `agent-framework-github-copilot` from `1.0.0rc4` to `1.0.0` and update its classifier from `Development Status :: 4 - Beta` to `Development Status :: 5 - Production/Stable`.
  - Update `python/PACKAGE_STATUS.md` to list the package as `released`.
  - Drop the `--pre` install flag from the package README and the provider sample README now that a stable release is published.
  - Add a `github-copilot-1.0.0` CHANGELOG section covering the promotion and the input-attachment forwarding that ships in this release (#7300).
  - Update the `uv.lock` pin for the package to `1.0.0`.

- **What is the impact of these changes?**
  - `agent-framework-github-copilot` becomes a stable, non-prerelease distribution. No public API change and non-breaking.
  - This is a standalone package promotion: `agent-framework-core` and the root `agent-framework` are intentionally **not** bumped. The `core[all]` extra references the package by name without a version pin, so core's published metadata is unaffected.

- **What do you want reviewers to focus on?**
  - Confirmation that a standalone promotion (no core/root bump) is the intended release shape for this cycle, and that the CHANGELOG section label/placement matches the standalone-cut convention.

### Related Issue

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
