### PR TITLE
.NET: Add BackgroundAgentsProvider.ReleaseSessionAsync to cancel and release per-session background tasks

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Agents.AI;
@@ -29,4 +30,25 @@ internal sealed class BackgroundAgentRuntimeState
     /// </summary>
     [JsonIgnore]
     public Dictionary<int, AgentSession> BackgroundTaskSessions { get; } = [];
+
+    /// <summary>
+    /// Gets the mapping of task IDs to the <see cref="CancellationTokenSource"/> controlling their run.
+    /// </summary>
+    /// <remarks>
+    /// A source is created when a task is started or continued, and is disposed and removed when the task is
+    /// finalized, cleared, or when the session is released via <see cref="BackgroundAgentsProvider.ReleaseSessionAsync"/>.
+    /// </remarks>
+    [JsonIgnore]
+    public Dictionary<int, CancellationTokenSource> TaskCancellations { get; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this runtime has been released via
+    /// <see cref="BackgroundAgentsProvider.ReleaseSessionAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Once released, all in-flight tasks have been cancelled and awaited, and the runtime references have been
+    /// dropped. Tools that would start new background work refuse to run against a released runtime.
+    /// </remarks>
+    [JsonIgnore]
+    public bool IsReleased { get; set; }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
@@ -63,4 +63,18 @@ internal sealed class BackgroundAgentRuntimeState
     /// </remarks>
     [JsonIgnore]
     public bool IsReleased { get; set; }
+
+    /// <summary>
+    /// Gets or sets the completion signalled once the release of this runtime has finished all of its cleanup.
+    /// </summary>
+    /// <remarks>
+    /// Set under <see cref="SyncRoot"/> by the caller that first releases the runtime, and completed once that
+    /// caller has finished waiting for the in-flight tasks and has dropped the runtime references. Callers that
+    /// arrive while a release is already in progress await this instead of returning early, so that a completed
+    /// <see cref="BackgroundAgentsProvider.ReleaseSessionAsync"/> always means the cleanup is done. It is completed
+    /// successfully even when the releasing caller fails, because a waiter should observe that cleanup finished
+    /// rather than inherit another caller's failure.
+    /// </remarks>
+    [JsonIgnore]
+    public TaskCompletionSource<bool>? ReleaseCompletion { get; set; }
 }

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentRuntimeState.cs
@@ -19,6 +19,18 @@ namespace Microsoft.Agents.AI;
 internal sealed class BackgroundAgentRuntimeState
 {
     /// <summary>
+    /// Gets an object used to synchronize access to the runtime references held by this instance.
+    /// </summary>
+    /// <remarks>
+    /// Background task registration happens on the agent's tool-invocation path, while
+    /// <see cref="BackgroundAgentsProvider.ReleaseSessionAsync"/> may be called concurrently by a host.
+    /// All mutations of the dictionaries below, and of <see cref="IsReleased"/>, must be performed under this lock
+    /// so that a task can never be registered into an already-released runtime.
+    /// </remarks>
+    [JsonIgnore]
+    public object SyncRoot { get; } = new();
+
+    /// <summary>
     /// Gets the mapping of task IDs to their in-flight <see cref="Task{AgentResponse}"/> instances.
     /// </summary>
     [JsonIgnore]

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
@@ -247,12 +247,8 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                         $"Cannot release the session because {pendingTaskIds.Count} background task(s) are still running. Pass cancelRunning: true to cancel them.");
                 }
 
-                // Continuations run asynchronously so that a waiting caller never resumes inline on the thread
-                // that is completing the release.
-                releaseCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                runtimeState.ReleaseCompletion = releaseCompletion;
-                runtimeState.IsReleased = true;
-
+                // Cancel before publishing the release. If cancelling throws, the runtime is left un-released so
+                // that the caller can retry, rather than being flagged as released with tasks still running.
                 foreach (int taskId in pendingTaskIds)
                 {
                     if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
@@ -267,6 +263,12 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                         }
                     }
                 }
+
+                // Continuations run asynchronously so that a waiting caller never resumes inline on the thread
+                // that is completing the release.
+                releaseCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                runtimeState.ReleaseCompletion = releaseCompletion;
+                runtimeState.IsReleased = true;
             }
         }
 

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
@@ -192,6 +192,13 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// session, and any tasks that were still running are recorded as
     /// <see cref="BackgroundTaskStatus.Failed"/> so a restored session does not report phantom running work.
     /// </para>
+    /// <para>
+    /// It is also safe to call concurrently. A caller that arrives while another release of the same session is
+    /// still in progress waits for that release to finish rather than returning early, so a completed call always
+    /// means the background tasks have been cancelled, awaited and cleaned up. Such a caller observes only its own
+    /// <paramref name="cancellationToken"/>; it neither inherits the in-progress release's failure nor is held up
+    /// by that caller's <paramref name="timeout"/>.
+    /// </para>
     /// </remarks>
     public async Task ReleaseSessionAsync(
         AgentSession session,
@@ -213,44 +220,64 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
         BackgroundAgentRuntimeState runtimeState = this._runtimeSessionState.GetOrInitializeState(session);
         BackgroundAgentState state = this._sessionState.GetOrInitializeState(session);
 
-        KeyValuePair<int, Task<AgentResponse>>[] trackedTasks;
-        HashSet<int> pendingTaskIds;
+        KeyValuePair<int, Task<AgentResponse>>[] trackedTasks = [];
+        HashSet<int> pendingTaskIds = [];
+        TaskCompletionSource<bool>? releaseCompletion = null;
+        Task? releaseInProgress = null;
 
         lock (runtimeState.SyncRoot)
         {
             if (runtimeState.IsReleased)
             {
-                return;
+                // A release is already in progress or has completed. Await it rather than returning early, so that
+                // a completed call always means the in-flight tasks have been cancelled, awaited and cleaned up.
+                releaseInProgress = runtimeState.ReleaseCompletion?.Task;
             }
-
-            trackedTasks = runtimeState.InFlightTasks.ToArray();
-
-            // Snapshot which tasks were still pending before anything is cancelled. Tasks that had already
-            // finished keep their real outcome; only these pending ones are reported as released.
-            pendingTaskIds = [.. trackedTasks.Where(t => !t.Value.IsCompleted).Select(t => t.Key)];
-
-            if (!cancelRunning && pendingTaskIds.Count > 0)
+            else
             {
-                throw new InvalidOperationException(
-                    $"Cannot release the session because {pendingTaskIds.Count} background task(s) are still running. Pass cancelRunning: true to cancel them.");
-            }
+                trackedTasks = runtimeState.InFlightTasks.ToArray();
 
-            runtimeState.IsReleased = true;
+                // Snapshot which tasks were still pending before anything is cancelled. Tasks that had already
+                // finished keep their real outcome; only these pending ones are reported as released.
+                pendingTaskIds = [.. trackedTasks.Where(t => !t.Value.IsCompleted).Select(t => t.Key)];
 
-            foreach (int taskId in pendingTaskIds)
-            {
-                if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
+                if (!cancelRunning && pendingTaskIds.Count > 0)
                 {
-                    try
+                    throw new InvalidOperationException(
+                        $"Cannot release the session because {pendingTaskIds.Count} background task(s) are still running. Pass cancelRunning: true to cancel them.");
+                }
+
+                // Continuations run asynchronously so that a waiting caller never resumes inline on the thread
+                // that is completing the release.
+                releaseCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                runtimeState.ReleaseCompletion = releaseCompletion;
+                runtimeState.IsReleased = true;
+
+                foreach (int taskId in pendingTaskIds)
+                {
+                    if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
                     {
-                        cts.Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // The source was already disposed by a concurrent finalization; nothing to cancel.
+                        try
+                        {
+                            cts.Cancel();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // The source was already disposed by a concurrent finalization; nothing to cancel.
+                        }
                     }
                 }
             }
+        }
+
+        if (releaseCompletion is null)
+        {
+            if (releaseInProgress is not null)
+            {
+                await AwaitReleaseInProgressAsync(releaseInProgress, cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
         }
 
         try
@@ -301,6 +328,36 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
 
             this._sessionState.SaveState(session, state);
             this._runtimeSessionState.SaveState(session, runtimeState);
+
+            // Signalled last so that any caller awaiting this release observes fully cleaned-up state. Completed
+            // successfully even when this caller failed, because the cleanup above always runs.
+            releaseCompletion.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Waits for a release that another caller started to finish its cleanup, giving up if the caller's own
+    /// <paramref name="cancellationToken"/> is signalled.
+    /// </summary>
+    private static async Task AwaitReleaseInProgressAsync(Task releaseInProgress, CancellationToken cancellationToken)
+    {
+        if (releaseInProgress.IsCompleted || !cancellationToken.CanBeCanceled)
+        {
+            // The release completion is never faulted or cancelled, so awaiting it cannot throw.
+            await releaseInProgress.ConfigureAwait(false);
+            return;
+        }
+
+        // Do not let this caller be held up by the releasing caller's timeout.
+        var cancellation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), cancellation))
+        {
+            await Task.WhenAny(releaseInProgress, cancellation.Task).ConfigureAwait(false);
+        }
+
+        if (!releaseInProgress.IsCompleted)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
         }
     }
 
@@ -474,13 +531,18 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     }
 
     /// <summary>
-    /// Starts a background run for the specified task, tracking both the resulting task and a
-    /// <see cref="CancellationTokenSource"/> that allows the run to be cancelled when the session is released.
+    /// Starts a background run for the specified task, tracking the resulting task, the background agent session,
+    /// and a <see cref="CancellationTokenSource"/> that allows the run to be cancelled when the session is released.
     /// </summary>
     /// <returns>
     /// <see langword="true"/> if the run was started and tracked; <see langword="false"/> if the session was
     /// released before the run could be registered, in which case nothing is started.
     /// </returns>
+    /// <remarks>
+    /// All references for the task are registered under a single acquisition of
+    /// <see cref="BackgroundAgentRuntimeState.SyncRoot"/>, so a concurrent release can never observe a partially
+    /// registered task, nor can a caller re-add references to a runtime that has already been released.
+    /// </remarks>
     private static bool StartTrackedRun(BackgroundAgentRuntimeState runtimeState, int taskId, AIAgent agent, string input, AgentSession subSession)
     {
         lock (runtimeState.SyncRoot)
@@ -497,6 +559,11 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
 
             var cts = new CancellationTokenSource();
             runtimeState.TaskCancellations[taskId] = cts;
+
+            // Registered here rather than by the caller so that the session reference cannot be re-added to a
+            // runtime that a concurrent release has already cleared. For a continued task this simply re-assigns
+            // the session the caller read from this same dictionary.
+            runtimeState.BackgroundTaskSessions[taskId] = subSession;
 
             // Wrap in Task.Run to fork the ExecutionContext. AIAgent.RunAsync is a non-async
             // method that synchronously sets the static AsyncLocal CurrentRunContext. Without
@@ -549,11 +616,6 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                         state.Tasks.Remove(taskInfo);
                         this._sessionState.SaveState(session, state);
                         return ReleasedRuntimeStartError;
-                    }
-
-                    lock (runtimeState.SyncRoot)
-                    {
-                        runtimeState.BackgroundTaskSessions[taskId] = subSession;
                     }
 
                     this._sessionState.SaveState(session, state);

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
@@ -157,7 +157,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// <summary>
     /// Releases all runtime state held for the specified session, cancelling and awaiting any in-flight background tasks.
     /// </summary>
-    /// <param name="session">The agent session whose background runtime should be released. If <see langword="null"/>, this method does nothing.</param>
+    /// <param name="session">The agent session whose background runtime should be released.</param>
     /// <param name="cancelRunning">
     /// <see langword="true"/> to cancel any background tasks that are still running; <see langword="false"/> to require that
     /// all background tasks have already completed.
@@ -169,6 +169,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// </param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests while waiting.</param>
     /// <returns>A task that represents the asynchronous release operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException"><paramref name="cancelRunning"/> is <see langword="false"/> and one or more background tasks are still running.</exception>
     /// <remarks>
     /// <para>
@@ -184,15 +185,12 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// </para>
     /// </remarks>
     public async Task ReleaseSessionAsync(
-        AgentSession? session,
+        AgentSession session,
         bool cancelRunning = true,
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default)
     {
-        if (session is null)
-        {
-            return;
-        }
+        _ = Throw.IfNull(session);
 
         BackgroundAgentRuntimeState runtimeState = this._runtimeSessionState.GetOrInitializeState(session);
         if (runtimeState.IsReleased)

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
@@ -65,6 +65,14 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
         {background_agents}
         """;
 
+    private const string ReleasedRuntimeStartError =
+        "Error: The background agents runtime for this session has been released. No new background tasks can be started.";
+
+    private const string ReleasedRuntimeContinueError =
+        "Error: The background agents runtime for this session has been released. Background tasks can no longer be continued.";
+
+    private const string ReleasedTaskCanceledMessage = "Task was canceled because the session was released.";
+
     private readonly Dictionary<string, AIAgent> _agents;
     private static readonly TimeSpan s_defaultReleaseTimeout = TimeSpan.FromSeconds(30);
     private readonly ProviderSessionState<BackgroundAgentState> _sessionState;
@@ -170,6 +178,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests while waiting.</param>
     /// <returns>A task that represents the asynchronous release operation.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is negative and is not <see cref="Timeout.InfiniteTimeSpan"/>.</exception>
     /// <exception cref="InvalidOperationException"><paramref name="cancelRunning"/> is <see langword="false"/> and one or more background tasks are still running.</exception>
     /// <remarks>
     /// <para>
@@ -192,66 +201,101 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     {
         _ = Throw.IfNull(session);
 
-        BackgroundAgentRuntimeState runtimeState = this._runtimeSessionState.GetOrInitializeState(session);
-        if (runtimeState.IsReleased)
+        TimeSpan effectiveTimeout = timeout ?? s_defaultReleaseTimeout;
+        if (effectiveTimeout < TimeSpan.Zero && effectiveTimeout != Timeout.InfiniteTimeSpan)
         {
-            return;
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                effectiveTimeout,
+                "The timeout must not be negative, unless it is Timeout.InfiniteTimeSpan.");
         }
 
+        BackgroundAgentRuntimeState runtimeState = this._runtimeSessionState.GetOrInitializeState(session);
         BackgroundAgentState state = this._sessionState.GetOrInitializeState(session);
 
-        var trackedTasks = runtimeState.InFlightTasks.ToArray();
-        if (!cancelRunning)
+        KeyValuePair<int, Task<AgentResponse>>[] trackedTasks;
+        HashSet<int> pendingTaskIds;
+
+        lock (runtimeState.SyncRoot)
         {
-            int runningCount = trackedTasks.Count(t => !t.Value.IsCompleted);
-            if (runningCount > 0)
+            if (runtimeState.IsReleased)
+            {
+                return;
+            }
+
+            trackedTasks = runtimeState.InFlightTasks.ToArray();
+
+            // Snapshot which tasks were still pending before anything is cancelled. Tasks that had already
+            // finished keep their real outcome; only these pending ones are reported as released.
+            pendingTaskIds = [.. trackedTasks.Where(t => !t.Value.IsCompleted).Select(t => t.Key)];
+
+            if (!cancelRunning && pendingTaskIds.Count > 0)
             {
                 throw new InvalidOperationException(
-                    $"Cannot release the session because {runningCount} background task(s) are still running. Pass cancelRunning: true to cancel them.");
+                    $"Cannot release the session because {pendingTaskIds.Count} background task(s) are still running. Pass cancelRunning: true to cancel them.");
+            }
+
+            runtimeState.IsReleased = true;
+
+            foreach (int taskId in pendingTaskIds)
+            {
+                if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
+                {
+                    try
+                    {
+                        cts.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The source was already disposed by a concurrent finalization; nothing to cancel.
+                    }
+                }
             }
         }
-
-        runtimeState.IsReleased = true;
 
         try
         {
-            if (trackedTasks.Length > 0)
-            {
-                foreach (var kvp in trackedTasks)
-                {
-                    if (!kvp.Value.IsCompleted &&
-                        runtimeState.TaskCancellations.TryGetValue(kvp.Key, out CancellationTokenSource? cts))
-                    {
-                        try
-                        {
-                            cts.Cancel();
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // The source was already disposed by a concurrent finalization; nothing to cancel.
-                        }
-                    }
-                }
-
-                await WaitForTasksAsync(trackedTasks.Select(t => t.Value), timeout ?? s_defaultReleaseTimeout, cancellationToken).ConfigureAwait(false);
-            }
+            await WaitForTasksAsync(trackedTasks.Select(t => t.Value), effectiveTimeout, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            foreach (int taskId in runtimeState.TaskCancellations.Keys)
+            lock (runtimeState.SyncRoot)
             {
-                DisposeTaskCancellation(runtimeState, taskId);
-            }
-
-            runtimeState.InFlightTasks.Clear();
-            runtimeState.BackgroundTaskSessions.Clear();
-
-            foreach (BackgroundTaskInfo task in state.Tasks)
-            {
-                if (task.Status == BackgroundTaskStatus.Running)
+                // Finalize every tracked task that actually finished, so successful results and real failure
+                // reasons are preserved rather than being overwritten with a release failure.
+                foreach (var kvp in trackedTasks)
                 {
-                    task.Status = BackgroundTaskStatus.Failed;
-                    task.ErrorText = "Task was canceled because the session was released.";
+                    BackgroundTaskInfo? tracked = state.Tasks.FirstOrDefault(t => t.Id == kvp.Key);
+                    if (tracked is null || tracked.Status != BackgroundTaskStatus.Running || !kvp.Value.IsCompleted)
+                    {
+                        continue;
+                    }
+
+                    FinalizeTask(tracked, kvp.Value, runtimeState);
+
+                    if (kvp.Value.IsCanceled && pendingTaskIds.Contains(kvp.Key))
+                    {
+                        // Report the actual reason rather than the generic cancellation message.
+                        tracked.ErrorText = ReleasedTaskCanceledMessage;
+                    }
+                }
+
+                foreach (int taskId in runtimeState.TaskCancellations.Keys.ToArray())
+                {
+                    DisposeTaskCancellation(runtimeState, taskId);
+                }
+
+                runtimeState.InFlightTasks.Clear();
+                runtimeState.BackgroundTaskSessions.Clear();
+
+                // Anything still running was abandoned (for example after the timeout elapsed).
+                foreach (BackgroundTaskInfo task in state.Tasks)
+                {
+                    if (task.Status == BackgroundTaskStatus.Running)
+                    {
+                        task.Status = BackgroundTaskStatus.Failed;
+                        task.ErrorText = ReleasedTaskCanceledMessage;
+                    }
                 }
             }
 
@@ -261,22 +305,26 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     }
 
     /// <summary>
-    /// Waits for the specified tasks to finish, ignoring their exceptions and giving up once the timeout elapses.
+    /// Waits for the specified tasks to finish, observing their exceptions and giving up once the timeout elapses.
     /// </summary>
     private static async Task WaitForTasksAsync(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken)
     {
-        Task[] pending = tasks.Where(t => !t.IsCompleted).ToArray();
+        // Attach an observer to every task, including those that already completed, so that a fault is always
+        // observed. Otherwise clearing the last reference to a faulted task can surface an UnobservedTaskException.
+        Task[] observers = tasks.Select(t => t.ContinueWith(
+            static antecedent => _ = antecedent.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default)).ToArray();
+
+        // Observers never fault, so awaiting them cannot throw.
+        Task[] pending = observers.Where(o => !o.IsCompleted).ToArray();
         if (pending.Length == 0)
         {
             return;
         }
 
-        // Observe faults/cancellations so that awaiting the group never throws.
-        Task all = Task.WhenAll(pending.Select(t => t.ContinueWith(
-            static _ => { },
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default)));
+        Task all = Task.WhenAll(pending);
 
         if (timeout == Timeout.InfiniteTimeSpan && !cancellationToken.CanBeCanceled)
         {
@@ -353,25 +401,28 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     private void TryRefreshTaskState(BackgroundAgentState state, BackgroundAgentRuntimeState runtimeState, AgentSession? session)
     {
         bool changed = false;
-        foreach (BackgroundTaskInfo task in state.Tasks)
+        lock (runtimeState.SyncRoot)
         {
-            if (task.Status != BackgroundTaskStatus.Running)
+            foreach (BackgroundTaskInfo task in state.Tasks)
             {
-                continue;
-            }
+                if (task.Status != BackgroundTaskStatus.Running)
+                {
+                    continue;
+                }
 
-            if (!runtimeState.InFlightTasks.TryGetValue(task.Id, out Task<AgentResponse>? inFlight))
-            {
-                // In-flight reference lost (e.g., after restart/deserialization).
-                task.Status = BackgroundTaskStatus.Lost;
-                changed = true;
-                continue;
-            }
+                if (!runtimeState.InFlightTasks.TryGetValue(task.Id, out Task<AgentResponse>? inFlight))
+                {
+                    // In-flight reference lost (e.g., after restart/deserialization).
+                    task.Status = BackgroundTaskStatus.Lost;
+                    changed = true;
+                    continue;
+                }
 
-            if (inFlight.IsCompleted)
-            {
-                FinalizeTask(task, inFlight, runtimeState);
-                changed = true;
+                if (inFlight.IsCompleted)
+                {
+                    FinalizeTask(task, inFlight, runtimeState);
+                    changed = true;
+                }
             }
         }
 
@@ -384,6 +435,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// <summary>
     /// Finalizes a task by extracting results from the completed Task and updating the BackgroundTaskInfo.
     /// </summary>
+    /// <remarks>Callers must hold <see cref="BackgroundAgentRuntimeState.SyncRoot"/>.</remarks>
     private static void FinalizeTask(BackgroundTaskInfo taskInfo, Task<AgentResponse> completedTask, BackgroundAgentRuntimeState runtimeState)
     {
         if (completedTask.Status == TaskStatus.RanToCompletion)
@@ -411,6 +463,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// <summary>
     /// Removes and disposes the <see cref="CancellationTokenSource"/> tracked for the specified task, if any.
     /// </summary>
+    /// <remarks>Callers must hold <see cref="BackgroundAgentRuntimeState.SyncRoot"/>.</remarks>
     private static void DisposeTaskCancellation(BackgroundAgentRuntimeState runtimeState, int taskId)
     {
         if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
@@ -424,20 +477,35 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
     /// Starts a background run for the specified task, tracking both the resulting task and a
     /// <see cref="CancellationTokenSource"/> that allows the run to be cancelled when the session is released.
     /// </summary>
-    private static void StartTrackedRun(BackgroundAgentRuntimeState runtimeState, int taskId, AIAgent agent, string input, AgentSession subSession)
+    /// <returns>
+    /// <see langword="true"/> if the run was started and tracked; <see langword="false"/> if the session was
+    /// released before the run could be registered, in which case nothing is started.
+    /// </returns>
+    private static bool StartTrackedRun(BackgroundAgentRuntimeState runtimeState, int taskId, AIAgent agent, string input, AgentSession subSession)
     {
-        // Replace any cancellation source left over from a previous run of the same task.
-        DisposeTaskCancellation(runtimeState, taskId);
+        lock (runtimeState.SyncRoot)
+        {
+            // Re-check under the lock: the session may have been released while the caller awaited session creation.
+            // Starting here would produce a task that is never tracked and therefore never cancelled.
+            if (runtimeState.IsReleased)
+            {
+                return false;
+            }
 
-        var cts = new CancellationTokenSource();
-        runtimeState.TaskCancellations[taskId] = cts;
+            // Replace any cancellation source left over from a previous run of the same task.
+            DisposeTaskCancellation(runtimeState, taskId);
 
-        // Wrap in Task.Run to fork the ExecutionContext. AIAgent.RunAsync is a non-async
-        // method that synchronously sets the static AsyncLocal CurrentRunContext. Without
-        // this isolation, the background agent's RunAsync would overwrite the outer (calling)
-        // agent's CurrentRunContext, corrupting all subsequent tool invocations in the
-        // same FICC batch.
-        runtimeState.InFlightTasks[taskId] = Task.Run(() => agent.RunAsync(input, subSession, cancellationToken: cts.Token), cts.Token);
+            var cts = new CancellationTokenSource();
+            runtimeState.TaskCancellations[taskId] = cts;
+
+            // Wrap in Task.Run to fork the ExecutionContext. AIAgent.RunAsync is a non-async
+            // method that synchronously sets the static AsyncLocal CurrentRunContext. Without
+            // this isolation, the background agent's RunAsync would overwrite the outer (calling)
+            // agent's CurrentRunContext, corrupting all subsequent tool invocations in the
+            // same FICC batch.
+            runtimeState.InFlightTasks[taskId] = Task.Run(() => agent.RunAsync(input, subSession, cancellationToken: cts.Token), cts.Token);
+            return true;
+        }
     }
 
     private AITool[] CreateTools(BackgroundAgentState state, BackgroundAgentRuntimeState runtimeState, AgentSession? session)
@@ -454,7 +522,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                 {
                     if (runtimeState.IsReleased)
                     {
-                        return "Error: The background agents runtime for this session has been released. No new background tasks can be started.";
+                        return ReleasedRuntimeStartError;
                     }
 
                     if (!this._agents.TryGetValue(agentName, out AIAgent? agent))
@@ -475,8 +543,18 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     // Create a dedicated session for this background task so it can be continued later.
                     AgentSession subSession = await agent.CreateSessionAsync().ConfigureAwait(false);
 
-                    StartTrackedRun(runtimeState, taskId, agent, input, subSession);
-                    runtimeState.BackgroundTaskSessions[taskId] = subSession;
+                    if (!StartTrackedRun(runtimeState, taskId, agent, input, subSession))
+                    {
+                        // The session was released while the background session was being created.
+                        state.Tasks.Remove(taskInfo);
+                        this._sessionState.SaveState(session, state);
+                        return ReleasedRuntimeStartError;
+                    }
+
+                    lock (runtimeState.SyncRoot)
+                    {
+                        runtimeState.BackgroundTaskSessions[taskId] = subSession;
+                    }
 
                     this._sessionState.SaveState(session, state);
                     return $"Background task {taskId} started on agent '{agentName}'.";
@@ -499,11 +577,14 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     // Collect in-flight tasks matching the requested IDs (including already-completed ones,
                     // since Task.WhenAny returns immediately for completed tasks).
                     var waitableTasks = new List<(int Id, Task<AgentResponse> Task)>();
-                    foreach (int id in taskIds)
+                    lock (runtimeState.SyncRoot)
                     {
-                        if (runtimeState.InFlightTasks.TryGetValue(id, out Task<AgentResponse>? inFlight))
+                        foreach (int id in taskIds)
                         {
-                            waitableTasks.Add((id, inFlight));
+                            if (runtimeState.InFlightTasks.TryGetValue(id, out Task<AgentResponse>? inFlight))
+                            {
+                                waitableTasks.Add((id, inFlight));
+                            }
                         }
                     }
 
@@ -533,7 +614,14 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     BackgroundTaskInfo? taskInfo = state.Tasks.FirstOrDefault(t => t.Id == completedEntry.Id);
                     if (taskInfo is not null)
                     {
-                        FinalizeTask(taskInfo, completedEntry.Task, runtimeState);
+                        lock (runtimeState.SyncRoot)
+                        {
+                            if (taskInfo.Status == BackgroundTaskStatus.Running)
+                            {
+                                FinalizeTask(taskInfo, completedEntry.Task, runtimeState);
+                            }
+                        }
+
                         this._sessionState.SaveState(session, state);
                     }
 
@@ -604,7 +692,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                 {
                     if (runtimeState.IsReleased)
                     {
-                        return "Error: The background agents runtime for this session has been released. Background tasks can no longer be continued.";
+                        return ReleasedRuntimeContinueError;
                     }
 
                     this.TryRefreshTaskState(state, runtimeState, session);
@@ -630,7 +718,13 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                         return $"Error: Agent '{taskInfo.AgentName}' is no longer available.";
                     }
 
-                    if (!runtimeState.BackgroundTaskSessions.TryGetValue(taskId, out AgentSession? subSession))
+                    AgentSession? subSession;
+                    lock (runtimeState.SyncRoot)
+                    {
+                        _ = runtimeState.BackgroundTaskSessions.TryGetValue(taskId, out subSession);
+                    }
+
+                    if (subSession is null)
                     {
                         return $"Error: Session for task {taskId} is no longer available.";
                     }
@@ -641,7 +735,13 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     taskInfo.ErrorText = null;
 
                     // Wrap in Task.Run to isolate the ExecutionContext (see StartBackgroundTask comment).
-                    StartTrackedRun(runtimeState, taskId, agent, text, subSession);
+                    if (!StartTrackedRun(runtimeState, taskId, agent, text, subSession))
+                    {
+                        taskInfo.Status = BackgroundTaskStatus.Failed;
+                        taskInfo.ErrorText = ReleasedTaskCanceledMessage;
+                        this._sessionState.SaveState(session, state);
+                        return ReleasedRuntimeContinueError;
+                    }
 
                     this._sessionState.SaveState(session, state);
                     return $"Task {taskId} continued with new input.";
@@ -673,9 +773,12 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     state.Tasks.Remove(taskInfo);
 
                     // Clean up runtime references.
-                    runtimeState.InFlightTasks.Remove(taskId);
-                    runtimeState.BackgroundTaskSessions.Remove(taskId);
-                    DisposeTaskCancellation(runtimeState, taskId);
+                    lock (runtimeState.SyncRoot)
+                    {
+                        runtimeState.InFlightTasks.Remove(taskId);
+                        runtimeState.BackgroundTaskSessions.Remove(taskId);
+                        DisposeTaskCancellation(runtimeState, taskId);
+                    }
 
                     this._sessionState.SaveState(session, state);
                     return $"Task {taskId} cleared.";

--- a/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/BackgroundAgents/BackgroundAgentsProvider.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Agents.AI;
 /// </list>
 /// </para>
 /// <para>
+/// Background tasks are tracked per session and keep running until they complete. When a host is finished with a
+/// session it should call <see cref="ReleaseSessionAsync"/> to cancel and await any in-flight tasks, so that
+/// abandoned work does not continue to invoke models and tools in the background.
+/// </para>
+/// <para>
 /// <strong>Security considerations:</strong> The agents passed to the constructor are delegated
 /// arbitrary work by the parent agent — the parent sends them text input (which may include content
 /// derived from the parent's own untrusted context) and receives back whatever text they produce. A
@@ -61,6 +66,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
         """;
 
     private readonly Dictionary<string, AIAgent> _agents;
+    private static readonly TimeSpan s_defaultReleaseTimeout = TimeSpan.FromSeconds(30);
     private readonly ProviderSessionState<BackgroundAgentState> _sessionState;
     private readonly ProviderSessionState<BackgroundAgentRuntimeState> _runtimeSessionState;
     private readonly string _instructions;
@@ -146,6 +152,151 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
         }
 
         return incomplete;
+    }
+
+    /// <summary>
+    /// Releases all runtime state held for the specified session, cancelling and awaiting any in-flight background tasks.
+    /// </summary>
+    /// <param name="session">The agent session whose background runtime should be released. If <see langword="null"/>, this method does nothing.</param>
+    /// <param name="cancelRunning">
+    /// <see langword="true"/> to cancel any background tasks that are still running; <see langword="false"/> to require that
+    /// all background tasks have already completed.
+    /// </param>
+    /// <param name="timeout">
+    /// The maximum amount of time to wait for cancelled tasks to finish. Defaults to 30 seconds when <see langword="null"/>.
+    /// Use <see cref="Timeout.InfiniteTimeSpan"/> to wait indefinitely. If the timeout elapses, the remaining tasks are
+    /// abandoned rather than blocking the caller.
+    /// </param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests while waiting.</param>
+    /// <returns>A task that represents the asynchronous release operation.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="cancelRunning"/> is <see langword="false"/> and one or more background tasks are still running.</exception>
+    /// <remarks>
+    /// <para>
+    /// Background tasks continue to execute — invoking models and tools — even after a host stops using the session
+    /// that started them. Hosts should call this method when a conversation ends, or from their own eviction policy,
+    /// so that abandoned work is stopped instead of running to completion with results nobody will read.
+    /// </para>
+    /// <para>
+    /// This method is idempotent: releasing an already-released session does nothing. Once released, the
+    /// <c>background_agents_start_task</c> and <c>background_agents_continue_task</c> tools refuse to run for that
+    /// session, and any tasks that were still running are recorded as
+    /// <see cref="BackgroundTaskStatus.Failed"/> so a restored session does not report phantom running work.
+    /// </para>
+    /// </remarks>
+    public async Task ReleaseSessionAsync(
+        AgentSession? session,
+        bool cancelRunning = true,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (session is null)
+        {
+            return;
+        }
+
+        BackgroundAgentRuntimeState runtimeState = this._runtimeSessionState.GetOrInitializeState(session);
+        if (runtimeState.IsReleased)
+        {
+            return;
+        }
+
+        BackgroundAgentState state = this._sessionState.GetOrInitializeState(session);
+
+        var trackedTasks = runtimeState.InFlightTasks.ToArray();
+        if (!cancelRunning)
+        {
+            int runningCount = trackedTasks.Count(t => !t.Value.IsCompleted);
+            if (runningCount > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot release the session because {runningCount} background task(s) are still running. Pass cancelRunning: true to cancel them.");
+            }
+        }
+
+        runtimeState.IsReleased = true;
+
+        try
+        {
+            if (trackedTasks.Length > 0)
+            {
+                foreach (var kvp in trackedTasks)
+                {
+                    if (!kvp.Value.IsCompleted &&
+                        runtimeState.TaskCancellations.TryGetValue(kvp.Key, out CancellationTokenSource? cts))
+                    {
+                        try
+                        {
+                            cts.Cancel();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // The source was already disposed by a concurrent finalization; nothing to cancel.
+                        }
+                    }
+                }
+
+                await WaitForTasksAsync(trackedTasks.Select(t => t.Value), timeout ?? s_defaultReleaseTimeout, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            foreach (int taskId in runtimeState.TaskCancellations.Keys)
+            {
+                DisposeTaskCancellation(runtimeState, taskId);
+            }
+
+            runtimeState.InFlightTasks.Clear();
+            runtimeState.BackgroundTaskSessions.Clear();
+
+            foreach (BackgroundTaskInfo task in state.Tasks)
+            {
+                if (task.Status == BackgroundTaskStatus.Running)
+                {
+                    task.Status = BackgroundTaskStatus.Failed;
+                    task.ErrorText = "Task was canceled because the session was released.";
+                }
+            }
+
+            this._sessionState.SaveState(session, state);
+            this._runtimeSessionState.SaveState(session, runtimeState);
+        }
+    }
+
+    /// <summary>
+    /// Waits for the specified tasks to finish, ignoring their exceptions and giving up once the timeout elapses.
+    /// </summary>
+    private static async Task WaitForTasksAsync(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        Task[] pending = tasks.Where(t => !t.IsCompleted).ToArray();
+        if (pending.Length == 0)
+        {
+            return;
+        }
+
+        // Observe faults/cancellations so that awaiting the group never throws.
+        Task all = Task.WhenAll(pending.Select(t => t.ContinueWith(
+            static _ => { },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default)));
+
+        if (timeout == Timeout.InfiniteTimeSpan && !cancellationToken.CanBeCanceled)
+        {
+            await all.ConfigureAwait(false);
+            return;
+        }
+
+        using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task delay = Task.Delay(timeout, delayCts.Token);
+
+        Task winner = await Task.WhenAny(all, delay).ConfigureAwait(false);
+        delayCts.Cancel();
+
+        if (winner != all)
+        {
+            // The wait was abandoned; the remaining tasks are left to finish on their own.
+            cancellationToken.ThrowIfCancellationRequested();
+        }
     }
 
     /// <summary>
@@ -256,6 +407,39 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
         }
 
         runtimeState.InFlightTasks.Remove(taskInfo.Id);
+        DisposeTaskCancellation(runtimeState, taskInfo.Id);
+    }
+
+    /// <summary>
+    /// Removes and disposes the <see cref="CancellationTokenSource"/> tracked for the specified task, if any.
+    /// </summary>
+    private static void DisposeTaskCancellation(BackgroundAgentRuntimeState runtimeState, int taskId)
+    {
+        if (runtimeState.TaskCancellations.TryGetValue(taskId, out CancellationTokenSource? cts))
+        {
+            runtimeState.TaskCancellations.Remove(taskId);
+            cts.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Starts a background run for the specified task, tracking both the resulting task and a
+    /// <see cref="CancellationTokenSource"/> that allows the run to be cancelled when the session is released.
+    /// </summary>
+    private static void StartTrackedRun(BackgroundAgentRuntimeState runtimeState, int taskId, AIAgent agent, string input, AgentSession subSession)
+    {
+        // Replace any cancellation source left over from a previous run of the same task.
+        DisposeTaskCancellation(runtimeState, taskId);
+
+        var cts = new CancellationTokenSource();
+        runtimeState.TaskCancellations[taskId] = cts;
+
+        // Wrap in Task.Run to fork the ExecutionContext. AIAgent.RunAsync is a non-async
+        // method that synchronously sets the static AsyncLocal CurrentRunContext. Without
+        // this isolation, the background agent's RunAsync would overwrite the outer (calling)
+        // agent's CurrentRunContext, corrupting all subsequent tool invocations in the
+        // same FICC batch.
+        runtimeState.InFlightTasks[taskId] = Task.Run(() => agent.RunAsync(input, subSession, cancellationToken: cts.Token), cts.Token);
     }
 
     private AITool[] CreateTools(BackgroundAgentState state, BackgroundAgentRuntimeState runtimeState, AgentSession? session)
@@ -270,6 +454,11 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     [Description("The request to pass to the background agent.")] string input,
                     [Description("A description of the task used to identify the task later.")] string description) =>
                 {
+                    if (runtimeState.IsReleased)
+                    {
+                        return "Error: The background agents runtime for this session has been released. No new background tasks can be started.";
+                    }
+
                     if (!this._agents.TryGetValue(agentName, out AIAgent? agent))
                     {
                         return $"Error: No background agent found with name '{agentName}'. Available agents: {string.Join(", ", this._agents.Keys)}";
@@ -288,12 +477,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     // Create a dedicated session for this background task so it can be continued later.
                     AgentSession subSession = await agent.CreateSessionAsync().ConfigureAwait(false);
 
-                    // Wrap in Task.Run to fork the ExecutionContext. AIAgent.RunAsync is a non-async
-                    // method that synchronously sets the static AsyncLocal CurrentRunContext. Without
-                    // this isolation, the background agent's RunAsync would overwrite the outer (calling)
-                    // agent's CurrentRunContext, corrupting all subsequent tool invocations in the
-                    // same FICC batch.
-                    runtimeState.InFlightTasks[taskId] = Task.Run(() => agent.RunAsync(input, subSession));
+                    StartTrackedRun(runtimeState, taskId, agent, input, subSession);
                     runtimeState.BackgroundTaskSessions[taskId] = subSession;
 
                     this._sessionState.SaveState(session, state);
@@ -420,6 +604,11 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
             AIFunctionFactory.Create(
                 (int taskId, string text) =>
                 {
+                    if (runtimeState.IsReleased)
+                    {
+                        return "Error: The background agents runtime for this session has been released. Background tasks can no longer be continued.";
+                    }
+
                     this.TryRefreshTaskState(state, runtimeState, session);
 
                     BackgroundTaskInfo? taskInfo = state.Tasks.FirstOrDefault(t => t.Id == taskId);
@@ -454,7 +643,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     taskInfo.ErrorText = null;
 
                     // Wrap in Task.Run to isolate the ExecutionContext (see StartBackgroundTask comment).
-                    runtimeState.InFlightTasks[taskId] = Task.Run(() => agent.RunAsync(text, subSession));
+                    StartTrackedRun(runtimeState, taskId, agent, text, subSession);
 
                     this._sessionState.SaveState(session, state);
                     return $"Task {taskId} continued with new input.";
@@ -488,6 +677,7 @@ public sealed class BackgroundAgentsProvider : AIContextProvider
                     // Clean up runtime references.
                     runtimeState.InFlightTasks.Remove(taskId);
                     runtimeState.BackgroundTaskSessions.Remove(taskId);
+                    DisposeTaskCancellation(runtimeState, taskId);
 
                     this._sessionState.SaveState(session, state);
                     return $"Task {taskId} cleared.";

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
@@ -1258,6 +1258,46 @@ public class BackgroundAgentsProviderTests
     }
 
     /// <summary>
+    /// Verify that a failure to cancel the running tasks leaves the session un-released, rather than marking it
+    /// released while its tasks are still running.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_CancellationThrows_LeavesSessionUnreleasedAsync()
+    {
+        // Arrange — a cancellation callback that throws makes CancellationTokenSource.Cancel throw.
+        var runEntered = new TaskCompletionSource<bool>();
+        var runGate = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
+        {
+            ct.Register(() => throw new InvalidOperationException("Cancellation callback failed."));
+            runEntered.TrySetResult(true);
+            await runGate.Task;
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        Assert.True(await runEntered.Task);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AggregateException>(() => provider.ReleaseSessionAsync(session));
+
+        // Assert — the release did not take effect, so the session remains usable and can be released again.
+        BackgroundAgentRuntimeState runtimeState = GetRuntimeState(provider, session);
+        Assert.False(runtimeState.IsReleased);
+        Assert.Null(runtimeState.ReleaseCompletion);
+        Assert.Single(provider.GetIncompleteTasks(session));
+
+        runGate.SetResult(true);
+    }
+
+    /// <summary>
     /// Verify that a start racing with a release does not register an untracked background task.
     /// </summary>
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
@@ -894,9 +894,11 @@ public class BackgroundAgentsProviderTests
     public async Task ReleaseSessionAsync_CancelsInFlightTaskAsync()
     {
         // Arrange
+        var callbackEntered = new TaskCompletionSource<bool>();
         var observedCancellation = new TaskCompletionSource<bool>();
         var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
         {
+            callbackEntered.SetResult(true);
             try
             {
                 await Task.Delay(Timeout.Infinite, ct);
@@ -919,6 +921,10 @@ public class BackgroundAgentsProviderTests
             ["input"] = "Task 1",
             ["description"] = "First task",
         });
+
+        // Wait until the run is actually executing, otherwise cancellation may prevent the
+        // delegate from ever being scheduled and the cancellation signal would never be set.
+        Assert.True(await callbackEntered.Task);
 
         // Act
         await provider.ReleaseSessionAsync(session);
@@ -1175,6 +1181,124 @@ public class BackgroundAgentsProviderTests
         await Assert.ThrowsAsync<ArgumentNullException>(() => provider.ReleaseSessionAsync(null!));
     }
 
+    /// <summary>
+    /// Verify that a task which completed but has not yet been refreshed keeps its result instead of
+    /// being reported as canceled by the release.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_CompletedButUnrefreshedTask_KeepsResultAsync()
+    {
+        // Arrange
+        var runEntered = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", _ =>
+        {
+            runEntered.TrySetResult(true);
+            return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "Result 1")));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Wait until the run has actually started, so it cannot be cancelled before it produces a result.
+        // The persisted state is never refreshed, so the task is still marked Running when the release begins.
+        Assert.True(await runEntered.Task);
+
+        // Act
+        await provider.ReleaseSessionAsync(session);
+
+        // Assert — the successful result is preserved rather than overwritten with a release failure.
+        object? result = await GetTool(tools, "background_agents_get_task_results").InvokeAsync(new AIFunctionArguments
+        {
+            ["taskId"] = 1,
+        });
+
+        Assert.Equal("Result 1", GetStringResult(result));
+    }
+
+    /// <summary>
+    /// Verify that an invalid timeout is rejected before the session is released.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_NegativeTimeout_ThrowsWithoutReleasingAsync()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<AgentResponse>();
+        var agent = CreateMockAgentWithRunResult("Research", tcs.Task);
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => provider.ReleaseSessionAsync(session, timeout: TimeSpan.FromSeconds(-5)));
+
+        // Assert — the session was not released, so the task is untouched and new tasks can still start.
+        Assert.Single(provider.GetIncompleteTasks(session));
+
+        object? startResult = await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 2",
+            ["description"] = "Second task",
+        });
+
+        Assert.DoesNotContain("released", GetStringResult(startResult));
+
+        tcs.SetResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done")));
+    }
+
+    /// <summary>
+    /// Verify that a start racing with a release does not register an untracked background task.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_DuringStart_RefusesToRegisterTaskAsync()
+    {
+        // Arrange — session creation blocks so the release can happen mid-start.
+        var sessionCreationGate = new TaskCompletionSource<bool>();
+        var runStarted = false;
+        var agent = CreateMockAgentWithGatedSession(
+            "Research",
+            sessionCreationGate.Task,
+            () =>
+            {
+                runStarted = true;
+                return Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done")));
+            });
+
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        Task<object?> startTask = GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        }).AsTask();
+
+        // Act — release while the start is awaiting session creation, then let creation finish.
+        await provider.ReleaseSessionAsync(session);
+        sessionCreationGate.SetResult(true);
+
+        object? startResult = await startTask;
+
+        // Assert — the start was refused, no run was launched, and no task was recorded.
+        Assert.Contains("released", GetStringResult(startResult));
+        Assert.False(runStarted);
+        Assert.Empty(provider.GetIncompleteTasks(session));
+
+        object? allTasks = await GetTool(tools, "background_agents_get_all_tasks").InvokeAsync(new AIFunctionArguments());
+        Assert.Equal("No tasks.", GetStringResult(allTasks));
+    }
+
     #endregion
 
     #region Helper Methods
@@ -1253,6 +1377,30 @@ public class BackgroundAgentsProviderTests
                 ItExpr.IsAny<AgentRunOptions>(),
                 ItExpr.IsAny<CancellationToken>())
             .Returns((IEnumerable<ChatMessage> _, AgentSession _, AgentRunOptions _, CancellationToken ct) => callback(ct));
+        return mock.Object;
+    }
+
+    private static AIAgent CreateMockAgentWithGatedSession(string name, Task sessionGate, Func<Task<AgentResponse>> callback)
+    {
+        var mock = new Mock<AIAgent>();
+        mock.SetupGet(a => a.Name).Returns(name);
+        mock.Protected()
+            .Setup<ValueTask<AgentSession>>(
+                "CreateSessionCoreAsync",
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(async () =>
+            {
+                await sessionGate;
+                return new ChatClientAgentSession();
+            });
+        mock.Protected()
+            .Setup<Task<AgentResponse>>(
+                "RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession>(),
+                ItExpr.IsAny<AgentRunOptions>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(callback);
         return mock.Object;
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
@@ -1162,17 +1162,17 @@ public class BackgroundAgentsProviderTests
     }
 
     /// <summary>
-    /// Verify that releasing a null session does nothing.
+    /// Verify that releasing a null session throws.
     /// </summary>
     [Fact]
-    public async Task ReleaseSessionAsync_NullSession_DoesNothingAsync()
+    public async Task ReleaseSessionAsync_NullSession_ThrowsAsync()
     {
         // Arrange
         var agent = CreateMockAgent("Research", "Research agent");
         var provider = new BackgroundAgentsProvider(new[] { agent });
 
-        // Act & Assert — does not throw.
-        await provider.ReleaseSessionAsync(null);
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() => provider.ReleaseSessionAsync(null!));
     }
 
     #endregion

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
@@ -885,6 +885,298 @@ public class BackgroundAgentsProviderTests
 
     #endregion
 
+    #region ReleaseSessionAsync Tests
+
+    /// <summary>
+    /// Verify that releasing a session cancels and awaits an in-flight background task.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_CancelsInFlightTaskAsync()
+    {
+        // Arrange
+        var observedCancellation = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
+        {
+            try
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                observedCancellation.SetResult(true);
+                throw;
+            }
+
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "never"));
+        });
+
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+        AIFunction startBackgroundTask = GetTool(tools, "background_agents_start_task");
+
+        await startBackgroundTask.InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act
+        await provider.ReleaseSessionAsync(session);
+
+        // Assert — the background run observed cancellation and no tasks remain running.
+        Assert.True(await observedCancellation.Task);
+        Assert.Empty(provider.GetIncompleteTasks(session));
+    }
+
+    /// <summary>
+    /// Verify that releasing a session more than once is a no-op.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_IsIdempotentAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "never"));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+        AIFunction startBackgroundTask = GetTool(tools, "background_agents_start_task");
+
+        await startBackgroundTask.InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act
+        await provider.ReleaseSessionAsync(session);
+        await provider.ReleaseSessionAsync(session);
+
+        // Assert — the second release did not throw and the state remains released.
+        Assert.Empty(provider.GetIncompleteTasks(session));
+    }
+
+    /// <summary>
+    /// Verify that releasing one session does not affect background tasks in another session.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_DoesNotAffectOtherSessionsAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "never"));
+        });
+        var provider = new BackgroundAgentsProvider(new[] { agent });
+
+        var (toolsA, sessionA) = await CreateToolsForSessionAsync(provider);
+        var (toolsB, sessionB) = await CreateToolsForSessionAsync(provider);
+
+        await GetTool(toolsA, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task A",
+            ["description"] = "Session A task",
+        });
+
+        await GetTool(toolsB, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task B",
+            ["description"] = "Session B task",
+        });
+
+        // Act
+        await provider.ReleaseSessionAsync(sessionA);
+
+        // Assert — session B's task is untouched.
+        Assert.Empty(provider.GetIncompleteTasks(sessionA));
+        Assert.Single(provider.GetIncompleteTasks(sessionB));
+    }
+
+    /// <summary>
+    /// Verify that releasing with cancelRunning false throws when tasks are still running.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_CancelRunningFalseWithRunningTask_ThrowsAsync()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<AgentResponse>();
+        var agent = CreateMockAgentWithRunResult("Research", tcs.Task);
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.ReleaseSessionAsync(session, cancelRunning: false));
+
+        // Assert — the task is left running because the release was rejected.
+        Assert.Single(provider.GetIncompleteTasks(session));
+
+        tcs.SetResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done")));
+    }
+
+    /// <summary>
+    /// Verify that releasing with cancelRunning false succeeds when all tasks have completed.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_CancelRunningFalseWithCompletedTask_SucceedsAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgentWithRunResult("Research", Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"))));
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Ensure the run has completed before releasing.
+        await GetTool(tools, "background_agents_wait_for_first_completion").InvokeAsync(new AIFunctionArguments
+        {
+            ["taskIds"] = new List<int> { 1 },
+        });
+
+        Assert.Empty(provider.GetIncompleteTasks(session));
+
+        // Act
+        await provider.ReleaseSessionAsync(session, cancelRunning: false);
+
+        // Assert — subsequent starts are rejected, confirming the runtime was released.
+        object? result = await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 2",
+            ["description"] = "Second task",
+        });
+
+        Assert.Contains("released", GetStringResult(result));
+    }
+
+    /// <summary>
+    /// Verify that a task still running when the session is released is recorded as failed.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_MarksRunningTasksAsFailedAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgentWithCancellableCallback("Research", async ct =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "never"));
+        });
+
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act
+        await provider.ReleaseSessionAsync(session);
+
+        // Assert
+        object? result = await GetTool(tools, "background_agents_get_all_tasks").InvokeAsync(new AIFunctionArguments());
+        string text = GetStringResult(result);
+        Assert.Contains("[Failed]", text);
+    }
+
+    /// <summary>
+    /// Verify that the start and continue tools return an error after the session is released.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_ToolsReturnErrorAfterReleaseAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgentWithRunResult("Research", Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"))));
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        await provider.ReleaseSessionAsync(session);
+
+        // Act
+        object? startResult = await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 2",
+            ["description"] = "Second task",
+        });
+
+        object? continueResult = await GetTool(tools, "background_agents_continue_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["taskId"] = 1,
+            ["text"] = "More work",
+        });
+
+        // Assert
+        Assert.Contains("released", GetStringResult(startResult));
+        Assert.Contains("released", GetStringResult(continueResult));
+    }
+
+    /// <summary>
+    /// Verify that a task ignoring cancellation does not block the release beyond the timeout.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_TimeoutAbandonsUncooperativeTaskAsync()
+    {
+        // Arrange — the run never observes its cancellation token.
+        var tcs = new TaskCompletionSource<AgentResponse>();
+        var agent = CreateMockAgentWithRunResult("Research", tcs.Task);
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        // Act
+        await provider.ReleaseSessionAsync(session, timeout: TimeSpan.FromMilliseconds(50));
+
+        // Assert — release completed despite the task still being pending.
+        Assert.False(tcs.Task.IsCompleted);
+        Assert.Empty(provider.GetIncompleteTasks(session));
+
+        tcs.SetResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "late")));
+    }
+
+    /// <summary>
+    /// Verify that releasing a null session does nothing.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_NullSession_DoesNothingAsync()
+    {
+        // Arrange
+        var agent = CreateMockAgent("Research", "Research agent");
+        var provider = new BackgroundAgentsProvider(new[] { agent });
+
+        // Act & Assert — does not throw.
+        await provider.ReleaseSessionAsync(null);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static AIAgent CreateMockAgent(string? name, string? description)
@@ -942,6 +1234,45 @@ public class BackgroundAgentsProviderTests
 
         AIContext result = await provider.InvokingAsync(context);
         return (result.Tools!, provider);
+    }
+
+    private static AIAgent CreateMockAgentWithCancellableCallback(string name, Func<CancellationToken, Task<AgentResponse>> callback)
+    {
+        var mock = new Mock<AIAgent>();
+        mock.SetupGet(a => a.Name).Returns(name);
+        mock.Protected()
+            .Setup<ValueTask<AgentSession>>(
+                "CreateSessionCoreAsync",
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(new ValueTask<AgentSession>(new ChatClientAgentSession()));
+        mock.Protected()
+            .Setup<Task<AgentResponse>>(
+                "RunCoreAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession>(),
+                ItExpr.IsAny<AgentRunOptions>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns((IEnumerable<ChatMessage> _, AgentSession _, AgentRunOptions _, CancellationToken ct) => callback(ct));
+        return mock.Object;
+    }
+
+    private static async Task<(IEnumerable<AITool> Tools, BackgroundAgentsProvider Provider, AgentSession Session)> CreateToolsWithSessionAsync(AIAgent agent)
+    {
+        var provider = new BackgroundAgentsProvider(new[] { agent });
+        var (tools, session) = await CreateToolsForSessionAsync(provider);
+        return (tools, provider, session);
+    }
+
+    private static async Task<(IEnumerable<AITool> Tools, AgentSession Session)> CreateToolsForSessionAsync(BackgroundAgentsProvider provider)
+    {
+        var mockAgent = new Mock<AIAgent>().Object;
+        var session = new ChatClientAgentSession();
+#pragma warning disable MAAI001
+        var context = new AIContextProvider.InvokingContext(mockAgent, session, new AIContext());
+#pragma warning restore MAAI001
+
+        AIContext result = await provider.InvokingAsync(context);
+        return (result.Tools!, session);
     }
 
     private static AIContextProvider.InvokingContext CreateInvokingContext()

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/BackgroundAgents/BackgroundAgentsProviderTests.cs
@@ -1299,6 +1299,179 @@ public class BackgroundAgentsProviderTests
         Assert.Equal("No tasks.", GetStringResult(allTasks));
     }
 
+    /// <summary>
+    /// Verify that a release racing with a start never leaves behind a background agent session, which would
+    /// otherwise be retained for the lifetime of the parent session.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_ConcurrentWithStart_LeavesNoRegisteredSessionsAsync()
+    {
+        // Registering the task and its session under a single lock makes this invariant hold for every possible
+        // interleaving. Repeat so that a range of interleavings is exercised.
+        for (int i = 0; i < 50; i++)
+        {
+            // Arrange
+            var agent = CreateMockAgentWithCancellableCallback(
+                "Research",
+                _ => Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"))));
+            var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+            // Act — start a task and release the session concurrently.
+            Task<object?> startTask = GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+            {
+                ["agentName"] = "Research",
+                ["input"] = "Task 1",
+                ["description"] = "First task",
+            }).AsTask();
+
+            Task releaseTask = Task.Run(() => provider.ReleaseSessionAsync(session));
+
+            await startTask;
+            await releaseTask;
+
+            // Assert — the release owns the cleanup, so no runtime reference may survive it.
+            BackgroundAgentRuntimeState runtimeState = GetRuntimeState(provider, session);
+            Assert.Empty(runtimeState.BackgroundTaskSessions);
+            Assert.Empty(runtimeState.InFlightTasks);
+            Assert.Empty(runtimeState.TaskCancellations);
+        }
+    }
+
+    /// <summary>
+    /// Verify that a caller releasing a session while another release is in progress waits for that release to
+    /// finish rather than returning while tasks are still being cleaned up.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_ConcurrentReleases_AllWaitForCleanupAsync()
+    {
+        // Arrange — the run ignores cancellation, so the first release stays in its wait until the gate opens.
+        var runEntered = new TaskCompletionSource<bool>();
+        var runGate = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", async _ =>
+        {
+            runEntered.TrySetResult(true);
+            await runGate.Task;
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        Assert.True(await runEntered.Task);
+
+        // Act — the first release blocks on the running task; the second arrives while it is still waiting.
+        Task firstRelease = provider.ReleaseSessionAsync(session, timeout: Timeout.InfiniteTimeSpan);
+        Task secondRelease = provider.ReleaseSessionAsync(session, timeout: Timeout.InfiniteTimeSpan);
+
+        // Assert — the second caller must not report a completed release while cleanup is still outstanding.
+        await Task.Delay(50);
+        Assert.False(firstRelease.IsCompleted);
+        Assert.False(secondRelease.IsCompleted);
+
+        runGate.SetResult(true);
+        await firstRelease;
+        await secondRelease;
+
+        // Assert — both callers observe fully cleaned-up state.
+        BackgroundAgentRuntimeState runtimeState = GetRuntimeState(provider, session);
+        Assert.Empty(runtimeState.InFlightTasks);
+        Assert.Empty(runtimeState.BackgroundTaskSessions);
+        Assert.Empty(runtimeState.TaskCancellations);
+    }
+
+    /// <summary>
+    /// Verify that a caller waiting on an in-progress release observes its own cancellation token rather than
+    /// being held up by the releasing caller.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_ConcurrentRelease_ObservesOwnCancellationAsync()
+    {
+        // Arrange
+        var runEntered = new TaskCompletionSource<bool>();
+        var runGate = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", async _ =>
+        {
+            runEntered.TrySetResult(true);
+            await runGate.Task;
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        Assert.True(await runEntered.Task);
+
+        Task firstRelease = provider.ReleaseSessionAsync(session, timeout: Timeout.InfiniteTimeSpan);
+
+        // Act & Assert — the second caller gives up on its own token instead of waiting for the first.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => provider.ReleaseSessionAsync(session, cancellationToken: cts.Token));
+
+        Assert.False(firstRelease.IsCompleted);
+
+        runGate.SetResult(true);
+        await firstRelease;
+    }
+
+    /// <summary>
+    /// Verify that a caller waiting on an in-progress release does not inherit the failure of the caller that
+    /// started it.
+    /// </summary>
+    [Fact]
+    public async Task ReleaseSessionAsync_ConcurrentRelease_DoesNotInheritFirstCallerFailureAsync()
+    {
+        // Arrange — the run never completes, so the first release only ends when its own token is cancelled.
+        var runEntered = new TaskCompletionSource<bool>();
+        var runGate = new TaskCompletionSource<bool>();
+        var agent = CreateMockAgentWithCancellableCallback("Research", async _ =>
+        {
+            runEntered.TrySetResult(true);
+            await runGate.Task;
+            return new AgentResponse(new ChatMessage(ChatRole.Assistant, "done"));
+        });
+        var (tools, provider, session) = await CreateToolsWithSessionAsync(agent);
+
+        await GetTool(tools, "background_agents_start_task").InvokeAsync(new AIFunctionArguments
+        {
+            ["agentName"] = "Research",
+            ["input"] = "Task 1",
+            ["description"] = "First task",
+        });
+
+        Assert.True(await runEntered.Task);
+
+        using var cts = new CancellationTokenSource();
+        Task firstRelease = provider.ReleaseSessionAsync(session, timeout: Timeout.InfiniteTimeSpan, cancellationToken: cts.Token);
+        Task secondRelease = provider.ReleaseSessionAsync(session, timeout: Timeout.InfiniteTimeSpan);
+
+        // Act — the first caller abandons its wait.
+        cts.Cancel();
+
+        // Assert — the second caller still completes successfully once the cleanup has run.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstRelease);
+        await secondRelease;
+
+        BackgroundAgentRuntimeState runtimeState = GetRuntimeState(provider, session);
+        Assert.Empty(runtimeState.InFlightTasks);
+        Assert.Empty(runtimeState.BackgroundTaskSessions);
+        Assert.Empty(runtimeState.TaskCancellations);
+
+        runGate.SetResult(true);
+    }
+
     #endregion
 
     #region Helper Methods
@@ -1421,6 +1594,14 @@ public class BackgroundAgentsProviderTests
 
         AIContext result = await provider.InvokingAsync(context);
         return (result.Tools!, session);
+    }
+
+    private static BackgroundAgentRuntimeState GetRuntimeState(BackgroundAgentsProvider provider, AgentSession session)
+    {
+        // The runtime state key is the second of the provider's state keys.
+        string runtimeStateKey = provider.StateKeys[1];
+        Assert.True(session.StateBag.TryGetValue(runtimeStateKey, out BackgroundAgentRuntimeState? runtimeState, AgentJsonUtilities.DefaultOptions));
+        return runtimeState!;
     }
 
     private static AIContextProvider.InvokingContext CreateInvokingContext()


### PR DESCRIPTION
### Motivation & Context

`BackgroundAgentsProvider` starts each background task with `Task.Run(() => agent.RunAsync(input, subSession))` — with no `CancellationToken`. There is no way for a host to signal "this session is over", so when a conversation ends or a host evicts a session, any background tasks that were still running keep executing: they continue invoking models and calling tools, producing results nobody will ever read, and any faults they raise go unobserved. In a long-lived host serving many concurrent sessions (for example a shared-agent web server), this is wasted compute and unwanted side effects for every abandoned conversation.

This is the .NET counterpart of the Python work in #7450 / #7385, adapted to the .NET design. Notably, the .NET provider does **not** have Python's unbounded `dict[session_id, _RuntimeState]` leak: runtime state is stored per-session in `AgentSession.StateBag` via `ProviderSessionState<T>`, so dropping the session already releases the memory. Porting Python's provider-level registry would actually introduce the very leak that fix removes, so this change focuses on the part that is genuinely missing in .NET — task lifecycle and cancellation.

### Description & Review Guide

- **What are the major changes?**
  - New public API on `BackgroundAgentsProvider`:
    ```csharp
    public async Task ReleaseSessionAsync(
        AgentSession session,
        bool cancelRunning = true,
        TimeSpan? timeout = null,
        CancellationToken cancellationToken = default)
    ```
    It cancels and awaits all in-flight background tasks for the session, then disposes and clears the runtime references. It is idempotent, and throws `InvalidOperationException` when `cancelRunning: false` and tasks are still running, so background work is never silently orphaned.
  - Per-task cancellation plumbing: `BackgroundAgentRuntimeState` now tracks a `CancellationTokenSource` per task (alongside a new `IsReleased` flag), and the token is passed into `agent.RunAsync(...)`. A shared `StartTrackedRun` / `DisposeTaskCancellation` helper pair keeps start, continue, finalize, and clear paths consistent and avoids duplicating the lifecycle logic.
  - The wait is bounded — 30 seconds by default, configurable via `timeout`, with `Timeout.InfiniteTimeSpan` supported. A task that ignores its cancellation token is abandoned rather than wedging host eviction or shutdown.
  - After release, `background_agents_start_task` and `background_agents_continue_task` return an error string instead of starting new work, and any tasks still `Running` at release time are recorded as `Failed` with an explanatory message, so a restored/serialized session does not report phantom running work.
  - Eight new unit tests covering cancellation and await semantics, idempotency, session isolation, both `cancelRunning: false` paths, terminal-status marking, tool behaviour after release, the timeout path, and argument validation.

- **What is the impact of these changes?**
  - Hosts can deterministically tear down a session when a conversation ends, or from their own LRU/TTL eviction policy, and be confident that no background work outlives it.
  - The change is additive. The only behavioural difference for existing callers is that background runs now receive a real `CancellationToken`, which is only ever signalled by an explicit `ReleaseSessionAsync` call.
  - Hosts already have a handle to the provider via `GetService<BackgroundAgentsProvider>()`, so no new harness surface was needed.

- **What do you want reviewers to focus on?**
  - The cancel/await/timeout semantics in `ReleaseSessionAsync` and `WaitForTasksAsync`, in particular that faults on abandoned tasks are observed so they never surface as unobserved task exceptions.
  - Whether marking still-running tasks as `Failed` on release is the right terminal status, versus reusing `Lost`.
  - The decision not to port Python's provider-level session registry, per the reasoning in Motivation & Context above.

### Related Issue

Fixes #7596

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
