### PR TITLE
Python: fix(python): exclude unsupported ChatOptions in Ollama chat client (#7054)

### DIFF
--- a/python/packages/ollama/agent_framework_ollama/_chat_client.py
+++ b/python/packages/ollama/agent_framework_ollama/_chat_client.py
@@ -400,8 +400,16 @@ class OllamaChatClient(
 
             messages = prepend_instructions_to_messages(list(messages), instructions, role="system")
 
-        # Keys to exclude from processing
-        exclude_keys = {"instructions", "tool_choice"}
+        # Keys to exclude from processing (unsupported in Ollama API)
+        exclude_keys = {
+            "instructions",
+            "tool_choice",
+            "allow_multiple_tool_calls",
+            "user",
+            "store",
+            "logit_bias",
+            "metadata",
+        }
 
         # Build run_options and model_options separately
         run_options: dict[str, Any] = {}

--- a/python/packages/ollama/tests/test_ollama_chat_client.py
+++ b/python/packages/ollama/tests/test_ollama_chat_client.py
@@ -810,3 +810,52 @@ class TestParallelToolCallUniqueness:
         assert formatted[0].tool_name == "search:advanced", (
             f"Expected bare name 'search:advanced', got '{formatted[0].tool_name}'"
         )
+
+
+def test_prepare_options_excludes_unsupported_chat_options() -> None:
+    """Verify that unsupported ChatOptions fields are excluded from Ollama run_options even when non-None."""
+    client = OllamaChatClient(host="http://localhost:12345", model="test-model")
+    messages = [Message(role="user", contents=["hello"])]
+    options = {
+        "allow_multiple_tool_calls": False,
+        "user": "test-user-id",
+        "store": True,
+        "logit_bias": {"101": 1.5},
+        "metadata": {"session": "123"},
+        "tool_choice": "auto",
+        "instructions": "Be helpful.",
+    }
+
+    prepared = client._prepare_options(messages, options)
+
+    for unsupported_key in [
+        "allow_multiple_tool_calls",
+        "user",
+        "store",
+        "logit_bias",
+        "metadata",
+        "tool_choice",
+        "instructions",
+    ]:
+        assert unsupported_key not in prepared, f"Key {unsupported_key} should be excluded from run_options"
+
+
+@pytest.mark.asyncio
+async def test_get_response_with_unsupported_options(mock_chat_completion_response: OllamaChatResponse) -> None:
+    """Verify that get_response succeeds when options include unsupported fields."""
+    mock_client = MagicMock(spec=AsyncClient)
+    mock_client._client = MagicMock()
+    mock_client._client.base_url = "http://localhost:12345"
+    mock_client.chat = AsyncMock(return_value=mock_chat_completion_response)
+
+    client = OllamaChatClient(client=mock_client, model="test-model")
+    messages = [Message(role="user", contents=["hello"])]
+    options = {"allow_multiple_tool_calls": False, "user": "test-user"}
+
+    res = await client.get_response(messages=messages, options=options)
+    assert res is not None
+
+    mock_client.chat.assert_called_once()
+    _, kwargs = mock_client.chat.call_args
+    assert "allow_multiple_tool_calls" not in kwargs
+    assert "user" not in kwargs


### PR DESCRIPTION
### Motivation & Context

When using `OllamaChatClient` (for example, with orchestration patterns like `HandoffBuilder` or when passing options like `allow_multiple_tool_calls=False`, `user`, `store`, `logit_bias`, `metadata`), requests fail with a runtime `TypeError`:
`AsyncClient.chat() got an unexpected keyword argument 'allow_multiple_tool_calls'`.

`OllamaChatOptions` explicitly marks these options as unsupported in Ollama (`tool_choice: None`, `allow_multiple_tool_calls: None`, `user: None`, `store: None`, `logit_bias: None`, `metadata: None`). However, `OllamaChatClient._prepare_options()` previously only excluded `instructions` and `tool_choice` from `exclude_keys`, while relying on `value is None` for other options. When `allow_multiple_tool_calls=False` or another non-None unsupported option was passed, `_prepare_options()` added it to `run_options`, which was then unpacked into `ollama.AsyncClient.chat()` as an unknown kwarg.

### Description & Review Guide

- **What are the major changes?**
  Added all unsupported `OllamaChatOptions` fields (`allow_multiple_tool_calls`, `user`, `store`, `logit_bias`, `metadata`) to `exclude_keys` in `OllamaChatClient._prepare_options()`.
- **What is the impact of these changes?**
  Prevents runtime `TypeError` crashes when non-None unsupported `ChatOptions` (e.g. `allow_multiple_tool_calls=False` injected by `HandoffAgentExecutor` or passed by users) are provided to `OllamaChatClient`.
- **What do you want reviewers to focus on?**
  `OllamaChatClient._prepare_options()` in `python/packages/ollama/agent_framework_ollama/_chat_client.py` and the corresponding unit tests in `python/packages/ollama/tests/test_ollama_chat_client.py`.

### Related Issue

Fixes #7054

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**