### PR TITLE
.NET: Fix documented default for ChatHistoryMemoryProviderOptions.FunctionToolDescription

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Memory/ChatHistoryMemoryProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Memory/ChatHistoryMemoryProviderOptions.cs
@@ -27,7 +27,7 @@ public sealed class ChatHistoryMemoryProviderOptions
     /// <summary>
     /// Gets or sets the description of the exposed search tool when operating in on-demand mode.
     /// </summary>
-    /// <value>Defaults to "Allows searching through previous chat history to help answer the user question.".</value>
+    /// <value>Defaults to "Allows searching for related previous chat history to help answer the user question.".</value>
     public string? FunctionToolDescription { get; set; }
 
     /// <summary>


### PR DESCRIPTION
### Motivation & Context

`ChatHistoryMemoryProviderOptions.FunctionToolDescription` documents a default that is not the one the provider applies, so IntelliSense and the published XML docs show the wrong string.

### Description & Review Guide

The `<value>` text now quotes `ChatHistoryMemoryProvider.DefaultFunctionToolDescription` verbatim. Sibling `TextSearchProviderOptions.FunctionToolDescription` already matches its own default the same way. Comment only, no behavior change.

### Related Issue

N/A - documentation only; CONTRIBUTING allows skipping the issue step for trivial changes.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] **This is not a breaking change.**