### PR TITLE
Python: fix LineTooLong error in CopilotStudioAgent

### DIFF
--- a/python/packages/copilotstudio/agent_framework_copilotstudio/_agent.py
+++ b/python/packages/copilotstudio/agent_framework_copilotstudio/_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterable, Awaitable, Sequence
 from typing import Any, Literal, TypedDict, overload
 
+import aiohttp
 from agent_framework import (
     AgentMiddlewareTypes,
     AgentResponse,
@@ -20,9 +21,38 @@ from agent_framework import (
 from agent_framework._settings import load_settings
 from agent_framework._types import AgentRunInputs
 from agent_framework.exceptions import AgentException
+from microsoft_agents.activity import Activity, ActivityTypes
 from microsoft_agents.copilotstudio.client import AgentType, ConnectionSettings, CopilotClient, PowerPlatformCloud
 
 from ._acquire_token import acquire_token
+
+
+async def _patched_post_request(
+    self: CopilotClient, url: str, data: dict[str, Any], headers: dict[str, Any]
+) -> AsyncIterable[Activity]:
+    async with aiohttp.ClientSession() as session, session.post(url, json=data, headers=headers) as response:
+        if response.status != 200:
+            raise aiohttp.ClientError(f"Error sending request: {response.status}")
+        event_type = None
+        buffer = b""
+        async for chunk in response.content.iter_any():
+            buffer += chunk
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                if line.startswith(b"event:"):
+                    event_type = line[6:].decode("utf-8").strip()
+                if line.startswith(b"data:") and event_type == "activity":
+                    activity_data = line[5:].decode("utf-8").strip()
+                    activity = Activity.model_validate_json(activity_data)
+
+                    if activity.type == ActivityTypes.message:
+                        self._current_conversation_id = activity.conversation.id  # pyright: ignore[reportPrivateUsage]
+
+                    yield activity
+
+
+# Monkeypatch CopilotClient to handle data lines larger than 512KB without LineTooLong errors.
+CopilotClient.post_request = _patched_post_request
 
 
 class CopilotStudioSettings(TypedDict, total=False):

--- a/python/packages/copilotstudio/agent_framework_copilotstudio/_agent.py
+++ b/python/packages/copilotstudio/agent_framework_copilotstudio/_agent.py
@@ -32,7 +32,8 @@ async def _patched_post_request(
 ) -> AsyncIterable[Activity]:
     async with aiohttp.ClientSession() as session, session.post(url, json=data, headers=headers) as response:
         if response.status != 200:
-            raise aiohttp.ClientError(f"Error sending request: {response.status}")
+            detail = await response.text()
+            raise AgentException(f"Copilot Studio request to {url} failed ({response.status}): {detail}")
         event_type = None
         buffer = b""
         async for chunk in response.content.iter_any():
@@ -49,6 +50,18 @@ async def _patched_post_request(
                         self._current_conversation_id = activity.conversation.id  # pyright: ignore[reportPrivateUsage]
 
                     yield activity
+        if buffer:
+            line = buffer
+            if line.startswith(b"event:"):
+                event_type = line[6:].decode("utf-8").strip()
+            if line.startswith(b"data:") and event_type == "activity":
+                activity_data = line[5:].decode("utf-8").strip()
+                activity = Activity.model_validate_json(activity_data)
+
+                if activity.type == ActivityTypes.message:
+                    self._current_conversation_id = activity.conversation.id  # pyright: ignore[reportPrivateUsage]
+
+                yield activity
 
 
 # Monkeypatch CopilotClient to handle data lines larger than 512KB without LineTooLong errors.

--- a/python/packages/copilotstudio/tests/test_line_too_long_bug.py
+++ b/python/packages/copilotstudio/tests/test_line_too_long_bug.py
@@ -23,7 +23,7 @@ async def mock_server_handler(request: web.Request) -> web.StreamResponse:
     # Write event type line
     await response.write(b"event: activity\n")
     # Write data line
-    data_line = f'data: {{"type":"message","text":"{long_data}","conversation":{{"id":"test"}}}}\n'.encode("utf-8")
+    data_line = f'data: {{"type":"message","text":"{long_data}","conversation":{{"id":"test"}}}}\n'.encode()
     await response.write(data_line)
     return response
 

--- a/python/packages/copilotstudio/tests/test_line_too_long_bug.py
+++ b/python/packages/copilotstudio/tests/test_line_too_long_bug.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from collections.abc import AsyncIterable
+
+import pytest
+from aiohttp import web
+from microsoft_agents.activity import Activity
+from microsoft_agents.copilotstudio.client import ConnectionSettings, CopilotClient
+from agent_framework_copilotstudio import CopilotStudioAgent
+
+
+async def mock_server_handler(request: web.Request) -> web.StreamResponse:
+    headers = {"Content-Type": "text/event-stream"}
+    response = web.StreamResponse(headers=headers)
+    await response.prepare(request)
+
+    # 600KB line (larger than aiohttp default limit of 524288 bytes)
+    long_data = "x" * 600000
+
+    # Write event type line
+    await response.write(b"event: activity\n")
+    # Write data line
+    data_line = f'data: {{"type":"message","text":"{long_data}","conversation":{{"id":"test"}}}}\n'.encode("utf-8")
+    await response.write(data_line)
+    return response
+
+
+@pytest.fixture
+async def local_server() -> AsyncIterable[str]:
+    app = web.Application()
+    app.router.add_post("/test", mock_server_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+
+    address = runner.addresses[0]
+    port = address[1]
+    # Yield the URL to the test
+    yield f"http://127.0.0.1:{port}/test"
+
+    await site.stop()
+    await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_copilot_client_post_request_long_line(local_server: str) -> None:
+    settings = ConnectionSettings(
+        environment_id="env",
+        agent_identifier="agent",
+        cloud=None,
+        copilot_agent_type=None,
+        custom_power_platform_cloud=None,
+    )
+    client = CopilotClient(settings=settings, token="token")
+
+    activities: list[Activity] = []
+    async for activity in client.post_request(local_server, {}, {}):
+        activities.append(activity)
+
+    assert len(activities) == 1
+    assert activities[0].text == "x" * 600000

--- a/python/packages/copilotstudio/tests/test_line_too_long_bug.py
+++ b/python/packages/copilotstudio/tests/test_line_too_long_bug.py
@@ -6,7 +6,10 @@ import pytest
 from aiohttp import web
 from microsoft_agents.activity import Activity
 from microsoft_agents.copilotstudio.client import ConnectionSettings, CopilotClient
-from agent_framework_copilotstudio import CopilotStudioAgent
+
+import agent_framework_copilotstudio  # noqa: F401
+
+# Side-effect import: applies CopilotClient.post_request monkeypatch.
 
 
 async def mock_server_handler(request: web.Request) -> web.StreamResponse:

--- a/python/packages/core/tests/core/test_function_invocation_logic.py
+++ b/python/packages/core/tests/core/test_function_invocation_logic.py
@@ -2374,6 +2374,7 @@ def test_replace_approval_contents_with_results_allows_reused_call_id_after_comp
         ("call_reused", "second output"),
     ]
 
+
 def test_replace_approval_contents_with_results_uses_result_call_ids_for_placeholders() -> None:
     from agent_framework._tools import _collect_approval_responses, _replace_approval_contents_with_results
 


### PR DESCRIPTION
### Motivation & Context

This PR resolves **Issue #7257** where calling `CopilotStudioAgent` fails with `aiohttp.http_exceptions.LineTooLong: 400` when receiving streaming response data larger than 512KB (for example, when fetching a large payload from a Salesforce connector in Copilot Studio).

The root cause is that the underlying dependency `microsoft-agents-copilotstudio-client` implements `CopilotClient.post_request` using line-based iteration (`async for line in response.content:`). Under `aiohttp`, line-based reading triggers a hardcoded limit of `524288` bytes (512 KB) for any single line. 

### Proposed Changes

Since the client is an external dependency, we fix this in the framework layer by monkeypatching the client's HTTP request handler:

1. **Monkeypatch `CopilotClient.post_request`**:
   * Patched `post_request` inside `agent_framework_copilotstudio/_agent.py` to read the response content in raw chunks via `response.content.iter_any()`.
   * Implemented custom chunk-based buffer splitting on newlines (`\n`) to parse SSE activities. This avoids line-limit exceptions entirely and handles lines of arbitrary length.
   * Suppressed Pyright `reportPrivateUsage` warning with an inline comment, since monkeypatching requires access to the client's protected `_current_conversation_id` field.

2. **Added Regression Test**:
   * Created `packages/copilotstudio/tests/test_line_too_long_bug.py`.
   * The test spins up a local asynchronous HTTP/SSE server that returns an event payload of **600 KB** (exceeding the 512 KB limit).
   * Verifies that the patched client handles the stream correctly and parses the message without throwing exceptions.

### Testing & Validation

1. **Unit Tests**:
   * Ran the new test and verified it passes:
     ```bash
     uv run pytest packages/copilotstudio/tests/test_line_too_long_bug.py
     # 1 passed in 0.17s
     ```
   * Ran the full `copilotstudio` package test suite:
     ```bash
     uv run poe test -P copilotstudio
     # 34 passed in 0.60s
     ```

2. **Static Analysis**:
   * Verified all linter, formatter, and type-checking checks pass with zero errors:
     ```bash
     uv run poe check -P copilotstudio
     # All formatting, lint, Pyright, MyPy, Ty, and Zuban tasks passed
     ```

Closes #7257
