### PR TITLE
Python: fix(workflows): preserve all trace contexts in FanInEdgeRunner aggregation

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_edge_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_edge_runner.py
@@ -359,13 +359,20 @@ class FanInEdgeRunner(EdgeRunner):
                     # fan-in aggregation are fully preserved. Using the singular
                     # backward-compat properties would silently drop all but the
                     # first context per message.
+                    #
+                    # Pair contexts and span IDs per-message (via zip) so that a
+                    # message with mismatched counts only drops its own orphans
+                    # instead of shifting all subsequent pairs out of alignment
+                    # when the flattened lists are later zipped by
+                    # ``create_processing_span``.
                     trace_contexts: list[dict[str, str]] = []
                     source_span_ids: list[str] = []
                     for msg in messages_to_send:
-                        if msg.trace_contexts:
-                            trace_contexts.extend(msg.trace_contexts)
-                        if msg.source_span_ids:
-                            source_span_ids.extend(msg.source_span_ids)
+                        msg_contexts = msg.trace_contexts or []
+                        msg_span_ids = msg.source_span_ids or []
+                        for trace_context, span_id in zip(msg_contexts, msg_span_ids, strict=False):
+                            trace_contexts.append(trace_context)
+                            source_span_ids.append(span_id)
 
                     # Create a new Message object for the aggregated data
                     aggregated_message = WorkflowMessage(

--- a/python/packages/core/agent_framework/_workflows/_edge_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_edge_runner.py
@@ -353,9 +353,19 @@ class FanInEdgeRunner(EdgeRunner):
                     # Send aggregated data to target
                     aggregated_data = [msg.data for msg in messages_to_send]
 
-                    # Collect all trace contexts and source span IDs for fan-in linking
-                    trace_contexts = [msg.trace_context for msg in messages_to_send if msg.trace_context]
-                    source_span_ids = [msg.source_span_id for msg in messages_to_send if msg.source_span_id]
+                    # Collect all trace contexts and source span IDs for fan-in linking.
+                    # Iterate over the plural fields (trace_contexts / source_span_ids)
+                    # so that messages carrying multiple contexts from a previous
+                    # fan-in aggregation are fully preserved. Using the singular
+                    # backward-compat properties would silently drop all but the
+                    # first context per message.
+                    trace_contexts: list[dict[str, str]] = []
+                    source_span_ids: list[str] = []
+                    for msg in messages_to_send:
+                        if msg.trace_contexts:
+                            trace_contexts.extend(msg.trace_contexts)
+                        if msg.source_span_ids:
+                            source_span_ids.extend(msg.source_span_ids)
 
                     # Create a new Message object for the aggregated data
                     aggregated_message = WorkflowMessage(

--- a/python/packages/core/tests/workflow/test_edge.py
+++ b/python/packages/core/tests/workflow/test_edge.py
@@ -1191,6 +1191,105 @@ async def test_fan_in_edge_group_with_multiple_message_types_failed() -> None:
         )
 
 
+class TraceCapturingAggregator(Executor):
+    """Fan-in aggregator that captures the trace contexts passed to execute()."""
+
+    def __init__(self, *, id: str) -> None:
+        super().__init__(id=id)
+        self.captured_trace_contexts: list[dict[str, str]] | None = None
+        self.captured_source_span_ids: list[str] | None = None
+        self.call_count: int = 0
+
+    @handler
+    async def mock_aggregator_handler(self, message: list[MockMessage], ctx: WorkflowContext) -> None:
+        self.call_count += 1
+
+    async def execute(
+        self,
+        message: WorkflowMessage,
+        source_executor_ids: list[str],
+        state: Any,
+        ctx: Any,
+        *,
+        trace_contexts: list[dict[str, str]] | None = None,
+        source_span_ids: list[str] | None = None,
+    ) -> None:
+        self.captured_trace_contexts = trace_contexts
+        self.captured_source_span_ids = source_span_ids
+        await super().execute(
+            message,
+            source_executor_ids,
+            state,
+            ctx,
+            trace_contexts=trace_contexts,
+            source_span_ids=source_span_ids,
+        )
+
+
+async def test_fan_in_preserves_multiple_trace_contexts_per_message() -> None:
+    """Fan-in must aggregate ALL trace contexts, not just the first per message.
+
+    Each incoming message may carry multiple trace_contexts (e.g. when it is
+    itself the product of a prior fan-in). The aggregated message must include
+    every trace context and source span ID from every source message; using the
+    singular backward-compat properties (trace_context / source_span_id) would
+    silently drop all but the first context per message.
+    """
+    source1 = MockExecutor(id="source_executor_1")
+    source2 = MockExecutor(id="source_executor_2")
+    target = TraceCapturingAggregator(id="target_executor")
+
+    executors: dict[str, Executor] = {source1.id: source1, source2.id: source2, target.id: target}
+    edge_group = FanInEdgeGroup(source_ids=[source1.id, source2.id], target_id=target.id)
+    edge_runner = create_edge_runner(edge_group, executors)
+
+    state = State()
+    ctx = InProcRunnerContext()
+    data = MockMessage(data="test")
+
+    # Source 1 carries TWO trace contexts (simulating a prior fan-in aggregation)
+    multi_contexts_1 = [
+        {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+        {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-aaaaaaaaaaaaaaaa-01"},
+    ]
+    multi_span_ids_1 = ["00f067aa0ba902b7", "aaaaaaaaaaaaaaaa"]
+
+    # Source 2 carries a single trace context
+    single_contexts_2 = [
+        {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b8-01"},
+    ]
+    single_span_ids_2 = ["00f067aa0ba902b8"]
+
+    # Send first message (buffered)
+    assert await edge_runner.send_message(
+        WorkflowMessage(
+            data=data, source_id=source1.id, trace_contexts=multi_contexts_1, source_span_ids=multi_span_ids_1
+        ),
+        state,
+        ctx,
+    )
+
+    # Send second message (triggers delivery)
+    assert await edge_runner.send_message(
+        WorkflowMessage(
+            data=data, source_id=source2.id, trace_contexts=single_contexts_2, source_span_ids=single_span_ids_2
+        ),
+        state,
+        ctx,
+    )
+
+    # The target executor should have received ALL 3 trace contexts (2 + 1),
+    # not just 2 (one per message via the singular property).
+    assert target.call_count == 1
+    assert target.captured_trace_contexts is not None
+    assert len(target.captured_trace_contexts) == 3
+    assert target.captured_trace_contexts == multi_contexts_1 + single_contexts_2
+
+    assert target.captured_source_span_ids is not None
+    assert len(target.captured_source_span_ids) == 3
+    assert target.captured_source_span_ids == multi_span_ids_1 + single_span_ids_2
+
+
 # endregion FanInEdgeGroup
 
 # region SwitchCaseEdgeGroup

--- a/python/packages/core/tests/workflow/test_edge.py
+++ b/python/packages/core/tests/workflow/test_edge.py
@@ -1192,7 +1192,13 @@ async def test_fan_in_edge_group_with_multiple_message_types_failed() -> None:
 
 
 class TraceCapturingAggregator(Executor):
-    """Fan-in aggregator that captures the trace contexts passed to execute()."""
+    """Fan-in aggregator that captures the trace contexts received by its handler.
+
+    Captures the source trace data from the :class:`WorkflowContext` passed to
+    the handler rather than overriding :meth:`Executor.execute` (which is
+    documented as *do not override* — it owns locking, span creation, handler
+    dispatch, and context construction).
+    """
 
     def __init__(self, *, id: str) -> None:
         super().__init__(id=id)
@@ -1203,27 +1209,8 @@ class TraceCapturingAggregator(Executor):
     @handler
     async def mock_aggregator_handler(self, message: list[MockMessage], ctx: WorkflowContext) -> None:
         self.call_count += 1
-
-    async def execute(
-        self,
-        message: WorkflowMessage,
-        source_executor_ids: list[str],
-        state: Any,
-        ctx: Any,
-        *,
-        trace_contexts: list[dict[str, str]] | None = None,
-        source_span_ids: list[str] | None = None,
-    ) -> None:
-        self.captured_trace_contexts = trace_contexts
-        self.captured_source_span_ids = source_span_ids
-        await super().execute(
-            message,
-            source_executor_ids,
-            state,
-            ctx,
-            trace_contexts=trace_contexts,
-            source_span_ids=source_span_ids,
-        )
+        self.captured_trace_contexts = list(ctx._trace_contexts)
+        self.captured_source_span_ids = list(ctx._source_span_ids)
 
 
 async def test_fan_in_preserves_multiple_trace_contexts_per_message() -> None:


### PR DESCRIPTION
## Problem

`FanInEdgeRunner` collected trace contexts and source span IDs using the singular backward-compat properties (`msg.trace_context` / `msg.source_span_id`), which return only the **first** element of the plural lists:

```python
# Before (buggy)
trace_contexts = [msg.trace_context for msg in messages_to_send if msg.trace_context]
source_span_ids = [msg.source_span_id for msg in messages_to_send if msg.source_span_id]
```

When a message arriving at a fan-in already carries multiple trace contexts (e.g. from a prior fan-in aggregation in a nested topology), all but the first context per message are **silently dropped**. This breaks distributed tracing span links for any workflow with nested fan-in groups.

## Fix

Iterate over the plural fields (`trace_contexts` / `source_span_ids`) and `extend` the aggregated lists so every trace context and source span ID from every source message is preserved:

```python
# After (fixed)
trace_contexts: list[dict[str, str]] = []
source_span_ids: list[str] = []
for msg in messages_to_send:
    if msg.trace_contexts:
        trace_contexts.extend(msg.trace_contexts)
    if msg.source_span_ids:
        source_span_ids.extend(msg.source_span_ids)
```

## Test

Added `test_fan_in_preserves_multiple_trace_contexts_per_message` which:
1. Sends a message carrying **two** trace contexts through a fan-in edge group (simulating a prior fan-in aggregation)
2. Sends a second message with one trace context
3. Asserts the target executor receives all **3** trace contexts and **3** source span IDs (not just 2)

This test fails on the old code (`assert 2 == 3`) and passes with the fix.

All existing workflow and edge tests continue to pass (55 passed; the only 2 failures in the broader suite are pre-existing and caused by a missing `openai` optional dependency, unrelated to this change).

## Checklist

- [x] Code follows existing style conventions
- [x] Unit test added and passing
- [x] No breaking changes — the singular properties still exist for backward compatibility; only the fan-in aggregation path now uses the plural fields
- [x] No new dependencies introduced