### PR TITLE
.NET: Graduate GitHub Copilot agent to stable

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
+++ b/dotnet/src/Microsoft.Agents.AI.GitHub.Copilot/Microsoft.Agents.AI.GitHub.Copilot.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsReleaseCandidate>true</IsReleaseCandidate>
+    <IsReleased>true</IsReleased>
     <!-- GitHub.Copilot.SDK only supports .NET 8.0+ -->
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
     <NoWarn>$(NoWarn);GHCP001</NoWarn>
@@ -13,6 +13,12 @@
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <!-- Disable package validation baseline until the first release -->
+  <PropertyGroup>
+    <PackageValidationBaselineVersion />
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Agents.AI.Abstractions\Microsoft.Agents.AI.Abstractions.csproj" />


### PR DESCRIPTION
### Motivation & Context

The `Microsoft.Agents.AI.GitHub.Copilot` package has been shipping as a release candidate (`1.15.0-rc{N}`). Its public API is now stable, so this graduates it to a released package. This mirrors the GitHub Copilot agent's promotion to stable on the Python side.

### Description & Review Guide

- **What are the major changes?**
  - In `Microsoft.Agents.AI.GitHub.Copilot.csproj`, replace `<IsReleaseCandidate>true</IsReleaseCandidate>` with `<IsReleased>true</IsReleased>` so the package builds with the stable central version (no `-rc`/prerelease suffix).
  - Clear the package-validation baseline (`<PackageValidationBaselineVersion />`) and set `<EnablePackageValidation>false</EnablePackageValidation>` for this first stable release, since the package has never shipped a stable NuGet to validate against. This mirrors the `Microsoft.Agents.AI.Harness` graduation in #7119.

- **What is the impact of these changes?**
  - The package graduates from release candidate to released and will publish at the central stable version in the next coordinated .NET release.
  - Verified locally: `dotnet pack -c Release` produces `Microsoft.Agents.AI.GitHub.Copilot.1.15.0.nupkg` (stable, no `-rc` suffix) with no package-validation error.
  - **Non-breaking**: the package exposes no `[Experimental]` APIs, so unlike the harness graduation there are no experimental attributes to remove.

- **What do you want reviewers to focus on?**
  - Confirmation that disabling package validation for this first stable release is the intended approach (consistent with the harness precedent), to be re-enabled against the stable baseline in a future release.

### Related Issue

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
