### PR TITLE
.NET: Fix Handoff orchestration sample not responding to user input

### DIFF
--- a/dotnet/samples/03-workflows/Orchestration/Handoff/Program.cs
+++ b/dotnet/samples/03-workflows/Orchestration/Handoff/Program.cs
@@ -59,6 +59,10 @@ static async Task RunWorkflowAsync(Workflow workflow)
         }
 
         await run.TrySendMessageAsync(userInput);
+
+        // Agents are wrapped as executors that cache incoming messages and only run when they receive a TurnToken,
+        // so the turn must be triggered explicitly after sending the user input.
+        await run.TrySendMessageAsync(new TurnToken(emitEvents: true));
         string? speakingAgent = null;
         await foreach (WorkflowEvent evt in run.WatchStreamAsync(cts.Token))
         {


### PR DESCRIPTION
### Motivation & Context

The Handoff orchestration sample appeared to hang; after typing a message and pressing Enter, nothing happened and it just showed a new prompt. The sample sent the user's input into the workflow but never sent the `TurnToken` that actually triggers the agents to run. Because agents wrapped as workflow executors cache incoming messages and only start processing once they receive a `TurnToken`, the input sat unprocessed and no response was produced. This fix sends a `TurnToken` right after the user input, matching the pattern used by all other agent-workflow samples, so the intake agent now routes the request and the expert's response streams back.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
