### PR TITLE
Python: Fix duplicate streamed tool calls in DevUI

### DIFF
--- a/python/packages/devui/agent_framework_devui/_mapper.py
+++ b/python/packages/devui/agent_framework_devui/_mapper.py
@@ -1340,9 +1340,9 @@ class MessageMapper:
         """
         events: list[ResponseFunctionCallArgumentsDeltaEvent | ResponseOutputItemAddedEvent] = []
 
-        # CASE 1: New function call (has call_id and name)
-        # This is the first event that establishes the function call
-        if content.call_id and content.name:
+        # CASE 1: New function call (has a call_id and name not seen in an earlier chunk)
+        # Streaming providers may repeat call metadata with every argument chunk.
+        if content.call_id and content.name and content.call_id not in context["active_function_calls"]:
             # Use call_id as item_id (simpler, and call_id uniquely identifies the call)
             item_id = content.call_id
 

--- a/python/packages/devui/tests/devui/test_mapper.py
+++ b/python/packages/devui/tests/devui/test_mapper.py
@@ -139,6 +139,36 @@ async def test_function_call_mapping(mapper: MessageMapper, test_request: AgentF
     assert "TestCity" in full_json
 
 
+async def test_streaming_function_call_mapping_adds_item_once(
+    mapper: MessageMapper, test_request: AgentFrameworkRequest
+) -> None:
+    """Test repeated function metadata does not add duplicate output items."""
+    first_update = create_test_agent_update([
+        Content.from_function_call(
+            call_id="call_123",
+            name="get_weather",
+            arguments='{"location":',
+        )
+    ])
+    second_update = create_test_agent_update([
+        Content.from_function_call(
+            call_id="call_123",
+            name="get_weather",
+            arguments='"Seattle"}',
+        )
+    ])
+
+    events = [
+        *await mapper.convert_event(first_update, test_request),
+        *await mapper.convert_event(second_update, test_request),
+    ]
+
+    added_events = [event for event in events if event.type == "response.output_item.added"]
+    assert len(added_events) == 1
+    delta_events = [event for event in events if event.type == "response.function_call_arguments.delta"]
+    assert "".join(event.delta for event in delta_events) == '{"location":"Seattle"}'
+
+
 async def test_function_result_content_with_string_result(
     mapper: MessageMapper, test_request: AgentFrameworkRequest
 ) -> None:


### PR DESCRIPTION
### Motivation & Context

DevUI renders repeated copies of a single streamed tool call when the provider includes the same call ID and function name on each arguments chunk. This makes one framework tool execution appear as several calls in the chat.

The mapper should announce each unique function call once and continue forwarding all argument deltas for that call.

### Description & Review Guide

- **What are the major changes?** `MessageMapper` now emits `response.output_item.added` only when a function call ID is first observed. A regression test covers two argument chunks that repeat the same call metadata.
- **What is the impact of these changes?** DevUI displays one tool-call item per framework call while preserving streamed arguments. There is no public API change.
- **What do you want reviewers to focus on?** Confirm that using the request-scoped `active_function_calls` map correctly handles repeated provider metadata without affecting parallel calls.


### Related Issue

Fixes #7651

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.