### PR TITLE
.NET: Preserve table state after declarative EditTable Add

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/EditTableExecutor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/EditTableExecutor.cs
@@ -34,7 +34,7 @@ internal sealed class EditTableExecutor(EditTable model, WorkflowFormulaState st
                 EvaluationResult<DataValue> addResult = this.Evaluator.GetValue(addItemValue);
                 RecordValue newRecord = BuildRecord(tableValue.Type.ToRecord(), addResult.Value.ToFormula());
                 await tableValue.AppendAsync(newRecord, cancellationToken).ConfigureAwait(false);
-                await this.AssignAsync(variablePath, newRecord, context).ConfigureAwait(false);
+                await this.AssignAsync(variablePath, tableValue, context).ConfigureAwait(false);
                 break;
             case TableChangeType.Remove:
                 ValueExpression removeItemValue = Throw.IfNull(this.Model.Value, $"{nameof(this.Model)}.{nameof(this.Model.Value)}");

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/EditTableV2Executor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/ObjectModel/EditTableV2Executor.cs
@@ -33,7 +33,7 @@ internal sealed class EditTableV2Executor(EditTableV2 model, WorkflowFormulaStat
             EvaluationResult<DataValue> expressionResult = this.Evaluator.GetValue(addItemValue);
             RecordValue newRecord = BuildRecord(tableValue.Type.ToRecord(), expressionResult.Value.ToFormula());
             await tableValue.AppendAsync(newRecord, cancellationToken).ConfigureAwait(false);
-            await this.AssignAsync(this.Model.ItemsVariable, newRecord, context).ConfigureAwait(false);
+            await this.AssignAsync(this.Model.ItemsVariable, tableValue, context).ConfigureAwait(false);
         }
         else if (changeType is ClearItemsOperation)
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/EditTableExecutorTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/EditTableExecutorTest.cs
@@ -33,11 +33,42 @@ public sealed class EditTableExecutorTest(ITestOutputHelper output) : WorkflowAc
             changeType: TableChangeType.Add,
             value: new RecordDataValue([new("id", new NumberDataValue(7))]));
 
-        // Verify the variable now contains the added record
+        // Verify the variable remains a table containing the added record
         FormulaValue resultValue = this.State.Get("MyTable");
-        RecordValue resultRecord = Assert.IsAssignableFrom<RecordValue>(resultValue);
-        DecimalValue idValue = Assert.IsType<DecimalValue>(resultRecord.GetField("id"));
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(resultValue);
+        Assert.Equal(2, resultTable.Rows.Count());
+        DecimalValue idValue = Assert.IsType<DecimalValue>(resultTable.Rows.Last().Value.GetField("id"));
         Assert.Equal(7, idValue.Value);
+    }
+
+    [Fact]
+    public async Task ConsecutiveAddsPreserveTableAsync()
+    {
+        // Arrange
+        FormulaValue tableValue = this.State.Engine.Eval("[{id: 1}]");
+        this.State.Set("MyTable", tableValue);
+
+        EditTable firstAdd = this.CreateModel(
+            nameof(ConsecutiveAddsPreserveTableAsync),
+            "MyTable",
+            TableChangeType.Add,
+            new RecordDataValue([new("id", new NumberDataValue(2))]));
+        EditTable secondAdd = this.CreateModel(
+            nameof(ConsecutiveAddsPreserveTableAsync),
+            "MyTable",
+            TableChangeType.Add,
+            new RecordDataValue([new("id", new NumberDataValue(3))]));
+
+        // Act
+        await this.ExecuteAsync(new EditTableExecutor(firstAdd, this.State));
+        await this.ExecuteAsync(new EditTableExecutor(secondAdd, this.State));
+
+        // Assert
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(this.State.Get("MyTable"));
+        decimal[] ids = resultTable.Rows
+            .Select(row => Assert.IsType<DecimalValue>(row.Value.GetField("id")).Value)
+            .ToArray();
+        Assert.Equal([1, 2, 3], ids);
     }
 
     [Fact]
@@ -57,9 +88,11 @@ public sealed class EditTableExecutorTest(ITestOutputHelper output) : WorkflowAc
                 new("name", new StringDataValue("Second"))
             ]));
 
-        // Verify the variable now contains the added record
+        // Verify the variable remains a table containing the added record
         FormulaValue resultValue = this.State.Get("MyTable");
-        RecordValue resultRecord = Assert.IsAssignableFrom<RecordValue>(resultValue);
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(resultValue);
+        Assert.Equal(2, resultTable.Rows.Count());
+        RecordValue resultRecord = resultTable.Rows.Last().Value;
         DecimalValue idValue = Assert.IsType<DecimalValue>(resultRecord.GetField("id"));
         Assert.Equal(2, idValue.Value);
         StringValue nameValue = Assert.IsType<StringValue>(resultRecord.GetField("name"));
@@ -83,9 +116,10 @@ public sealed class EditTableExecutorTest(ITestOutputHelper output) : WorkflowAc
             changeType: TableChangeType.Add,
             value: new RecordDataValue([new("id", new NumberDataValue(1))]));
 
-        // Verify the variable now contains the added record
+        // Verify the variable remains a table containing the added record
         FormulaValue resultValue = this.State.Get("MyTable");
-        RecordValue resultRecord = Assert.IsAssignableFrom<RecordValue>(resultValue);
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(resultValue);
+        RecordValue resultRecord = Assert.Single(resultTable.Rows).Value;
         DecimalValue idValue = Assert.IsType<DecimalValue>(resultRecord.GetField("id"));
         Assert.Equal(1, idValue.Value);
     }
@@ -345,11 +379,12 @@ public sealed class EditTableExecutorTest(ITestOutputHelper output) : WorkflowAc
         EditTableExecutor action = new(model, this.State);
         await this.ExecuteAsync(action);
 
-        // Assert - Variable should contain the newly added record
+        // Assert - Variable should remain a table containing the newly added record
         VerifyModel(model, action);
         FormulaValue resultValue = this.State.Get("MyTable");
-        RecordValue resultRecord = Assert.IsAssignableFrom<RecordValue>(resultValue);
-        DecimalValue idValue = Assert.IsType<DecimalValue>(resultRecord.GetField("id"));
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(resultValue);
+        Assert.Equal(2, resultTable.Rows.Count());
+        DecimalValue idValue = Assert.IsType<DecimalValue>(resultTable.Rows.Last().Value.GetField("id"));
         Assert.Equal(10, idValue.Value);
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/EditTableV2ExecutorTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/ObjectModel/EditTableV2ExecutorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Agents.AI.Workflows.Declarative.ObjectModel;
 using Microsoft.Agents.ObjectModel;
@@ -144,7 +145,7 @@ public sealed class EditTableV2ExecutorTest(ITestOutputHelper output) : Workflow
         this.State.Set("TestTable", tableValue);
 
         // Arrange, Act, Assert
-        await this.ExecuteTestAsync<RecordValue>(
+        await this.ExecuteTestAsync<TableValue>(
             displayName: nameof(AddItemOperationWithSingleFieldRecordAsync),
             variableName: "TestTable",
             changeType: this.CreateAddItemOperation(new RecordDataValue.Builder
@@ -154,8 +155,8 @@ public sealed class EditTableV2ExecutorTest(ITestOutputHelper output) : Workflow
                     ["Name"] = new StringDataValue("John")
                 }
             }.Build()),
-            verifyAction: (variableName, recordValue) =>
-                Assert.Equal("John", recordValue.GetField("Name").ToObject())
+            verifyAction: (variableName, resultTable) =>
+                Assert.Equal("John", Assert.Single(resultTable.Rows).Value.GetField("Name").ToObject())
             );
     }
 
@@ -168,13 +169,44 @@ public sealed class EditTableV2ExecutorTest(ITestOutputHelper output) : Workflow
         this.State.Set("TestTable", tableValue);
 
         // Act & Assert
-        await this.ExecuteTestAsync<RecordValue>(
+        await this.ExecuteTestAsync<TableValue>(
             displayName: nameof(AddItemOperationWithScalarValueAsync),
             variableName: "TestTable",
             changeType: this.CreateAddItemOperation(new StringDataValue("TestValue")),
-            verifyAction: (variableName, recordValue) =>
-                Assert.Equal("TestValue", recordValue.GetField("Value").ToObject())
+            verifyAction: (variableName, resultTable) =>
+                Assert.Equal("TestValue", Assert.Single(resultTable.Rows).Value.GetField("Value").ToObject())
             );
+    }
+
+    [Fact]
+    public async Task ConsecutiveAddItemOperationsPreserveTableAsync()
+    {
+        // Arrange
+        RecordType recordType = RecordType.Empty().Add("Value", FormulaType.String);
+        RecordValue initialRecord = FormulaValue.NewRecordFromFields(
+            recordType,
+            new NamedValue("Value", FormulaValue.New("Initial")));
+        this.State.Set("TestTable", FormulaValue.NewTable(recordType, initialRecord));
+
+        EditTableV2 firstAdd = this.CreateModel(
+            nameof(ConsecutiveAddItemOperationsPreserveTableAsync),
+            "TestTable",
+            this.CreateAddItemOperation(new StringDataValue("First")));
+        EditTableV2 secondAdd = this.CreateModel(
+            nameof(ConsecutiveAddItemOperationsPreserveTableAsync),
+            "TestTable",
+            this.CreateAddItemOperation(new StringDataValue("Second")));
+
+        // Act
+        await this.ExecuteAsync(new EditTableV2Executor(firstAdd, this.State));
+        await this.ExecuteAsync(new EditTableV2Executor(secondAdd, this.State));
+
+        // Assert
+        TableValue resultTable = Assert.IsAssignableFrom<TableValue>(this.State.Get("TestTable"));
+        string[] values = resultTable.Rows
+            .Select(row => Assert.IsType<StringValue>(row.Value.GetField("Value")).Value)
+            .ToArray();
+        Assert.Equal(["Initial", "First", "Second"], values);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation & Context

Declarative `EditTable` and `EditTableV2` currently replace their items variable with the newly added record after an Add operation. A second Add then fails because the variable is no longer a table. This change keeps the mutated table bound to the variable so repeated additions work as expected.

AI assistance was used for codebase analysis and test scaffolding. The final implementation, diff, and validation results were reviewed by KXH.

### Description & Review Guide

- **What are the major changes?** Assign the mutated `TableValue` after Add in both executors; update existing Add assertions; add regression tests that execute two consecutive additions and verify row order.
- **What is the impact of these changes?** Declarative workflows can add multiple records to the same table without losing the table binding. Update and delete behavior is unchanged.
- **What do you want reviewers to focus on?** The post-Add assignment semantics in both executor versions and whether the updated assertions capture the intended state contract. Validation: 841 tests passed on `net10.0`, 841 tests passed on `net472`, the declarative project built across all target frameworks with 0 warnings/errors, and `dotnet format --verify-no-changes` passed.

### Related Issue

Fixes #7323

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add [BREAKING] to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.