### PR TITLE
.NET: Add regression tests and sample guidance for stable agent IDs in checkpointed workflows

### DIFF
--- a/dotnet/samples/03-workflows/Checkpoint/CheckpointAndRehydrate/Program.cs
+++ b/dotnet/samples/03-workflows/Checkpoint/CheckpointAndRehydrate/Program.cs
@@ -81,7 +81,12 @@ public static class Program
         }
         Console.WriteLine($"Number of checkpoints created: {checkpoints.Count}");
 
-        // Rehydrate a new workflow instance from a saved checkpoint and continue execution
+        // <rehydrate_workflow>
+        // A rehydrated workflow must preserve the topology and executor identities of the workflow that
+        // created the checkpoint. This executor-only workflow rebuilds identically because its executors
+        // use fixed ids. Agent-based workflows must recreate each local agent with the same
+        // ChatClientAgentOptions.Id (and, if set, the same Name), otherwise the executor ids no longer
+        // match the checkpoint and resume fails.
         var newWorkflow = WorkflowFactory.BuildWorkflow();
         const int CheckpointIndex = 5;
         Console.WriteLine($"\n\nHydrating a new workflow instance from the {CheckpointIndex + 1}th checkpoint.");
@@ -89,6 +94,7 @@ public static class Program
 
         await using StreamingRun newCheckpointedRun =
             await InProcessExecution.ResumeStreamingAsync(newWorkflow, savedCheckpoint, checkpointManager);
+        // </rehydrate_workflow>
 
         await foreach (WorkflowEvent evt in newCheckpointedRun.WatchStreamAsync())
         {

--- a/dotnet/samples/03-workflows/Orchestration/Handoff/AgentRegistry.cs
+++ b/dotnet/samples/03-workflows/Orchestration/Handoff/AgentRegistry.cs
@@ -10,50 +10,81 @@ using Microsoft.Extensions.AI;
 /// <param name="chatClient">The <see cref="IChatClient"/> to use as the agent backend.</param>
 internal sealed class AgentRegistry(IChatClient chatClient)
 {
+    // <stable_agent_identity>
+    // Give each agent a stable, unique Id so its workflow executor identity stays the same when the
+    // workflow is reconstructed (for example per request or dependency-injection scope), which keeps
+    // checkpoints resumable. If an agent also has a Name, keep that stable too, since the executor
+    // identity includes it. Use a fixed logical role here, not a conversation, request, or user id.
     internal const string IntakeAgentName = "Assistant";
-    public AIAgent IntakeAgent { get; } = chatClient.AsAIAgent(
-        instructions:
-            """
+    public AIAgent IntakeAgent { get; } = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Id = "intake-agent",
+        Name = IntakeAgentName,
+        ChatOptions = new()
+        {
+            Instructions =
+                """
                 You receive a user request and are responsible for routing to the correct initial expert agent.
                 """,
-        IntakeAgentName
-        );
+        },
+    });
+    // </stable_agent_identity>
 
     internal const string LiquidityAnalysisAgentName = "Liquidity Analysis";
-    public AIAgent LiquidityAnalysisAgent { get; } = chatClient.AsAIAgent(
-        instructions:
-            """
+    public AIAgent LiquidityAnalysisAgent { get; } = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Id = "liquidity-analysis-agent",
+        Name = LiquidityAnalysisAgentName,
+        ChatOptions = new()
+        {
+            Instructions =
+                """
                 You are responsible for Liquidity Analysis.
                 """,
-        LiquidityAnalysisAgentName
-        );
+        },
+    });
 
     internal const string TaxAnalysisAgentName = "Tax Analysis";
-    public AIAgent TaxAnalysisAgent { get; } = chatClient.AsAIAgent(
-        instructions:
-            """
-                You are responsible for Tax Analysis. 
+    public AIAgent TaxAnalysisAgent { get; } = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Id = "tax-analysis-agent",
+        Name = TaxAnalysisAgentName,
+        ChatOptions = new()
+        {
+            Instructions =
+                """
+                You are responsible for Tax Analysis.
                 """,
-        TaxAnalysisAgentName
-        );
+        },
+    });
 
     internal const string ForeignExchangeAgentName = "Foreign Exchange Analysis";
-    public AIAgent ForeignExchangeAgent { get; } = chatClient.AsAIAgent(
-        instructions:
-            """
-                You are responsible for Foreign Exchange Analysis. 
+    public AIAgent ForeignExchangeAgent { get; } = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Id = "foreign-exchange-agent",
+        Name = ForeignExchangeAgentName,
+        ChatOptions = new()
+        {
+            Instructions =
+                """
+                You are responsible for Foreign Exchange Analysis.
                 """,
-        ForeignExchangeAgentName
-        );
+        },
+    });
 
     internal const string EquityAgentName = "Equity Analysis";
-    public AIAgent EquityAgent { get; } = chatClient.AsAIAgent(
-        instructions:
-            """
-                You are responsible for Equity Analysis. 
+    public AIAgent EquityAgent { get; } = chatClient.AsAIAgent(new ChatClientAgentOptions
+    {
+        Id = "equity-analysis-agent",
+        Name = EquityAgentName,
+        ChatOptions = new()
+        {
+            Instructions =
+                """
+                You are responsible for Equity Analysis.
                 """,
-        EquityAgentName
-        );
+        },
+    });
 
     public IEnumerable<AIAgent> Experts => [this.LiquidityAnalysisAgent, this.TaxAnalysisAgent, this.ForeignExchangeAgent, this.EquityAgent];
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
@@ -37,7 +37,9 @@ public class WorkflowAgentCheckpointIdentityTests
 
         // Act: complete a first turn (triage hands off to the specialist), then serialize the session.
         AgentResponse firstResponse = await firstGeneration.RunAsync("Please help me.", session);
-        firstResponse.Text.Should().Contain(SpecialistReply, "the first turn should route triage -> specialist");
+        firstResponse.Text.Should().Be(
+            $"{SpecialistReply}:turn:1",
+            "the first turn should route triage -> specialist, and the specialist observes a single user turn");
 
         JsonElement serialized = await firstGeneration.SerializeSessionAsync(session);
 
@@ -48,10 +50,12 @@ public class WorkflowAgentCheckpointIdentityTests
 
         AgentResponse secondResponse = await secondGeneration.RunAsync("Anything else?", resumedSession);
 
-        // Assert: the reconstructed workflow resumes from the checkpoint and completes without a compatibility error.
-        secondResponse.Text.Should().Contain(
-            SpecialistReply,
-            "stable inner agent ids keep the executor identities compatible with the checkpoint across reconstruction");
+        // Assert: the specialist observes both user turns, which is only possible if the checkpointed conversation was
+        // restored. A fresh (non-resumed) session would restart the count at turn:1, so this distinguishes a genuine
+        // resume from a compatible-but-empty restart.
+        secondResponse.Text.Should().Be(
+            $"{SpecialistReply}:turn:2",
+            "stable inner agent ids keep the executor identities compatible and the reconstructed workflow resumes from the checkpoint");
     }
 
     [Fact]
@@ -155,9 +159,13 @@ public class WorkflowAgentCheckpointIdentityTests
         return new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("handoff-call", handoffTool)]));
     });
 
-    // The specialist returns a fixed reply.
-    private static StatelessMockChatClient CreateSpecialistClient() => new((_, _) =>
-        new ChatResponse(new ChatMessage(ChatRole.Assistant, SpecialistReply)));
+    // The specialist echoes how many user turns it has observed. Because a genuine resume restores the prior turn
+    // from the checkpoint, the count advances across turns, distinguishing a real resume from a fresh restart.
+    private static StatelessMockChatClient CreateSpecialistClient() => new((messages, _) =>
+    {
+        int observedUserTurns = messages.Count(m => m.Role == ChatRole.User);
+        return new ChatResponse(new ChatMessage(ChatRole.Assistant, $"{SpecialistReply}:turn:{observedUserTurns}"));
+    });
 
     /// <summary>
     /// A minimal <see cref="IChatClient"/> whose response is a pure function of the request, so reconstructing it

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Workflows.UnitTests;
+
+/// <summary>
+/// Verifies that a workflow hosted as an <see cref="AIAgent"/> resumes a serialized session after its inner
+/// agents are reconstructed only when each inner agent keeps a stable executor identity. A stable
+/// <see cref="ChatClientAgentOptions.Id"/> is sufficient; if an agent also sets a
+/// <see cref="ChatClientAgentOptions.Name"/>, that name must stay stable because the executor id includes it.
+/// </summary>
+public class WorkflowAgentCheckpointIdentityTests
+{
+    private const string TriageName = "triage_agent";
+    private const string SpecialistName = "specialist_agent";
+    private const string SpecialistReply = "SPECIALIST_REPLY";
+
+    // Held constant across reconstruction so resume differences come only from the inner agent identities.
+    private const string OuterWorkflowAgentId = "workflow-agent";
+
+    [Fact]
+    public async Task WorkflowAgentSession_WithStableInnerAgentIds_ResumesAcrossReconstructionAsync()
+    {
+        // Arrange: build a first-generation workflow agent whose inner agents have stable, explicit ids.
+        AIAgent firstGeneration = BuildWorkflowAgent(useStableInnerIds: true);
+        AgentSession session = await firstGeneration.CreateSessionAsync();
+
+        // Act: complete a first turn (triage hands off to the specialist), then serialize the session.
+        AgentResponse firstResponse = await firstGeneration.RunAsync("Please help me.", session);
+        firstResponse.Text.Should().Contain(SpecialistReply, "the first turn should route triage -> specialist");
+
+        JsonElement serialized = await firstGeneration.SerializeSessionAsync(session);
+
+        // Reconstruct a completely fresh object graph (new clients, agents, and workflow) using the same stable ids,
+        // modeling a second dependency-injection scope.
+        AIAgent secondGeneration = BuildWorkflowAgent(useStableInnerIds: true);
+        AgentSession resumedSession = await secondGeneration.DeserializeSessionAsync(serialized);
+
+        AgentResponse secondResponse = await secondGeneration.RunAsync("Anything else?", resumedSession);
+
+        // Assert: the reconstructed workflow resumes from the checkpoint and completes without a compatibility error.
+        secondResponse.Text.Should().Contain(
+            SpecialistReply,
+            "stable inner agent ids keep the executor identities compatible with the checkpoint across reconstruction");
+    }
+
+    [Fact]
+    public async Task WorkflowAgentSession_WithoutStableInnerAgentIds_FailsAcrossReconstructionAsync()
+    {
+        // Arrange: build a first-generation workflow agent whose inner agents receive random ids (no explicit id).
+        AIAgent firstGeneration = BuildWorkflowAgent(useStableInnerIds: false);
+        AgentSession session = await firstGeneration.CreateSessionAsync();
+
+        // Complete a first turn and serialize the session; a completed handoff turn captures a checkpoint.
+        AgentResponse firstResponse = await firstGeneration.RunAsync("Please help me.", session);
+        firstResponse.Text.Should().Contain(SpecialistReply, "the first turn should route triage -> specialist");
+
+        JsonElement serialized = await firstGeneration.SerializeSessionAsync(session);
+
+        // Reconstruct with new random inner ids but the SAME outer workflow-agent id, proving that a stable outer id
+        // alone does not stabilize the inner executor identities.
+        AIAgent secondGeneration = BuildWorkflowAgent(useStableInnerIds: false);
+
+        // Act: deserialization itself succeeds; the incompatibility surfaces only when the resuming run validates the
+        // checkpoint against the reconstructed workflow.
+        AgentSession resumedSession = await secondGeneration.DeserializeSessionAsync(serialized);
+
+        Func<Task> resumeAndRun = () => secondGeneration.RunAsync("Anything else?", resumedSession);
+
+        // Assert: the second run throws because the reconstructed executor ids no longer match the checkpoint.
+        await resumeAndRun.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("The specified checkpoint is not compatible with the workflow associated with this runner.");
+    }
+
+    /// <summary>
+    /// Builds a fresh Handoff workflow-as-agent object graph. Every call constructs new chat clients, agents, and a
+    /// new workflow, modeling reconstruction across dependency-injection scopes.
+    /// </summary>
+    /// <param name="useStableInnerIds">
+    /// When <see langword="true"/>, each inner agent is assigned a deterministic <see cref="ChatClientAgentOptions.Id"/>.
+    /// When <see langword="false"/>, the id is left unset so each agent receives a random per-instance id.
+    /// </param>
+    private static AIAgent BuildWorkflowAgent(bool useStableInnerIds)
+    {
+        AIAgent triage = CreateTriageClient().AsAIAgent(new ChatClientAgentOptions
+        {
+            Id = useStableInnerIds ? "triage-agent" : null,
+            Name = TriageName,
+            Description = "Routes the request to a specialist.",
+            ChatOptions = new() { Instructions = "Always hand off to the specialist." },
+        });
+
+        AIAgent specialist = CreateSpecialistClient().AsAIAgent(new ChatClientAgentOptions
+        {
+            Id = useStableInnerIds ? "specialist-agent" : null,
+            Name = SpecialistName,
+            Description = "Handles the request once triage hands off.",
+            ChatOptions = new() { Instructions = "Answer the request." },
+        });
+
+        Workflow workflow = AgentWorkflowBuilder.CreateHandoffBuilderWith(triage)
+            .WithHandoff(triage, specialist)
+            .Build();
+
+        return workflow.AsAIAgent(id: OuterWorkflowAgentId, name: OuterWorkflowAgentId);
+    }
+
+    // Triage hands off to the specialist by calling the handoff tool present on the request.
+    private static StatelessMockChatClient CreateTriageClient() => new((messages, options) =>
+    {
+        string? handoffTool = options?.Tools?
+            .FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+
+        return new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("handoff-call", handoffTool!)]));
+    });
+
+    // The specialist returns a fixed reply.
+    private static StatelessMockChatClient CreateSpecialistClient() => new((_, _) =>
+        new ChatResponse(new ChatMessage(ChatRole.Assistant, SpecialistReply)));
+
+    /// <summary>
+    /// A minimal <see cref="IChatClient"/> whose response is a pure function of the request, so reconstructing it
+    /// preserves behavior.
+    /// </summary>
+    private sealed class StatelessMockChatClient(Func<IEnumerable<ChatMessage>, ChatOptions?, ChatResponse> responseFactory) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(responseFactory(messages, options));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var update in (await this.GetResponseAsync(messages, options, cancellationToken).ConfigureAwait(false)).ToChatResponseUpdates())
+            {
+                yield return update;
+            }
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/WorkflowAgentCheckpointIdentityTests.cs
@@ -82,6 +82,32 @@ public class WorkflowAgentCheckpointIdentityTests
             .WithMessage("The specified checkpoint is not compatible with the workflow associated with this runner.");
     }
 
+    [Fact]
+    public async Task WorkflowAgentSession_WithStableIdsButChangedInnerNames_FailsAcrossReconstructionAsync()
+    {
+        // Arrange: first generation uses stable ids and the default inner names.
+        AIAgent firstGeneration = BuildWorkflowAgent(useStableInnerIds: true);
+        AgentSession session = await firstGeneration.CreateSessionAsync();
+
+        AgentResponse firstResponse = await firstGeneration.RunAsync("Please help me.", session);
+        firstResponse.Text.Should().Contain(SpecialistReply, "the first turn should route triage -> specialist");
+
+        JsonElement serialized = await firstGeneration.SerializeSessionAsync(session);
+
+        // Reconstruct with the SAME stable ids but different inner names. Because the executor id is derived from
+        // both the name and the id, changing only the name still breaks checkpoint compatibility.
+        AIAgent secondGeneration = BuildWorkflowAgent(useStableInnerIds: true, nameSuffix: "-renamed");
+
+        // Act: deserialization succeeds; the incompatibility surfaces on the resuming run.
+        AgentSession resumedSession = await secondGeneration.DeserializeSessionAsync(serialized);
+
+        Func<Task> resumeAndRun = () => secondGeneration.RunAsync("Anything else?", resumedSession);
+
+        // Assert: changing a set name invalidates the executor identity even though the id is stable.
+        await resumeAndRun.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("The specified checkpoint is not compatible with the workflow associated with this runner.");
+    }
+
     /// <summary>
     /// Builds a fresh Handoff workflow-as-agent object graph. Every call constructs new chat clients, agents, and a
     /// new workflow, modeling reconstruction across dependency-injection scopes.
@@ -90,12 +116,16 @@ public class WorkflowAgentCheckpointIdentityTests
     /// When <see langword="true"/>, each inner agent is assigned a deterministic <see cref="ChatClientAgentOptions.Id"/>.
     /// When <see langword="false"/>, the id is left unset so each agent receives a random per-instance id.
     /// </param>
-    private static AIAgent BuildWorkflowAgent(bool useStableInnerIds)
+    /// <param name="nameSuffix">
+    /// Optional suffix appended to each inner agent's <see cref="ChatClientAgentOptions.Name"/>. Used to simulate a
+    /// reconstruction that keeps ids stable but changes names.
+    /// </param>
+    private static AIAgent BuildWorkflowAgent(bool useStableInnerIds, string nameSuffix = "")
     {
         AIAgent triage = CreateTriageClient().AsAIAgent(new ChatClientAgentOptions
         {
             Id = useStableInnerIds ? "triage-agent" : null,
-            Name = TriageName,
+            Name = TriageName + nameSuffix,
             Description = "Routes the request to a specialist.",
             ChatOptions = new() { Instructions = "Always hand off to the specialist." },
         });
@@ -103,7 +133,7 @@ public class WorkflowAgentCheckpointIdentityTests
         AIAgent specialist = CreateSpecialistClient().AsAIAgent(new ChatClientAgentOptions
         {
             Id = useStableInnerIds ? "specialist-agent" : null,
-            Name = SpecialistName,
+            Name = SpecialistName + nameSuffix,
             Description = "Handles the request once triage hands off.",
             ChatOptions = new() { Instructions = "Answer the request." },
         });
@@ -118,10 +148,11 @@ public class WorkflowAgentCheckpointIdentityTests
     // Triage hands off to the specialist by calling the handoff tool present on the request.
     private static StatelessMockChatClient CreateTriageClient() => new((messages, options) =>
     {
-        string? handoffTool = options?.Tools?
-            .FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name;
+        string handoffTool = options?.Tools?
+            .FirstOrDefault(t => t.Name.StartsWith("handoff_to_", StringComparison.Ordinal))?.Name
+            ?? throw new InvalidOperationException("Expected a handoff tool to be available to the triage agent.");
 
-        return new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("handoff-call", handoffTool!)]));
+        return new ChatResponse(new ChatMessage(ChatRole.Assistant, [new FunctionCallContent("handoff-call", handoffTool)]));
     });
 
     // The specialist returns a fixed reply.


### PR DESCRIPTION
### Motivation & Context

When a workflow is hosted as an agent and later rebuilt (for example, agents registered as scoped in dependency injection), its inner agents get brand-new random IDs unless you set them explicitly. Because a workflow's saved checkpoint is tied to those IDs, resuming the session on a later request fails with `InvalidDataException: The specified checkpoint is not compatible with the workflow...`. This is the problem reported in #4793.

The fix is already available today: give each inner agent a stable, unique `ChatClientAgentOptions.Id` (and, if you set a `Name`, keep it stable too). This PR doesn't change product behavior; it adds coverage and guidance, so the pattern is clear and protected.

The samples also expose tagged snippet regions so the documentation can reference them directly.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
