### PR TITLE
Python: isolate dependency upper-bound validation

### DIFF
--- a/python/packages/ag-ui/pyproject.toml
+++ b/python/packages/ag-ui/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "agent-framework-core>=1.11.0,<2",
     "ag-ui-protocol>=0.1.19,<0.2",
-    "fastapi>=0.121.0,<0.138.1",
+    "fastapi>=0.121.0,<0.140.0",
     "sse-starlette>=3.4.5,<4",
     "uvicorn[standard]>=0.30.0,<1"
 ]
@@ -33,6 +33,7 @@ dependencies = [
 dev = [
     "pytest==9.1.1",
     "httpx==0.28.1",
+    "agent-framework-orchestrations",
 ]
 
 [build-system]

--- a/python/scripts/dependencies/_dependency_bounds_upper_impl.py
+++ b/python/scripts/dependencies/_dependency_bounds_upper_impl.py
@@ -592,7 +592,12 @@ def _build_internal_graph(workspace_root: Path, package_map: dict[str, Path]) ->
             data = tomli.load(f)
         project = data.get("project", {}) or {}
         dependencies: list[str] = list(project.get("dependencies", []) or [])
-        for values in (project.get("optional-dependencies", {}) or {}).values():
+        for extra_name, values in (project.get("optional-dependencies", {}) or {}).items():
+            # Package plans intentionally do not enable aggregate `all` extras. Following
+            # their internal dependencies here would pull unrelated workspace packages into
+            # an otherwise package-scoped probe and create false version conflicts.
+            if extra_name == "all":
+                continue
             dependencies.extend([value for value in (values or []) if isinstance(value, str)])
         for values in (data.get("dependency-groups", {}) or {}).values():
             dependencies.extend([value for value in (values or []) if isinstance(value, str)])
@@ -795,10 +800,14 @@ def _run_tasks(
 ) -> tuple[bool, str | None]:
     # Every probe runs inside a fresh isolated uv environment. Clearing VIRTUAL_ENV avoids
     # leaking the caller's active environment into the subprocess and keeps validation from
-    # mutating the repo's active `.venv`.
+    # mutating the repo's active `.venv`. Selecting the package is also required: `--isolated`
+    # isolates the environment, but uv would otherwise install every member of the parent workspace.
     env = dict(os.environ)
     env["UV_PRERELEASE"] = "allow"
     env.pop("VIRTUAL_ENV", None)
+    project_config = tomli.loads((project_dir / "pyproject.toml").read_text())
+    project_name = str(project_config["project"]["name"])
+
     for task_name in tasks:
         command = [
             "uv",
@@ -807,6 +816,8 @@ def _run_tasks(
             str(project_dir),
             "run",
             "--isolated",
+            "--package",
+            project_name,
             "--resolution",
             resolution,
             "--prerelease",

--- a/python/scripts/dependencies/tests/test_dependency_bounds_upper.py
+++ b/python/scripts/dependencies/tests/test_dependency_bounds_upper.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from packaging.version import Version
+
+from scripts.dependencies._dependency_bounds_upper_impl import (
+    _build_internal_graph,
+    _build_workspace_package_map,
+    _resolve_internal_editables,
+    _run_tasks,
+)
+
+
+def test_upper_bound_probe_is_independent_from_parent_workspace(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pyproject.toml").write_text("[dependency-groups]\ndev = []\n")
+    project_dir = tmp_path / "packages" / "provider"
+    project_dir.mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text(
+        """
+[project]
+name = "agent-framework-provider"
+version = "1.0.0"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=9"]
+feature = ["httpx>=0.28"]
+
+[dependency-groups]
+test = ["pytest-cov>=7"]
+"""
+    )
+    internal_editable = tmp_path / "packages" / "core"
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs) -> CompletedProcess[str]:
+        captured_commands.append(command)
+        return CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.dependencies._dependency_bounds_upper_impl.subprocess.run", fake_run)
+
+    success, error = _run_tasks(
+        project_dir,
+        workspace_root=tmp_path,
+        tasks=["pyright"],
+        internal_editables=[internal_editable],
+        resolution="highest",
+        dependency_pin=("fastapi", Version("0.139.2")),
+        dependency_groups=["test"],
+        include_dev_extra=True,
+        optional_extras=["feature"],
+        timeout_seconds=60,
+    )
+
+    assert success
+    assert error is None
+    assert len(captured_commands) == 1
+    command = captured_commands[0]
+    assert "--isolated" in command
+    assert "--no-project" not in command
+    assert command[command.index("--package") + 1] == "agent-framework-provider"
+    assert command[command.index("--group") + 1] == "test"
+    assert command.count("--extra") == 2
+    assert "dev" in command
+    assert "feature" in command
+    assert str(internal_editable) in command
+    assert "fastapi==0.139.2" in command
+
+
+def test_internal_editables_exclude_unselected_all_extra(tmp_path: Path) -> None:
+    packages_dir = tmp_path / "packages"
+    project_files = {
+        "target": """
+[project]
+name = "agent-framework-target"
+version = "1.0.0"
+dependencies = ["agent-framework-core"]
+
+[project.optional-dependencies]
+dev = ["agent-framework-helper"]
+""",
+        "core": """
+[project]
+name = "agent-framework-core"
+version = "1.0.0"
+dependencies = []
+
+[project.optional-dependencies]
+all = ["agent-framework-unrelated"]
+""",
+        "helper": """
+[project]
+name = "agent-framework-helper"
+version = "1.0.0"
+dependencies = ["agent-framework-core"]
+""",
+        "unrelated": """
+[project]
+name = "agent-framework-unrelated"
+version = "1.0.0"
+dependencies = []
+""",
+    }
+    for package_path, content in project_files.items():
+        project_dir = packages_dir / package_path
+        project_dir.mkdir(parents=True)
+        (project_dir / "pyproject.toml").write_text(content)
+
+    package_map = _build_workspace_package_map(tmp_path)
+    graph = _build_internal_graph(tmp_path, package_map)
+    editables = _resolve_internal_editables("agent-framework-target", package_map, graph)
+
+    assert packages_dir / "core" in editables
+    assert packages_dir / "helper" in editables
+    assert packages_dir / "unrelated" not in editables

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -210,6 +210,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "agent-framework-orchestrations", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -218,7 +219,8 @@ dev = [
 requires-dist = [
     { name = "ag-ui-protocol", specifier = ">=0.1.19,<0.2" },
     { name = "agent-framework-core", editable = "packages/core" },
-    { name = "fastapi", specifier = ">=0.121.0,<0.138.1" },
+    { name = "agent-framework-orchestrations", marker = "extra == 'dev'", editable = "packages/orchestrations" },
+    { name = "fastapi", specifier = ">=0.121.0,<0.140.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = "==0.28.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "sse-starlette", specifier = ">=3.4.5,<4" },


### PR DESCRIPTION
### Motivation & Context

The weekly dependency maintenance workflow reported newer FastAPI candidates for `agent-framework-ag-ui` as failing before checks could run. The isolated uv command was still resolving unrelated workspace members, so `agent-framework-devui`'s existing FastAPI cap blocked the AG-UI probe.

This also exposed that the AG-UI package tests use `agent-framework-orchestrations` without declaring it in the package's development dependencies.

### Description & Review Guide

- **What are the major changes?**
  - Select the target workspace package explicitly for each upper-bound probe.
  - Keep the internal editable closure aligned with the extras the probe actually enables by excluding the aggregate `all` extra.
  - Declare the AG-UI test dependency on `agent-framework-orchestrations` and expand the validated FastAPI range through 0.139.x.
- **What is the impact of these changes?** Package-scoped dependency probes no longer inherit unrelated workspace constraints, and `agent-framework-ag-ui` supports `fastapi>=0.121.0,<0.140.0`.
- **What do you want reviewers to focus on?** Whether the internal editable closure now matches the package/extras selected by the validation command.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Fixes #7339

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
