### PR TITLE
.NET: Workflows: quarantine flaky InputWaiter timeout test (#7360)

### DIFF
--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/InputWaiterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/InputWaiterTests.cs
@@ -107,7 +107,7 @@ public sealed class InputWaiterTests : IDisposable
         await this._waiter.WaitForInputAsync(TimeSpan.FromSeconds(1));
     }
 
-    [Fact]
+    [Fact(Skip = "Flaky in merge_group; see https://github.com/microsoft/agent-framework/issues/7360")]
     public async Task InputWaiter_WaitForInputAsync_CompletesWhenTimeoutExpiresAsync()
     {
         // Verify that a finite timeout releases the block even without a signal.
@@ -115,6 +115,12 @@ public sealed class InputWaiterTests : IDisposable
         // we intentionally do not assert that it stays blocked until the timeout,
         // because that would re-introduce the same wall-clock flakiness
         // described in BlocksUntilSignaledAsync (see comment on that test).
+        //
+        // The generous outer bound is itself not generous enough: on the loaded
+        // net472/windows-latest leg, thread pool starvation can delay the 300ms
+        // continuation past the 5s guard, so Task.Delay wins the race and the
+        // identity assertion below fails. Quarantined until the assertion is
+        // rewritten to not depend on scheduling latency.
         Task waitTask = this._waiter.WaitForInputAsync(TimeSpan.FromMilliseconds(300));
 
         Task completed = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(5)));


### PR DESCRIPTION
## Summary

Quarantines the flaky workflows unit test `InputWaiterTests.InputWaiter_WaitForInputAsync_CompletesWhenTimeoutExpiresAsync` so the merge_group queue stops blocking on it. Tracking issue: #7360.

## Why

Across the last 18 failed `dotnet-build-and-test` runs, this test failed 7 times, always on the `net472` / `windows-latest` leg and always in a `merge_group` run. It blocks PRs that do not touch the workflows code at all: the most recent occurrence blocked #7337, which only adds a sample.

| Run | Date | PR |
| --- | --- | --- |
| 30299144911 | 2026-07-27 | #7337 (GitHub Copilot BYOK sample) |
| 30293327057 | 2026-07-27 | |
| 29760053213 | 2026-07-20 | |
| 29312897500 | 2026-07-14 | |
| 29284546765 | 2026-07-13 | |
| 29274908654 | 2026-07-13 | |
| 29273373355 | 2026-07-13 | |

Failure signature:

```
Expected object to refer to System.Threading.Tasks.Task`1[System.Threading.Tasks.VoidTaskResult] {Status=WaitingForActivation}
because the wait task should complete once the timeout expires,
but found System.Threading.Tasks.Task+DelayPromise {Status=RanToCompletion}.
```

The test races a 300 ms `SemaphoreSlim` timeout against a 5 s `Task.Delay` guard and then asserts which one won by object identity. On the loaded `net472` leg, thread pool starvation can delay the 300 ms continuation past the 5 s guard, so `Task.Delay` wins the `WhenAny` and `BeSameAs` fails. `InputWaiter` itself is behaving correctly, the test just cannot guarantee it observes the timeout in time. See #7360 for the full hypothesis.

## Change

Replace `[Fact]` with `[Fact(Skip = "Flaky in merge_group; see https://github.com/microsoft/agent-framework/issues/7360")]` on the affected test, matching the convention already used for #5845, and add a short comment explaining why the existing outer bound is not sufficient.

No product code changes.

## Validation

- `dotnet build --tl:off --framework net472` on `Microsoft.Agents.AI.Workflows.UnitTests` succeeds with 0 warnings, 0 errors.
- Running the class on `net472` reports `total: 7, failed: 0, skipped: 1`, with the skipped test being the quarantined one.
- `dotnet format --verify-no-changes` on the changed file passes.

## Follow-up

The assertion should be rewritten so it no longer depends on scheduling latency, then the test re-enabled. Note that `Task.WaitAsync(TimeSpan)` is not available on `net472`, so any replacement has to work on .NET Framework as well. Tracked in #7360.
