### PR TITLE
.NET: Updating version for dotnet release 1.16.0

### DIFF
--- a/dotnet/nuget/nuget-package.props
+++ b/dotnet/nuget/nuget-package.props
@@ -1,14 +1,14 @@
 <Project>
   <PropertyGroup>
     <!-- Central version prefix - applies to all nuget packages. -->
-    <VersionPrefix>1.15.0</VersionPrefix>
+    <VersionPrefix>1.16.0</VersionPrefix>
     <RCNumber>1</RCNumber>
-    <DateSuffix>260722</DateSuffix>
+    <DateSuffix>260730</DateSuffix>
     <PackageVersion Condition="'$(IsReleaseCandidate)' == 'true'">$(VersionPrefix)-rc$(RCNumber)</PackageVersion>
     <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix).$(DateSuffix).1</PackageVersion>
     <PackageVersion Condition="'$(IsReleaseCandidate)' != 'true' AND '$(VersionSuffix)' == ''">$(VersionPrefix)-preview.$(DateSuffix).1</PackageVersion>
     <PackageVersion Condition="'$(IsReleased)' == 'true'">$(VersionPrefix)</PackageVersion>
-    <GitTag>1.15.0</GitTag>
+    <GitTag>1.16.0</GitTag>
 
     <Configurations>Debug;Release;Publish</Configurations>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
### Motivation & Context

Version bump for the .NET 1.16.0 release.

### Description & Review Guide

- **What are the major changes?** Updated `VersionPrefix`, `DateSuffix`, and `GitTag` in `dotnet/nuget/nuget-package.props`.
- **What is the impact of these changes?** All NuGet packages will use version 1.16.0.
- **What do you want reviewers to focus on?** N/A

### Related Issue

N/A

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.