### PR TITLE
.NET: Allow agents to opt into concurrent tool invocation

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -68,6 +68,9 @@ public sealed class ChatClientAgentOptions
     /// <remarks>
     /// This setting is independent of <see cref="ChatOptions.AllowMultipleToolCalls"/>, which controls whether
     /// a model may return multiple tool calls in a single response. The default is <see langword="false"/>.
+    /// This option has no effect when <see cref="UseProvidedChatClientAsIs"/> is <see langword="true"/>.
+    /// When using a custom chat client stack, configure <see cref="FunctionInvokingChatClient.AllowConcurrentInvocation"/>
+    /// directly on its <see cref="FunctionInvokingChatClient"/> instance.
     /// </remarks>
     public bool AllowConcurrentInvocation { get; set; }
 

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgentOptions.cs
@@ -62,6 +62,16 @@ public sealed class ChatClientAgentOptions
     public bool UseProvidedChatClientAsIs { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether functions may be invoked concurrently when a model response
+    /// contains multiple function calls.
+    /// </summary>
+    /// <remarks>
+    /// This setting is independent of <see cref="ChatOptions.AllowMultipleToolCalls"/>, which controls whether
+    /// a model may return multiple tool calls in a single response. The default is <see langword="false"/>.
+    /// </remarks>
+    public bool AllowConcurrentInvocation { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to set the <see cref="ChatClientAgent.ChatHistoryProvider"/> to <see langword="null"/>
     /// if the underlying AI service indicates that it manages chat history (for example, by returning a conversation id in the response), but a <see cref="ChatHistoryProvider"/> is configured for the agent.
     /// </summary>
@@ -288,6 +298,7 @@ public sealed class ChatClientAgentOptions
             ChatHistoryProvider = this.ChatHistoryProvider,
             AIContextProviders = this.AIContextProviders is null ? null : new List<AIContextProvider>(this.AIContextProviders),
             UseProvidedChatClientAsIs = this.UseProvidedChatClientAsIs,
+            AllowConcurrentInvocation = this.AllowConcurrentInvocation,
             ClearOnChatHistoryProviderConflict = this.ClearOnChatHistoryProviderConflict,
             WarnOnChatHistoryProviderConflict = this.WarnOnChatHistoryProviderConflict,
             ThrowOnChatHistoryProviderConflict = this.ThrowOnChatHistoryProviderConflict,

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
@@ -96,7 +96,10 @@ public static class ChatClientExtensions
             {
                 var loggerFactory = services.GetService<ILoggerFactory>();
 
-                return new FunctionInvokingChatClient(innerClient, loggerFactory, services);
+                return new FunctionInvokingChatClient(innerClient, loggerFactory, services)
+                {
+                    AllowConcurrentInvocation = options?.AllowConcurrentInvocation is true,
+                };
             });
         }
 

--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientExtensions.cs
@@ -90,7 +90,8 @@ public static class ChatClientExtensions
                 new InvocableFunctionBypassingChatClient(innerClient, services.GetService<ILoggerFactory>()));
         }
 
-        if (chatClient.GetService<FunctionInvokingChatClient>() is null)
+        var functionInvokingChatClient = chatClient.GetService<FunctionInvokingChatClient>();
+        if (functionInvokingChatClient is null)
         {
             chatBuilder.Use((innerClient, services) =>
             {
@@ -101,6 +102,10 @@ public static class ChatClientExtensions
                     AllowConcurrentInvocation = options?.AllowConcurrentInvocation is true,
                 };
             });
+        }
+        else if (options?.AllowConcurrentInvocation is true)
+        {
+            functionInvokingChatClient.AllowConcurrentInvocation = true;
         }
 
         // MessageInjectingChatClient is injected when EnableMessageInjection is enabled.

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentOptionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientAgentOptionsTests.cs
@@ -24,6 +24,7 @@ public class ChatClientAgentOptionsTests
         Assert.Null(options.ChatHistoryProvider);
         Assert.Null(options.AIContextProviders);
         Assert.False(options.UseProvidedChatClientAsIs);
+        Assert.False(options.AllowConcurrentInvocation);
         Assert.True(options.ClearOnChatHistoryProviderConflict);
         Assert.True(options.WarnOnChatHistoryProviderConflict);
         Assert.True(options.ThrowOnChatHistoryProviderConflict);
@@ -131,6 +132,7 @@ public class ChatClientAgentOptionsTests
             ChatHistoryProvider = mockChatHistoryProvider,
             AIContextProviders = [mockAIContextProvider],
             UseProvidedChatClientAsIs = true,
+            AllowConcurrentInvocation = true,
             ClearOnChatHistoryProviderConflict = false,
             WarnOnChatHistoryProviderConflict = false,
             ThrowOnChatHistoryProviderConflict = false,
@@ -149,6 +151,7 @@ public class ChatClientAgentOptionsTests
         Assert.Same(original.ChatHistoryProvider, clone.ChatHistoryProvider);
         Assert.Equal(original.AIContextProviders, clone.AIContextProviders);
         Assert.Equal(original.UseProvidedChatClientAsIs, clone.UseProvidedChatClientAsIs);
+        Assert.Equal(original.AllowConcurrentInvocation, clone.AllowConcurrentInvocation);
         Assert.Equal(original.ClearOnChatHistoryProviderConflict, clone.ClearOnChatHistoryProviderConflict);
         Assert.Equal(original.WarnOnChatHistoryProviderConflict, clone.WarnOnChatHistoryProviderConflict);
         Assert.Equal(original.ThrowOnChatHistoryProviderConflict, clone.ThrowOnChatHistoryProviderConflict);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientExtensionsTests.cs
@@ -73,6 +73,22 @@ public sealed class ChatClientExtensionsTests
     }
 
     [Fact]
+    public void CreateAIAgent_WithConcurrentInvocation_EnablesConcurrentFunctionInvocation()
+    {
+        // Arrange
+        var chatClientMock = new Mock<IChatClient>();
+        var options = new ChatClientAgentOptions { AllowConcurrentInvocation = true };
+
+        // Act
+        var agent = chatClientMock.Object.AsAIAgent(options);
+
+        // Assert
+        var functionInvokingClient = agent.ChatClient.GetService<FunctionInvokingChatClient>();
+        Assert.NotNull(functionInvokingClient);
+        Assert.True(functionInvokingClient.AllowConcurrentInvocation);
+    }
+
+    [Fact]
     public void CreateAIAgent_WithNullClient_Throws()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ChatClientExtensionsTests.cs
@@ -88,6 +88,27 @@ public sealed class ChatClientExtensionsTests
         Assert.True(functionInvokingClient.AllowConcurrentInvocation);
     }
 
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void CreateAIAgent_WithExistingFunctionInvokingChatClient_ConfiguresConcurrentInvocation(bool initiallyEnabled, bool allowConcurrentInvocation)
+    {
+        // Arrange
+        var chatClientMock = new Mock<IChatClient>();
+        var chatClient = chatClientMock.Object.AsBuilder()
+            .UseFunctionInvocation(configure: client => client.AllowConcurrentInvocation = initiallyEnabled)
+            .Build();
+        var options = new ChatClientAgentOptions { AllowConcurrentInvocation = allowConcurrentInvocation };
+
+        // Act
+        var agent = chatClient.AsAIAgent(options);
+
+        // Assert
+        var functionInvokingClient = agent.ChatClient.GetService<FunctionInvokingChatClient>();
+        Assert.NotNull(functionInvokingClient);
+        Assert.True(functionInvokingClient.AllowConcurrentInvocation);
+    }
+
     [Fact]
     public void CreateAIAgent_WithNullClient_Throws()
     {


### PR DESCRIPTION
### Motivation & Context

`AsAIAgent()` always left its default `FunctionInvokingChatClient` in serial invocation mode, even when the model returned multiple independent tool calls. This adds an explicit, backward-compatible opt-in for concurrent execution while preserving the current serial default.

### Description & Review Guide

- **What are the major changes?** Add `ChatClientAgentOptions.AllowConcurrentInvocation`, pass it to the default function-invocation middleware, preserve it when cloning options, and cover both paths with focused unit tests.
- **What is the impact of these changes?** Existing agents remain serial by default; callers may opt in when their tools are safe to execute concurrently.
- **What do you want reviewers to focus on?** The separation between model-side `AllowMultipleToolCalls` and runtime function-invocation concurrency.

### Related Issue

Fixes #7640

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.