### PR TITLE
Python: Fix Gemini harness tool declarations

### DIFF
--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -890,9 +890,14 @@ class RawGeminiChatClient(
             kwargs["response_schema"] = response_schema
         elif (schema := self._extract_response_schema(response_format)) is not None:
             kwargs["response_schema"] = schema
-        if tools := self._prepare_tools(options):
+        tools = self._prepare_tools(options)
+        if tools:
             kwargs["tools"] = tools
-        if tool_config := self._prepare_tool_config(options.get("tool_choice")):
+        tool_config = self._prepare_tool_config(options.get("tool_choice"))
+        if tools and not self._vertexai and self._requires_server_side_tool_invocations(tools):
+            tool_config = tool_config or types.ToolConfig()
+            tool_config.include_server_side_tool_invocations = True
+        if tool_config:
             kwargs["tool_config"] = tool_config
         if thinking_config := options.get("thinking_config"):
             thinking_config_kwargs = {k: v for k, v in thinking_config.items() if v is not None}
@@ -975,7 +980,7 @@ class RawGeminiChatClient(
             types.FunctionDeclaration(
                 name=tool.name,
                 description=tool.description or "",
-                parameters=tool.parameters(),  # type: ignore[arg-type]
+                parameters_json_schema=tool.parameters(),
             )
             for tool in tools_option
             if isinstance(tool, FunctionTool)
@@ -987,6 +992,20 @@ class RawGeminiChatClient(
         result.extend(tool for tool in tools_option if isinstance(tool, types.Tool))
 
         return result or None
+
+    @staticmethod
+    def _requires_server_side_tool_invocations(tools: Sequence[types.Tool]) -> bool:
+        """Return whether Gemini Developer API requires server-side tool invocation reporting."""
+        has_function_declarations = any(tool.function_declarations for tool in tools)
+        return has_function_declarations and any(RawGeminiChatClient._has_server_side_tool(tool) for tool in tools)
+
+    @staticmethod
+    def _has_server_side_tool(tool: types.Tool) -> bool:
+        """Return whether the Gemini tool declares a native server-side tool."""
+        return any(
+            field_name != "function_declarations" and getattr(tool, field_name, None) is not None
+            for field_name in type(tool).model_fields
+        )
 
     def _prepare_tool_config(self, tool_choice: Any) -> types.ToolConfig | None:
         """Build a Gemini ``ToolConfig`` from the framework ``tool_choice`` value.

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -7,14 +7,14 @@ import datetime
 import json
 import logging
 import os
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agent_framework import Agent, Content, FunctionTool, Message
 from google.genai import types
 from pydantic import BaseModel
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, TypedDict
 
 from agent_framework_gemini import GeminiChatClient, GeminiChatOptions, RawGeminiChatClient, ThinkingConfig
 

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -7,13 +7,14 @@ import datetime
 import json
 import logging
 import os
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agent_framework import Agent, Content, FunctionTool, Message
 from google.genai import types
 from pydantic import BaseModel
+from typing_extensions import NotRequired
 
 from agent_framework_gemini import GeminiChatClient, GeminiChatOptions, RawGeminiChatClient, ThinkingConfig
 
@@ -39,6 +40,12 @@ skip_if_no_credentials = pytest.mark.skipif(
 )
 
 _TEST_MODEL = os.getenv("GOOGLE_MODEL") or os.getenv("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+
+class _ToolListItem(TypedDict):
+    title: str
+    description: NotRequired[str]
+
 
 # stub helpers
 
@@ -1733,6 +1740,31 @@ async def test_function_tool_converted_to_function_declaration() -> None:
     assert function_declaration.name == "get_weather"
 
 
+async def test_function_tool_json_schema_forwarded_to_parameters_json_schema() -> None:
+    """Forwards full JSON Schema from FunctionTool instead of coercing it into Gemini's Schema subset."""
+
+    def add_items(items: list[_ToolListItem]) -> str:
+        """Add items."""
+        return "ok"
+
+    tool = FunctionTool(name="add_items", func=add_items)
+    schema = tool.parameters()
+    assert "$defs" in schema
+
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="Done")]))
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Add items")])],
+        options={"tools": [tool]},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    function_declaration = _first_function_declaration(config)
+    assert function_declaration.parameters is None
+    assert function_declaration.parameters_json_schema == schema
+
+
 async def test_callable_tool_resolved_via_validate_options() -> None:
     """Raw callables passed as tools must be normalized by _validate_options into FunctionTools
     and reach the Gemini config as function declarations.
@@ -1754,6 +1786,63 @@ async def test_callable_tool_resolved_via_validate_options() -> None:
     assert config.tools is not None
     function_declaration = _first_function_declaration(config)
     assert function_declaration.name == "get_weather"
+
+
+async def test_developer_api_mixed_native_and_function_tools_enable_server_side_invocations() -> None:
+    """Enables Gemini Developer API server-side tool invocations when built-ins and function tools are mixed."""
+    tool = _make_dummy_tool()
+    search_tool = GeminiChatClient.get_web_search_tool()
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="Done")]))
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Search and call a tool")])],
+        options={"tools": [search_tool, tool]},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.tool_config is not None
+    assert config.tool_config.include_server_side_tool_invocations is True
+
+
+async def test_developer_api_mixed_native_and_function_tools_preserve_tool_choice() -> None:
+    """Preserves function calling mode while enabling Developer API server-side built-in tool invocations."""
+    tool = _make_dummy_tool()
+    search_tool = GeminiChatClient.get_web_search_tool()
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="Done")]))
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Search and call a tool")])],
+        options={"tools": [search_tool, tool], "tool_choice": "auto"},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    function_calling_config = _function_calling_config(config)
+    assert function_calling_config.mode == "AUTO"
+    assert config.tool_config is not None
+    assert config.tool_config.include_server_side_tool_invocations is True
+
+
+async def test_vertex_ai_mixed_native_and_function_tools_do_not_enable_server_side_invocations() -> None:
+    """Does not set the Developer API-only server-side invocation flag for Vertex AI."""
+    tool = _make_dummy_tool()
+    search_tool = GeminiChatClient.get_web_search_tool()
+    mock = MagicMock()
+    mock._api_client.vertexai = True
+    client = GeminiChatClient(client=mock, model="gemini-2.5-flash")
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="Done")]))
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Search and call a tool")])],
+        options={"tools": [search_tool, tool], "tool_choice": "auto"},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    function_calling_config = _function_calling_config(config)
+    assert function_calling_config.mode == "AUTO"
+    assert config.tool_config is not None
+    assert config.tool_config.include_server_side_tool_invocations is None
 
 
 # _coerce_to_dict


### PR DESCRIPTION
### Motivation & Context

Fixes #6954.

Gemini Developer API calls can combine native Gemini tools, such as Google Search grounding, with Agent Framework function tools. That mixed-tool path needs Gemini's server-side tool invocation reporting enabled so native tool calls are returned alongside function calls.

Function tool schemas also need to be forwarded through the Gemini SDK's JSON Schema field so richer Agent Framework tool schemas are preserved instead of being coerced into the SDK `Schema` subset.

Disclosure: This PR was prepared with AI assistance under human direction and review.

### Description & Review Guide

- **What are the major changes?**
  - Pass `FunctionTool` schemas through `parameters_json_schema` when building Gemini function declarations.
  - Enable `include_server_side_tool_invocations` for Gemini Developer API requests that mix native Gemini tools with function declarations.
  - Preserve existing `tool_choice` / function-calling configuration when adding that Developer API flag.
  - Add Gemini client tests for JSON Schema pass-through, mixed native/function tool config, preserved `tool_choice`, and Vertex AI behavior.
- **What is the impact of these changes?**
  - The failing Gemini harness mixed-tool scenario gets the native tool-call reporting it needs while keeping Vertex AI behavior unchanged.
- **What do you want reviewers to focus on?**
  - Whether the Developer API-only condition is the right scope for enabling server-side tool invocation reporting on mixed native/function tool requests.

### Related Issue

Fixes #6954

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) -- a workflow keeps the label and title prefix in sync automatically.
