### PR TITLE
Python: track agent-hooks feature usage

### DIFF
--- a/docs/specs/feature-usage-bit-registry.md
+++ b/docs/specs/feature-usage-bit-registry.md
@@ -136,7 +136,8 @@ only to approved first-party endpoints.
 | 15 | `core.in_memory_skills_source` | In-memory / programmatic skills | `agent_framework.InMemorySkillsSource` |
 | 16 | `core.mcp_skills_source` | MCP-backed skills | `agent_framework.MCPSkillsSource` |
 | 17 | `core.session_store` | Agent session store | `agent_framework.SessionStore` / `FileSessionStore` |
-| 18–31 | _reserved_ | core growth | — |
+| 18 | `core.agent_hooks` | Agent Hooks middleware | `agent_framework.create_agent_hooks_middleware` |
+| 19–31 | _reserved_ | core growth | — |
 | 32 | `orchestration.sequential` | Sequential orchestration | `agent_framework_orchestrations.SequentialBuilder` |
 | 33 | `orchestration.concurrent` | Concurrent orchestration | `agent_framework_orchestrations.ConcurrentBuilder` |
 | 34 | `orchestration.group_chat` | Group-chat orchestration | `agent_framework_orchestrations.GroupChatBuilder` |

--- a/python/packages/core/agent_framework/_agent_hooks.py
+++ b/python/packages/core/agent_framework/_agent_hooks.py
@@ -120,6 +120,7 @@ from ._sessions import (
     _current_run_identity,  # pyright: ignore[reportPrivateUsage]
     _RunPersistenceGate,  # pyright: ignore[reportPrivateUsage]
 )
+from ._telemetry import FeatureIndex, mark_feature_used
 from ._types import (
     AgentResponse,
     AgentResponseUpdate,
@@ -1610,6 +1611,7 @@ def create_agent_hooks_middleware_from_emitter(
 
 
 def _build_bundle(config: _AgentHooksConfig) -> MiddlewareBundle:
+    mark_feature_used(FeatureIndex.CORE_AGENT_HOOKS)
     return MiddlewareBundle([
         _AgentHooksAgentMiddleware(config),
         _AgentHooksChatMiddleware(config),

--- a/python/packages/core/agent_framework/_telemetry.py
+++ b/python/packages/core/agent_framework/_telemetry.py
@@ -54,6 +54,7 @@ class FeatureIndex(IntEnum):
     CORE_IN_MEMORY_SKILLS_SOURCE = 15
     CORE_MCP_SKILLS_SOURCE = 16
     CORE_SESSION_STORE = 17
+    CORE_AGENT_HOOKS = 18
 
 
 # This environment variable is reserved by the Foundry hosting environment to

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import pytest
 
 import agent_framework
+import agent_framework._telemetry as telemetry
 from agent_framework import (
     Agent,
     AgentContext,
@@ -153,6 +154,23 @@ FULL_TOOL_RUN_POINTS = [
 # endregion
 
 # region Factory validation
+
+
+@pytest.mark.parametrize("factory_kind", ["managed", "host_owned"])
+@requires_sdk
+def test_agent_hooks_factories_activate_feature_telemetry(factory_kind: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(telemetry, "_feature_mask", 0)
+    monkeypatch.setattr(telemetry, "IS_TELEMETRY_ENABLED", True)
+    monkeypatch.setenv(telemetry.FEATURE_MASK_DISABLED_ENV_VAR, "false")
+
+    if factory_kind == "managed":
+        create_agent_hooks_middleware([AllowGuard()])
+    else:
+        emitter = InterceptionEmitter().register(AllowGuard())
+        builder = AgentContextBuilder(agent_id="a", framework="agent-framework", session_id="s")
+        create_agent_hooks_middleware_from_emitter(emitter, builder)
+
+    assert telemetry.get_feature_token() == "v1.40000"
 
 
 @requires_sdk


### PR DESCRIPTION
### Motivation & Context

The experimental agent-hooks integration needs a dedicated feature-usage bit so its adoption can be measured through the existing privacy-preserving telemetry mask.

### Description & Review Guide

- **What are the major changes?** Allocates Python core feature index 18 to `core.agent_hooks`, records the bit when either public agent-hooks middleware factory successfully builds a bundle, documents the allocation, and tests both factory paths.
- **What is the impact of these changes?** Existing feature bits remain unchanged. Processes that construct agent-hooks middleware now include bit 18 in subsequent feature-usage tokens.
- **What do you want reviewers to focus on?** Whether bundle construction is the appropriate activation boundary for both public factories.

### Related Issue

N/A — no related open issue was identified.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
