### PR TITLE
Python: Ignore excluded tool results during compaction

### DIFF
--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -894,10 +894,11 @@ class ToolResultCompactionStrategy:
             if group_id in keep_ids:
                 continue
             group_msgs = grouped.get(group_id, [])
-            included_group_msgs = [msg for msg in group_msgs if not msg.additional_properties.get(EXCLUDED_KEY, False)]
             # Build a call_id → function_name map from function_call contents.
             call_id_to_name: dict[str, str] = {}
-            for msg in included_group_msgs:
+            for msg in group_msgs:
+                if msg.additional_properties.get(EXCLUDED_KEY, False):
+                    continue
                 for content in msg.contents:
                     if content.type == "function_call" and content.call_id and content.name:
                         call_id_to_name[content.call_id] = content.name
@@ -905,7 +906,9 @@ class ToolResultCompactionStrategy:
                         call_id_to_name[content.call_id] = content.tool_name
             # Collect tool results with the function name for context.
             tool_results: list[str] = []
-            for msg in included_group_msgs:
+            for msg in group_msgs:
+                if msg.additional_properties.get(EXCLUDED_KEY, False):
+                    continue
                 for content in msg.contents:
                     if content.type == "function_result":
                         result_text = content.result if isinstance(content.result, str) else str(content.result)

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -894,9 +894,10 @@ class ToolResultCompactionStrategy:
             if group_id in keep_ids:
                 continue
             group_msgs = grouped.get(group_id, [])
+            included_group_msgs = [msg for msg in group_msgs if not msg.additional_properties.get(EXCLUDED_KEY, False)]
             # Build a call_id → function_name map from function_call contents.
             call_id_to_name: dict[str, str] = {}
-            for msg in group_msgs:
+            for msg in included_group_msgs:
                 for content in msg.contents:
                     if content.type == "function_call" and content.call_id and content.name:
                         call_id_to_name[content.call_id] = content.name
@@ -904,7 +905,7 @@ class ToolResultCompactionStrategy:
                         call_id_to_name[content.call_id] = content.tool_name
             # Collect tool results with the function name for context.
             tool_results: list[str] = []
-            for msg in group_msgs:
+            for msg in included_group_msgs:
                 for content in msg.contents:
                     if content.type == "function_result":
                         result_text = content.result if isinstance(content.result, str) else str(content.result)

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -772,6 +772,43 @@ async def test_tool_result_compaction_preserves_tool_results_in_summary() -> Non
     assert "found 3 docs" in summary_msgs[0].text  # type: ignore[operator]
 
 
+async def test_tool_result_compaction_does_not_restore_excluded_results() -> None:
+    """A summary must use only results that remain in the included context."""
+    excluded_payload = "excluded payload " * 2_000
+    messages = [
+        Message(role="user", contents=["u"]),
+        Message(
+            role="assistant",
+            contents=[
+                Content.from_function_call(call_id="c1", name="get_weather", arguments="{}"),
+                Content.from_function_call(call_id="c2", name="search_docs", arguments="{}"),
+            ],
+        ),
+        _tool_result("c1", "sunny"),
+        _tool_result("c2", excluded_payload),
+        Message(role="assistant", contents=["done"]),
+    ]
+    strategy = ToolResultCompactionStrategy(keep_last_tool_call_groups=0)
+    tokenizer = CharacterEstimatorTokenizer()
+    annotate_message_groups(messages, tokenizer=tokenizer)
+    original_group = messages[1:4]
+    excluded_result = messages[3]
+    excluded_result.additional_properties[EXCLUDED_KEY] = True
+    original_message_ids = [message.message_id for message in original_group if message.message_id]
+    token_count_before = included_token_count(messages)
+
+    await strategy(messages)
+    annotate_message_groups(messages, tokenizer=tokenizer)
+
+    summary = next(
+        message for message in included_messages(messages) if (message.text or "").startswith("[Tool results:")
+    )
+    assert summary.text == "[Tool results: get_weather: sunny]"
+    assert included_token_count(messages) < token_count_before
+    assert _group_unknown_value(summary, SUMMARY_OF_MESSAGE_IDS_KEY) == original_message_ids
+    assert _group_unknown_value(excluded_result, SUMMARIZED_BY_SUMMARY_ID_KEY) == summary.message_id
+
+
 async def test_tool_result_compaction_bidirectional_tracing() -> None:
     """Summary and originals should link to each other like SummarizationStrategy does."""
     messages = [


### PR DESCRIPTION
### Motivation & Context

`ToolResultCompactionStrategy` could summarize messages that had already been marked as excluded when only part of a tool group remained in context. This could restore a large excluded tool result inside the generated summary and increase context token usage instead of reducing it.

This change keeps excluded content out of generated summaries while preserving the existing provenance links between each original message and its summary.

### Description & Review Guide

- **What are the major changes?** Summary content and function-call mappings are now built only from included messages in the selected group. The complete group is still used for provenance IDs and backlinks. A regression test covers excluded-content restoration, token growth, and bidirectional provenance.
- **What is the impact of these changes?** Partially included tool groups compact without reintroducing excluded payloads. Existing function-call and MCP result handling remains unchanged, and there is no public API change.
- **What do you want reviewers to focus on?** Please review the boundary between included summary content and full-group provenance, particularly the use of filtered messages for content while retaining all original message IDs for traceability.

### Related Issue

Fixes #7387

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
