### PR TITLE
Python: fix LocalEvaluator reporting zero-check items as passed

### DIFF
--- a/python/packages/core/agent_framework/_evaluation.py
+++ b/python/packages/core/agent_framework/_evaluation.py
@@ -1520,7 +1520,8 @@ class LocalEvaluator:
     """Evaluation provider that runs checks locally without API calls.
 
     Implements the ``Evaluator`` protocol. Each check function is applied
-    to every item. An item passes only if all checks pass.
+    to every item. An item passes only if at least one check was evaluated
+    and all evaluated checks pass.
 
     Examples:
         Basic usage:
@@ -1560,8 +1561,9 @@ class LocalEvaluator:
     ) -> EvalResults:
         """Run all checks on each item and return aggregated results.
 
-        An item passes only if every check passes for that item. Per-check
-        breakdowns are available in ``per_evaluator``.
+        An item passes only if every check passes for that item. An item with
+        no checks to evaluate fails, since a pass would carry no evidence.
+        Per-check breakdowns are available in ``per_evaluator``.
 
         Supports both sync and async check functions (from
         :func:`evaluator`).
@@ -1574,7 +1576,7 @@ class LocalEvaluator:
 
         for item_idx, item in enumerate(items):
             check_results = await asyncio.gather(*[_run_check(fn, item) for fn in self._checks])
-            item_passed = True
+            item_passed = bool(check_results)
             item_scores: list[EvalScoreResult] = []
             for result in check_results:
                 counts = per_check.setdefault(result.check_name, {"passed": 0, "failed": 0, "errored": 0})

--- a/python/packages/core/tests/core/test_local_eval.py
+++ b/python/packages/core/tests/core/test_local_eval.py
@@ -375,6 +375,18 @@ class TestErrorHandling:
 
 class TestLocalEvaluatorIntegration:
     @pytest.mark.asyncio
+    async def test_zero_checks(self):
+        """A LocalEvaluator with no checks produces items with 0 scores, which count as failed."""
+        local = LocalEvaluator()
+        results = await local.evaluate([_make_item()])
+
+        assert results.result_counts == {"passed": 0, "failed": 1, "errored": 0}
+        assert results.all_passed is False
+        assert results.items[0].scores == []
+        with pytest.raises(EvalNotPassedError):
+            results.raise_for_status()
+
+    @pytest.mark.asyncio
     async def test_mixed_checks(self):
         """Function evaluators mix with built-in checks in LocalEvaluator."""
 


### PR DESCRIPTION
### Motivation & Context

`LocalEvaluator()` with no checks reports every item as passed. The item
carries zero `EvalScoreResult` evidence, yet the run reports
`{"passed": 1, "failed": 0, "errored": 0}`, `all_passed` is `True`, and
`raise_for_status()` does not raise.

That combination is a silent false pass on exactly the surfaces a caller wires
into a quality gate. An empty check sequence is realistic when checks come from
configuration, optional plugins, or a filter that matches nothing.

.NET in this repository already treats this case as a failure:
`AgentEvaluationResults.ItemPassed` ends with `return result.Metrics.Count > 0;`
and `LocalEvaluator_WithZeroChecks_ItemsHaveZeroMetricsAndFailAsync` asserts
`Passed == 0, Failed == 1` for an item with no metrics. This change brings
Python in line with that contract.

### Description & Review Guide

- **What are the major changes?**

  Two files. In `LocalEvaluator.evaluate`, `item_passed` is initialized from
  `bool(check_results)` instead of an unconditional `True`, so an item with no
  evaluated checks fails closed instead of inheriting vacuous truth from a loop
  that never runs. One regression test is added beside the existing local
  evaluator tests, and the `LocalEvaluator` class and `evaluate()` docstrings
  now state the zero-check case.

  No API, signature, dependency, or serialization change.

- **What is the impact of these changes?**

  A caller running `LocalEvaluator()` with zero checks now gets
  `passed=0, failed=1`, `all_passed is False`, and a raising
  `raise_for_status()`. Behavior for any evaluator with at least one check is
  unchanged, because the initializer is equivalent to `True` whenever
  `check_results` is non-empty.

  This is an observable behavior change for the zero-check path. I have left
  "not a breaking change" checked, on the grounds that the affected callers are
  receiving a verdict with no evidence behind it and the evals surface is
  marked `@experimental(feature_id=ExperimentalFeature.EVALS)`. If you would
  rather treat it as breaking, say so and I will add the label and title
  prefix.

- **What do you want reviewers to focus on?**

  Whether fail-closed is the semantics you want on the Python side, or whether
  you would prefer an explicit error at construction/evaluation time for an
  evaluator with no checks. I chose to mirror the existing .NET guard rather
  than introduce a new exception type, but the alternative is reasonable and
  would be a larger change.

  Opened as a draft so the direction can be settled against real code. Say the
  word and I will mark it ready.

### Related Issue

Fixes #7397

<!-- Bundled triage note — keep in the PR body so it arrives with this
     notification rather than as a separate ping on the issue. -->

Small triage note: issue automation inferred `.NET` from the parity context
and added it alongside `python`; the label-prefix workflow then changed the
title to `.NET: Python: [Bug]: ...`. I restored the Python-only title. This fix
changes only Python — .NET appears solely as the precedent being matched.
Could a maintainer remove the stale `.NET` label when convenient?

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

