### PR TITLE
.NET: Fix IDE0039 by using local functions in samples

### DIFF
--- a/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step01_BasicTextRAG/Program.cs
+++ b/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step01_BasicTextRAG/Program.cs
@@ -37,7 +37,7 @@ TextSearchStore textSearchStore = new(vectorStore, "product-and-policy-info", 30
 await textSearchStore.UpsertDocumentsAsync(GetSampleDocuments());
 
 // Create an adapter function that the TextSearchProvider can use to run searches against the TextSearchStore.
-Func<string, CancellationToken, Task<IEnumerable<TextSearchProvider.TextSearchResult>>> SearchAdapter = async (text, ct) =>
+async Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchAdapterAsync(string text, CancellationToken ct)
 {
     // Here we are limiting the search results to the single top result to demonstrate that we are accurately matching
     // specific search results for each question, but in a real world case, more results should be used.
@@ -49,7 +49,7 @@ Func<string, CancellationToken, Task<IEnumerable<TextSearchProvider.TextSearchRe
         Text = r.Text ?? string.Empty,
         RawRepresentation = r
     });
-};
+}
 
 // Configure the options for the TextSearchProvider.
 TextSearchProviderOptions textSearchOptions = new()
@@ -63,7 +63,7 @@ AIAgent agent = aiProjectClient
     .AsAIAgent(new ChatClientAgentOptions
     {
         ChatOptions = new() { ModelId = deploymentName, Instructions = "You are a helpful support specialist for Contoso Outdoors. Answer questions using the provided context and cite the source document when available." },
-        AIContextProviders = [new TextSearchProvider(SearchAdapter, textSearchOptions)],
+        AIContextProviders = [new TextSearchProvider(SearchAdapterAsync, textSearchOptions)],
         // Since we are using ChatCompletion which stores chat history locally, we can also add a message filter
         // that removes messages produced by the TextSearchProvider before they are added to the chat history, so that
         // we don't bloat chat history with all the search result messages.

--- a/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step02_CustomVectorStoreRAG/Program.cs
+++ b/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step02_CustomVectorStoreRAG/Program.cs
@@ -40,7 +40,7 @@ await UploadDataFromMarkdown(afOverviewUrl, "Microsoft Agent Framework Overview"
 await UploadDataFromMarkdown(afMigrationUrl, "Semantic Kernel to Microsoft Agent Framework Migration Guide", documentationCollection, 2000, 200);
 
 // Create an adapter function that the TextSearchProvider can use to run searches against the collection.
-Func<string, CancellationToken, Task<IEnumerable<TextSearchProvider.TextSearchResult>>> SearchAdapter = async (text, ct) =>
+async Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchAdapterAsync(string text, CancellationToken ct)
 {
     List<TextSearchProvider.TextSearchResult> results = [];
     await foreach (var result in documentationCollection.SearchAsync(text, 5, cancellationToken: ct))
@@ -54,7 +54,7 @@ Func<string, CancellationToken, Task<IEnumerable<TextSearchProvider.TextSearchRe
         });
     }
     return results;
-};
+}
 
 // Configure the options for the TextSearchProvider.
 TextSearchProviderOptions textSearchOptions = new()
@@ -72,7 +72,7 @@ AIAgent agent = aiProjectClient
     .AsAIAgent(new ChatClientAgentOptions
     {
         ChatOptions = new() { ModelId = deploymentName, Instructions = "You are a helpful support specialist for the Microsoft Agent Framework. Answer questions using the provided context and cite the source document when available. Keep responses brief." },
-        AIContextProviders = [new TextSearchProvider(SearchAdapter, textSearchOptions)],
+        AIContextProviders = [new TextSearchProvider(SearchAdapterAsync, textSearchOptions)],
         // Configure a filter on the InMemoryChatHistoryProvider so that we don't persist the messages produced by the TextSearchProvider in chat history.
         // The default is to persist all messages except those that came from chat history in the first place.
         // You may choose to persist the TextSearchProvider messages, if you want the search output to be provided to the model in future interactions as well.

--- a/dotnet/samples/02-agents/Agents/Agent_Step17_AdditionalAIContext/Program.cs
+++ b/dotnet/samples/02-agents/Agents/Agent_Step17_AdditionalAIContext/Program.cs
@@ -23,7 +23,7 @@ var endpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT") ??
 var deploymentName = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-5.4-mini";
 
 // A sample function to load the next three calendar events for the user.
-Func<Task<string[]>> loadNextThreeCalendarEvents = async () =>
+async Task<string[]> LoadNextThreeCalendarEventsAsync()
 {
     // In a real implementation, this method would connect to a calendar service
     return
@@ -32,7 +32,7 @@ Func<Task<string[]>> loadNextThreeCalendarEvents = async () =>
         "Team meeting today at 17:00",
         "Birthday party today at 20:00"
     ];
-};
+}
 
 // Create an agent with an AI context provider attached that aggregates two other providers.
 // You must dissable client side conversation storage for clients that support it:
@@ -64,7 +64,7 @@ AIAgent agent = new AIProjectClient(
         // The agent will call each provider in sequence, accumulating context from each.
         AIContextProviders = [
             new TodoListAIContextProvider(),
-            new CalendarSearchAIContextProvider(loadNextThreeCalendarEvents)
+            new CalendarSearchAIContextProvider(LoadNextThreeCalendarEventsAsync)
         ],
     });
 


### PR DESCRIPTION
### Motivation & Context

`dotnet format --verify-no-changes` fails on three .NET samples with IDE0039 (prefer local function over lambda assigned to a `Func<>` variable). That breaks format CI for these sample projects.

### Description & Review Guide

- **What are the major changes?**
  Convert three lambda-to-`Func<>` assignments into local functions and update the call sites to pass the method group:
  - `Agent_Step17_AdditionalAIContext` calendar loader
  - `AgentWithRAG_Step01_BasicTextRAG` search adapter
  - `AgentWithRAG_Step02_CustomVectorStoreRAG` search adapter
- **What is the impact of these changes?**
  Sample behavior is unchanged. Format/analyzer IDE0039 is satisfied.
- **What do you want reviewers to focus on?**
  Confirm the local function signatures still match the expected delegates (`Func<Task<string[]>>` and `Func<string, CancellationToken, Task<IEnumerable<TextSearchResult>>>`).

### Related Issue

No open issue. Small analyzer/format fix for sample code.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
