### PR TITLE
.NET: keep compaction active for local-history sentinel

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Compaction/CompactionProvider.cs
@@ -128,7 +128,8 @@ public sealed class CompactionProvider : AIContextProvider
 
         ChatClientAgentSession? chatClientSession = session.GetService<ChatClientAgentSession>();
         if (chatClientSession is not null &&
-            !string.IsNullOrWhiteSpace(chatClientSession.ConversationId))
+            !string.IsNullOrWhiteSpace(chatClientSession.ConversationId) &&
+            chatClientSession.ConversationId != PerServiceCallChatHistoryPersistingChatClient.LocalHistoryConversationId)
         {
             logger.LogCompactionProviderSkipped("session managed by remote service");
             return context.AIContext;

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Compaction/CompactionProviderTests.cs
@@ -132,6 +132,66 @@ public sealed class CompactionProviderTests
     }
 
     [Fact]
+    public async Task InvokingAsyncDoesNotSkipCompactionForLocalHistorySentinelAsync()
+    {
+        // Arrange
+        TruncationCompactionStrategy strategy = new(CompactionTriggers.Always, minimumPreservedGroups: 1);
+        CompactionProvider provider = new(strategy);
+
+        Mock<AIAgent> mockAgent = new() { CallBase = true };
+        ChatClientAgentSession session = new()
+        {
+            ConversationId = PerServiceCallChatHistoryPersistingChatClient.LocalHistoryConversationId,
+        };
+        List<ChatMessage> messages =
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, "A1"),
+            new ChatMessage(ChatRole.User, "Q2"),
+        ];
+
+        AIContextProvider.InvokingContext context = new(
+            mockAgent.Object,
+            session,
+            new AIContext { Messages = messages });
+
+        // Act
+        AIContext result = await provider.InvokingAsync(context);
+
+        // Assert
+        Assert.NotNull(result.Messages);
+        Assert.Single(result.Messages);
+    }
+
+    [Fact]
+    public async Task InvokingAsyncSkipsCompactionForRealServiceConversationIdAsync()
+    {
+        // Arrange
+        TruncationCompactionStrategy strategy = new(CompactionTriggers.Always, minimumPreservedGroups: 1);
+        CompactionProvider provider = new(strategy);
+
+        Mock<AIAgent> mockAgent = new() { CallBase = true };
+        ChatClientAgentSession session = new() { ConversationId = "service-conversation-id" };
+        List<ChatMessage> messages =
+        [
+            new ChatMessage(ChatRole.User, "Q1"),
+            new ChatMessage(ChatRole.Assistant, "A1"),
+            new ChatMessage(ChatRole.User, "Q2"),
+        ];
+
+        AIContextProvider.InvokingContext context = new(
+            mockAgent.Object,
+            session,
+            new AIContext { Messages = messages });
+
+        // Act
+        AIContext result = await provider.InvokingAsync(context);
+
+        // Assert
+        Assert.Same(messages, result.Messages);
+    }
+
+    [Fact]
     public async Task InvokingAsyncNoCompactionNeededReturnsOriginalMessagesAsync()
     {
         // Arrange — trigger never fires → no compaction


### PR DESCRIPTION
### Motivation & Context

`PerServiceCallChatHistoryPersistingChatClient` sets `_agent_local_chat_history` to signal that history is managed locally between service calls. `CompactionProvider` currently treats any non-empty session conversation ID as service-managed, so after the first model call it bypasses configured in-loop compaction even though the framework still owns the history.

### Description & Review Guide

- **What are the major changes?**
  - Exclude the existing local-history sentinel from the service-managed-history skip condition.
  - Add regression tests covering both the local sentinel and a genuine service conversation ID.
- **What is the impact of these changes?**
  - In-loop compaction remains active for framework-managed local history, while genuine service-managed history continues to skip local compaction.
- **What do you want reviewers to focus on?**
  - The narrow sentinel classification, which follows the history-ownership semantics established in #7284 without changing public API or broader conversation-ID handling.

### Related Issue

Fixes #7518

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
