### PR TITLE
.NET: Create session for tool approval agent when none provided

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
@@ -115,6 +115,13 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
             return new AgentResponse(new ChatMessage(ChatRole.Assistant, [nextQueuedItem]));
         }
 
+        // When the caller did not supply a session, create one and use it for every inner call.
+        // The auto-approval loop re-invokes the inner agent with only the injected approval
+        // responses; without a session the inner agent has no conversation history to reconstruct
+        // the original request, which produces an empty request to the underlying service. Threading
+        // a session preserves the history across re-invocations.
+        session ??= await this.InnerAgent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
+
         // 3. Call the inner agent in a loop. If the inner agent returns approval requests
         //    that are ALL auto-approved by standing rules, we immediately re-call with the
         //    collected approval responses injected. This avoids returning empty responses.
@@ -157,6 +164,11 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
             yield return new AgentResponseUpdate(ChatRole.Assistant, [nextQueuedItem]);
             yield break;
         }
+
+        // When the caller did not supply a session, create one and use it for every inner call so
+        // conversation history is preserved across auto-approval re-invocations. See the non-streaming
+        // RunCoreAsync for details.
+        session ??= await this.InnerAgent.CreateSessionAsync(cancellationToken).ConfigureAwait(false);
 
         // 3. Stream from the inner agent in a loop. If all approval requests from the stream
         //    are auto-approved by standing rules, we immediately re-stream with the collected

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
@@ -1962,8 +1962,165 @@ public class ToolApprovalAgentTests
     }
 
     /// <summary>
-    /// Verify that when auto-approval rule does not match, request is surfaced to the caller.
+    /// Verify that when no session is supplied, the agent creates one and threads it to the inner
+    /// agent across auto-approval re-invocations. Without a session, the inner agent would receive
+    /// only the injected approval response (with no history) on the second call, producing an empty
+    /// request to the underlying service (repro for issue #7210).
     /// </summary>
+    [Fact]
+    public async Task RunAsync_AutoApprovalRule_NoSession_CreatesAndThreadsSessionAsync()
+    {
+        // Arrange
+        var createdSession = new ChatClientAgentSession();
+        var approvalRequest = new ToolApprovalRequestContent("req1", new FunctionCallContent("call1", "ReadTool"));
+
+        var capturedSessions = new List<AgentSession?>();
+        var callCount = 0;
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<ValueTask<AgentSession>>("CreateSessionCoreAsync", ItExpr.IsAny<CancellationToken>())
+            .Returns(new ValueTask<AgentSession>(createdSession));
+        innerAgent
+            .Protected()
+            .Setup<Task<AgentResponse>>("RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<IEnumerable<ChatMessage>, AgentSession?, AgentRunOptions?, CancellationToken>(
+                (_, session, _, _) => capturedSessions.Add(session))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return new AgentResponse([new ChatMessage(ChatRole.Assistant, [approvalRequest])]);
+                }
+
+                return new AgentResponse([new ChatMessage(ChatRole.Assistant, "Done")]);
+            });
+
+        var options = new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule]
+        };
+        var agent = new ToolApprovalAgent(innerAgent.Object, options);
+
+        // Act — invoke WITHOUT a session.
+        var response = await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")]);
+
+        // Assert — auto-approval re-invoked the inner agent, and both calls received the same,
+        // non-null session so conversation history is preserved across the re-invocation.
+        Assert.Equal(2, callCount);
+        Assert.Equal("Done", response.Text);
+        Assert.Equal(2, capturedSessions.Count);
+        Assert.All(capturedSessions, s => Assert.Same(createdSession, s));
+    }
+
+    /// <summary>
+    /// Streaming counterpart of <see cref="RunAsync_AutoApprovalRule_NoSession_CreatesAndThreadsSessionAsync"/>:
+    /// when no session is supplied, the streaming path also creates one and threads it to the inner
+    /// agent across auto-approval re-invocations.
+    /// </summary>
+    [Fact]
+    public async Task RunStreamingAsync_AutoApprovalRule_NoSession_CreatesAndThreadsSessionAsync()
+    {
+        // Arrange
+        var createdSession = new ChatClientAgentSession();
+        var approvalRequest = new ToolApprovalRequestContent("req1", new FunctionCallContent("call1", "ReadTool"));
+
+        var capturedSessions = new List<AgentSession?>();
+        var callCount = 0;
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<ValueTask<AgentSession>>("CreateSessionCoreAsync", ItExpr.IsAny<CancellationToken>())
+            .Returns(new ValueTask<AgentSession>(createdSession));
+        innerAgent
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<IEnumerable<ChatMessage>, AgentSession?, AgentRunOptions?, CancellationToken>(
+                (_, session, _, ct) =>
+                {
+                    capturedSessions.Add(session);
+                    callCount++;
+                    AgentResponseUpdate[] streamUpdates = callCount == 1
+                        ? [new AgentResponseUpdate(ChatRole.Assistant, [approvalRequest])]
+                        : [new AgentResponseUpdate(ChatRole.Assistant, "Done")];
+                    return ToAsyncEnumerableAsync(streamUpdates, ct);
+                });
+
+        var options = new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule]
+        };
+        var agent = new ToolApprovalAgent(innerAgent.Object, options);
+
+        // Act — invoke WITHOUT a session.
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in agent.RunStreamingAsync([new ChatMessage(ChatRole.User, "Hi")]))
+        {
+            updates.Add(update);
+        }
+
+        // Assert — both inner calls received the same, non-null session.
+        Assert.Equal(2, callCount);
+        Assert.Equal("Done", string.Concat(updates.Select(u => u.Text)));
+        Assert.Equal(2, capturedSessions.Count);
+        Assert.All(capturedSessions, s => Assert.Same(createdSession, s));
+    }
+
+    /// <summary>
+    /// Verify that when no session is supplied, the agent creates exactly one session and threads
+    /// it to the inner agent, even when no approval re-invocation is needed.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_NoApprovalRequest_NoSession_CreatesSingleSessionAsync()
+    {
+        // Arrange
+        var createdSession = new ChatClientAgentSession();
+        var createSessionCallCount = 0;
+        var capturedSessions = new List<AgentSession?>();
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<ValueTask<AgentSession>>("CreateSessionCoreAsync", ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                createSessionCallCount++;
+                return new ValueTask<AgentSession>(createdSession);
+            });
+        innerAgent
+            .Protected()
+            .Setup<Task<AgentResponse>>("RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<IEnumerable<ChatMessage>, AgentSession?, AgentRunOptions?, CancellationToken>(
+                (_, session, _, _) => capturedSessions.Add(session))
+            .ReturnsAsync(new AgentResponse([new ChatMessage(ChatRole.Assistant, "Done")]));
+
+        var agent = new ToolApprovalAgent(innerAgent.Object, new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule]
+        });
+
+        // Act
+        var response = await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")]);
+
+        // Assert — a single session was created and threaded to the inner agent.
+        Assert.Equal("Done", response.Text);
+        Assert.Equal(1, createSessionCallCount);
+        Assert.Single(capturedSessions);
+        Assert.Same(createdSession, capturedSessions[0]);
+    }
+
     [Fact]
     public async Task RunAsync_AutoApprovalRule_DoesNotMatchSurfacesToCallerAsync()
     {


### PR DESCRIPTION
### Motivation & Context

When an agent is wrapped with the tool-approval middleware (`UseToolApproval` / `ToolApprovalAgent`) and configured with auto-approval rules, invoking it **without an explicit `AgentSession`** could fail after the first tool call with an HTTP 400 from the model provider:

```
Missing required parameter: 'input'.
```

The tool-approval agent auto-approves the surfaced approval requests and then re-invokes the inner agent with **only** the injected approval-response message. When no session was supplied, the inner `ChatClientAgent` had no conversation history to reconstruct the request, so it sent an empty `input` to the Responses API, which the service rejected.

Because the history is otherwise persisted in the session, the same flow works when a session is passed — matching the "works with a session, fails without one" symptom reported in #7210. I was unable to reproduce the reporter's exact scenario, but this is a strong candidate for the underlying cause.

### Description & Review Guide

- **What are the major changes?**
  - In `ToolApprovalAgent.RunCoreAsync` and `RunCoreStreamingAsync`, when the caller does not supply a session, one is now created via `this.InnerAgent.CreateSessionAsync(cancellationToken)` before the auto-approval loop and threaded through every inner run. This preserves conversation history across auto-approval re-invocations.
  - Added unit tests covering the no-session auto-approval flow for both the non-streaming and streaming paths (asserting the same non-null session is threaded to every inner call), plus a test confirming a single session is created when none is supplied.

- **What is the impact of these changes?**
  - Agents using tool approval with auto-approval rules and no explicit session no longer emit an empty follow-up request after a tool call. Behavior is unchanged when a session is supplied. Not a breaking change.

- **What do you want reviewers to focus on?**
  - Whether creating an internal session when none is provided is the right layer for this fix, and that it does not interfere with the existing session-state (approval-rule) bag semantics.

### Related Issue

Related to #7210. Linking for tracking; not using a closing keyword because the reporter's exact repro is unconfirmed, so this should not auto-close the issue on merge.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
