### PR TITLE
.NET: Add GitHub Copilot BYOK sample

### DIFF
--- a/dotnet/agent-framework-dotnet.slnx
+++ b/dotnet/agent-framework-dotnet.slnx
@@ -31,6 +31,7 @@
     <Project Path="samples/02-agents/AgentProviders/custom/Agent_With_CustomImplementation/Agent_With_CustomImplementation.csproj" />
     <Project Path="samples/02-agents/AgentProviders/dapr/Agent_With_Dapr/Agent_With_Dapr.csproj" />
     <Project Path="samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot/Agent_With_GitHubCopilot.csproj" />
+    <Project Path="samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Agent_With_GitHubCopilot_BYOK.csproj" />
     <Project Path="samples/02-agents/AgentProviders/google-gemini/Agent_With_GoogleGemini/Agent_With_GoogleGemini.csproj" />
     <Project Path="samples/02-agents/AgentProviders/ollama/Agent_With_Ollama/Agent_With_Ollama.csproj" />
     <Project Path="samples/02-agents/AgentProviders/onnx/Agent_With_ONNX/Agent_With_ONNX.csproj" />

--- a/dotnet/eng/verify-samples/AgentsSamples.cs
+++ b/dotnet/eng/verify-samples/AgentsSamples.cs
@@ -841,7 +841,7 @@ internal static class AgentsSamples
             Name = "Agent_With_GitHubCopilot_BYOK",
             ProjectPath = "samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK",
             RequiredEnvironmentVariables = ["BYOK_BASE_URL", "BYOK_API_KEY"],
-            OptionalEnvironmentVariables = ["BYOK_MODEL_ID"],
+            OptionalEnvironmentVariables = ["BYOK_PROVIDER_TYPE", "BYOK_MODEL_ID"],
             ExpectedOutputDescription =
             [
                 "The output should contain a user prompt and a response about the benefits of BYOK.",

--- a/dotnet/eng/verify-samples/AgentsSamples.cs
+++ b/dotnet/eng/verify-samples/AgentsSamples.cs
@@ -838,6 +838,19 @@ internal static class AgentsSamples
 
         new SampleDefinition
         {
+            Name = "Agent_With_GitHubCopilot_BYOK",
+            ProjectPath = "samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK",
+            RequiredEnvironmentVariables = ["BYOK_BASE_URL", "BYOK_API_KEY"],
+            OptionalEnvironmentVariables = ["BYOK_MODEL_ID"],
+            ExpectedOutputDescription =
+            [
+                "The output should contain a user prompt and a response about the benefits of BYOK.",
+                "The output should not contain error messages or stack traces.",
+            ],
+        },
+
+        new SampleDefinition
+        {
             Name = "Agent_With_GoogleGemini",
             ProjectPath = "samples/02-agents/AgentProviders/google-gemini/Agent_With_GoogleGemini",
             RequiredEnvironmentVariables = ["GOOGLE_GENAI_API_KEY"],

--- a/dotnet/samples/02-agents/AgentProviders/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/README.md
@@ -60,6 +60,7 @@ covering basics, function tools, structured output, middleware, MCP, code interp
 | Sample | Description |
 | --- | --- |
 | [GitHub Copilot](./github-copilot/Agent_With_GitHubCopilot/) | Create an AIAgent using GitHub Copilot SDK |
+| [GitHub Copilot BYOK](./github-copilot/Agent_With_GitHubCopilot_BYOK/) | Route GitHub Copilot agent requests through your own OpenAI-compatible endpoint (Bring Your Own Key) |
 
 ### [Google Gemini](./google-gemini/)
 

--- a/dotnet/samples/02-agents/AgentProviders/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/README.md
@@ -60,7 +60,7 @@ covering basics, function tools, structured output, middleware, MCP, code interp
 | Sample | Description |
 | --- | --- |
 | [GitHub Copilot](./github-copilot/Agent_With_GitHubCopilot/) | Create an AIAgent using GitHub Copilot SDK |
-| [GitHub Copilot BYOK](./github-copilot/Agent_With_GitHubCopilot_BYOK/) | Route GitHub Copilot agent requests through your own OpenAI-compatible endpoint (Bring Your Own Key) |
+| [GitHub Copilot BYOK](./github-copilot/Agent_With_GitHubCopilot_BYOK/) | Route GitHub Copilot agent requests through your own endpoint (Bring Your Own Key) |
 
 ### [Google Gemini](./google-gemini/)
 

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Agent_With_GitHubCopilot_BYOK.csproj
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Agent_With_GitHubCopilot_BYOK.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);GHCP001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHub.Copilot.SDK" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\Microsoft.Agents.AI.GitHub.Copilot\Microsoft.Agents.AI.GitHub.Copilot.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// This sample shows how to configure a GitHub Copilot agent with BYOK (Bring Your Own Key),
+// routing requests through your own OpenAI-compatible endpoint instead of the GitHub Copilot backend.
+//
+// SECURITY NOTE: BYOK uses static credentials (no automatic token refresh) and usage is tracked
+// by your provider rather than GitHub. Keep API keys out of source control; load them from
+// environment variables or a secret store, as shown here.
+
+using GitHub.Copilot;
+using Microsoft.Agents.AI;
+
+string baseUrl = Environment.GetEnvironmentVariable("BYOK_BASE_URL")
+    ?? throw new InvalidOperationException("The BYOK_BASE_URL environment variable is not set.");
+string apiKey = Environment.GetEnvironmentVariable("BYOK_API_KEY")
+    ?? throw new InvalidOperationException("The BYOK_API_KEY environment variable is not set.");
+string modelId = Environment.GetEnvironmentVariable("BYOK_MODEL_ID") ?? "gpt-4o";
+
+// Create and start a Copilot client
+await using CopilotClient copilotClient = new();
+await copilotClient.StartAsync();
+
+// Provider routes the session through a custom endpoint instead of the GitHub Copilot backend.
+// WireApi "completions" is the broadly compatible choice; use "responses" for providers that
+// support the OpenAI Responses API. BYOK also requires Model to be set at the session level.
+SessionConfig sessionConfig = new()
+{
+    Model = modelId,
+    Provider = new ProviderConfig
+    {
+        Type = "openai",
+        WireApi = "completions",
+        BaseUrl = baseUrl,
+        ApiKey = apiKey,
+        ModelId = modelId,
+    },
+};
+
+AIAgent agent = copilotClient.AsAIAgent(sessionConfig, ownsClient: true);
+
+string prompt = "What are the benefits of using your own API keys with an agent framework?";
+Console.WriteLine($"User: {prompt}\n");
+
+await foreach (AgentResponseUpdate update in agent.RunStreamingAsync(prompt))
+{
+    Console.Write(update);
+}
+
+Console.WriteLine();

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 // This sample shows how to configure a GitHub Copilot agent with BYOK (Bring Your Own Key),
 // routing requests through your own endpoint (OpenAI, Azure OpenAI, Anthropic, or an

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/Program.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 // This sample shows how to configure a GitHub Copilot agent with BYOK (Bring Your Own Key),
-// routing requests through your own OpenAI-compatible endpoint instead of the GitHub Copilot backend.
+// routing requests through your own endpoint (OpenAI, Azure OpenAI, Anthropic, or an
+// OpenAI-compatible service such as vLLM/LiteLLM/Ollama) instead of the GitHub Copilot backend.
 //
 // SECURITY NOTE: BYOK uses static credentials (no automatic token refresh) and usage is tracked
 // by your provider rather than GitHub. Keep API keys out of source control; load them from
@@ -10,6 +11,7 @@
 using GitHub.Copilot;
 using Microsoft.Agents.AI;
 
+string providerType = Environment.GetEnvironmentVariable("BYOK_PROVIDER_TYPE") ?? "openai";
 string baseUrl = Environment.GetEnvironmentVariable("BYOK_BASE_URL")
     ?? throw new InvalidOperationException("The BYOK_BASE_URL environment variable is not set.");
 string apiKey = Environment.GetEnvironmentVariable("BYOK_API_KEY")
@@ -21,14 +23,15 @@ await using CopilotClient copilotClient = new();
 await copilotClient.StartAsync();
 
 // Provider routes the session through a custom endpoint instead of the GitHub Copilot backend.
-// WireApi "completions" is the broadly compatible choice; use "responses" for providers that
-// support the OpenAI Responses API. BYOK also requires Model to be set at the session level.
+// Type is "openai", "azure", or "anthropic". WireApi "completions" is the broadly compatible
+// choice; use "responses" for providers that support the OpenAI Responses API. BYOK also
+// requires Model to be set at the session level.
 SessionConfig sessionConfig = new()
 {
     Model = modelId,
     Provider = new ProviderConfig
     {
-        Type = "openai",
+        Type = providerType,
         WireApi = "completions",
         BaseUrl = baseUrl,
         ApiKey = apiKey,

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
@@ -1,0 +1,73 @@
+# Prerequisites
+
+Before you begin, ensure you have the following prerequisites:
+
+- .NET 10 SDK or later
+- GitHub Copilot CLI installed and available in your PATH (or provide a custom path)
+- An OpenAI-compatible endpoint and API key (OpenAI, Azure OpenAI, Anthropic, or a compatible
+  service such as vLLM, LiteLLM, or Ollama)
+
+## Setting up GitHub Copilot CLI
+
+To use this sample, you need to have the GitHub Copilot CLI installed. You can install it by
+following the instructions at:
+https://github.com/github/copilot-sdk
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BYOK_BASE_URL` | Base URL of your OpenAI-compatible endpoint | *(required)* |
+| `BYOK_API_KEY` | API key for that endpoint | *(required)* |
+| `BYOK_MODEL_ID` | Model name to request (e.g. "gpt-4o") | `gpt-4o` |
+
+## Running the Sample
+
+```powershell
+dotnet run
+```
+
+The sample will:
+
+1. Create a GitHub Copilot client with default options
+2. Configure a session with a `Provider` (BYOK) pointing at your own endpoint instead of the
+   default GitHub Copilot backend
+3. Send a message to the agent
+4. Stream the response
+
+## About BYOK (Bring Your Own Key)
+
+BYOK lets you route model requests through your own API keys and infrastructure instead of the
+GitHub Copilot backend — useful for enterprise deployments, custom hosting, or direct billing
+arrangements. See [GitHub's BYOK documentation](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok)
+for the full list of supported providers and configuration options.
+
+```csharp
+using GitHub.Copilot;
+using Microsoft.Agents.AI;
+
+await using CopilotClient copilotClient = new();
+await copilotClient.StartAsync();
+
+SessionConfig sessionConfig = new()
+{
+    // BYOK requires Model to also be set at the session level.
+    Model = "gpt-4o",
+    Provider = new ProviderConfig
+    {
+        Type = "openai",
+        WireApi = "completions",
+        BaseUrl = "https://api.example.com/v1",
+        ApiKey = "your-api-key",
+        ModelId = "gpt-4o",
+    },
+};
+
+AIAgent agent = copilotClient.AsAIAgent(sessionConfig, ownsClient: true);
+AgentResponse response = await agent.RunAsync("Hello!");
+Console.WriteLine(response);
+```
+
+> **Note:** BYOK uses static credentials only — dynamic token refresh is not automatic, and
+> model availability depends entirely on your provider's offerings. Usage is tracked through
+> your provider rather than GitHub.

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
@@ -54,7 +54,7 @@ SessionConfig sessionConfig = new()
     Model = "gpt-4o",
     Provider = new ProviderConfig
     {
-        Type = "openai",
+        Type = "azure", // or "openai", "anthropic"
         WireApi = "completions",
         BaseUrl = "https://api.example.com/v1",
         ApiKey = "your-api-key",

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
@@ -1,10 +1,18 @@
+# About BYOK (Bring Your Own Key)
+
+BYOK lets you route model requests through your own API keys and infrastructure instead of the
+GitHub Copilot backend — useful for enterprise deployments, custom hosting, or direct billing
+arrangements. See [GitHub's BYOK documentation](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok)
+for the full list of supported providers and configuration options.
+
 # Prerequisites
 
 Before you begin, ensure you have the following prerequisites:
 
 - .NET 10 SDK or later
 - GitHub Copilot CLI installed and available in your PATH (or provide a custom path)
-- An OpenAI-compatible endpoint and API key (OpenAI, Azure OpenAI, or a compatible service such as vLLM, LiteLLM, or Ollama)
+- An OpenAI, Azure OpenAI, Anthropic, or OpenAI-compatible endpoint and API key (e.g. vLLM,
+  LiteLLM, or Ollama)
 
 ## Setting up GitHub Copilot CLI
 
@@ -16,7 +24,8 @@ https://github.com/github/copilot-sdk
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `BYOK_BASE_URL` | Base URL of your OpenAI-compatible endpoint | *(required)* |
+| `BYOK_PROVIDER_TYPE` | Provider type (`openai`, `azure`, `anthropic`) | `openai` |
+| `BYOK_BASE_URL` | Base URL of your provider endpoint | *(required)* |
 | `BYOK_API_KEY` | API key for that endpoint | *(required)* |
 | `BYOK_MODEL_ID` | Model name to request (e.g. "gpt-4o") | `gpt-4o` |
 
@@ -34,12 +43,7 @@ The sample will:
 3. Send a message to the agent
 4. Stream the response
 
-## About BYOK (Bring Your Own Key)
-
-BYOK lets you route model requests through your own API keys and infrastructure instead of the
-GitHub Copilot backend — useful for enterprise deployments, custom hosting, or direct billing
-arrangements. See [GitHub's BYOK documentation](https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok)
-for the full list of supported providers and configuration options.
+## Advanced Usage
 
 ```csharp
 using GitHub.Copilot;
@@ -55,10 +59,10 @@ SessionConfig sessionConfig = new()
     Provider = new ProviderConfig
     {
         Type = "azure", // or "openai", "anthropic"
-        WireApi = "completions",
+        WireApi = "completions", // or "responses"
         BaseUrl = "https://api.example.com/v1",
         ApiKey = "your-api-key",
-        ModelId = "your-model-id",
+        ModelId = "your-model-id", // "deployment-name"
     },
 };
 

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
@@ -58,7 +58,7 @@ SessionConfig sessionConfig = new()
         WireApi = "completions",
         BaseUrl = "https://api.example.com/v1",
         ApiKey = "your-api-key",
-        ModelId = "gpt-4o",
+        ModelId = "your-model-id",
     },
 };
 

--- a/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/github-copilot/Agent_With_GitHubCopilot_BYOK/README.md
@@ -4,8 +4,7 @@ Before you begin, ensure you have the following prerequisites:
 
 - .NET 10 SDK or later
 - GitHub Copilot CLI installed and available in your PATH (or provide a custom path)
-- An OpenAI-compatible endpoint and API key (OpenAI, Azure OpenAI, Anthropic, or a compatible
-  service such as vLLM, LiteLLM, or Ollama)
+- An OpenAI-compatible endpoint and API key (OpenAI, Azure OpenAI, or a compatible service such as vLLM, LiteLLM, or Ollama)
 
 ## Setting up GitHub Copilot CLI
 


### PR DESCRIPTION
### Motivation & Context

GitHub Copilot supports BYOK (Bring Your Own Key — https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/byok), letting requests be routed through a custom OpenAI/Azure/Anthropic-compatible endpoint instead of the default GitHub Copilot backend. `SessionConfig.Provider` is already passed straight through by `GitHubCopilotAgent` (see `CopyResumeSessionConfig`), but there was no sample demonstrating the scenario end-to-end.

### Description & Review Guide

- **What are the major changes?** Adds a new `Agent_With_GitHubCopilot_BYOK` sample project under `dotnet/samples/02-agents/AgentProviders/github-copilot/`, showing how to set `SessionConfig { Model, Provider = new ProviderConfig { Type, WireApi, BaseUrl, ApiKey, ModelId } }` to route through a custom endpoint, reading `BYOK_BASE_URL`/`BYOK_API_KEY`/`BYOK_MODEL_ID` from the environment. Wires the project into `agent-framework-dotnet.slnx`, adds a row to `AgentProviders/README.md`, and registers a `SampleDefinition` in `eng/verify-samples/AgentsSamples.cs` (skipped automatically when the required env vars are unset).
- **What is the impact of these changes?** Documentation/sample only — no changes to library code.
- **What do you want reviewers to focus on?** Whether the `ProviderConfig` properties used match current guidance.
- **Note:** I could not build locally because this repo pins the .NET 10 SDK and only .NET 8 was available in my environment. I instead verified every type, property, and namespace used (`ProviderConfig`, `SessionConfig.Provider`, `SessionConfig.Model`) against the `github/copilot-sdk` source at tag `v1.0.5`, which matches the version pinned in `Directory.Packages.props`. Please run a build/CI pass to confirm.

### Related Issue

Fixes #

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**