### PR TITLE
Python: Persist Foundry hosted agent session IDs

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -138,6 +138,16 @@ def _uses_foundry_agent_session(conversation_id: Any) -> bool:
     )
 
 
+def _get_foundry_agent_session_id(response: Any) -> str | None:
+    """Return a hosted agent session id from a Foundry response payload."""
+    agent_session_id = getattr(response, "agent_session_id", None)
+    if isinstance(agent_session_id, str) and agent_session_id:
+        return agent_session_id
+
+    session_id = getattr(getattr(response, "session", None), "id", None)
+    return session_id if isinstance(session_id, str) and session_id else None
+
+
 def _build_agent_reference(agent_name: str, agent_version: str | None) -> dict[str, str]:
     """Build the Responses API ``agent_reference`` payload for non-preview Foundry agent calls.
 
@@ -428,6 +438,8 @@ class RawFoundryAgentChatClient(
         parsed_response = super()._parse_response_from_openai(response, options)
         if _uses_foundry_agent_session(options.get("conversation_id")):
             parsed_response.conversation_id = None
+        elif agent_session_id := _get_foundry_agent_session_id(response):
+            parsed_response.conversation_id = agent_session_id
         return parsed_response
 
     @override
@@ -449,6 +461,8 @@ class RawFoundryAgentChatClient(
             )
         if _uses_foundry_agent_session(options.get("conversation_id")):
             update.conversation_id = None
+        elif agent_session_id := _get_foundry_agent_session_id(getattr(event, "response", None)):
+            update.conversation_id = agent_session_id
         return update
 
     @override

--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -144,7 +144,11 @@ def _get_foundry_agent_session_id(response: Any) -> str | None:
     if isinstance(agent_session_id, str) and agent_session_id:
         return agent_session_id
 
-    session_id = getattr(getattr(response, "session", None), "id", None)
+    session = getattr(response, "session", None)
+    if isinstance(session, Mapping):
+        session_id = cast(Mapping[str, Any], session).get("id")
+    else:
+        session_id = getattr(session, "id", None)
     return session_id if isinstance(session_id, str) and session_id else None
 
 

--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -438,7 +438,7 @@ class RawFoundryAgentChatClient(
         parsed_response = super()._parse_response_from_openai(response, options)
         if _uses_foundry_agent_session(options.get("conversation_id")):
             parsed_response.conversation_id = None
-        elif agent_session_id := _get_foundry_agent_session_id(response):
+        elif options.get("store") is not False and (agent_session_id := _get_foundry_agent_session_id(response)):
             parsed_response.conversation_id = agent_session_id
         return parsed_response
 
@@ -461,7 +461,9 @@ class RawFoundryAgentChatClient(
             )
         if _uses_foundry_agent_session(options.get("conversation_id")):
             update.conversation_id = None
-        elif agent_session_id := _get_foundry_agent_session_id(getattr(event, "response", None)):
+        elif options.get("store") is not False and (
+            agent_session_id := _get_foundry_agent_session_id(getattr(event, "response", None))
+        ):
             update.conversation_id = agent_session_id
         return update
 

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -37,6 +37,7 @@ from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from openai import AsyncOpenAI
+from openai.types.responses.response import Response as OpenAIResponse
 
 from agent_framework_foundry._agent import (
     FoundryAgent,
@@ -804,11 +805,26 @@ def test_raw_foundry_agent_chat_client_parse_response_suppresses_conversation_id
     assert result.conversation_id is None
 
 
+def _openai_response_with_session_id(session_id: str) -> OpenAIResponse:
+    return OpenAIResponse.model_validate({
+        "id": "resp_123",
+        "created_at": 0,
+        "model": "test-model",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+        "session": {"id": session_id},
+    })
+
+
 @pytest.mark.parametrize(
     "response",
     [
         SimpleNamespace(agent_session_id="agent-session-123"),
         SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+        _openai_response_with_session_id("agent-session-123"),
         SimpleNamespace(agent_session_id="agent-session-123", session=SimpleNamespace(id="session-id-should-not-win")),
     ],
 )
@@ -887,6 +903,7 @@ def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_fo
     [
         SimpleNamespace(agent_session_id="agent-session-123"),
         SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+        _openai_response_with_session_id("agent-session-123"),
         SimpleNamespace(agent_session_id="agent-session-123", session=SimpleNamespace(id="session-id-should-not-win")),
     ],
 )

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -832,6 +832,30 @@ def test_raw_foundry_agent_chat_client_parse_response_uses_hosted_agent_session_
     assert result.conversation_id == "agent-session-123"
 
 
+def test_raw_foundry_agent_chat_client_parse_response_respects_store_false_for_agent_session_id() -> None:
+    """Test that hosted agent session ids are not promoted when storage is disabled."""
+
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+    )
+
+    parsed = ChatResponse(conversation_id=None)
+    with patch(
+        "agent_framework_openai._chat_client.RawOpenAIChatClient._parse_response_from_openai",
+        return_value=parsed,
+    ):
+        result = client._parse_response_from_openai(
+            response=SimpleNamespace(agent_session_id="agent-session-123"),
+            options={"store": False},
+        )
+
+    assert result.conversation_id is None
+
+
 def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_for_agent_sessions() -> None:
     """Test that agent-session stream updates do not overwrite session.service_session_id."""
 
@@ -857,7 +881,14 @@ def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_fo
     assert result.conversation_id is None
 
 
-def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id() -> None:
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(agent_session_id="agent-session-123"),
+        SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+    ],
+)
+def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id(response: Any) -> None:
     """Test that first-turn hosted agent stream updates persist the service session id."""
 
     mock_project = MagicMock()
@@ -869,7 +900,7 @@ def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id(
     )
 
     event = MagicMock(type="response.created")
-    event.response = SimpleNamespace(agent_session_id="agent-session-123")
+    event.response = response
     parsed = ChatResponseUpdate(conversation_id="resp_123")
     with patch(
         "agent_framework_openai._chat_client.RawOpenAIChatClient._parse_chunk_from_openai",
@@ -882,6 +913,33 @@ def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id(
         )
 
     assert result.conversation_id == "agent-session-123"
+
+
+def test_raw_foundry_agent_chat_client_parse_chunk_respects_store_false_for_agent_session_id() -> None:
+    """Test that hosted agent session stream ids are not promoted when storage is disabled."""
+
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+    )
+
+    event = MagicMock(type="response.created")
+    event.response = SimpleNamespace(agent_session_id="agent-session-123")
+    parsed = ChatResponseUpdate(conversation_id=None)
+    with patch(
+        "agent_framework_openai._chat_client.RawOpenAIChatClient._parse_chunk_from_openai",
+        return_value=parsed,
+    ):
+        result = client._parse_chunk_from_openai(
+            event=event,
+            options={"store": False},
+            function_call_ids={},
+        )
+
+    assert result.conversation_id is None
 
 
 def test_raw_foundry_agent_chat_client_check_model_presence_is_noop() -> None:

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -809,6 +809,7 @@ def test_raw_foundry_agent_chat_client_parse_response_suppresses_conversation_id
     [
         SimpleNamespace(agent_session_id="agent-session-123"),
         SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+        SimpleNamespace(agent_session_id="agent-session-123", session=SimpleNamespace(id="session-id-should-not-win")),
     ],
 )
 def test_raw_foundry_agent_chat_client_parse_response_uses_hosted_agent_session_id(response: Any) -> None:
@@ -886,6 +887,7 @@ def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_fo
     [
         SimpleNamespace(agent_session_id="agent-session-123"),
         SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+        SimpleNamespace(agent_session_id="agent-session-123", session=SimpleNamespace(id="session-id-should-not-win")),
     ],
 )
 def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id(response: Any) -> None:

--- a/python/packages/foundry/tests/foundry/test_foundry_agent.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_agent.py
@@ -804,6 +804,34 @@ def test_raw_foundry_agent_chat_client_parse_response_suppresses_conversation_id
     assert result.conversation_id is None
 
 
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(agent_session_id="agent-session-123"),
+        SimpleNamespace(session=SimpleNamespace(id="agent-session-123")),
+    ],
+)
+def test_raw_foundry_agent_chat_client_parse_response_uses_hosted_agent_session_id(response: Any) -> None:
+    """Test that first-turn hosted agent responses persist the service session id."""
+
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+    )
+
+    parsed = ChatResponse(conversation_id="resp_123")
+    with patch(
+        "agent_framework_openai._chat_client.RawOpenAIChatClient._parse_response_from_openai",
+        return_value=parsed,
+    ):
+        result = client._parse_response_from_openai(response=response, options={})
+
+    assert result.conversation_id == "agent-session-123"
+
+
 def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_for_agent_sessions() -> None:
     """Test that agent-session stream updates do not overwrite session.service_session_id."""
 
@@ -827,6 +855,33 @@ def test_raw_foundry_agent_chat_client_parse_chunk_suppresses_conversation_id_fo
         )
 
     assert result.conversation_id is None
+
+
+def test_raw_foundry_agent_chat_client_parse_chunk_uses_hosted_agent_session_id() -> None:
+    """Test that first-turn hosted agent stream updates persist the service session id."""
+
+    mock_project = MagicMock()
+    mock_project.get_openai_client.return_value = MagicMock()
+
+    client = RawFoundryAgentChatClient(
+        project_client=mock_project,
+        agent_name="test-agent",
+    )
+
+    event = MagicMock(type="response.created")
+    event.response = SimpleNamespace(agent_session_id="agent-session-123")
+    parsed = ChatResponseUpdate(conversation_id="resp_123")
+    with patch(
+        "agent_framework_openai._chat_client.RawOpenAIChatClient._parse_chunk_from_openai",
+        return_value=parsed,
+    ):
+        result = client._parse_chunk_from_openai(
+            event=event,
+            options={},
+            function_call_ids={},
+        )
+
+    assert result.conversation_id == "agent-session-123"
 
 
 def test_raw_foundry_agent_chat_client_check_model_presence_is_noop() -> None:


### PR DESCRIPTION
### Motivation & Context

Fixes #7503.

Foundry hosted agents return a durable hosted session handle (`agent_session_id`, or `session.id` on some payload shapes). The core Agent Framework session update path already persists `ChatResponse.conversation_id` into `session.service_session_id`, and `_prepare_options` already sends a hosted session ID back as `extra_body.agent_session_id`.

The missing piece was the first-turn Foundry parser boundary: when no hosted session ID was sent in the request yet, the parser could leave the transient Responses API ID as `conversation_id` instead of promoting the durable hosted agent session handle.

### Description & Review Guide

- **What are the major changes?**
  - Adds a small Foundry-local helper to read `agent_session_id` or `session.id` from the raw Foundry response payload.
  - Promotes that hosted session ID into `conversation_id` for first-turn non-streaming responses and streaming response events.
  - Preserves `store=False` semantics by not promoting hosted session IDs when response storage is explicitly disabled.
  - Keeps the existing continuation behavior that suppresses transient response IDs when a hosted session ID was already supplied.
- **What is the impact of these changes?**
  - A first hosted-agent turn can populate `session.service_session_id` with the durable Foundry session handle, allowing follow-up turns to reuse the same hosted runtime session through the existing `extra_body.agent_session_id` path.
  - No public API changes.
- **What do you want reviewers to focus on?**
  - Whether `agent_session_id` should take precedence over `session.id` for these Foundry payloads.
  - Whether streaming should only read the session handle from `event.response`, as this patch does.

Validation:

- `uv run pytest packages/foundry/tests/foundry/test_foundry_agent.py -k "hosted_agent_session_id or suppresses_conversation_id_for_agent_sessions"`
- `uv run pytest packages/foundry/tests/foundry/test_foundry_agent.py`
- `uv run poe test -P foundry`
- `uv run poe syntax`
- `uv run poe --directory packages/foundry syntax`
- `uv run poe --directory packages/foundry pyright`
- `uv run poe --directory packages/foundry build`

I also attempted `uv run poe check`; it passed workspace syntax and reached type checking, including `packages/foundry`, then failed in unrelated `packages/lab` and `packages/core` optional-dependency imports in this fresh container environment (`orjson`, `pyarrow`, `graphviz`, OpenTelemetry OTLP exporters, and related Lab-only dependencies).

### Related Issue

Fixes #7503

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
