### PR TITLE
Python: Fix Actions token environment

### DIFF
--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           COSMOSDB_ENDPOINT: https://localhost:8081
           COSMOSDB_KEY: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           OpenAI__ApiKey: ${{ secrets.OPENAI__APIKEY }}
           OpenAI__ChatModelId: ${{ vars.OPENAI__CHATMODELID }}
           OpenAI__ChatReasoningModelId: ${{ vars.OPENAI__CHATREASONINGMODELID }}

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -509,7 +509,7 @@ jobs:
       contents: read
     timeout-minutes: 60
     env:
-      COPILOT_GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
       GITHUB_COPILOT_TIMEOUT: "120"
     defaults:
       run:

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -680,7 +680,7 @@ jobs:
       contents: read
     timeout-minutes: 60
     env:
-      COPILOT_GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
       GITHUB_COPILOT_TIMEOUT: "120"
     defaults:
       run:

--- a/.github/workflows/python-sample-validation.yml
+++ b/.github/workflows/python-sample-validation.yml
@@ -240,7 +240,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      COPILOT_GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
       GITHUB_COPILOT_MODEL: claude-opus-4.6
     defaults:
       run:

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
@@ -15,10 +15,20 @@ public class GitHubCopilotAgentTests
 {
     private static void SkipIfCopilotNotConfigured()
     {
-        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("COPILOT_GITHUB_TOKEN")) &&
-            string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_TOKEN")))
+        bool actionsAuth =
+            string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_TOKEN"));
+        bool localOptIn =
+            string.Equals(
+                Environment.GetEnvironmentVariable("RUN_COPILOT_INTEGRATION_TESTS"),
+                "true",
+                StringComparison.OrdinalIgnoreCase);
+
+        if (!actionsAuth && !localOptIn)
         {
-            Assert.Skip("COPILOT_GITHUB_TOKEN or GITHUB_TOKEN not set; skipping GitHub Copilot integration tests.");
+            Assert.Skip(
+                "GitHub Actions auth is unavailable and RUN_COPILOT_INTEGRATION_TESTS is not true; " +
+                "skipping GitHub Copilot integration tests.");
         }
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.GitHub.Copilot.IntegrationTests/GitHubCopilotAgentTests.cs
@@ -15,9 +15,10 @@ public class GitHubCopilotAgentTests
 {
     private static void SkipIfCopilotNotConfigured()
     {
-        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("COPILOT_GITHUB_TOKEN")))
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("COPILOT_GITHUB_TOKEN")) &&
+            string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_TOKEN")))
         {
-            Assert.Skip("COPILOT_GITHUB_TOKEN not set; skipping GitHub Copilot integration tests.");
+            Assert.Skip("COPILOT_GITHUB_TOKEN or GITHUB_TOKEN not set; skipping GitHub Copilot integration tests.");
         }
     }
 

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -3475,11 +3475,37 @@ class TestGitHubCopilotAttachments:
 
 
 # ---------------------------------------------------------------------------
-# Integration tests — require COPILOT_GITHUB_TOKEN env var
+# Integration tests — require user-token or GitHub Actions authentication
 # ---------------------------------------------------------------------------
+def _copilot_integration_configured() -> bool:
+    return any(os.getenv(name, "").strip() for name in ("COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN"))
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({}, False),
+        ({"COPILOT_GITHUB_TOKEN": "user-token"}, True),
+        ({"GITHUB_TOKEN": "actions-token"}, True),
+    ],
+)
+def test_copilot_integration_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: dict[str, str],
+    expected: bool,
+) -> None:
+    """Integration tests accept either user-token or GitHub Actions auth."""
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    assert _copilot_integration_configured() is expected
+
+
 skip_if_copilot_integration_tests_disabled = pytest.mark.skipif(
-    os.getenv("COPILOT_GITHUB_TOKEN", "") == "",
-    reason="No COPILOT_GITHUB_TOKEN provided; skipping integration tests.",
+    not _copilot_integration_configured(),
+    reason="No COPILOT_GITHUB_TOKEN or GITHUB_TOKEN provided; skipping integration tests.",
 )
 
 

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -3475,18 +3475,22 @@ class TestGitHubCopilotAttachments:
 
 
 # ---------------------------------------------------------------------------
-# Integration tests — require user-token or GitHub Actions authentication
+# Integration tests — require GitHub Actions auth or explicit local opt-in
 # ---------------------------------------------------------------------------
 def _copilot_integration_configured() -> bool:
-    return any(os.getenv(name, "").strip() for name in ("COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN"))
+    actions_auth = os.getenv("GITHUB_ACTIONS", "").lower() == "true" and bool(os.getenv("GITHUB_TOKEN", "").strip())
+    local_opt_in = os.getenv("RUN_COPILOT_INTEGRATION_TESTS", "").lower() == "true"
+    return actions_auth or local_opt_in
 
 
 @pytest.mark.parametrize(
     ("environment", "expected"),
     [
         ({}, False),
-        ({"COPILOT_GITHUB_TOKEN": "user-token"}, True),
-        ({"GITHUB_TOKEN": "actions-token"}, True),
+        ({"GITHUB_TOKEN": "unrelated-token"}, False),
+        ({"GITHUB_ACTIONS": "true"}, False),
+        ({"GITHUB_ACTIONS": "true", "GITHUB_TOKEN": "actions-token"}, True),
+        ({"RUN_COPILOT_INTEGRATION_TESTS": "true"}, True),
     ],
 )
 def test_copilot_integration_configured(
@@ -3494,9 +3498,10 @@ def test_copilot_integration_configured(
     environment: dict[str, str],
     expected: bool,
 ) -> None:
-    """Integration tests accept either user-token or GitHub Actions auth."""
-    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    """Integration tests require Actions auth or an explicit local opt-in."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("RUN_COPILOT_INTEGRATION_TESTS", raising=False)
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
 
@@ -3505,7 +3510,9 @@ def test_copilot_integration_configured(
 
 skip_if_copilot_integration_tests_disabled = pytest.mark.skipif(
     not _copilot_integration_configured(),
-    reason="No COPILOT_GITHUB_TOKEN or GITHUB_TOKEN provided; skipping integration tests.",
+    reason=(
+        "GitHub Actions auth is unavailable and RUN_COPILOT_INTEGRATION_TESTS is not true; skipping integration tests."
+    ),
 )
 
 


### PR DESCRIPTION
### Motivation & Context

Copilot integration and sample-validation jobs grant `copilot-requests: write`, but exposed the built-in Actions token through a user-token environment variable. Copilot CLI interpreted that value as a PAT-style credential and attempted a user lookup, which could fail with `401: Bad credentials` instead of using organization-billed Actions authentication.

This change removes the user-token environment dependency from these workflows and integration-test guards.

### Description & Review Guide

- **What are the major changes?** Pass the built-in workflow token through the native `GITHUB_TOKEN` variable in the Python, .NET, merge, and sample-validation Copilot jobs. In GitHub Actions, integration tests run only when `GITHUB_ACTIONS=true` and `GITHUB_TOKEN` is available. Local integration tests require `RUN_COPILOT_INTEGRATION_TESTS=true` and use the developer’s stored Copilot device login.
- **What is the impact of these changes?** Copilot tests use the supported organization-billed Actions authentication path. Local tests remain explicitly opt-in without requiring a separate user-token environment variable.
- **What do you want reviewers to focus on?** Confirm the Actions authentication-variable semantics and that the explicit local opt-in correctly avoids accidental costly integration-test runs.


### Related Issue

Fixes #7425

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.