### PR TITLE
.NET: expose workflow routing metadata

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Expose workflow routing metadata for external inspection and tooling ([#7459](https://github.com/microsoft/agent-framework/pull/7459))
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Added support for durable workflows ([#4436](https://github.com/microsoft/agent-framework/pull/4436))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/WorkflowAnalyzer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/WorkflowAnalyzer.cs
@@ -113,9 +113,11 @@ internal static class WorkflowAnalyzer
     /// </summary>
     /// <param name="graphInfo">The graph info to populate.</param>
     /// <param name="edges">The dictionary of edges grouped by source executor ID.</param>
-    private static void PopulateGraphFromEdges(WorkflowGraphInfo graphInfo, Dictionary<string, HashSet<Edge>> edges)
+    private static void PopulateGraphFromEdges(
+        WorkflowGraphInfo graphInfo,
+        IReadOnlyDictionary<string, IReadOnlyCollection<Edge>> edges)
     {
-        foreach ((string sourceId, HashSet<Edge> edgeSet) in edges)
+        foreach ((string sourceId, IReadOnlyCollection<Edge> edgeSet) in edges)
         {
             List<string> successors = graphInfo.Successors[sourceId];
 

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/DirectEdgeData.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/DirectEdgeData.cs
@@ -36,5 +36,5 @@ public sealed class DirectEdgeData : EdgeData
     public PredicateT? Condition { get; }
 
     /// <inheritdoc />
-    internal override EdgeConnection Connection { get; }
+    public override EdgeConnection Connection { get; }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/EdgeData.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/EdgeData.cs
@@ -12,7 +12,7 @@ public abstract class EdgeData
     /// <summary>
     /// Gets the connection representation of the edge.
     /// </summary>
-    internal abstract EdgeConnection Connection { get; }
+    public abstract EdgeConnection Connection { get; }
 
     internal EdgeData(EdgeId id, string? label = null)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeMap.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Execution/EdgeMap.cs
@@ -23,7 +23,10 @@ internal sealed class EdgeMap
                    Workflow workflow,
                    IStepTracer? stepTracer)
         : this(runContext,
-               workflow.Edges,
+               // Adapt the public read-only edge view while preserving the existing internal constructor contract.
+               workflow.Edges.ToDictionary(
+                   keySelector: kvp => kvp.Key,
+                   elementSelector: kvp => new HashSet<Edge>(kvp.Value)),
                workflow.Ports.Values,
                workflow.StartExecutorId,
                stepTracer)

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/FanInEdgeData.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/FanInEdgeData.cs
@@ -28,5 +28,5 @@ internal sealed class FanInEdgeData : EdgeData
     public string SinkId { get; }
 
     /// <inheritdoc />
-    internal override EdgeConnection Connection { get; }
+    public override EdgeConnection Connection { get; }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/FanOutEdgeData.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/FanOutEdgeData.cs
@@ -8,10 +8,10 @@ using AssignerF = System.Func<object?, int, System.Collections.Generic.IEnumerab
 namespace Microsoft.Agents.AI.Workflows;
 
 /// <summary>
-/// Represents a connection from a single node to a set of nodes, optionally associated with a paritition selector
+/// Represents a connection from a single node to a set of nodes, optionally associated with a partition selector
 /// function which maps incoming messages to a subset of the target set.
 /// </summary>
-internal sealed class FanOutEdgeData : EdgeData
+public sealed class FanOutEdgeData : EdgeData
 {
     internal FanOutEdgeData(string sourceId, List<string> sinkIds, EdgeId edgeId, AssignerF? assigner = null, string? label = null) : base(edgeId, label)
     {
@@ -38,5 +38,5 @@ internal sealed class FanOutEdgeData : EdgeData
     public AssignerF? EdgeAssigner { get; }
 
     /// <inheritdoc />
-    internal override EdgeConnection Connection { get; }
+    public override EdgeConnection Connection { get; }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/InProc/InProcessRunnerContext.cs
@@ -237,7 +237,7 @@ internal sealed class InProcessRunnerContext : IRunnerContext
 
         MessageEnvelope envelope = new(message, sourceId, declaredType, targetId: targetId, traceContext: traceContext);
 
-        if (this._workflow.Edges.TryGetValue(sourceId, out HashSet<Edge>? edges))
+        if (this._workflow.Edges.TryGetValue(sourceId, out IReadOnlyCollection<Edge>? edges))
         {
             foreach (Edge edge in edges)
             {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
@@ -28,6 +28,8 @@ public class Workflow
     /// </summary>
     /// <remarks>
     /// This property exposes the live routing data through read-only interfaces; it is not a deep-copy snapshot.
+    /// The read-only interfaces do not provide deep immutability: callers that downcast the returned collections or
+    /// mutate the lists on an edge connection can affect the live routing data. Treat the returned data as read-only.
     /// Use <see cref="ReflectEdges"/> when a serializable representation of the workflow graph is required.
     /// </remarks>
     public IReadOnlyDictionary<string, IReadOnlyCollection<Edge>> Edges { get; internal init; } =

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Workflow.cs
@@ -23,7 +23,16 @@ public class Workflow
     /// </summary>
     internal Dictionary<string, ExecutorBinding> ExecutorBindings { get; init; } = [];
 
-    internal Dictionary<string, HashSet<Edge>> Edges { get; init; } = [];
+    /// <summary>
+    /// Gets the workflow edges grouped by their source executor identifier.
+    /// </summary>
+    /// <remarks>
+    /// This property exposes the live routing data through read-only interfaces; it is not a deep-copy snapshot.
+    /// Use <see cref="ReflectEdges"/> when a serializable representation of the workflow graph is required.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<Edge>> Edges { get; internal init; } =
+        new Dictionary<string, IReadOnlyCollection<Edge>>();
+
     internal Dictionary<string, HashSet<OutputTag>> OutputExecutors { get; init; } = new(StringComparer.Ordinal);
 
     internal bool IsTerminalOutput(string executorId)

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowBuilder.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/WorkflowBuilder.cs
@@ -636,7 +636,9 @@ public class WorkflowBuilder
         var workflow = new Workflow(this._startExecutorId, this._name, this._description, this._telemetryContext)
         {
             ExecutorBindings = this._executorBindings,
-            Edges = this._edges,
+            Edges = this._edges.ToDictionary(
+                keySelector: kvp => kvp.Key,
+                elementSelector: kvp => (IReadOnlyCollection<Edge>)kvp.Value),
             Ports = this._requestPorts,
             OutputExecutors = this._outputExecutors
         };

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/WorkflowPublicApiTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/WorkflowPublicApiTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Reflection;
+using Microsoft.Agents.AI.Workflows;
+
+namespace Microsoft.Agents.AI.DurableTask.UnitTests.Workflows;
+
+public sealed class WorkflowPublicApiTests
+{
+    [Fact]
+    public void WorkflowRoutingMetadata_IsAccessibleToExternalConsumers()
+    {
+        // Arrange
+        FunctionExecutor<string> source = new("source", static (_, _, _) => default);
+        FunctionExecutor<string> directTarget = new("direct-target", static (_, _, _) => default);
+        FunctionExecutor<string> fanOutTarget1 = new("fan-out-target-1", static (_, _, _) => default);
+        FunctionExecutor<string> fanOutTarget2 = new("fan-out-target-2", static (_, _, _) => default);
+
+        Workflow workflow = new WorkflowBuilder(source)
+            .AddEdge<string>(source, directTarget, static message => message == "direct")
+            .AddFanOutEdge<string>(
+                source,
+                [fanOutTarget1, fanOutTarget2],
+                static (message, _) => message == "fan-out" ? [0, 1] : [])
+            .Build();
+
+        // Act
+        IReadOnlyDictionary<string, IReadOnlyCollection<Edge>> edges = workflow.Edges;
+        Edge directEdge = Assert.Single(edges[source.Id], edge => edge.Kind == EdgeKind.Direct);
+        Edge fanOutEdge = Assert.Single(edges[source.Id], edge => edge.Kind == EdgeKind.FanOut);
+        DirectEdgeData directData = Assert.IsType<DirectEdgeData>(directEdge.Data);
+        FanOutEdgeData fanOutData = Assert.IsType<FanOutEdgeData>(fanOutEdge.Data);
+
+        // Assert
+        Assert.Equal([source.Id], directEdge.Data.Connection.SourceIds);
+        Assert.Equal([directTarget.Id], directEdge.Data.Connection.SinkIds);
+        Assert.NotNull(directData.Condition);
+        Assert.True(directData.Condition!("direct"));
+        Assert.False(directData.Condition!("other"));
+
+        Assert.Equal(source.Id, fanOutData.SourceId);
+        Assert.Equal([fanOutTarget1.Id, fanOutTarget2.Id], fanOutData.SinkIds);
+        Assert.Equal([source.Id], fanOutEdge.Data.Connection.SourceIds);
+        Assert.Equal([fanOutTarget1.Id, fanOutTarget2.Id], fanOutEdge.Data.Connection.SinkIds);
+        Assert.NotNull(fanOutData.EdgeAssigner);
+        Assert.Equal([0, 1], fanOutData.EdgeAssigner!("fan-out", 2));
+
+        PropertyInfo edgesProperty = typeof(Workflow).GetProperty(nameof(Workflow.Edges))!;
+        Assert.True(edgesProperty.GetMethod!.IsPublic);
+        Assert.True(edgesProperty.SetMethod!.IsAssembly);
+        Assert.Equal(typeof(IReadOnlyDictionary<string, IReadOnlyCollection<Edge>>), edgesProperty.PropertyType);
+    }
+}


### PR DESCRIPTION
## Summary

- expose workflow routing metadata needed by external workflow inspection and tooling
- make Workflow.Edges, EdgeData.Connection, and FanOutEdgeData publicly accessible
- adapt internal consumers and add external-assembly API regression coverage

Fixes #7448

## Details

This change keeps the existing routing implementation and internal construction boundaries intact while exposing the requested read-only API surface:

- Workflow.Edges is exposed as an IReadOnlyDictionary<string, IReadOnlyCollection<Edge>> view.
- EdgeData.Connection and the concrete connection properties are public.
- FanOutEdgeData is public and sealed.
- Internal consumers are adapted to the read-only collection types; EdgeMap rebuilds its internal HashSet map at the existing boundary.
- The Workflow.Edges property is an interface view over live routing data, not a deep immutable snapshot.
- Added XML documentation and corrected the public partition spelling.

## Tests

- Workflows unit tests: 744 passed, 0 failed
- DurableTask unit tests: 150 passed, 0 failed
- Workflows Release multi-target build: net10.0, net9.0, net8.0, netstandard2.0, net472; 0 warnings, 0 errors
- Full net10.0 test run: 6680 passed, 51 skipped, 0 failed
- Full solution build: 0 warnings, 0 errors
- NuGet package validation passed
- dotnet format --verify-no-changes passed
- git diff --check passed

The new tests are in an external test assembly and fail to compile against the pre-change API, covering the intended public-API boundary.