### PR TITLE
Python: feat(ollama): Add retry logic for transient errors in OllamaChatClient

### DIFF
--- a/python/packages/ollama/agent_framework_ollama/_chat_client.py
+++ b/python/packages/ollama/agent_framework_ollama/_chat_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import random
 import sys
 import uuid
 from collections.abc import (
@@ -16,6 +18,7 @@ from collections.abc import (
 from itertools import chain
 from typing import Any, ClassVar, Generic, TypedDict
 
+import httpx
 from agent_framework import (
     BaseChatClient,
     ChatAndFunctionMiddlewareTypes,
@@ -44,6 +47,7 @@ from ollama import AsyncClient
 # Rename imported types to avoid naming conflicts with Agent Framework types
 from ollama._types import ChatResponse as OllamaChatResponse
 from ollama._types import Message as OllamaMessage
+from ollama._types import ResponseError
 from pydantic import BaseModel
 
 from ._feature_usage import FeatureIndex
@@ -310,6 +314,7 @@ class OllamaChatClient(
         function_invocation_configuration: FunctionInvocationConfiguration | None = None,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
+        max_retries: int = 2,
     ) -> None:
         """Initialize an Ollama Chat client.
 
@@ -339,6 +344,7 @@ class OllamaChatClient(
         self.client = client or AsyncClient(host=ollama_settings.get("host"))
         # Save Host URL for serialization with to_dict()
         self.host = str(self.client._client.base_url)  # type: ignore[reportUnknownMemberType,reportPrivateUsage,reportUnknownArgumentType]
+        self.max_retries = max_retries
 
         super().__init__(
             additional_properties=additional_properties,
@@ -359,20 +365,42 @@ class OllamaChatClient(
         if stream:
             # Streaming mode
             async def _stream() -> AsyncIterable[ChatResponseUpdate]:
+                """
+                Streaming response handler.
+                If a stream starts successfully but fails mid-stream (i.e., tokens have
+                already been yielded), it will NOT be retried. Retrying mid-stream would
+                re-emit a divergent token sequence to the consumer.
+                """
                 validated_options = await self._validate_options(options)
                 options_dict = self._prepare_options(messages, validated_options)
                 mark_feature_used(FeatureIndex.OLLAMA)
-                try:
-                    response_object: AsyncIterable[OllamaChatResponse] = await self.client.chat(  # type: ignore[misc]
-                        stream=True,
-                        **options_dict,
-                        **kwargs,
-                    )
-                except Exception as ex:
-                    raise ChatClientException(f"Ollama streaming chat request failed : {ex}", ex) from ex
 
-                async for part in response_object:
-                    yield self._parse_streaming_response_from_ollama(part)
+                for attempt in range(self.max_retries + 1):
+                    first_chunk_received = False
+                    try:
+                        response_object: AsyncIterable[OllamaChatResponse] = await self.client.chat(  # type: ignore[misc]
+                            stream=True, **options_dict, **kwargs
+                        )
+                        async for part in response_object:
+                            first_chunk_received = True
+                            yield self._parse_streaming_response_from_ollama(part)
+                        return
+
+                    except Exception as ex:
+                        if first_chunk_received:
+                            raise ChatClientException(
+                                f"Ollama streaming chat request failed mid-stream: {ex}", ex
+                            ) from ex
+
+                        if attempt == self.max_retries or not self._is_transient_error(ex):
+                            raise ChatClientException(f"Ollama streaming chat request failed: {ex}", ex) from ex
+
+                        backoff = self._get_retry_delay(attempt, ex)
+                        logger.warning(
+                            f"Transient error before streaming. Retrying in {backoff:.2f}s "
+                            f"({attempt + 1}/{self.max_retries}). Error: {ex}"
+                        )
+                        await asyncio.sleep(backoff)
 
             return self._build_response_stream(_stream(), response_format=options.get("response_format"))
 
@@ -381,19 +409,25 @@ class OllamaChatClient(
             validated_options = await self._validate_options(options)
             options_dict = self._prepare_options(messages, validated_options)
             mark_feature_used(FeatureIndex.OLLAMA)
-            try:
-                response: OllamaChatResponse = await self.client.chat(  # type: ignore[misc]
-                    stream=False,
-                    **options_dict,
-                    **kwargs,
-                )
-            except Exception as ex:
-                raise ChatClientException(f"Ollama chat request failed : {ex}", ex) from ex
 
-            return self._parse_response_from_ollama(
-                response,
-                response_format=validated_options.get("response_format"),
-            )
+            for attempt in range(self.max_retries + 1):
+                try:
+                    response: OllamaChatResponse = await self.client.chat(  # type: ignore[misc]
+                        stream=False, **options_dict, **kwargs
+                    )
+                    return self._parse_response_from_ollama(
+                        response,
+                        response_format=validated_options.get("response_format"),
+                    )
+                except Exception as ex:
+                    if attempt == self.max_retries or not self._is_transient_error(ex):
+                        raise ChatClientException(f"Ollama chat request failed: {ex}", ex) from ex
+
+                    backoff = self._get_retry_delay(attempt, ex)
+                    logger.warning(
+                        f"Transient error. Retrying in {backoff:.2f}s ({attempt + 1}/{self.max_retries}). Error: {ex}"
+                    )
+                    await asyncio.sleep(backoff)
 
         return _get_response()
 
@@ -648,3 +682,51 @@ class OllamaChatClient(
                 # Pass through all other tools unchanged
                 chat_tools.append(tool)
         return chat_tools
+
+    def _is_transient_error(self, ex: Exception) -> bool:
+        """Determine if an exception is a transient error that should be retried."""
+        if isinstance(ex, ResponseError):
+            status_code = getattr(ex, "status_code", None)
+            if status_code is not None:
+                if status_code >= 500 or status_code in (408, 409, 429):
+                    return True
+
+        if isinstance(
+            ex,
+            (
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.PoolTimeout,
+                httpx.TimeoutException,
+                httpx.NetworkError,
+                httpx.ReadError,
+                httpx.WriteError,
+                httpx.RemoteProtocolError,
+            ),
+        ):
+            return True
+
+        ex_str = str(ex).lower()
+        if "goaway" in ex_str or "connection reset" in ex_str or "eof occurred" in ex_str:
+            return True
+
+        return False
+
+    def _get_retry_delay(self, attempt: int, ex: Exception) -> float:
+        """Calculate retry delay. Respects Retry-After header if present, else uses exponential backoff."""
+        if isinstance(ex, ResponseError):
+            response = getattr(ex, "response", None)
+            if response is not None and hasattr(response, "headers"):
+                retry_after = response.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        return float(retry_after)
+                    except ValueError:
+                        pass
+
+        base_delay = 0.5
+        max_delay = 10.0
+        backoff = min(base_delay * (2**attempt) + random.uniform(0, 0.5), max_delay)
+        return backoff

--- a/python/packages/ollama/tests/test_ollama_chat_client.py
+++ b/python/packages/ollama/tests/test_ollama_chat_client.py
@@ -20,6 +20,7 @@ from agent_framework.exceptions import ChatClientException, ChatClientInvalidReq
 from ollama import AsyncClient
 from ollama._types import ChatResponse as OllamaChatResponse
 from ollama._types import Message as OllamaMessage
+from ollama._types import ResponseError
 from openai import AsyncStream
 from pydantic import BaseModel
 from pytest import fixture
@@ -810,3 +811,200 @@ class TestParallelToolCallUniqueness:
         assert formatted[0].tool_name == "search:advanced", (
             f"Expected bare name 'search:advanced', got '{formatted[0].tool_name}'"
         )
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_retries_transient_5xx_errors(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+    mock_chat_completion_response: OllamaChatResponse,
+) -> None:
+    """Transient 5xx errors should be retried up to max_retries."""
+    error = ResponseError("Bad Gateway", 502)
+    mock_chat.side_effect = [error, mock_chat_completion_response]
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+    result = await ollama_client.get_response(messages=chat_history)
+
+    assert result.text == "test"
+    assert mock_chat.await_count == 2
+    assert mock_sleep.await_count == 1
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_does_not_retry_4xx_errors(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+) -> None:
+    """Non-transient 4xx errors (like 400 Bad Request) should fail immediately."""
+    error = ResponseError("Bad Request", 400)
+    mock_chat.side_effect = error
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+
+    with pytest.raises(ChatClientException) as exc_info:
+        await ollama_client.get_response(messages=chat_history)
+
+    assert "Ollama chat request failed" in str(exc_info.value)
+    assert mock_chat.await_count == 1
+    assert mock_sleep.await_count == 0
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_streaming_does_not_retry_mid_stream_errors(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+) -> None:
+    """If a stream starts successfully but fails mid-stream, it should NOT be retried."""
+
+    async def failing_stream():
+        yield OllamaChatResponse(message=OllamaMessage(content="hello", role="assistant"), model="test")
+        raise ResponseError("Server crashed mid-stream", 502)
+
+    mock_chat.return_value = failing_stream()
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+
+    with pytest.raises(ChatClientException) as exc_info:
+        async for _ in ollama_client.get_response(messages=chat_history, stream=True):
+            pass
+
+    assert "mid-stream" in str(exc_info.value).lower()
+    assert mock_chat.await_count == 1
+    assert mock_sleep.await_count == 0
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_retries_httpx_connect_error(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+    mock_chat_completion_response: OllamaChatResponse,
+) -> None:
+    """httpx connection errors should be retried."""
+    import httpx
+
+    error = httpx.ConnectError("Connection refused")
+    mock_chat.side_effect = [error, mock_chat_completion_response]
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+    result = await ollama_client.get_response(messages=chat_history)
+
+    assert result.text == "test"
+    assert mock_chat.await_count == 2
+    assert mock_sleep.await_count == 1
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_retries_goaway_string_error(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+    mock_chat_completion_response: OllamaChatResponse,
+) -> None:
+    """Transport-level GOAWAY string errors should be retried."""
+    error = Exception("http2: server sent GOAWAY and closed the connection")
+    mock_chat.side_effect = [error, mock_chat_completion_response]
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+    result = await ollama_client.get_response(messages=chat_history)
+
+    assert result.text == "test"
+    assert mock_chat.await_count == 2
+    assert mock_sleep.await_count == 1
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_max_retries_zero(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+) -> None:
+    """max_retries=0 should fail immediately without retrying."""
+    error = ResponseError("Bad Gateway", 502)
+    mock_chat.side_effect = error
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=0)
+
+    with pytest.raises(ChatClientException):
+        await ollama_client.get_response(messages=chat_history)
+
+    assert mock_chat.await_count == 1
+    assert mock_sleep.await_count == 0
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_all_retries_exhausted(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+) -> None:
+    """If all retries are exhausted, the final error should be wrapped in ChatClientException."""
+    error = ResponseError("Service Unavailable", 503)
+    mock_chat.side_effect = error
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+
+    with pytest.raises(ChatClientException) as exc_info:
+        await ollama_client.get_response(messages=chat_history)
+
+    assert "Ollama chat request failed" in str(exc_info.value)
+    assert mock_chat.await_count == 3
+    assert mock_sleep.await_count == 2
+
+
+@patch("agent_framework_ollama._chat_client.asyncio.sleep", new_callable=AsyncMock)
+@patch.object(AsyncClient, "chat", new_callable=AsyncMock)
+async def test_cmc_streaming_retries_pre_stream_success(
+    mock_chat: AsyncMock,
+    mock_sleep: AsyncMock,
+    ollama_unit_test_env: dict[str, str],
+    chat_history: list[Message],
+    mock_chat_completion_response: OllamaChatResponse,
+) -> None:
+    """If a stream fails pre-stream but succeeds on retry, output should be yielded correctly."""
+
+    async def successful_stream():
+        yield OllamaChatResponse(message=OllamaMessage(content="hello", role="assistant"), model="test")
+
+    error = ResponseError("Bad Gateway", 502)
+    mock_chat.side_effect = [error, successful_stream()]
+    chat_history.append(Message(contents=["hello world"], role="user"))
+
+    ollama_client = OllamaChatClient(max_retries=2)
+
+    chunks = []
+    async for update in ollama_client.get_response(messages=chat_history, stream=True):
+        chunks.append(update)
+
+    assert len(chunks) > 0
+    assert chunks[0].text == "hello"
+    assert mock_chat.await_count == 2
+    assert mock_sleep.await_count == 1
+
+
+# endregion


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

1. **Why is this change required?** `OllamaChatClient` had no built-in retry mechanism for transient provider failures, creating a parity gap with `OpenAIChatClient` (which relies on the OpenAI SDK's built-in retries). A single transient error (HTTP 429, 5xx, connection reset) would abort the entire run.
2. **What problem does it solve?** It prevents full agent run failures due to momentary network blips or Ollama backend rate limits. 
3. **What scenario does it contribute to?** Swapping providers from OpenAI to Ollama now silently maintains the same resilience safety net out-of-the-box, without requiring developers to write custom middleware.
4. **Related Issue:** Resolves #6942.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
  - Added a `max_retries: int = 2` parameter to `OllamaChatClient.__init__` (matching the OpenAI SDK default).
  - Wrapped both streaming (`_stream`) and non-streaming (`_get_response`) request paths in a retry loop (`for attempt in range(self.max_retries + 1)`).
  - Added `_is_transient_error` helper using `isinstance` checks for `ollama._types.ResponseError` (retrying 429, ≥500, 408, 409) and `httpx` network exceptions, along with string fallbacks for transport-level HTTP/2 GOAWAY errors.
  - Added `_get_retry_delay` helper to parse `Retry-After` headers if present, falling back to OpenAI-like exponential backoff (base 0.5s) with jitter.
  - Added 8 new unit tests covering: 5xx retry success, 4xx no-retry, httpx errors, GOAWAY string errors, `max_retries=0`, exhausted retries, and pre-stream streaming retries.

- **What is the impact of these changes?** 
  Transient errors occurring *before* the first token is emitted will now be safely retried. This increases reliability for Ollama users without changing the API surface.

- **What do you want reviewers to focus on?**
  Please focus on the **mid-stream invariant**. As noted in the issue, retrying a stream *after* tokens have already been yielded would re-emit a divergent token sequence. The `first_chunk_received` flag enforces that mid-stream errors raise immediately rather than retrying.

### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Closes #6942

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.