### PR TITLE
Python: Add GitHub Copilot BYOK sample

### DIFF
--- a/python/samples/02-agents/providers/github_copilot/README.md
+++ b/python/samples/02-agents/providers/github_copilot/README.md
@@ -53,4 +53,4 @@ See the [observability samples](../../../02-agents/observability/) for full exam
 | [`github_copilot_with_mcp.py`](github_copilot_with_mcp.py) | Shows how to configure MCP (Model Context Protocol) servers, including local (stdio) and remote (HTTP) servers. |
 | [`github_copilot_with_instruction_directories.py`](github_copilot_with_instruction_directories.py) | Shows how to configure custom instruction directories for project-specific or team-shared guidelines. |
 | [`github_copilot_with_multiple_permissions.py`](github_copilot_with_multiple_permissions.py) | Shows how to combine multiple permission types for complex tasks that require shell, read, and write access. |
-| [`github_copilot_with_byok.py`](github_copilot_with_byok.py) | Shows how to configure BYOK (Bring Your Own Key) to route requests through your own OpenAI-compatible endpoint instead of the GitHub Copilot backend. |
+| [`github_copilot_with_byok.py`](github_copilot_with_byok.py) | Shows how to configure BYOK (Bring Your Own Key) to route requests through your own endpoint instead of the GitHub Copilot backend. |

--- a/python/samples/02-agents/providers/github_copilot/README.md
+++ b/python/samples/02-agents/providers/github_copilot/README.md
@@ -53,3 +53,4 @@ See the [observability samples](../../../02-agents/observability/) for full exam
 | [`github_copilot_with_mcp.py`](github_copilot_with_mcp.py) | Shows how to configure MCP (Model Context Protocol) servers, including local (stdio) and remote (HTTP) servers. |
 | [`github_copilot_with_instruction_directories.py`](github_copilot_with_instruction_directories.py) | Shows how to configure custom instruction directories for project-specific or team-shared guidelines. |
 | [`github_copilot_with_multiple_permissions.py`](github_copilot_with_multiple_permissions.py) | Shows how to combine multiple permission types for complex tasks that require shell, read, and write access. |
+| [`github_copilot_with_byok.py`](github_copilot_with_byok.py) | Shows how to configure BYOK (Bring Your Own Key) to route requests through your own OpenAI-compatible endpoint instead of the GitHub Copilot backend. |

--- a/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
+++ b/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
@@ -9,10 +9,10 @@ such as vLLM/LiteLLM/Ollama) instead of the default GitHub Copilot backend, usin
 SDK's BYOK support.
 
 Set the following environment variables before running:
-    BYOK_BASE_URL - Base URL of your OpenAI-compatible endpoint.
-    BYOK_API_KEY  - API key for that endpoint.
-    BYOK_MODEL_ID - Model name to request (e.g. "gpt-4o"). Defaults to "gpt-4o".
-
+    BYOK_PROVIDER_TYPE - Provider type ("openai", "azure", "anthropic"). Defaults to "openai".
+    BYOK_BASE_URL      - Base URL of your provider endpoint.
+    BYOK_API_KEY       - API key for that endpoint.
+    BYOK_MODEL_ID      - Model name to request (e.g. "gpt-4o"). Defaults to "gpt-4o".
 SECURITY NOTE: BYOK uses static credentials (no automatic token refresh) and usage is tracked
 by your provider rather than GitHub. Keep API keys out of source control; load them from
 environment variables or a secret store, as shown here.

--- a/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
+++ b/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""
+GitHub Copilot Agent with BYOK (Bring Your Own Key)
+
+This sample demonstrates how to configure GitHubCopilotAgent to route model requests through
+your own OpenAI-compatible endpoint (OpenAI, Azure OpenAI, Anthropic, or a compatible service
+such as vLLM/LiteLLM/Ollama) instead of the default GitHub Copilot backend, using the Copilot
+SDK's BYOK support.
+
+Set the following environment variables before running:
+    BYOK_BASE_URL - Base URL of your OpenAI-compatible endpoint.
+    BYOK_API_KEY  - API key for that endpoint.
+    BYOK_MODEL_ID - Model name to request (e.g. "gpt-4o"). Defaults to "gpt-4o".
+
+SECURITY NOTE: BYOK uses static credentials (no automatic token refresh) and usage is tracked
+by your provider rather than GitHub. Keep API keys out of source control; load them from
+environment variables or a secret store, as shown here.
+"""
+
+import asyncio
+import os
+
+from agent_framework.github import GitHubCopilotAgent, GitHubCopilotOptions
+from copilot.session import ProviderConfig
+
+
+async def main() -> None:
+    print("=== GitHub Copilot Agent with BYOK (Bring Your Own Key) ===\n")
+
+    model_id = os.environ.get("BYOK_MODEL_ID", "gpt-4o")
+
+    # ProviderConfig routes the session through a custom endpoint instead of the GitHub
+    # Copilot backend. `wire_api="completions"` is the broadly compatible choice; use
+    # "responses" for providers that support the OpenAI Responses API.
+    provider: ProviderConfig = {
+        "type": "openai",
+        "base_url": os.environ["BYOK_BASE_URL"],
+        "api_key": os.environ["BYOK_API_KEY"],
+        "wire_api": "completions",
+        "model_id": model_id,
+    }
+
+    # BYOK requires the model to also be set at the session level.
+    agent: GitHubCopilotAgent[GitHubCopilotOptions] = GitHubCopilotAgent(
+        instructions="You are a helpful assistant.",
+        default_options=GitHubCopilotOptions(model=model_id, provider=provider),
+    )
+
+    async with agent:
+        query = "What are the benefits of using your own API keys with an agent framework?"
+        print(f"User: {query}")
+        result = await agent.run(query)
+        print(f"\nAgent: {result}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
+++ b/python/samples/02-agents/providers/github_copilot/github_copilot_with_byok.py
@@ -4,15 +4,16 @@
 GitHub Copilot Agent with BYOK (Bring Your Own Key)
 
 This sample demonstrates how to configure GitHubCopilotAgent to route model requests through
-your own OpenAI-compatible endpoint (OpenAI, Azure OpenAI, Anthropic, or a compatible service
-such as vLLM/LiteLLM/Ollama) instead of the default GitHub Copilot backend, using the Copilot
-SDK's BYOK support.
+your own endpoint (OpenAI, Azure OpenAI, Anthropic, or an OpenAI-compatible service such as
+vLLM/LiteLLM/Ollama) instead of the default GitHub Copilot backend, using the Copilot SDK's
+BYOK support.
 
 Set the following environment variables before running:
     BYOK_PROVIDER_TYPE - Provider type ("openai", "azure", "anthropic"). Defaults to "openai".
     BYOK_BASE_URL      - Base URL of your provider endpoint.
     BYOK_API_KEY       - API key for that endpoint.
     BYOK_MODEL_ID      - Model name to request (e.g. "gpt-4o"). Defaults to "gpt-4o".
+
 SECURITY NOTE: BYOK uses static credentials (no automatic token refresh) and usage is tracked
 by your provider rather than GitHub. Keep API keys out of source control; load them from
 environment variables or a secret store, as shown here.
@@ -20,6 +21,7 @@ environment variables or a secret store, as shown here.
 
 import asyncio
 import os
+from typing import Literal, cast
 
 from agent_framework.github import GitHubCopilotAgent, GitHubCopilotOptions
 from copilot.session import ProviderConfig
@@ -29,12 +31,13 @@ async def main() -> None:
     print("=== GitHub Copilot Agent with BYOK (Bring Your Own Key) ===\n")
 
     model_id = os.environ.get("BYOK_MODEL_ID", "gpt-4o")
+    provider_type = cast(Literal["openai", "azure", "anthropic"], os.environ.get("BYOK_PROVIDER_TYPE", "openai"))
 
     # ProviderConfig routes the session through a custom endpoint instead of the GitHub
     # Copilot backend. `wire_api="completions"` is the broadly compatible choice; use
     # "responses" for providers that support the OpenAI Responses API.
     provider: ProviderConfig = {
-        "type": "openai",
+        "type": provider_type,
         "base_url": os.environ["BYOK_BASE_URL"],
         "api_key": os.environ["BYOK_API_KEY"],
         "wire_api": "completions",


### PR DESCRIPTION
### Motivation & Context

GitHub Copilot supports BYOK (Bring Your Own Key — https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok), letting requests be routed through a custom OpenAI/Azure/Anthropic-compatible endpoint instead of the default GitHub Copilot backend. `GitHubCopilotOptions.provider` already forwards a `ProviderConfig` straight through to the Copilot SDK, but there was no sample demonstrating the scenario end-to-end.

### Description & Review Guide

- **What are the major changes?** Adds `github_copilot_with_byok.py` under `python/samples/02-agents/providers/github_copilot/`, showing how to set `GitHubCopilotOptions(model=..., provider=ProviderConfig(...))` to route through a custom endpoint, reading `BYOK_BASE_URL`/`BYOK_API_KEY`/`BYOK_MODEL_ID` from the environment. Updates the folder's `README.md` table to list the new sample.
- **What is the impact of these changes?** Documentation/sample only — no changes to library code.
- **What do you want reviewers to focus on?** Whether the `ProviderConfig` fields used (`type`, `base_url`, `api_key`, `wire_api`, `model_id`) match current guidance, and whether the security note on static BYOK credentials is clear enough.

Verified with `ruff check`, `ruff format --check`, and `pyright` (all clean).

### Related Issue

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**