### PR TITLE
.NET: Bound the tool-approval auto-approval loop (#7472)

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Agents.AI;
 /// first is returned to the caller while the rest are queued. On subsequent calls, queued items are re-evaluated
 /// against rules (which may have been updated by the caller's "always approve" response) and presented one at a time.
 /// Once all queued requests are resolved, the collected responses are injected and the inner agent is called again.
+/// This one-at-a-time behavior no longer applies once the auto-approval cap
+/// (<see cref="ToolApprovalAgentOptions.MaxAutoApprovalIterations"/>) is reached: the final inner turn is returned
+/// as-is, so more than one approval request may be surfaced to the caller at once.
 /// </item>
 /// <item>
 /// <b>Inbound (caller to agent):</b> When the caller sends an <see cref="AlwaysApproveToolApprovalResponseContent"/>,

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Agents.AI;
 public sealed class ToolApprovalAgent : DelegatingAIAgent
 {
     /// <summary>The default value used for <see cref="ToolApprovalAgentOptions.MaxAutoApprovalIterations"/> when none is specified.</summary>
-    public const int DefaultMaxAutoApprovalIterations = 10;
+    public const int DefaultMaxAutoApprovalIterations = 40;
 
     private readonly ProviderSessionState<ToolApprovalState> _sessionState;
     private readonly JsonSerializerOptions _jsonSerializerOptions;

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgent.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI;
 
@@ -47,9 +48,13 @@ namespace Microsoft.Agents.AI;
 /// </remarks>
 public sealed class ToolApprovalAgent : DelegatingAIAgent
 {
+    /// <summary>The default value used for <see cref="ToolApprovalAgentOptions.MaxAutoApprovalIterations"/> when none is specified.</summary>
+    public const int DefaultMaxAutoApprovalIterations = 10;
+
     private readonly ProviderSessionState<ToolApprovalState> _sessionState;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly Func<ToolAutoApprovalRuleContext, ValueTask<bool>>[]? _autoApprovalRules;
+    private readonly int _maxAutoApprovalIterations;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolApprovalAgent"/> class.
@@ -65,6 +70,8 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
     {
         this._jsonSerializerOptions = options?.JsonSerializerOptions ?? AgentJsonUtilities.DefaultOptions;
         this._autoApprovalRules = options?.AutoApprovalRules?.ToArray();
+        this._maxAutoApprovalIterations = Throw.IfLessThan(
+            options?.MaxAutoApprovalIterations ?? DefaultMaxAutoApprovalIterations, 1);
         this._sessionState = new ProviderSessionState<ToolApprovalState>(
             _ => new ToolApprovalState(),
             "toolApprovalState",
@@ -125,10 +132,24 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
         // 3. Call the inner agent in a loop. If the inner agent returns approval requests
         //    that are ALL auto-approved by standing rules, we immediately re-call with the
         //    collected approval responses injected. This avoids returning empty responses.
-        while (true)
+        //
+        //    The loop is bounded by _maxAutoApprovalIterations. Each pass is a fresh inner
+        //    invocation, so a per-request cap (FunctionInvokingChatClient.MaximumIterationsPerRequest)
+        //    restarts every time and cannot bound it; without a cap here a model that keeps
+        //    requesting an auto-approved tool bills indefinitely.
+        for (int iteration = 0; ; iteration++)
         {
             // Inject any collected approval responses as a user message ahead of the caller's messages.
             var processedMessages = this.InjectCollectedResponses(callerMessages, state, session);
+
+            if (iteration >= this._maxAutoApprovalIterations)
+            {
+                // Cap reached: take one final turn without auto-approving again, so any approval
+                // request it surfaces goes to the caller to decide rather than continuing the chain.
+                // Returning here without this call would hand back a response whose approval requests
+                // were already stripped — the empty response the loop exists to avoid.
+                return await this.InnerAgent.RunAsync(processedMessages, session, options, cancellationToken).ConfigureAwait(false);
+            }
 
             var response = await this.InnerAgent.RunAsync(processedMessages, session, options, cancellationToken).ConfigureAwait(false);
 
@@ -173,10 +194,25 @@ public sealed class ToolApprovalAgent : DelegatingAIAgent
         // 3. Stream from the inner agent in a loop. If all approval requests from the stream
         //    are auto-approved by standing rules, we immediately re-stream with the collected
         //    approval responses injected. This avoids returning empty streams.
-        while (true)
+        //
+        //    Bounded by _maxAutoApprovalIterations for the same reason as the non-streaming path:
+        //    every pass is a fresh inner invocation, so no per-request cap can bound it.
+        for (int iteration = 0; ; iteration++)
         {
             // Inject any collected approval responses as a user message ahead of the caller's messages.
             var processedMessages = this.InjectCollectedResponses(callerMessages, state, session);
+
+            if (iteration >= this._maxAutoApprovalIterations)
+            {
+                // Cap reached: take one final turn without auto-approving again. Updates are yielded
+                // as-is, so any approval request reaches the caller to decide instead of continuing.
+                await foreach (var update in this.InnerAgent.RunStreamingAsync(processedMessages, session, options, cancellationToken).ConfigureAwait(false))
+                {
+                    yield return update;
+                }
+
+                yield break;
+            }
 
             // Stream from the inner agent. Non-approval content is yielded immediately.
             // Approval requests are collected (not yielded) so we can classify the full batch.

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
@@ -56,8 +56,7 @@ public class ToolApprovalAgentOptions
     /// <para>
     /// Each re-invocation is a fresh call to the inner agent, so a per-request cap such as
     /// <c>FunctionInvokingChatClient.MaximumIterationsPerRequest</c> restarts every time and cannot bound this
-    /// loop. Without this cap a model that keeps requesting an auto-approved tool — for example a skill-loading
-    /// tool under <see cref="ToolApprovalAgent.AllToolsAutoApprovalRule"/> — drives an unbounded sequence of
+    /// loop. Without this cap a model that keeps requesting an auto-approved tool, drives an unbounded sequence of
     /// billable model calls.
     /// </para>
     /// <para>

--- a/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/ToolApproval/ToolApprovalAgentOptions.cs
@@ -46,4 +46,25 @@ public class ToolApprovalAgentOptions
     /// </para>
     /// </remarks>
     public IEnumerable<Func<ToolAutoApprovalRuleContext, ValueTask<bool>>>? AutoApprovalRules { get; set; }
+
+    /// <summary>
+    /// Gets or sets the safety cap on how many times the inner agent is re-invoked within a single run
+    /// because every surfaced approval request was auto-approved, or <see langword="null"/> to use
+    /// <see cref="ToolApprovalAgent.DefaultMaxAutoApprovalIterations"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each re-invocation is a fresh call to the inner agent, so a per-request cap such as
+    /// <c>FunctionInvokingChatClient.MaximumIterationsPerRequest</c> restarts every time and cannot bound this
+    /// loop. Without this cap a model that keeps requesting an auto-approved tool — for example a skill-loading
+    /// tool under <see cref="ToolApprovalAgent.AllToolsAutoApprovalRule"/> — drives an unbounded sequence of
+    /// billable model calls.
+    /// </para>
+    /// <para>
+    /// On reaching the cap the agent performs one final inner invocation without auto-approving again, so any
+    /// remaining approval request is surfaced to the caller to decide instead of being approved automatically.
+    /// Raise this value if you intend to allow longer auto-approval chains.
+    /// </para>
+    /// </remarks>
+    public int? MaxAutoApprovalIterations { get; set; }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
@@ -2529,8 +2529,10 @@ public class ToolApprovalAgentTests
     [InlineData(-1)]
     public void Constructor_MaxAutoApprovalIterationsBelowOne_Throws(int value)
     {
+        // Arrange
         var innerAgent = new Mock<AIAgent>().Object;
 
+        // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => new ToolApprovalAgent(innerAgent, new ToolApprovalAgentOptions
         {
             MaxAutoApprovalIterations = value,

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/ToolApproval/ToolApprovalAgentTests.cs
@@ -2392,4 +2392,150 @@ public class ToolApprovalAgentTests
     }
 
     #endregion
+
+    #region Auto-approval iteration cap
+
+    /// <summary>
+    /// Verify that a model which never stops requesting an auto-approved tool cannot drive an
+    /// unbounded number of inner invocations. Regression test for the runaway auto-approval loop
+    /// where every pass is a fresh inner call, so no per-request cap can bound it.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AutoApprovedToolRequestedForever_StopsAtIterationCapAsync()
+    {
+        // Arrange — the inner agent always asks for an auto-approved tool and never answers.
+        var session = new ChatClientAgentSession();
+        var callCount = 0;
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<Task<AgentResponse>>("RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return new AgentResponse([new ChatMessage(ChatRole.Assistant,
+                    [new ToolApprovalRequestContent($"req{callCount}", new FunctionCallContent($"call{callCount}", "load_skill"))])]);
+            });
+
+        var options = new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule],
+            MaxAutoApprovalIterations = 3,
+        };
+        var agent = new ToolApprovalAgent(innerAgent.Object, options);
+
+        // Act
+        var response = await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert — 3 auto-approving passes plus one final turn that does not auto-approve.
+        Assert.Equal(4, callCount);
+
+        // The final turn's approval request is surfaced to the caller instead of being auto-approved,
+        // so the caller regains control rather than receiving the stripped (empty) response.
+        Assert.NotEmpty(response.Messages.SelectMany(m => m.Contents).OfType<ToolApprovalRequestContent>());
+    }
+
+    /// <summary>
+    /// Verify the streaming path is bounded by the same cap as the non-streaming path.
+    /// </summary>
+    [Fact]
+    public async Task RunStreamingAsync_AutoApprovedToolRequestedForever_StopsAtIterationCapAsync()
+    {
+        // Arrange
+        var session = new ChatClientAgentSession();
+        var callCount = 0;
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() =>
+            {
+                callCount++;
+                return ToAsyncEnumerableAsync([
+                    new AgentResponseUpdate(ChatRole.Assistant,
+                        new List<AIContent> { new ToolApprovalRequestContent($"req{callCount}", new FunctionCallContent($"call{callCount}", "load_skill")) })
+                ]);
+            });
+
+        var options = new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule],
+            MaxAutoApprovalIterations = 3,
+        };
+        var agent = new ToolApprovalAgent(innerAgent.Object, options);
+
+        // Act
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in agent.RunStreamingAsync([new ChatMessage(ChatRole.User, "Hi")], session))
+        {
+            updates.Add(update);
+        }
+
+        // Assert — bounded the same way, and the final turn's request reaches the caller.
+        Assert.Equal(4, callCount);
+        Assert.NotEmpty(updates.SelectMany(u => u.Contents).OfType<ToolApprovalRequestContent>());
+    }
+
+    /// <summary>
+    /// Verify that the cap defaults to <see cref="ToolApprovalAgent.DefaultMaxAutoApprovalIterations"/>
+    /// when the caller does not configure one.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_NoCapConfigured_UsesDefaultMaxAutoApprovalIterationsAsync()
+    {
+        // Arrange
+        var session = new ChatClientAgentSession();
+        var callCount = 0;
+        var innerAgent = new Mock<AIAgent>();
+        innerAgent
+            .Protected()
+            .Setup<Task<AgentResponse>>("RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return new AgentResponse([new ChatMessage(ChatRole.Assistant,
+                    [new ToolApprovalRequestContent($"req{callCount}", new FunctionCallContent($"call{callCount}", "load_skill"))])]);
+            });
+
+        var agent = new ToolApprovalAgent(innerAgent.Object, new ToolApprovalAgentOptions
+        {
+            AutoApprovalRules = [ToolApprovalAgent.AllToolsAutoApprovalRule],
+        });
+
+        // Act
+        await agent.RunAsync([new ChatMessage(ChatRole.User, "Hi")], session);
+
+        // Assert
+        Assert.Equal(ToolApprovalAgent.DefaultMaxAutoApprovalIterations + 1, callCount);
+    }
+
+    /// <summary>
+    /// Verify that a cap below 1 is rejected, since it would leave no turn to run.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_MaxAutoApprovalIterationsBelowOne_Throws(int value)
+    {
+        var innerAgent = new Mock<AIAgent>().Object;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ToolApprovalAgent(innerAgent, new ToolApprovalAgentOptions
+        {
+            MaxAutoApprovalIterations = value,
+        }));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
### Motivation & Context

`ToolApprovalAgent` re-invokes the inner agent whenever **every** surfaced approval request was auto-approved, and it did so from two unbounded `while (true)` loops, one in `RunCoreAsync`, one in `RunCoreStreamingAsync`.

Each pass is a *fresh* `InnerAgent.RunAsync` / `RunStreamingAsync` call. A per-request cap such as `FunctionInvokingChatClient.MaximumIterationsPerRequest` therefore restarts on every pass and cannot bound the chain — nothing bounded it at all. Under `AgentSkillsProvider.AllToolsAutoApprovalRule` a model that keeps requesting an auto-approved tool drives billable model calls indefinitely. The reporter measured 100M+ tokens over three days before an Azure budget caught it.

**Note on scope.** #7472 was filed against the `Agent_Step06_McpBasedSkills` sample and asks for a stronger warning there. The sample is not the defect  the same `AllToolsAutoApprovalRule` pattern is used by `Agent_Step01_FileBasedSkills`, `Agent_Step07_SkillsAutoApproval` and `Hosted-AgentSkills`, and by any user code that wires that rule. A sample warning would leave the runaway reachable everywhere else, so this bounds the loop in the framework instead.

The Python implementation is not affected, and the contrast is what identified the fix: Python caps the equivalent flow at `DEFAULT_MAX_ITERATIONS` (40) *and* persists `attempt_count` in the budget state across approval resumes, so a resumed run continues the count instead of restarting it (`python/packages/core/agent_framework/_tools.py`). .NET started a clean request on every approval pass.

### Description & Review Guide

- **What are the major changes?**
  - New `ToolApprovalAgentOptions.MaxAutoApprovalIterations` (nullable), defaulting to the new `ToolApprovalAgent.DefaultMaxAutoApprovalIterations` (10).
  - Both auto-approval loops became bounded `for` loops.
  - Constructor validates with `Throw.IfLessThan(..., 1)`.
  - Naming, default value and validation deliberately mirror the existing `LoopAgent.DefaultMaxIterations` / `LoopAgentOptions.MaxIterations` pair in the same assembly, so there is one convention for loop safety caps rather than two.
  - Four tests reproduce the runaway on both the streaming and non-streaming paths, using an inner agent that never stops requesting an auto-approved tool. Inner invocations equal the cap plus the final turn and scale with the configured cap, so they fail if the bound is removed; before this change they would not terminate.

- **What is the impact of these changes?**
  - Additive and non-breaking: existing callers get a default bound of 10 auto-approval re-invocations, and anyone needing longer chains sets `MaxAutoApprovalIterations`.
  - No sample changes are required with the loop bounded, Step01, Step06, Step07 and `Hosted-AgentSkills` are safe as written.

- **What do you want reviewers to focus on?**

  The behaviour **at** the cap. Returning early is wrong: when every request is auto-approved, `ProcessAndQueueOutboundApprovalRequestsAsync` calls `RemoveAllToolApprovalRequests`, so the response has already had its approval requests stripped returning it hands the caller the empty response the loop exists to avoid.

  Instead, on reaching the cap the agent takes one final inner turn *without* auto-approving again, so any remaining approval request is surfaced for the caller to decide. That is the direct analogue of the Python behaviour when its budget is spent (log, then one final request with `tool_choice="none"`), and it degrades to a human decision rather than an exception or a silent truncation.

  Second, the default of 10 and the two new public members. The default matches `LoopAgent`, but a legitimate auto-approval chain longer than 10 would now need to opt in; if you prefer 40 for parity with Python's `DEFAULT_MAX_ITERATIONS`, that is a one-line change. And since CONTRIBUTING asks that new APIs be discussed first, I am happy to swap `MaxAutoApprovalIterations` for a hard-coded internal constant if you would rather not add public surface for this.

### Related Issue

Fixes #7472

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix)  a workflow keeps the label and title prefix in sync automatically.
