### PR TITLE
Python: Warn when advertised MCP archives are rejected

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -4721,16 +4721,16 @@ class _ArchiveEntryLoader:
 
         blob = _mcp_first_blob(result)
         if blob is None:
-            logger.debug("Skipping skill '%s': archive resource returned no binary content", entry.name)
+            logger.warning("Skipping skill '%s': archive resource returned no binary content", entry.name)
             return None
 
         data, mime_type = blob
         if not data:
-            logger.debug("Skipping skill '%s': archive resource returned empty content", entry.name)
+            logger.warning("Skipping skill '%s': archive resource returned empty content", entry.name)
             return None
 
         if len(data) > self._max_size_bytes:
-            logger.debug(
+            logger.warning(
                 "Skipping skill '%s': archive resource exceeds the maximum allowed size (%d bytes)",
                 entry.name,
                 self._max_size_bytes,
@@ -4749,7 +4749,9 @@ class _ArchiveEntryLoader:
         """
         archive_format = _detect_archive_format(data, mime_type, entry.url)
         if archive_format is _ArchiveFormat.UNKNOWN:
-            logger.debug("Skipping skill '%s': unsupported archive media type '%s'", entry.name, mime_type or "(none)")
+            logger.warning(
+                "Skipping skill '%s': unsupported archive media type '%s'", entry.name, mime_type or "(none)"
+            )
             return None
 
         try:
@@ -4766,13 +4768,13 @@ class _ArchiveEntryLoader:
         """Assemble an in-memory :class:`FileSkill` from the archive's extracted files."""
         skill_md_key = self._find_skill_md(files)
         if skill_md_key is None:
-            logger.debug("Skipping skill '%s': archive contains no SKILL.md", entry.name)
+            logger.warning("Skipping skill '%s': archive contains no SKILL.md", entry.name)
             return None
 
         try:
             content = files[skill_md_key].decode("utf-8")
         except UnicodeDecodeError:
-            logger.debug("Skipping skill '%s': SKILL.md is not valid UTF-8", entry.name)
+            logger.warning("Skipping skill '%s': SKILL.md is not valid UTF-8", entry.name)
             return None
 
         frontmatter = FileSkillsSource._extract_frontmatter(  # pyright: ignore[reportPrivateUsage]
@@ -4782,7 +4784,7 @@ class _ArchiveEntryLoader:
             return None
 
         if frontmatter.name != entry.name:
-            logger.debug(
+            logger.warning(
                 "Skipping skill '%s': SKILL.md frontmatter name '%s' does not match the advertised entry name",
                 entry.name,
                 frontmatter.name,

--- a/python/packages/core/tests/core/test_mcp_skills.py
+++ b/python/packages/core/tests/core/test_mcp_skills.py
@@ -917,6 +917,23 @@ class TestMCPSkillsSourceArchive:
         skills = await source.get_skills(_SOURCE_CTX)
         assert skills == []
 
+    async def test_frontmatter_name_mismatch_is_logged_as_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        url = "skill://archives/packaged-skill.zip"
+        index = _make_archive_index("packaged-skill", url)
+        mismatched = ARCHIVE_SKILL_MD.replace("name: packaged-skill", "name: different-name")
+        archive = _make_zip({"SKILL.md": mismatched.encode()})
+        client = _archive_client(index, url, archive, "application/zip")
+
+        source = MCPSkillsSource(client=client)
+        with caplog.at_level("WARNING", logger="agent_framework._skills"):
+            skills = await source.get_skills(_SOURCE_CTX)
+
+        assert skills == []
+        assert any(
+            record.levelname == "WARNING" and "does not match the advertised entry name" in record.message
+            for record in caplog.records
+        )
+
     @pytest.mark.asyncio
     async def test_archive_without_skill_md_is_skipped(self) -> None:
         url = "skill://archives/packaged-skill.zip"


### PR DESCRIPTION
### Motivation & Context

`MCPSkillsSource` can advertise an archive skill in `skill://index.json` and then return fewer skills when that archive is rejected during download or materialization. The refusal was only logged at DEBUG, so operators could not distinguish a missing skill from one that was never published.

This change makes refusals of well-formed, advertised archive entries visible at WARNING. It keeps malformed index entries and MCP `-32002` missing-resource responses at DEBUG because those cases can be expected during capability discovery.

### Description & Review Guide

- **What are the major changes?**
  - Promote archive refusal logs for empty/non-binary content, download-size limits, unsupported formats, missing `SKILL.md`, invalid UTF-8, and frontmatter name mismatches from DEBUG to WARNING.
  - Add a regression test covering the frontmatter name mismatch path.
- **What is the impact of these changes?**
  - There is no API or behavior change: rejected archives are still skipped, but the reason is visible at the default operational log level.
  - Archive safety limits and validation remain unchanged.
- **What do you want reviewers to focus on?**
  - Whether the WARNING/DEBUG boundary is appropriate for advertised archive entries versus malformed or unavailable index resources.

AI assistance was used to help draft the patch and regression test; I reviewed the resulting diff and ran the relevant test suites.

### Related Issue

Fixes #7619

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
