### PR TITLE
.NET: Fix misleading workflow protocol attribute diagnostics

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Analysis/SemanticAnalyzer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Analysis/SemanticAnalyzer.cs
@@ -280,9 +280,8 @@ internal static class SemanticAnalyzer
         if (!first.DerivesFromExecutor)
         {
             allDiagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.NotAnExecutor,
+                DiagnosticDescriptors.ProtocolClassNotAnExecutor,
                 classLocation,
-                first.ClassName,
                 first.ClassName));
             return AnalysisResult.WithDiagnostics(allDiagnostics.ToImmutable());
         }
@@ -290,7 +289,7 @@ internal static class SemanticAnalyzer
         if (!first.IsPartialClass)
         {
             allDiagnostics.Add(Diagnostic.Create(
-                DiagnosticDescriptors.ClassMustBePartial,
+                DiagnosticDescriptors.ProtocolClassMustBePartial,
                 classLocation,
                 first.ClassName));
             return AnalysisResult.WithDiagnostics(allDiagnostics.ToImmutable());

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Diagnostics/DiagnosticDescriptors.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Generators/Diagnostics/DiagnosticDescriptors.cs
@@ -104,4 +104,26 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true));
+
+    /// <summary>
+    /// MAFGENWF008: Executor with protocol attributes must be partial.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ProtocolClassMustBePartial = Register(new(
+        id: "MAFGENWF008",
+        title: "Executor with protocol attributes must be partial",
+        messageFormat: "Class '{0}' uses [SendsMessage] or [YieldsOutput] but is not declared as partial",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true));
+
+    /// <summary>
+    /// MAFGENWF009: Protocol attributes on non-Executor class.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ProtocolClassNotAnExecutor = Register(new(
+        id: "MAFGENWF009",
+        title: "Protocol attributes on non-Executor class",
+        messageFormat: "Class '{0}' uses [SendsMessage] or [YieldsOutput] but does not derive from Executor",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true));
 }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Attributes/SendsMessageAttribute.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Attributes/SendsMessageAttribute.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Agents.AI.Workflows;
 /// This attribute can be applied multiple times to declare multiple message types.
 /// It is inherited by derived classes, allowing base executors to declare common message types.
 /// </para>
+/// <para>
+/// When this attribute is applied to an executor class and the workflows source generator is referenced,
+/// the class must be declared <c>partial</c> so the generator can add its protocol configuration.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Attributes/YieldsOutputAttribute.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Attributes/YieldsOutputAttribute.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Agents.AI.Workflows;
 /// This attribute can be applied multiple times to declare multiple output types.
 /// It is inherited by derived classes, allowing base executors to declare common output types.
 /// </para>
+/// <para>
+/// When this attribute is applied to an executor class and the workflows source generator is referenced,
+/// the class must be declared <c>partial</c> so the generator can add its protocol configuration.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Generators.UnitTests/ExecutorRouteGeneratorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Generators.UnitTests/ExecutorRouteGeneratorTests.cs
@@ -927,10 +927,12 @@ public class ExecutorRouteGeneratorTests
                       .And.RegisterSentMessageType("global::TestNamespace.MessageC");
     }
 
-    [Fact]
-    public void ProtocolOnly_NonPartialClass_ProducesDiagnostic()
+    [Theory]
+    [InlineData("SendsMessage")]
+    [InlineData("YieldsOutput")]
+    public void ProtocolOnly_NonPartialClass_ProducesProtocolDiagnostic(string attributeName)
     {
-        var source = """
+        var source = $$"""
             using System;
             using System.Threading;
             using System.Threading.Tasks;
@@ -940,7 +942,7 @@ public class ExecutorRouteGeneratorTests
 
             public class BroadcastMessage { }
 
-            [SendsMessage(typeof(BroadcastMessage))]
+            [{{attributeName}}(typeof(BroadcastMessage))]
             public class TestExecutor : Executor
             {
                 public TestExecutor() : base("test") { }
@@ -949,15 +951,57 @@ public class ExecutorRouteGeneratorTests
 
         var result = GeneratorTestHelper.RunGenerator(source);
 
-        // Should produce MAFGENWF003 diagnostic (class must be partial)
-        result.RunResult.Diagnostics.Should().Contain(d => d.Id == "MAFGENWF003");
+        result.RunResult.Diagnostics.Should().ContainSingle();
+        var diagnostic = result.RunResult.Diagnostics.Single();
+        diagnostic.Id.Should().Be("MAFGENWF008");
+        diagnostic.GetMessage().Should().Be(
+            "Class 'TestExecutor' uses [SendsMessage] or [YieldsOutput] but is not declared as partial");
         result.RunResult.GeneratedTrees.Should().BeEmpty();
     }
 
     [Fact]
-    public void ProtocolOnly_NonExecutorClass_ProducesDiagnostic()
+    public void ProtocolOnly_NonPartialExecutorOfT_ProducesProtocolDiagnostic()
     {
         var source = """
+            using System.Collections.Generic;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Microsoft.Agents.AI.Workflows;
+
+            namespace TestNamespace;
+
+            [YieldsOutput(typeof(List<string>))]
+            internal sealed class CompletionExecutor(string id) : Executor<List<ReduceComplete>>(id)
+            {
+                public override async ValueTask HandleAsync(
+                    List<ReduceComplete> message,
+                    IWorkflowContext context,
+                    CancellationToken cancellationToken = default)
+                {
+                    List<string> filePaths = message.ConvertAll(result => result.FilePath);
+                    await context.YieldOutputAsync(filePaths, cancellationToken);
+                }
+            }
+
+            internal sealed record ReduceComplete(string FilePath);
+            """;
+
+        var result = GeneratorTestHelper.RunGenerator(source);
+
+        result.RunResult.Diagnostics.Should().ContainSingle();
+        var diagnostic = result.RunResult.Diagnostics.Single();
+        diagnostic.Id.Should().Be("MAFGENWF008");
+        diagnostic.GetMessage().Should().Be(
+            "Class 'CompletionExecutor' uses [SendsMessage] or [YieldsOutput] but is not declared as partial");
+        result.RunResult.GeneratedTrees.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("SendsMessage")]
+    [InlineData("YieldsOutput")]
+    public void ProtocolOnly_NonExecutorClass_ProducesProtocolDiagnostic(string attributeName)
+    {
+        var source = $$"""
             using System;
             using System.Threading;
             using System.Threading.Tasks;
@@ -967,7 +1011,7 @@ public class ExecutorRouteGeneratorTests
 
             public class BroadcastMessage { }
 
-            [SendsMessage(typeof(BroadcastMessage))]
+            [{{attributeName}}(typeof(BroadcastMessage))]
             public partial class NotAnExecutor
             {
             }
@@ -975,8 +1019,11 @@ public class ExecutorRouteGeneratorTests
 
         var result = GeneratorTestHelper.RunGenerator(source);
 
-        // Should produce MAFGENWF004 diagnostic (must derive from Executor)
-        result.RunResult.Diagnostics.Should().Contain(d => d.Id == "MAFGENWF004");
+        result.RunResult.Diagnostics.Should().ContainSingle();
+        var diagnostic = result.RunResult.Diagnostics.Single();
+        diagnostic.Id.Should().Be("MAFGENWF009");
+        diagnostic.GetMessage().Should().Be(
+            "Class 'NotAnExecutor' uses [SendsMessage] or [YieldsOutput] but does not derive from Executor");
         result.RunResult.GeneratedTrees.Should().BeEmpty();
     }
 


### PR DESCRIPTION
### Motivation & Context

Protocol-only executors incorrectly receive diagnostics referring to `[MessageHandler]`. This makes the intentional `partial` requirement confusing.

### Description & Review Guide

- **What are the major changes?** Add dedicated diagnostics for  [SendsMessage]  and  [YieldsOutput] , clarify documentation, and add regression tests.
- **What is the impact of these changes?** Users receive accurate, actionable errors without changing existing behavior.
- **What do you want reviewers to focus on?** Diagnostic wording and separation from handler diagnostics.

Fixes #5163 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
