### PR TITLE
Python: .NET: Make skill resource guidance rule-only

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -158,8 +158,9 @@ public sealed partial class AgentSkillsProvider : AIContextProvider, IDisposable
         When a task aligns with a skill's domain, follow these steps in exact order:
         - Use `load_skill` to retrieve the skill's instructions.
         - Follow the provided guidance.
-        - Use `read_skill_resource` to read any referenced resources, using the name exactly as listed
-           (e.g. `"style-guide"` not `"style-guide.md"`, `"references/FAQ.md"` not `"FAQ.md"`).
+        - Use `read_skill_resource` only for a resource explicitly referenced by the loaded skill.
+        - Pass its resource path exactly as written in that skill.
+        - Never infer or guess resource paths.
         - Use `run_skill_script` to run referenced scripts, using the name exactly as listed.
         Only load what is needed, when it is needed.
         """;

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -80,6 +80,26 @@ public sealed class AgentSkillsProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task InvokingCoreAsync_DefaultPromptUsesRuleOnlyResourceGuidanceAsync()
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("resource-guidance", "Resource guidance test", "Body.");
+        var provider = new AgentSkillsProvider(skill);
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+
+        // Act
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result.Instructions);
+        Assert.Contains("only for a resource explicitly referenced by the loaded skill", result.Instructions);
+        Assert.Contains("Pass its resource path exactly as written in that skill", result.Instructions);
+        Assert.Contains("Never infer or guess resource paths", result.Instructions);
+        Assert.DoesNotContain("style-guide", result.Instructions);
+        Assert.DoesNotContain("references/FAQ.md", result.Instructions);
+    }
+
+    [Fact]
     public async Task InvokingCoreAsync_NullInputInstructions_SetsInstructionsAsync()
     {
         // Arrange
@@ -437,6 +457,25 @@ public sealed class AgentSkillsProviderTests : IDisposable
         Assert.Contains("---", text);
         Assert.Contains("name: content-skill", text);
         Assert.Contains("Skill body.", text);
+    }
+
+    [Fact]
+    public async Task LoadSkill_ListsExplicitResourcePathExactlyAsync()
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("resource-skill", "Resource path test", "Consult the explicitly referenced guide.");
+        skill.AddResource("references/actual-guide.md", "Guide content");
+        var provider = new AgentSkillsProvider(skill);
+        var invokingContext = new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext());
+        var result = await provider.InvokingAsync(invokingContext, CancellationToken.None);
+        var loadSkillTool = result.Tools!.First(t => t.Name == "load_skill") as AIFunction;
+
+        // Act
+        var content = await loadSkillTool!.InvokeAsync(
+            new AIFunctionArguments(new Dictionary<string, object?> { ["skillName"] = "resource-skill" }));
+
+        // Assert
+        Assert.Contains("<resource name=\"references/actual-guide.md\"/>", content!.ToString());
     }
 
     [Fact]

--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1809,8 +1809,9 @@ When a task aligns with a skill's domain, follow these steps in exact order:
 Only load what is needed, when it is needed."""
 
 RESOURCE_INSTRUCTIONS: Final[str] = (
-    "- Use `read_skill_resource` to read any referenced resources, using the name exactly as listed\n"
-    '   (e.g. `"style-guide"` not `"style-guide.md"`, `"references/FAQ.md"` not `"FAQ.md"`).\n'
+    "- Use `read_skill_resource` only for a resource explicitly referenced by the loaded skill.\n"
+    "- Pass its resource path exactly as written in that skill.\n"
+    "- Never infer or guess resource paths.\n"
 )
 
 SCRIPT_RUNNER_INSTRUCTIONS: Final[str] = (

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -676,6 +676,20 @@ class TestBuildSkillsInstructionPrompt:
         assert "<description>Does stuff.</description>" in prompt
         assert "load_skill" in prompt
 
+    def test_default_prompt_uses_rule_only_resource_guidance(self) -> None:
+        skills = [
+            InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="Does stuff."), instructions="Body"),
+        ]
+
+        prompt = SkillsProvider._create_instructions(None, skills)
+
+        assert prompt is not None
+        assert "only for a resource explicitly referenced by the loaded skill" in prompt
+        assert "Pass its resource path exactly as written in that skill" in prompt
+        assert "Never infer or guess resource paths" in prompt
+        assert "style-guide" not in prompt
+        assert "references/FAQ.md" not in prompt
+
     def test_skills_sorted_alphabetically(self) -> None:
         skills = [
             InlineSkill(frontmatter=SkillFrontmatter(name="zebra", description="Z skill."), instructions="Body"),
@@ -805,6 +819,18 @@ class TestSkillsProvider:
         await _init_provider(provider)
         result = await provider._load_skill(_raw_skills(provider), "my-skill")
         assert "See [doc](references/FAQ.md)." in result
+
+    async def test_load_skill_lists_explicit_resource_path_exactly(self) -> None:
+        skill = InlineSkill(
+            frontmatter=SkillFrontmatter(name="my-skill", description="Skill."),
+            instructions="Consult the explicitly referenced guide.",
+            resources=[InlineSkillResource(name="references/actual-guide.md", content="Guide content")],
+        )
+        provider = SkillsProvider([skill])
+
+        result = await provider._load_skill([skill], "my-skill")
+
+        assert '<resource name="references/actual-guide.md"/>' in result
 
     async def test_load_skill_unknown_returns_error(self, tmp_path: Path) -> None:
         provider = SkillsProvider.from_paths(str(tmp_path))


### PR DESCRIPTION
### Motivation & Context

`AgentSkillsProvider` currently places fictional resource names in the default
Python and .NET instructions. A model can mistake those examples for resources
that the loaded skill actually provides and make a guaranteed-to-fail
`read_skill_resource` call.

This change keeps resource access grounded in the loaded skill while preserving
the existing resource discovery and tool APIs.

Fixes #7663

### Description & Review Guide

- **What are the major changes?**
  - Replace the concrete resource-name examples in both implementations with
    matching rule-only guidance: read only explicitly referenced resources,
    preserve the referenced path exactly, and never infer resource paths.
  - Add focused Python and .NET prompt regressions that reject the fictional
    examples.
  - Add positive controls showing that a real resource path remains advertised
    exactly when the loaded skill explicitly provides it.
- **What is the impact of these changes?**
  - Default skill instructions no longer prime models with nonexistent resource
    names. Public APIs and valid resource listings are unchanged.
- **What do you want reviewers to focus on?**
  - Confirm that the three resource rules remain equivalent across Python and
    .NET and that the C# assertions match the existing skills-test conventions.

The focused Python regressions fail against the base prompt and pass with this
change. The complete Python `test_skills.py` file and core syntax checks pass.
The .NET tests were not run locally because the .NET CLI was unavailable; draft
CI is expected to provide that validation.

### Related Issue

Fixes #7663

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
