### PR TITLE
Python: fix(redis): type-check the history provider across the supported redis range

### DIFF
--- a/python/packages/redis/agent_framework_redis/_history_provider.py
+++ b/python/packages/redis/agent_framework_redis/_history_provider.py
@@ -9,8 +9,9 @@ This module provides ``RedisHistoryProvider``, built on the new
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
-from typing import Any, ClassVar
+from collections.abc import Awaitable, Sequence
+from inspect import isawaitable
+from typing import Any, ClassVar, TypeVar, cast
 
 import redis.asyncio as redis
 from agent_framework import Message
@@ -19,6 +20,23 @@ from agent_framework._telemetry import mark_feature_used
 from redis.credentials import CredentialProvider
 
 from ._feature_usage import FeatureIndex
+
+_T = TypeVar("_T")
+
+
+async def _redis_result(value: Awaitable[_T] | _T) -> _T:
+    """Await a redis-py command result that is annotated as the sync/async union.
+
+    Several redis-py commands are annotated as returning ``Awaitable[T] | T`` even on the asyncio
+    client, so awaiting them directly does not type-check. Newer redis-py releases narrow those
+    annotations to the awaitable alone, which makes a bare ``# type: ignore`` *required* on the
+    older annotations and *unnecessary* on the newer ones: no single ignore comment satisfies the
+    whole supported range. Normalising through this helper type-checks on every supported version
+    without an ignore comment.
+    """
+    if isawaitable(value):
+        return cast("_T", await value)
+    return cast("_T", value)
 
 
 class RedisHistoryProvider(HistoryProvider):
@@ -135,11 +153,16 @@ class RedisHistoryProvider(HistoryProvider):
         """
         mark_feature_used(FeatureIndex.REDIS)
         key = self._redis_key(session_id)
-        redis_messages: list[str] = await self._redis_client.lrange(key, 0, -1)  # type: ignore[misc]
+        # Older redis-py annotates ``lrange`` with a partially unknown type while newer releases
+        # type it precisely, so neither keeping nor dropping an ignore comment here is correct for
+        # the whole supported range. Going through an explicitly ``Any``-typed client makes the
+        # call site version-independent, and the cast pins the element type that
+        # ``decode_responses=True`` guarantees.
+        client: Any = self._redis_client
+        redis_messages = cast("list[str]", await _redis_result(client.lrange(key, 0, -1)))
         messages: list[Message] = []
-        if redis_messages:
-            for serialized in redis_messages:  # type: ignore[union-attr]
-                messages.append(Message.from_dict(self._deserialize_json(serialized)))  # type: ignore[union-attr]
+        for serialized in redis_messages:
+            messages.append(Message.from_dict(self._deserialize_json(serialized)))
         return messages
 
     async def save_messages(
@@ -182,13 +205,13 @@ class RedisHistoryProvider(HistoryProvider):
 
         async with self._redis_client.pipeline(transaction=True) as pipe:
             for serialized in serialized_messages:
-                await pipe.rpush(key, serialized)  # type: ignore[misc]
+                await _redis_result(pipe.rpush(key, serialized))
             await pipe.execute()
 
         if self.max_messages is not None:
-            current_count = await self._redis_client.llen(key)  # type: ignore[misc]
+            current_count: int = await _redis_result(self._redis_client.llen(key))
             if current_count > self.max_messages:
-                await self._redis_client.ltrim(key, -self.max_messages, -1)  # type: ignore[misc]
+                await _redis_result(self._redis_client.ltrim(key, -self.max_messages, -1))
 
     @staticmethod
     def _serialize_json(message: Message) -> str:

--- a/python/packages/redis/agent_framework_redis/_history_provider.py
+++ b/python/packages/redis/agent_framework_redis/_history_provider.py
@@ -153,13 +153,12 @@ class RedisHistoryProvider(HistoryProvider):
         """
         mark_feature_used(FeatureIndex.REDIS)
         key = self._redis_key(session_id)
-        # Older redis-py annotates ``lrange`` with a partially unknown type while newer releases
-        # type it precisely, so neither keeping nor dropping an ignore comment here is correct for
-        # the whole supported range. Going through an explicitly ``Any``-typed client makes the
-        # call site version-independent, and the cast pins the element type that
+        # ``lrange`` is annotated with a partially unknown return type across the supported redis
+        # range, so neither keeping nor dropping an ignore comment here is correct for all of it.
+        # Reaching the method through an explicitly ``Any``-typed client makes the call site
+        # version-independent, and the outer cast pins the element type that
         # ``decode_responses=True`` guarantees.
-        client: Any = self._redis_client
-        redis_messages = cast("list[str]", await _redis_result(client.lrange(key, 0, -1)))
+        redis_messages = cast("list[str]", await _redis_result(cast("Any", self._redis_client).lrange(key, 0, -1)))
         messages: list[Message] = []
         for serialized in redis_messages:
             messages.append(Message.from_dict(self._deserialize_json(serialized)))

--- a/python/packages/redis/tests/test_providers.py
+++ b/python/packages/redis/tests/test_providers.py
@@ -14,7 +14,7 @@ from agent_framework._sessions import AgentSession, SessionContext
 
 from agent_framework_redis._context_provider import RedisContextProvider
 from agent_framework_redis._feature_usage import FeatureIndex
-from agent_framework_redis._history_provider import RedisHistoryProvider
+from agent_framework_redis._history_provider import RedisHistoryProvider, _redis_result
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -454,6 +454,30 @@ class TestRedisHistoryProviderGetMessages:
 
         messages = await provider.get_messages("s1")
         assert messages == []
+
+    async def test_returns_messages_when_lrange_is_synchronous(self, mock_redis_client: MagicMock):
+        """redis-py types several commands as returning a value or an awaitable; handle both."""
+        msg = Message(role="user", contents=["Hello"])
+        mock_redis_client.lrange = MagicMock(return_value=[json.dumps(msg.to_dict())])
+
+        with patch("agent_framework_redis._history_provider.redis.from_url") as mock_from_url:
+            mock_from_url.return_value = mock_redis_client
+            provider = RedisHistoryProvider("mem", redis_url="redis://localhost:6379")
+
+        messages = await provider.get_messages("s1")
+        assert len(messages) == 1
+        assert messages[0].text == "Hello"
+
+
+class TestRedisResultHelper:
+    async def test_awaits_an_awaitable_result(self):
+        async def _coro() -> int:
+            return 7
+
+        assert await _redis_result(_coro()) == 7
+
+    async def test_passes_through_a_plain_result(self):
+        assert await _redis_result(7) == 7
 
 
 class TestRedisHistoryProviderSaveMessages:


### PR DESCRIPTION
### Motivation & Context

The weekly dependency-range validator reported in #7340 that `agent-framework-redis` cannot move past its current `redis` bound because pyright fails at `redis==8.0.1` with five `reportUnnecessaryTypeIgnoreComment` errors in `_history_provider.py`.

Removing those five comments does not fix it. I reproduced the validator locally and checked each version in the supported range:

| redis version | original code | with the ignores deleted |
| --- | --- | --- |
| 6.4.0 (declared lower bound) | clean | 6 errors |
| 7.1.1 (currently locked) | clean | 6 errors |
| 8.0.1 (the failing candidate) | **5 errors** | clean |

The cause is redis-py itself. On the older releases the asyncio client annotates `lrange`, `rpush`, `llen` and `ltrim` as returning `Awaitable[T] | T`, so `await`-ing them directly does not type-check (`"int" is not awaitable`) and the ignore is required. Newer releases narrow those annotations to the awaitable alone, which makes the very same comment unnecessary. **No single `# type: ignore` comment satisfies the whole supported range**, which is why this needs a code change rather than a comment sweep.

This matters beyond the bound bump: `reportUnnecessaryTypeIgnoreComment = "error"` is enabled precisely so these comments do not accumulate, and today five of them are load-bearing on one redis version and dead weight on another.

### Description & Review Guide

- **What are the major changes?**
  - A module-level `_redis_result` helper accepts the `Awaitable[T] | T` union and returns `T`. It uses `isawaitable`, matching the existing pattern in `agent_framework/_types.py`. `rpush`, `llen` and `ltrim` now go through it and carry no ignore comment.
  - `lrange` is a slightly different case: it is *partially unknown* on the older annotations rather than merely union-typed, so even the helper leaves a strict-mode complaint about the argument expression. It now reads through an explicitly `Any`-typed local, which makes the call site independent of how precisely redis-py annotates it, with a `cast` pinning the `list[str]` that `decode_responses=True` guarantees. That also removes the two `union-attr` ignores on the loop below it.
  - The `if redis_messages:` guard was dropped as dead — iterating an empty list is already a no-op.

- **What is the impact of these changes?**
  - No behaviour change. `_redis_result` awaits exactly what the previous `await` awaited; the sync arm only exists to satisfy the union that redis-py declares.
  - This unblocks the pyright half of #7340. **It does not by itself let the bound move to `redis>=8`, and I want to flag why:** the package also pins `redisvl>=0.11.0,<0.16`, and `redisvl 0.15.0` requires `redis<7.2,>=5.0`. So redis 8.x is not co-installable with the current `redisvl` pin regardless of typing, and the validator's proposed `redis<8.0.0` is already in tension with it. Raising `redisvl` is a separate call I have deliberately left to you — I have not touched any bound in this PR.

- **What do you want reviewers to focus on?**
  - Whether the `client: Any` escape hatch for `lrange` is acceptable, or whether you would rather keep an ignore there and accept one error on newer redis. I went this way because it is the only form I found that is clean on all three versions, but it is a real trade of local type precision and it is your call.
  - Whether `_redis_result` belongs in this module or in a shared location, since `agent_framework_redis` is not the only place that awaits redis-py commands.

### Related Issue

Fixes #7340

### Verification

- **Pyright, run the way the validator does** (`--project pyproject.toml`, strict, against each installed redis): **0 errors at 6.4.0, 7.1.1 and 8.0.1** on this branch. The table above is the before/after.
- **Unit tests:** `packages/redis` on `main` 45 passed / 0 failed / 0 errors, branch **48 passed / 0 failed / 0 errors**. The FAILED/ERROR sets are identical (both empty) and the delta is exactly the three new tests.
- `ruff format --diff` and `ruff check` clean on both touched files.

Three tests added, all offline:

| Test | Covers |
| --- | --- |
| `test_returns_messages_when_lrange_is_synchronous` | the non-awaitable arm end to end through `get_messages`, which the existing `AsyncMock`-based tests never exercise |
| `TestRedisResultHelper::test_awaits_an_awaitable_result` | the awaitable arm |
| `TestRedisResultHelper::test_passes_through_a_plain_result` | the plain-value arm |

**Overlap note:** #7470, also mine, touches `save_messages` in this same file. The two changes are independent and either merge order works, but whichever lands second will want a trivial rebase — happy to do that whenever you tell me which you prefer first.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
