### PR TITLE
Python: Enhance _OutputItemTracker to prevent duplicate function call streaming

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -996,11 +996,7 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
-            if (
-                content.user_input_request
-                and content.arguments is None
-                and content.call_id in self._seen_function_call_ids
-            ):
+            if content.user_input_request and not content.arguments and content.call_id in self._seen_function_call_ids:
                 return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -967,7 +967,7 @@ class _OutputItemTracker:
         self._reasoning_encrypted_content: str | None = None
         self._fc_builder: OutputItemFunctionCallBuilder | None = None
         self._mcp_builder: OutputItemMcpCallBuilder | None = None
-        self._seen_function_call_ids: set[str] = set()
+        self._outstanding_function_calls: dict[str, str | None] = {}
         self.needs_async = False
 
     def handle(self, content: Content) -> Generator[ResponseStreamEvent]:
@@ -996,7 +996,14 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
-            if content.user_input_request and not content.arguments and content.call_id in self._seen_function_call_ids:
+            # Declaration-only calls replay request metadata after the streamed call. Scope suppression to the
+            # outstanding occurrence because a call_id may be reused after its terminal result.
+            if (
+                content.user_input_request
+                and content.arguments is None
+                and content.call_id in self._outstanding_function_calls
+                and self._outstanding_function_calls[content.call_id] == content.name
+            ):
                 return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()
@@ -1005,6 +1012,12 @@ class _OutputItemTracker:
             self._accumulated.append(args_str)
             if self._fc_builder is not None:
                 yield self._fc_builder.emit_arguments_delta(args_str)
+
+        elif content.type == "function_result":
+            yield from self._close()
+            if content.call_id is not None:
+                self._outstanding_function_calls.pop(content.call_id, None)
+            self.needs_async = True
 
         elif content.type == "mcp_server_tool_call" and content.tool_name:
             key = content.call_id or f"{content.server_name or 'default'}::{content.tool_name}"
@@ -1083,7 +1096,7 @@ class _OutputItemTracker:
         )
         self._active_type = "function_call"
         self._active_id = content.call_id
-        self._seen_function_call_ids.add(content.call_id or "")
+        self._outstanding_function_calls[content.call_id or ""] = content.name
         yield self._fc_builder.emit_added()
 
     def _open_mcp_call(self, content: Content) -> Generator[ResponseStreamEvent]:

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -702,11 +702,7 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
-            if (
-                content.user_input_request
-                and content.arguments is None
-                and content.call_id in self._seen_function_call_ids
-            ):
+            if content.user_input_request and not content.arguments and content.call_id in self._seen_function_call_ids:
                 return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -673,7 +673,7 @@ class _OutputItemTracker:
         self._reasoning_encrypted_content: str | None = None
         self._fc_builder: OutputItemFunctionCallBuilder | None = None
         self._mcp_builder: OutputItemMcpCallBuilder | None = None
-        self._seen_function_call_ids: set[str] = set()
+        self._outstanding_function_calls: dict[str, str | None] = {}
         self.needs_async = False
 
     def handle(self, content: Content) -> Generator[ResponseStreamEvent]:
@@ -702,7 +702,14 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
-            if content.user_input_request and not content.arguments and content.call_id in self._seen_function_call_ids:
+            # Declaration-only calls replay request metadata after the streamed call. Scope suppression to the
+            # outstanding occurrence because a call_id may be reused after its terminal result.
+            if (
+                content.user_input_request
+                and content.arguments is None
+                and content.call_id in self._outstanding_function_calls
+                and self._outstanding_function_calls[content.call_id] == content.name
+            ):
                 return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()
@@ -711,6 +718,12 @@ class _OutputItemTracker:
             self._accumulated.append(args_str)
             if self._fc_builder is not None:
                 yield self._fc_builder.emit_arguments_delta(args_str)
+
+        elif content.type == "function_result":
+            yield from self._close()
+            if content.call_id is not None:
+                self._outstanding_function_calls.pop(content.call_id, None)
+            self.needs_async = True
 
         elif content.type == "mcp_server_tool_call" and content.tool_name:
             key = content.call_id or f"{content.server_name or 'default'}::{content.tool_name}"
@@ -789,7 +802,7 @@ class _OutputItemTracker:
         )
         self._active_type = "function_call"
         self._active_id = content.call_id
-        self._seen_function_call_ids.add(content.call_id or "")
+        self._outstanding_function_calls[content.call_id or ""] = content.name
         yield self._fc_builder.emit_added()
 
     def _open_mcp_call(self, content: Content) -> Generator[ResponseStreamEvent]:

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -967,6 +967,7 @@ class _OutputItemTracker:
         self._reasoning_encrypted_content: str | None = None
         self._fc_builder: OutputItemFunctionCallBuilder | None = None
         self._mcp_builder: OutputItemMcpCallBuilder | None = None
+        self._seen_function_call_ids: set[str] = set()
         self.needs_async = False
 
     def handle(self, content: Content) -> Generator[ResponseStreamEvent]:
@@ -995,6 +996,12 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
+            if (
+                content.user_input_request
+                and content.arguments is None
+                and content.call_id in self._seen_function_call_ids
+            ):
+                return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()
                 yield from self._open_function_call(content)
@@ -1080,6 +1087,7 @@ class _OutputItemTracker:
         )
         self._active_type = "function_call"
         self._active_id = content.call_id
+        self._seen_function_call_ids.add(content.call_id or "")
         yield self._fc_builder.emit_added()
 
     def _open_mcp_call(self, content: Content) -> Generator[ResponseStreamEvent]:

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -673,6 +673,7 @@ class _OutputItemTracker:
         self._reasoning_encrypted_content: str | None = None
         self._fc_builder: OutputItemFunctionCallBuilder | None = None
         self._mcp_builder: OutputItemMcpCallBuilder | None = None
+        self._seen_function_call_ids: set[str] = set()
         self.needs_async = False
 
     def handle(self, content: Content) -> Generator[ResponseStreamEvent]:
@@ -701,6 +702,12 @@ class _OutputItemTracker:
                     yield self._summary_part.emit_text_delta(content.text)
 
         elif content.type == "function_call" and content.call_id is not None:
+            if (
+                content.user_input_request
+                and content.arguments is None
+                and content.call_id in self._seen_function_call_ids
+            ):
+                return
             if self._active_type != "function_call" or self._active_id != content.call_id:
                 yield from self._close()
                 yield from self._open_function_call(content)
@@ -786,6 +793,7 @@ class _OutputItemTracker:
         )
         self._active_type = "function_call"
         self._active_id = content.call_id
+        self._seen_function_call_ids.add(content.call_id or "")
         yield self._fc_builder.emit_added()
 
     def _open_mcp_call(self, content: Content) -> Generator[ResponseStreamEvent]:

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1068,8 +1068,11 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
-    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(self) -> None:
-        metadata = Content.from_function_call("call_1", "search", arguments=None)
+    @pytest.mark.parametrize("arguments", [None, ""])
+    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(
+        self, arguments: str | None
+    ) -> None:
+        metadata = Content.from_function_call("call_1", "search", arguments=arguments)
         metadata.id = "call_1"
         metadata.user_input_request = True
         agent = _make_agent(

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1265,6 +1265,34 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
+    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(self) -> None:
+        metadata = Content.from_function_call("call_1", "search", arguments=None)
+        metadata.id = "call_1"
+        metadata.user_input_request = True
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_function_call("call_1", "search", arguments='{"q": "hello"}')],
+                    role="assistant",
+                ),
+                AgentResponseUpdate(contents=[Content.from_text("Waiting for the result")], role="assistant"),
+                AgentResponseUpdate(contents=[metadata], role="assistant"),
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, stream=True)
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+        function_items = [
+            event
+            for event in events
+            if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
+        ]
+        assert len(function_items) == 1
+        assert function_items[0]["data"]["item"]["call_id"] == "call_1"
+
     async def test_function_call_streaming_serializes_dataclass_arguments(self) -> None:
         @dataclass
         class HandoffLikeRequest:

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1068,6 +1068,34 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
+    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(self) -> None:
+        metadata = Content.from_function_call("call_1", "search", arguments=None)
+        metadata.id = "call_1"
+        metadata.user_input_request = True
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_function_call("call_1", "search", arguments='{"q": "hello"}')],
+                    role="assistant",
+                ),
+                AgentResponseUpdate(contents=[Content.from_text("Waiting for the result")], role="assistant"),
+                AgentResponseUpdate(contents=[metadata], role="assistant"),
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, stream=True)
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+        function_items = [
+            event
+            for event in events
+            if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
+        ]
+        assert len(function_items) == 1
+        assert function_items[0]["data"]["item"]["call_id"] == "call_1"
+
     async def test_function_call_streaming_serializes_dataclass_arguments(self) -> None:
         @dataclass
         class HandoffLikeRequest:

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1265,9 +1265,9 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
-    @pytest.mark.parametrize("arguments", [None, ""])
-    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(
-        self, arguments: str | None
+    @pytest.mark.parametrize(("arguments", "expected_count"), [(None, 1), ("", 2)])
+    async def test_declaration_only_metadata_replay_requires_none_arguments(
+        self, arguments: str | None, expected_count: int
     ) -> None:
         metadata = Content.from_function_call("call_1", "search", arguments=arguments)
         metadata.id = "call_1"
@@ -1293,8 +1293,37 @@ class TestStreaming:
             for event in events
             if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
         ]
-        assert len(function_items) == 1
-        assert function_items[0]["data"]["item"]["call_id"] == "call_1"
+        assert len(function_items) == expected_count
+
+    async def test_function_call_id_can_be_reused_after_terminal_result(self) -> None:
+        reused_call = Content.from_function_call("call_1", "search", arguments=None)
+        reused_call.id = "call_1"
+        reused_call.user_input_request = True
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_function_call("call_1", "search", arguments='{"q": "first"}')],
+                    role="assistant",
+                ),
+                AgentResponseUpdate(
+                    contents=[Content.from_function_result("call_1", result="first result")],
+                    role="tool",
+                ),
+                AgentResponseUpdate(contents=[reused_call], role="assistant"),
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, stream=True)
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+        function_items = [
+            event
+            for event in events
+            if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
+        ]
+        assert [event["data"]["item"]["call_id"] for event in function_items] == ["call_1", "call_1"]
 
     async def test_function_call_streaming_serializes_dataclass_arguments(self) -> None:
         @dataclass

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1265,8 +1265,11 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
-    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(self) -> None:
-        metadata = Content.from_function_call("call_1", "search", arguments=None)
+    @pytest.mark.parametrize("arguments", [None, ""])
+    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(
+        self, arguments: str | None
+    ) -> None:
+        metadata = Content.from_function_call("call_1", "search", arguments=arguments)
         metadata.id = "call_1"
         metadata.user_input_request = True
         agent = _make_agent(

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1068,9 +1068,9 @@ class TestStreaming:
         assert len(args_done) == 1
         assert args_done[0]["data"]["arguments"] == '{"q": "hello"}'
 
-    @pytest.mark.parametrize("arguments", [None, ""])
-    async def test_declaration_only_metadata_does_not_duplicate_streamed_function_call(
-        self, arguments: str | None
+    @pytest.mark.parametrize(("arguments", "expected_count"), [(None, 1), ("", 2)])
+    async def test_declaration_only_metadata_replay_requires_none_arguments(
+        self, arguments: str | None, expected_count: int
     ) -> None:
         metadata = Content.from_function_call("call_1", "search", arguments=arguments)
         metadata.id = "call_1"
@@ -1096,8 +1096,37 @@ class TestStreaming:
             for event in events
             if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
         ]
-        assert len(function_items) == 1
-        assert function_items[0]["data"]["item"]["call_id"] == "call_1"
+        assert len(function_items) == expected_count
+
+    async def test_function_call_id_can_be_reused_after_terminal_result(self) -> None:
+        reused_call = Content.from_function_call("call_1", "search", arguments=None)
+        reused_call.id = "call_1"
+        reused_call.user_input_request = True
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_function_call("call_1", "search", arguments='{"q": "first"}')],
+                    role="assistant",
+                ),
+                AgentResponseUpdate(
+                    contents=[Content.from_function_result("call_1", result="first result")],
+                    role="tool",
+                ),
+                AgentResponseUpdate(contents=[reused_call], role="assistant"),
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, stream=True)
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+        function_items = [
+            event
+            for event in events
+            if event["event"] == "response.output_item.added" and event["data"]["item"]["type"] == "function_call"
+        ]
+        assert [event["data"]["item"]["call_id"] for event in function_items] == ["call_1", "call_1"]
 
     async def test_function_call_streaming_serializes_dataclass_arguments(self) -> None:
         @dataclass


### PR DESCRIPTION
### Motivation & Context

Fixes bug where function call was duplicated when streaming response from declaration-only tool,

### Description & Review Guide

When the agent invokes the declaration-only tool, there is a second function call emitted containing just metadata. Both of these tools were being streamed to the user.

### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #7485

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
