### PR TITLE
Python: Normalize SDK role enums to str when creating Messages

### DIFF
--- a/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
+++ b/python/packages/azure-ai-search/agent_framework_azure_ai_search/_context_provider.py
@@ -13,6 +13,7 @@ import inspect
 import logging
 import sys
 from collections.abc import Awaitable, Callable
+from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, overload
 
 from agent_framework import (
@@ -138,6 +139,16 @@ logger = logging.getLogger("agent_framework.azure_ai_search")
 
 _DEFAULT_AGENTIC_MESSAGE_HISTORY_COUNT = 10
 _AZURE_SEARCH_RESOURCE_SCOPE = "https://search.azure.com/.default"
+
+
+def _normalize_role(role: Any) -> Any:
+    """Return the plain string role for a Knowledge Base role value.
+
+    The SDK role can be a ``str``-subclass enum. Agent Framework types ``Message.role`` as a plain
+    ``str``, and durable session-state serialization rejects scalar subclasses, so unwrap the enum
+    before it reaches a ``Message``.
+    """
+    return role.value if isinstance(role, Enum) else role
 
 
 def _installed_search_documents_version() -> str:
@@ -1081,7 +1092,7 @@ class AzureAISearchContextProvider(ContextProvider):
                 if annotations:
                     for c in contents:
                         c.annotations = annotations
-                result_messages.append(Message(role=kb_msg.role or "assistant", contents=contents))
+                result_messages.append(Message(role=_normalize_role(kb_msg.role) or "assistant", contents=contents))
 
         if not result_messages:
             return [Message(role="assistant", contents=["No results found from Knowledge Base."])]

--- a/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
+++ b/python/packages/azure-ai-search/tests/test_aisearch_context_provider.py
@@ -1797,6 +1797,30 @@ class TestParseMessagesFromKbResponse:
         assert result[1].role == "assistant"
         assert result[1].text == "answer"
 
+    def test_role_enum_is_normalized_to_plain_string(self) -> None:
+        from enum import Enum
+
+        from azure.search.documents.knowledgebases.models import (
+            KnowledgeBaseMessage,
+            KnowledgeBaseMessageTextContent,
+            KnowledgeBaseRetrievalResponse,
+        )
+
+        class _Role(str, Enum):
+            USER = "user"
+
+        # Search SDK versions may type the role as a str-subclass enum. Agent Framework types
+        # Message.role as a plain str, and durable session-state serialization rejects scalar
+        # subclasses, so the role must be unwrapped when the message is created.
+        response = KnowledgeBaseRetrievalResponse(
+            response=[KnowledgeBaseMessage(role=_Role.USER, content=[KnowledgeBaseMessageTextContent(text="q")])],
+            references=None,
+        )
+        result = AzureAISearchContextProvider._parse_messages_from_kb_response(response)
+        assert len(result) == 1
+        assert type(result[0].role) is str
+        assert result[0].role == "user"
+
     def test_none_response_returns_default(self) -> None:
         from azure.search.documents.knowledgebases.models import KnowledgeBaseRetrievalResponse
 

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -12,6 +12,7 @@ import threading
 from collections.abc import AsyncIterable, AsyncIterator, Generator, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, suppress
 from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Literal, Protocol, cast
 
@@ -131,6 +132,16 @@ logger = logging.getLogger(__name__)
 
 _AZURE_RESPONSES_MESSAGE_ROLE_TYPE = f"{MessageRole.__module__}:{MessageRole.__qualname__}"
 _HOSTED_RESPONSES_HISTORY_SOURCE_ID = "_foundry_responses_history"
+
+
+def _normalize_role(role: Any) -> str:
+    """Return the plain string role for an Azure Responses SDK role value.
+
+    ``MessageRole`` is a ``str``-subclass enum. Agent Framework types ``Message.role`` as a plain
+    ``str``, and durable session-state serialization rejects scalar subclasses, so unwrap the enum
+    before it reaches a ``Message``.
+    """
+    return role.value if isinstance(role, Enum) else role
 
 
 # region Approval Storage
@@ -1225,14 +1236,16 @@ async def _item_to_message(item: Item, *, approval_storage: ApprovalStorage | No
     """
     if item.type == "message":
         msg = cast(ItemMessage, item)
+        role = _normalize_role(msg.role)
         if isinstance(msg.content, str):
-            return Message(role=msg.role, contents=[Content.from_text(msg.content)])
-        return Message(role=msg.role, contents=[_convert_message_content(part) for part in msg.content])
+            return Message(role=role, contents=[Content.from_text(msg.content)])
+        return Message(role=role, contents=[_convert_message_content(part) for part in msg.content])
 
     if item.type == "output_message":
         output_msg = cast(ItemOutputMessage, item)
         return Message(
-            role=output_msg.role, contents=[_convert_output_message_content(part) for part in output_msg.content]
+            role=_normalize_role(output_msg.role),
+            contents=[_convert_output_message_content(part) for part in output_msg.content],
         )
 
     if item.type == "function_call":
@@ -1513,12 +1526,15 @@ async def _output_item_to_message(item: OutputItem, *, approval_storage: Approva
     if item.type == "output_message":
         output_msg = cast(OutputItemOutputMessage, item)
         return Message(
-            role=output_msg.role, contents=[_convert_output_message_content(part) for part in output_msg.content]
+            role=_normalize_role(output_msg.role),
+            contents=[_convert_output_message_content(part) for part in output_msg.content],
         )
 
     if item.type == "message":
         msg = cast(OutputItemMessage, item)
-        return Message(role=msg.role, contents=[_convert_message_content(part) for part in msg.content])
+        return Message(
+            role=_normalize_role(msg.role), contents=[_convert_message_content(part) for part in msg.content]
+        )
 
     if item.type == "function_call":
         fc = cast(OutputItemFunctionToolCall, item)

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -1581,6 +1581,35 @@ class TestOutputItemToMessage:
         assert len(msg.contents) == 1
         assert msg.contents[0].text == "hi"
 
+    async def test_role_enum_is_normalized_to_plain_string(self) -> None:
+        from azure.ai.agentserver.responses.models import (
+            MessageContentInputTextContent,
+            MessageRole,
+            OutputItemMessage,
+            OutputItemOutputMessage,
+            OutputMessageContentOutputTextContent,
+        )
+
+        # The SDK role is a str-subclass enum. Agent Framework types Message.role as a plain str, and
+        # durable session-state serialization rejects scalar subclasses, so it must be unwrapped here.
+        output_message = OutputItemOutputMessage({
+            "type": "output_message",
+            "role": MessageRole.ASSISTANT,
+            "content": [OutputMessageContentOutputTextContent({"type": "output_text", "text": "hello"})],
+            "status": "completed",
+            "id": "msg-1",
+        })
+        message = OutputItemMessage({
+            "type": "message",
+            "role": MessageRole.USER,
+            "content": [MessageContentInputTextContent({"type": "input_text", "text": "hi"})],
+        })
+
+        for item, expected in ((output_message, "assistant"), (message, "user")):
+            msg = await _output_item_to_message(item)
+            assert type(msg.role) is str
+            assert msg.role == expected
+
     async def test_function_call(self) -> None:
         from azure.ai.agentserver.responses.models import OutputItemFunctionToolCall
 
@@ -2017,6 +2046,35 @@ class TestItemToMessage:
         assert len(msg.contents) == 1
         assert msg.contents[0].type == "text"
         assert msg.contents[0].text == "hello"
+
+    async def test_message_role_enum_is_normalized_to_plain_string(self) -> None:
+        from azure.ai.agentserver.responses.models import ItemMessage, MessageContentInputTextContent, MessageRole
+
+        # The SDK role is a str-subclass enum. Agent Framework types Message.role as a plain str, and
+        # durable session-state serialization rejects scalar subclasses, so it must be unwrapped here.
+        string_item = ItemMessage({"type": "message", "role": MessageRole.USER, "content": "hello"})
+        content_item = ItemMessage({
+            "type": "message",
+            "role": MessageRole.USER,
+            "content": [MessageContentInputTextContent({"type": "input_text", "text": "hi"})],
+        })
+
+        for item in (string_item, content_item):
+            msg = await _item_to_message(item)
+            assert msg is not None
+            assert type(msg.role) is str
+            assert msg.role == "user"
+
+    async def test_normalized_role_survives_durable_session_state_serialization(self) -> None:
+        from agent_framework import AgentSession
+        from azure.ai.agentserver.responses.models import ItemMessage, MessageRole
+
+        msg = await _item_to_message(ItemMessage({"type": "message", "role": MessageRole.USER, "content": "hello"}))
+        assert msg is not None
+        session = AgentSession(session_id="enum-role")
+        session.state["messages"] = [msg]
+
+        assert AgentSession.from_dict(session.to_dict()).state["messages"][0].role == "user"
 
     async def test_message_with_input_text_content(self) -> None:
         from azure.ai.agentserver.responses.models import ItemMessage, MessageContentInputTextContent

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -2065,16 +2065,24 @@ class TestItemToMessage:
             assert type(msg.role) is str
             assert msg.role == "user"
 
-    async def test_normalized_role_survives_durable_session_state_serialization(self) -> None:
-        from agent_framework import AgentSession
+    async def test_normalized_role_survives_durable_session_state_serialization(self, tmp_path: Path) -> None:
+        from agent_framework import AgentSession, FileSessionStore
         from azure.ai.agentserver.responses.models import ItemMessage, MessageRole
 
+        # Persist through a real session store: durable state is validated on save, and an enum role
+        # fails there with "unsupported serialized type 'MessageRole'". AgentSession.to_dict() alone
+        # would not catch it, because it skips that validation.
         msg = await _item_to_message(ItemMessage({"type": "message", "role": MessageRole.USER, "content": "hello"}))
         assert msg is not None
         session = AgentSession(session_id="enum-role")
         session.state["messages"] = [msg]
 
-        assert AgentSession.from_dict(session.to_dict()).state["messages"][0].role == "user"
+        store = FileSessionStore(tmp_path)
+        await store.set("enum-role", session)
+        restored = await store.get("enum-role")
+
+        assert restored is not None
+        assert type(restored.state["messages"][0].role) is str
 
     async def test_message_with_input_text_content(self) -> None:
         from azure.ai.agentserver.responses.models import ItemMessage, MessageContentInputTextContent


### PR DESCRIPTION
### Motivation & Context

Running an agent as a Foundry hosted agent fails to persist session state when the conversation
came in over the Azure Responses API:

```
TypeError: Session state value at state.in_memory.messages[0].role has unsupported
serialized type 'MessageRole'
```

`MessageRole` in `azure.ai.agentserver.responses.models` is a `str`-subclass enum. The hosting
layer passes it straight through into `Message(role=...)`, but Agent Framework types
`Message.role` as a plain `str` (`Role = NewType("Role", str)`), and durable session-state
serialization identifies scalars by exact type (`type(value) in _STATE_SCALAR_TYPES`) rather than
`isinstance`. A `str` subclass therefore misses the scalar path and is rejected as unserializable.

The result is that any hosted agent using a session store breaks as soon as it tries to save
history — the messages look like ordinary strings right up to the point of serialization. This
change makes the role a genuine `str` at the boundary where the SDK type enters the framework, so
sessions round-trip normally.

### Description & Review Guide

- **What are the major changes?**

  Each provider now normalizes the role to a plain `str` at the point it constructs a `Message`,
  via a small module-local helper (`role.value if isinstance(role, Enum) else role`):

  - `foundry_hosting/_responses.py` — applied at all five SDK→`Message` conversion sites across
    `_item_to_message` and `_output_item_to_message`.
  - `azure-ai-search/_context_provider.py` — applied to `kb_msg.role` when parsing a Knowledge
    Base retrieval response, preserving the existing `or "assistant"` fallback.

  Four regression tests are added, including one that asserts a converted message survives an
  `AgentSession` serialization round-trip.

- **What is the impact of these changes?**

  Hosted agents can save and restore session state again. Not a breaking change: the normalized
  value compares equal to the enum member it replaces, so `msg.role == "user"` and any string
  handling behave exactly as before — only the runtime type narrows from a subclass to `str`,
  which is what the public type annotation already promised. Core is untouched.

  Note that `foundry_hosting` deliberately preserves `MessageRole` in *workflow checkpoints*
  through the `_AZURE_RESPONSES_MESSAGE_ROLE_TYPE` allowlist; that path is unaffected and its
  existing tests still pass.

- **What do you want reviewers to focus on?**

  Whether normalizing per provider is the right layer, versus making core's serializer accept
  scalar subclasses. Both were considered; the per-provider fix was chosen so that `Message.role`
  actually holds the type it is annotated with, rather than papering over the mismatch at the
  serialization boundary. Also worth a look: whether other providers construct `Message` from an
  SDK role type and were missed — a survey suggested not (`a2a` already maps to literals,
  `azure-cosmos-memory` already unwraps defensively, MCP's `Role` is a `Literal`), but a second
  pair of eyes would help.

<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Related to #6361

This was found while building the harness samples tracked by that issue, but it is a
general-purpose fix in the provider packages and does not complete the sample/blog work — so it is
linked without a closing keyword intentionally, and #6361 should stay open. There is no other open
PR for this change.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
