### PR TITLE
.NET: Add CodeQL suppression for DevUI proxy validation

### DIFF
--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
@@ -725,7 +725,7 @@ internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
             ? HttpCompletionOption.ResponseHeadersRead
             : HttpCompletionOption.ResponseContentRead;
 
-        using var response = await client.SendAsync(
+        using var response = await client.SendAsync( // CodeQL [SM03781] False positive: ValidateProxyTarget confirms the target host, scheme, and port match the configured backend, so the user-supplied path and query cannot change the destination.
             request, completionOption, context.RequestAborted).ConfigureAwait(false);
 
         if (streaming && response.Content.Headers.ContentType?.MediaType == "text/event-stream")


### PR DESCRIPTION
Adds an inline CodeQL suppression comment for the DevUI aggregator proxy. The proxy target is already validated by `ValidateProxyTarget` which ensures requests cannot leave the configured backend (host, scheme, and port are verified). The suppression documents this justification following the repo's established pattern.