### PR TITLE
Python: Preserve Mistral prompt-cache usage details

### DIFF
--- a/python/packages/mistral/agent_framework_mistral/_chat_client.py
+++ b/python/packages/mistral/agent_framework_mistral/_chat_client.py
@@ -853,6 +853,11 @@ class RawMistralChatClient(
             details["output_token_count"] = value
         if (value := usage.get("total_tokens")) is not None:
             details["total_token_count"] = value
+        prompt_tokens_details = usage.get("prompt_tokens_details")
+        if isinstance(prompt_tokens_details, Mapping):
+            if (value := prompt_tokens_details.get("cached_tokens")) is not None:
+                details["prompt/cached_tokens"] = value
+                details["cache_read_input_token_count"] = value
         return details or None
 
     # endregion

--- a/python/packages/mistral/agent_framework_mistral/_chat_client.py
+++ b/python/packages/mistral/agent_framework_mistral/_chat_client.py
@@ -855,9 +855,10 @@ class RawMistralChatClient(
             details["total_token_count"] = value
         prompt_tokens_details = usage.get("prompt_tokens_details")
         if isinstance(prompt_tokens_details, Mapping):
-            if (value := prompt_tokens_details.get("cached_tokens")) is not None:
-                details["prompt/cached_tokens"] = value
-                details["cache_read_input_token_count"] = value
+            cached_tokens = prompt_tokens_details.get("cached_tokens")
+            if isinstance(cached_tokens, int) and not isinstance(cached_tokens, bool):
+                details["prompt/cached_tokens"] = cached_tokens
+                details["cache_read_input_token_count"] = cached_tokens
         return details or None
 
     # endregion

--- a/python/packages/mistral/agent_framework_mistral/_chat_client.py
+++ b/python/packages/mistral/agent_framework_mistral/_chat_client.py
@@ -855,7 +855,7 @@ class RawMistralChatClient(
             details["total_token_count"] = value
         prompt_tokens_details = usage.get("prompt_tokens_details")
         if isinstance(prompt_tokens_details, Mapping):
-            cached_tokens = prompt_tokens_details.get("cached_tokens")
+            cached_tokens = cast("Mapping[str, Any]", prompt_tokens_details).get("cached_tokens")
             if isinstance(cached_tokens, int) and not isinstance(cached_tokens, bool):
                 details["prompt/cached_tokens"] = cached_tokens
                 details["cache_read_input_token_count"] = cached_tokens

--- a/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
+++ b/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
@@ -241,6 +241,29 @@ async def test_get_response_includes_cached_input_tokens() -> None:
     assert response.usage_details["cache_read_input_token_count"] == 80
 
 
+@pytest.mark.parametrize("cached_tokens", ["80", 80.5, True, False])
+async def test_get_response_ignores_invalid_cached_input_tokens(cached_tokens: Any) -> None:
+    client, _ = make_client(
+        json_response(
+            make_response_payload(
+                content="hello",
+                usage={
+                    "prompt_tokens": 100,
+                    "completion_tokens": 7,
+                    "total_tokens": 107,
+                    "prompt_tokens_details": {"cached_tokens": cached_tokens},
+                },
+            )
+        )
+    )
+
+    response = await client.get_response([Message("user", ["hi"])])
+
+    assert response.usage_details is not None
+    assert "prompt/cached_tokens" not in response.usage_details
+    assert "cache_read_input_token_count" not in response.usage_details
+
+
 @pytest.mark.parametrize(
     ("status_code", "expected_exception"),
     [

--- a/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
+++ b/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
@@ -220,6 +220,27 @@ async def test_get_response_basic() -> None:
     assert server.last_request["messages"] == [{"role": "user", "content": "hi"}]
 
 
+async def test_get_response_includes_cached_input_tokens() -> None:
+    client, _ = make_client(
+        json_response(
+            make_response_payload(
+                content="hello",
+                usage={
+                    "prompt_tokens": 100,
+                    "completion_tokens": 7,
+                    "total_tokens": 107,
+                    "prompt_tokens_details": {"cached_tokens": 80},
+                },
+            )
+        )
+    )
+
+    response = await client.get_response([Message("user", ["hi"])])
+
+    assert response.usage_details is not None
+    assert response.usage_details["cache_read_input_token_count"] == 80
+
+
 @pytest.mark.parametrize(
     ("status_code", "expected_exception"),
     [
@@ -684,7 +705,12 @@ async def test_streaming_response() -> None:
             make_chunk_payload(content="lo"),
             make_chunk_payload(
                 finish_reason="stop",
-                usage={"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+                usage={
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                    "prompt_tokens_details": {"cached_tokens": 2},
+                },
             ),
         )
     )
@@ -700,6 +726,8 @@ async def test_streaming_response() -> None:
         "input_token_count": 3,
         "output_token_count": 2,
         "total_token_count": 5,
+        "prompt/cached_tokens": 2,
+        "cache_read_input_token_count": 2,
     }
     assert server.last_request["stream"] is True
 


### PR DESCRIPTION
### Motivation & Context

Mistral chat-completion responses can include prompt cache hits under `usage.prompt_tokens_details.cached_tokens`. The Mistral adapter currently drops that field, so callers cannot observe cache reads through standard `UsageDetails`. This is especially visible in cost and telemetry reporting for cached prompts.

### Description & Review Guide

- **What are the major changes?**
  - Map `prompt_tokens_details.cached_tokens` to both `prompt/cached_tokens` and `cache_read_input_token_count` in `_parse_usage`.
  - Add regression coverage for non-streaming responses and final streaming usage chunks.
- **What is the impact of these changes?**
  - Existing usage fields are unchanged. Mistral cache-read information is now available through the same standard field used by other providers.
- **What do you want reviewers to focus on?**
  - Whether the mapping and type guard match the shape of Mistral usage payloads and the conventions used by other provider clients.

### Related Issue

Fixes #7589

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it is a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix) — a workflow keeps the label and title prefix in sync automatically.