### PR TITLE
Python: Clear stale service session on full-history replay

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -202,9 +202,14 @@ class AgentExecutor(Executor):
     ) -> None:
         """Handle an AgentExecutorRequest (canonical input).
 
-        This is the standard path: extend cache with provided messages; if should_respond
-        run the agent and emit an AgentExecutorResponse downstream.
+        This is the standard path: extend cache with provided messages; if should_respond,
+        run the agent and emit an AgentExecutorResponse downstream. When the request
+        replays function-call history, clear the service session because those messages
+        provide the continuation context explicitly.
         """
+        if any(content.type == "function_call" for message in request.messages for content in message.contents):
+            self._session.service_session_id = None
+
         self._cache.extend(request.messages)
 
         if request.should_respond:

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -3,7 +3,6 @@
 from collections.abc import AsyncIterable, Awaitable
 from typing import Any, Literal, overload
 
-import pytest
 from pydantic import PrivateAttr
 from typing_extensions import Never
 
@@ -429,15 +428,6 @@ class _FullHistoryReplayCoordinator(Executor):
         )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Tracks the executor-layer half of #3295: AgentExecutor should clear service_session_id "
-        "when handed a full prior conversation. The wire-level 'Duplicate item' API error is "
-        "already closed by the chat-client strip in #3295; this xfail covers the defense-in-depth "
-        "follow-up that makes the executor wiring reflect intent."
-    ),
-    strict=True,
-)
 async def test_run_request_with_full_history_clears_service_session_id() -> None:
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
@@ -465,6 +455,36 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     # "Duplicate item found" because the same function-call IDs appear in both
     # previous_response_id (server-stored) and the explicit input messages.
     assert spy_agent._captured_service_session_id is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_run_request_with_function_result_preserves_service_session_id() -> None:
+    """A function result continues the service-stored call instead of replaying it."""
+    spy_agent = _SessionIdCapturingAgent(id="result_spy_agent", name="ResultSpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="result_spy_agent")
+    spy_exec._session.service_session_id = "resp_PENDING_TOOL_CALL"  # pyright: ignore[reportPrivateUsage]
+
+    @executor(id="function_result_source")
+    async def function_result_source(
+        _: str,
+        ctx: WorkflowContext[AgentExecutorRequest, Any],
+    ) -> None:
+        await ctx.send_message(
+            AgentExecutorRequest(
+                messages=[
+                    Message(
+                        role="tool",
+                        contents=[Content.from_function_result(call_id="call_weather_1", result="Sunny, 72F")],
+                    )
+                ],
+                should_respond=True,
+            )
+        )
+
+    wf = WorkflowBuilder(start_executor=function_result_source).add_edge(function_result_source, spy_exec).build()
+
+    await wf.run("tool result")
+
+    assert spy_agent._captured_service_session_id == "resp_PENDING_TOOL_CALL"  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_from_response_preserves_service_session_id() -> None:


### PR DESCRIPTION
### Motivation & Context

`AgentExecutorRequest` can replay an explicit prior conversation, including model-issued function calls, while the target executor still carries a `service_session_id` from an earlier run. That combines caller-supplied history with an unrelated service-side continuation handle.

The executor-layer regression was already recorded as a strict xfail when #5690 fixed the OpenAI wire-format half of #3295. Running that test with `--runxfail` on current `main` fails because the agent receives `resp_PREVIOUS_RUN` instead of `None`.

### Description & Review Guide

- **What are the major changes?**
  - Clear `service_session_id` before handling an `AgentExecutorRequest` that replays model-issued `function_call` content.
  - Promote the existing strict xfail to a normal regression test.
  - Add a boundary test proving that a function-result-only request preserves the service session so it can continue the stored tool call.
- **What is the impact of these changes?**
  - Full-history replay no longer combines explicit function-call history with a stale service continuation.
  - Incremental function results and the existing `from_response` path continue to preserve `service_session_id`.
  - There is no public API or persistence-format change.
- **What do you want reviewers to focus on?**
  - Whether model-issued `function_call` content is the right narrow signal that distinguishes explicit replay from a function-result continuation.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

Validation:

- `.venv/bin/uv run pytest packages/core/tests/workflow/test_full_conversation.py -q` — 10 passed.
- `.venv/bin/uv run poe check -P core` — formatting, lint, source Pyright, and all five test type checkers passed; 3,690 tests passed, 18 skipped, and 1 unrelated test xfailed.

No live provider credentials were used. The regression captures the session value at the provider boundary, and #5690 retains the separate OpenAI wire-format protection.

### Related Issue

Follow-up to #3295 and #5690. The issue is already closed; this completes the executor-layer strict-xfail follow-up documented by the merged fix, so no closing keyword is used.

No open PR found for this executor behavior. #7345 covers approval replay and touches neither affected file.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
