### PR TITLE
.NET: Bump .NET SDK from 10.0.301 to 10.0.302

### DIFF
--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.301",
+        "version": "10.0.302",
         "rollForward": "minor",
         "allowPrerelease": false
     },


### PR DESCRIPTION
Bumps the pinned .NET SDK in dotnet/global.json from 10.0.301 to the patched 10.0.302 to address a security advisory (https://aka.ms/dotnet-security-notes). Version pin only; no functional impact.