### PR TITLE
Python: Preserve falsey EditTableV2 items

### DIFF
--- a/python/packages/declarative/agent_framework_declarative/_workflows/_executors_basic.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_executors_basic.py
@@ -361,7 +361,9 @@ class EditTableV2Executor(DeclarativeActionExecutor):
 
         table_path = self._action_def.get("table") or _get_variable_path(self._action_def, "variable")
         operation = self._action_def.get("operation", "add").lower()
-        item = self._action_def.get("item") or self._action_def.get("value")
+        item = self._action_def.get("item")
+        if item is None:
+            item = self._action_def.get("value")
         key_field = self._action_def.get("key")
         index = self._action_def.get("index")
 

--- a/python/packages/declarative/tests/test_graph_executors.py
+++ b/python/packages/declarative/tests/test_graph_executors.py
@@ -934,6 +934,49 @@ class TestEditTableV2Executor:
         result = state.get("Local.records")
         assert result == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
 
+    @pytest.mark.parametrize("item", [False, 0, "", [], {}])
+    async def test_edit_table_v2_add_preserves_falsey_item(self, mock_context, mock_state, item):
+        """Test EditTableV2 preserves a falsey item instead of treating it as missing."""
+        from agent_framework_declarative._workflows._executors_basic import EditTableV2Executor
+
+        state = DeclarativeWorkflowState(mock_state)
+        state.initialize()
+        state.set("Local.items", [True])
+
+        action_def = {
+            "kind": "EditTableV2",
+            "table": "Local.items",
+            "operation": "add",
+            "item": item,
+        }
+        executor = EditTableV2Executor(action_def)
+        await executor.handle_action(ActionTrigger(), mock_context)
+
+        result = state.get("Local.items")
+        assert result[:-1] == [True]
+        assert result[-1] == item
+        assert type(result[-1]) is type(item)
+
+    async def test_edit_table_v2_add_uses_legacy_value_when_item_is_none(self, mock_context, mock_state):
+        """Test EditTableV2 retains the legacy value fallback for a missing item."""
+        from agent_framework_declarative._workflows._executors_basic import EditTableV2Executor
+
+        state = DeclarativeWorkflowState(mock_state)
+        state.initialize()
+
+        action_def = {
+            "kind": "EditTableV2",
+            "table": "Local.items",
+            "operation": "add",
+            "item": None,
+            "value": "legacy",
+        }
+        executor = EditTableV2Executor(action_def)
+        await executor.handle_action(ActionTrigger(), mock_context)
+
+        result = state.get("Local.items")
+        assert result == ["legacy"]
+
     @pytest.mark.asyncio
     async def test_edit_table_v2_add_or_update_new(self, mock_context, mock_state):
         """Test EditTableV2 with addOrUpdate - adding new record."""


### PR DESCRIPTION
### Motivation & Context

`EditTableV2` accepts YAML/JSON values through its `item` field, including valid falsey values such as `false`, `0`, an empty string, an empty list, or an empty object. The Python executor currently selects `item` with a truthiness fallback, so adding any of those values stores the legacy `value` field instead (or `None` when `value` is absent). For example, adding `item: false` to `[true]` deterministically produces `[true, null]` instead of `[true, false]`, corrupting the workflow table value.

### Description & Review Guide

- **What are the major changes?** Replace the truthiness fallback with an explicit `None` check, and add regression coverage for `False`, `0`, `""`, `[]`, and `{}` plus boundary coverage that preserves the existing legacy `value` fallback when `item` is `None`. Local checks passed: `uv run poe test -P declarative` (686 passed, 254 skipped), `uv run poe syntax -P declarative` (2 tasks passed), `uv run poe pyright -P declarative` (0 errors), `uv run poe check` (all syntax, source typing, test typing, package tests, and Markdown code checks passed with exit 0), and `git diff --check`.
- **What is the impact of these changes?** Falsey table items retain their value and type. `None` continues to act as the missing-item sentinel for compatibility with the legacy `value` field. There are no public API, schema, provider, or unrelated operation changes.
- **What do you want reviewers to focus on?** The distinction between a present falsey `item` and the existing `None` fallback behavior.


### Related Issue

Fixes #7379

No other open pull request for #7379 was found during the duplicate check.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
