### PR TITLE
Python: surface Gemini thought summaries as reasoning content

### DIFF
--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -78,8 +78,8 @@ class ThinkingConfig(TypedDict, total=False):
     Attributes:
         include_thoughts: Whether to include thought summaries in the response. Thought summaries
             are condensed representations of the model's internal reasoning and appear as response
-            parts where ``part.thought`` is ``True``. Note: the framework currently excludes
-            thought parts from ``ChatResponse.contents`` and does not surface them as output.
+            parts where ``part.thought`` is ``True``. When set, the framework surfaces these parts
+            as ``text_reasoning`` content in ``ChatResponse.contents``.
         thinking_budget: Token budget for Gemini 2.5 models. Set to ``0`` to disable
             thinking or ``-1`` to enable a dynamic budget.
         thinking_level: Thinking level for Gemini 2.5 models and later. One of
@@ -1120,17 +1120,20 @@ class RawGeminiChatClient(
         )
 
     def _parse_parts(self, parts: Sequence[types.Part]) -> list[Content]:
-        """Convert Gemini response parts to framework Content objects, skipping thought/reasoning parts.
+        """Convert Gemini response parts to framework Content objects.
 
         Args:
             parts: Sequence of ``types.Part`` objects from a Gemini response candidate.
 
         Returns:
-            A list of framework ``Content`` objects (text, function_call, or function_result).
+            A list of framework ``Content`` objects (text_reasoning, text, function_call, or
+            function_result).
         """
         contents: list[Content] = []
         for part in parts:
             if part.thought:
+                if part.text:
+                    contents.append(Content.from_text_reasoning(text=part.text, raw_representation=part))
                 continue
             if part.text is not None:
                 contents.append(Content.from_text(text=part.text, raw_representation=part))

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -714,8 +714,8 @@ async def test_non_function_result_content_in_tool_message_is_skipped() -> None:
 # thinking parts
 
 
-async def test_thinking_parts_are_silently_skipped() -> None:
-    """Excludes thought-summary parts from ChatResponse.contents, returning only the final answer."""
+async def test_thinking_parts_are_surfaced_as_reasoning() -> None:
+    """Surfaces thought-summary parts as text_reasoning content alongside the final answer."""
     client, mock = _make_gemini_client()
     mock.aio.models.generate_content = AsyncMock(
         return_value=_make_response([
@@ -728,8 +728,26 @@ async def test_thinking_parts_are_silently_skipped() -> None:
         messages=[Message(role="user", contents=[Content.from_text("What is the answer?")])]
     )
 
-    assert len(response.messages[0].contents) == 1
+    contents = response.messages[0].contents
+    assert len(contents) == 2
+    assert contents[0].type == "text_reasoning"
+    assert contents[0].text == "I should think first..."
+    assert contents[1].type == "text"
     assert response.messages[0].text == "The answer is 42."
+
+
+async def test_empty_thinking_part_produces_no_reasoning_content() -> None:
+    """A thought part with no text yields no content rather than empty reasoning."""
+    client, _ = _make_gemini_client()
+
+    contents = client._parse_parts([
+        _make_part(text=None, thought=True),
+        _make_part(text="The answer is 42."),
+    ])
+
+    assert len(contents) == 1
+    assert contents[0].type == "text"
+    assert contents[0].text == "The answer is 42."
 
 
 def test_function_call_part_preserves_thought_signature_from_raw_part() -> None:


### PR DESCRIPTION
### Motivation & Context

`GeminiChatClient` never surfaced a Gemini model's reasoning. When
`thinking_config.include_thoughts` is set, Gemini returns **thought summaries**
(condensed traces of its internal reasoning) as response parts with
`part.thought = True`, but `_parse_parts` skipped every thought part. As a
result the reasoning never reached `ChatResponse.contents`, and downstream
consumers (AG-UI/CopilotKit, "thinking" UIs) showed nothing even when the caller
opted in via `include_thoughts`.

This also made behaviour inconsistent across providers: `OpenAIResponsesClient`
already surfaces reasoning as `Content.from_text_reasoning(...)`.

### Description & Review Guide

- **What are the major changes?**
  - `_parse_parts` now emits thought-summary parts as `text_reasoning` content
    (`Content.from_text_reasoning(text=..., raw_representation=part)`) instead of
    dropping them. A thought part with no text still produces no content.
  - Updated the `ThinkingConfig.include_thoughts` docstring to reflect that
    summaries are surfaced as `text_reasoning`.
  - Replaced `test_thinking_parts_are_silently_skipped` with
    `test_thinking_parts_are_surfaced_as_reasoning`, and added
    `test_empty_thinking_part_produces_no_reasoning_content`.

- **What is the impact of these changes?**
  - Gemini reasoning is now visible to downstream consumers, matching
    `OpenAIResponsesClient`. The change is round-trip safe: `_convert_message_contents`
    never re-emits reasoning text as a Part, so nothing is sent back to Gemini on
    replay. Thought parts are only returned when the caller sets
    `include_thoughts`, so default behaviour is unchanged.

- **What do you want reviewers to focus on?**
  - That the round-trip remains safe and that the existing Gemini 3
    `thought_signature`-as-reasoning path (on function-call parts) is unaffected.

### Related Issue

Fixes #7225

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
