### PR TITLE
Python: Forward function invocation kwargs through DevUI

### DIFF
--- a/python/packages/devui/agent_framework_devui/_executor.py
+++ b/python/packages/devui/agent_framework_devui/_executor.py
@@ -375,6 +375,8 @@ class AgentFrameworkExecutor:
                 run_kwargs: dict[str, Any] = {"stream": True}
                 if session:
                     run_kwargs["session"] = session
+                if request.function_invocation_kwargs is not None:
+                    run_kwargs["function_invocation_kwargs"] = request.function_invocation_kwargs
 
                 stream = cast(Any, agent.run(user_message, **run_kwargs))
                 async for update in stream:

--- a/python/packages/devui/agent_framework_devui/models/_openai_custom.py
+++ b/python/packages/devui/agent_framework_devui/models/_openai_custom.py
@@ -312,6 +312,9 @@ class AgentFrameworkRequest(BaseModel):
     # Reasoning parameters (for o-series models)
     reasoning: dict[str, Any] | None = None  # {"effort": "low" | "medium" | "high" | "minimal"}
 
+    # Agent Framework tool invocation context
+    function_invocation_kwargs: dict[str, Any] | None = None
+
     # Optional extra_body for advanced use cases
     extra_body: dict[str, Any] | None = None
 

--- a/python/packages/devui/tests/devui/test_execution.py
+++ b/python/packages/devui/tests/devui/test_execution.py
@@ -13,12 +13,16 @@ import asyncio
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from agent_framework import Agent, AgentExecutor, FunctionExecutor, WorkflowBuilder
 
 # Import mock classes from conftest for direct use in some tests
-from conftest import MockBaseChatClient  # pyrefly: ignore[missing-import] # pyright: ignore[reportMissingImports]
+from conftest import (  # pyrefly: ignore[missing-import] # pyright: ignore[reportMissingImports]
+    MockAgent,
+    MockBaseChatClient,
+)
 
 from agent_framework_devui._discovery import EntityDiscovery
 from agent_framework_devui._executor import AgentFrameworkExecutor, EntityNotFoundError
@@ -157,6 +161,27 @@ async def test_chat_client_receives_correct_messages(executor_with_real_agent):
     # Verify the input text is present in the messages
     all_text = " ".join(m.text or "" for m in messages)
     assert "2+2" in all_text, f"Expected '2+2' in messages, got text: '{all_text}'"
+
+
+async def test_agent_execution_forwards_function_invocation_kwargs() -> None:
+    """Forward request-scoped function invocation arguments to the agent."""
+    discovery = EntityDiscovery(None)
+    executor = AgentFrameworkExecutor(discovery, MessageMapper())
+    agent = MockAgent()
+    entity_info = await discovery.create_entity_info_from_object(agent, source="test")
+    discovery.register_entity(entity_info.id, entity_info, agent)
+    request = AgentFrameworkRequest(
+        metadata={"entity_id": entity_info.id},
+        input="hello",
+        stream=True,
+        function_invocation_kwargs={"tenantId": "abc123"},
+    )
+
+    with patch.object(agent, "run", wraps=agent.run) as run_spy:
+        async for _ in executor.execute_streaming(request):
+            pass
+
+    assert run_spy.call_args.kwargs["function_invocation_kwargs"] == {"tenantId": "abc123"}
 
 
 # =============================================================================


### PR DESCRIPTION
### Motivation & Context

DevUI accepts `function_invocation_kwargs` on its OpenAI-compatible response request, but the local agent executor previously dropped the mapping before calling `agent.run()`. Tools that depend on request-scoped values through `FunctionInvocationContext.kwargs` therefore failed when the same agent was invoked through DevUI.

### Description & Review Guide

- **What are the major changes?**
  - Added the optional `function_invocation_kwargs` field to `AgentFrameworkRequest`.
  - Forwarded the mapping through DevUI's agent execution path.
  - Added a focused regression test covering the request-to-agent handoff.
- **What is the impact of these changes?**
  - DevUI-hosted agents can now receive request-scoped function invocation arguments consistently with direct `agent.run()` calls.
- **What do you want reviewers to focus on?**
  - The optional request field and conditional forwarding in the local agent executor.

### Related Issue

Fixes #7344

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.