### PR TITLE
Python: Forward function_invocation_kwargs through DevUI to agent.run…

### DIFF
--- a/python/packages/devui/agent_framework_devui/_executor.py
+++ b/python/packages/devui/agent_framework_devui/_executor.py
@@ -376,6 +376,17 @@ class AgentFrameworkExecutor:
                 if session:
                     run_kwargs["session"] = session
 
+                # Forward request-scoped function_invocation_kwargs so tools can read them
+                # via FunctionInvocationContext. Accept them in extra_body (same channel as
+                # response_id/checkpoint_id) or as a top-level field (model_extra).
+                fik = None
+                if request.extra_body:
+                    fik = request.extra_body.get("function_invocation_kwargs")
+                if fik is None and request.model_extra:
+                    fik = request.model_extra.get("function_invocation_kwargs")
+                if isinstance(fik, dict):
+                    run_kwargs["function_invocation_kwargs"] = fik
+
                 stream = cast(Any, agent.run(user_message, **run_kwargs))
                 async for update in stream:
                     for trace_event in trace_collector.get_pending_events():

--- a/python/packages/devui/tests/devui/test_execution.py
+++ b/python/packages/devui/tests/devui/test_execution.py
@@ -596,6 +596,56 @@ async def test_executor_handles_streaming_agent():
     assert "Processed: hello" in text_events[0].delta
 
 
+@pytest.mark.parametrize(
+    "request_extras",
+    [
+        {"extra_body": {"function_invocation_kwargs": {"tenantId": "abc123"}}},  # documented channel
+        {"function_invocation_kwargs": {"tenantId": "abc123"}},  # top-level (model_extra), as issue #7344 tried
+    ],
+)
+async def test_agent_execution_forwards_function_invocation_kwargs(request_extras):
+    """DevUI forwards request function_invocation_kwargs into agent.run() (issue #7344)."""
+    from agent_framework import AgentResponseUpdate, AgentSession, Content
+
+    captured: dict[str, Any] = {}
+
+    class RecordingAgent:
+        """Agent that records the kwargs its run() is called with."""
+
+        id = "kwargs_test"
+        name = "Kwargs Test Agent"
+        description = "Records run() kwargs"
+
+        def run(self, messages=None, *, stream=False, session=None, **kwargs):
+            captured.update(kwargs)
+            return self._stream_impl(messages)
+
+        async def _stream_impl(self, messages):
+            yield AgentResponseUpdate(contents=[Content.from_text(text="ok")], role="assistant")
+
+        def create_session(self, **kwargs):
+            return AgentSession()
+
+    discovery = EntityDiscovery(None)
+    executor = AgentFrameworkExecutor(discovery, MessageMapper())
+
+    agent = RecordingAgent()
+    entity_info = await discovery.create_entity_info_from_object(agent, source="test")
+    discovery.register_entity(entity_info.id, entity_info, agent)
+
+    request = AgentFrameworkRequest(
+        metadata={"entity_id": entity_info.id},
+        input="hello",
+        stream=True,
+        **request_extras,
+    )
+
+    async for _event in executor.execute_streaming(request):
+        pass
+
+    assert captured.get("function_invocation_kwargs") == {"tenantId": "abc123"}
+
+
 # =============================================================================
 # Full Pipeline Tests for SequentialBuilder
 # =============================================================================


### PR DESCRIPTION
### Motivation & Context

DevUI couldn't forward `function_invocation_kwargs`. It built the agent run kwargs by hand and passed only `stream`/`session` to `agent.run()`, so tools that read request-scoped values via `FunctionInvocationContext`  a tenant id, auth token, user id received nothing when the agent was run through DevUI. The same agent works correctly outside DevUI via `agent.run(..., function_invocation_kwargs=...)`, which made DevUI unusable for any agent whose tools depend on invocation context. This affects both the chat UI and the OpenAI-compatible `/v1/responses` endpoint.

Fixes #7344.

### Description & Review Guide

- **What are the major changes?**
  - `_executor.py` (`_execute_agent`): read `function_invocation_kwargs` from the request and merge it into the kwargs passed to `agent.run()`. Accepted from either `extra_body.function_invocation_kwargs` (the same channel already used for `response_id` / `checkpoint_id`) or a top-level `function_invocation_kwargs` field (`model_extra`) in the shape the issue reporter originally tried.
  - `tests/devui/test_execution.py`: a parametrized test that drives a recording agent through `execute_streaming` and asserts the kwargs reach `run()`; covers both channels and fails without the fix.

- **This is a backend-only change; the frontend / DevUI web UI was not touched.** Passing `function_invocation_kwargs` now works over the API (e.g. `/v1/responses` with the field in `extra_body` or top-level). Adding a UI input for it is intentionally left out of this PR, since where it belongs (per-message vs per-session) is an open UX decision; happy to follow up separately if maintainers want it.

- **What is the impact of these changes?**
  - Additive and backward compatible; when the field is absent, behavior is unchanged. No public API signature changes (uses the existing `extra_body` extensibility).

- **What do you want reviewers to focus on?**
  - Whether accepting the value from **both** channels (`extra_body` and top-level `model_extra`) is desired, or `extra_body` alone.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/A
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Fixes #7344

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://githubk/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.