### PR TITLE
.NET: Align file tool descriptions with generated schema argument names

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileAccess/FileAccessProvider.cs
@@ -327,7 +327,7 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// <param name="globPattern">An optional glob pattern (e.g., "*.md") matched against entry names to filter the listing.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A list of entries, each with a name and a type of "file" or "directory" (subdirectories first).</returns>
-    [Description("List the direct child files and subdirectories of a directory. Omit the directory (or pass an empty string) to list the root. To enumerate a subdirectory, pass its relative path, for example \"reports\" or \"reports/2024\". Optionally filter entries with a glob_pattern (e.g. \"*.md\"). Subdirectories are listed before files, and each entry has a name and a type of \"file\" or \"directory\".")]
+    [Description("List the direct child files and subdirectories of a directory. Omit the directory (or pass an empty string) to list the root. To enumerate a subdirectory, pass its relative path, for example \"reports\" or \"reports/2024\". Optionally filter entries with a globPattern (e.g. \"*.md\"). Subdirectories are listed before files, and each entry has a name and a type of \"file\" or \"directory\".")]
     private async Task<List<FileStoreEntry>> LsAsync(string? directory = null, string? globPattern = null, CancellationToken cancellationToken = default)
     {
         string target = string.IsNullOrWhiteSpace(directory) ? string.Empty : directory!;
@@ -346,7 +346,7 @@ public sealed class FileAccessProvider : AIContextProvider, IDisposable
     /// <param name="replaceAll">When <see langword="true"/>, replace every occurrence; otherwise fail unless exactly one occurrence exists.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A confirmation message including the number of occurrences replaced, or a failure message.</returns>
-    [Description("Replace occurrences of old_string with new_string in a file. Fails if old_string is not found, or if it occurs more than once and replace_all is false. Returns the number of occurrences replaced.")]
+    [Description("Replace occurrences of oldString with newString in a file. Fails if oldString is not found, or if it occurs more than once and replaceAll is false. Returns the number of occurrences replaced.")]
     private async Task<string> ReplaceAsync(string fileName, string oldString, string newString, bool replaceAll = false, CancellationToken cancellationToken = default)
     {
         await this._writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Harness/FileMemory/FileMemoryProvider.cs
@@ -268,7 +268,7 @@ public sealed class FileMemoryProvider : AIContextProvider, IDisposable
     /// <param name="globPattern">An optional glob pattern (e.g., "*.md") matched against file names to filter the listing.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A list of file entries with names and optional descriptions.</returns>
-    [Description("List all memory files with their descriptions (if available). Optionally filter file names with a glob_pattern (e.g. \"*.md\"). Internal files (description sidecars and the memory index) are not shown.")]
+    [Description("List all memory files with their descriptions (if available). Optionally filter file names with a globPattern (e.g. \"*.md\"). Internal files (description sidecars and the memory index) are not shown.")]
     private async Task<List<FileListEntry>> LsAsync(string? globPattern = null, CancellationToken cancellationToken = default)
     {
         FileMemoryState state = this._sessionState.GetOrInitializeState(AIAgent.CurrentRunContext?.Session);
@@ -319,7 +319,7 @@ public sealed class FileMemoryProvider : AIContextProvider, IDisposable
     /// <param name="replaceAll">When <see langword="true"/>, replace every occurrence; otherwise fail unless exactly one occurrence exists.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A confirmation message including the number of occurrences replaced, or a failure message.</returns>
-    [Description("Replace occurrences of old_string with new_string in a memory file. Fails if old_string is not found, or if it occurs more than once and replace_all is false. Returns the number of occurrences replaced.")]
+    [Description("Replace occurrences of oldString with newString in a memory file. Fails if oldString is not found, or if it occurs more than once and replaceAll is false. Returns the number of occurrences replaced.")]
     private async Task<string> ReplaceAsync(string fileName, string oldString, string newString, bool replaceAll = false, CancellationToken cancellationToken = default)
     {
         string normalized = StorePaths.NormalizeRelativePath(fileName);
@@ -394,7 +394,7 @@ public sealed class FileMemoryProvider : AIContextProvider, IDisposable
     /// <param name="globPattern">An optional glob pattern to filter which files to search (e.g., "*.md", "research*"). Leave empty or omit to search all files.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A list of search results with matching file names, snippets, and matching lines.</returns>
-    [Description("Search memory file contents using a regular expression pattern (case-insensitive). Optionally filter which files to search using a glob_pattern (e.g., \"*.md\", \"research*\"). Returns matching file names, content snippets, and matching lines with line numbers.")]
+    [Description("Search memory file contents using a regular expression pattern (case-insensitive). Optionally filter which files to search using a globPattern (e.g., \"*.md\", \"research*\"). Returns matching file names, content snippets, and matching lines with line numbers.")]
     private async Task<List<FileSearchResult>> GrepAsync(string regexPattern, string? globPattern = null, CancellationToken cancellationToken = default)
     {
         FileMemoryState state = this._sessionState.GetOrInitializeState(AIAgent.CurrentRunContext?.Session);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessToolDescriptionSchemaTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileAccess/FileAccessToolDescriptionSchemaTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Moq;
+
+namespace Microsoft.Agents.AI.UnitTests.Harness.FileAccess;
+
+/// <summary>
+/// Verifies that each file access tool's description refers to arguments by the same
+/// names that <see cref="AIFunctionFactory"/> exposes in the generated JSON schema.
+/// </summary>
+public class FileAccessToolDescriptionSchemaTests
+{
+    [Fact]
+    public async Task LsTool_Description_UsesSchemaArgumentNameAsync()
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(FileAccessProvider.LsToolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — the description and the generated schema agree on the filter argument name.
+        Assert.Contains("globPattern", tool.Description);
+        Assert.DoesNotContain("glob_pattern", tool.Description);
+        Assert.Contains("globPattern", schemaArguments);
+    }
+
+    [Fact]
+    public async Task ReplaceTool_Description_UsesSchemaArgumentNamesAsync()
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(FileAccessProvider.ReplaceToolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — the description and the generated schema agree on the replace argument names.
+        Assert.Contains("oldString", tool.Description);
+        Assert.Contains("newString", tool.Description);
+        Assert.Contains("replaceAll", tool.Description);
+        Assert.DoesNotContain("old_string", tool.Description);
+        Assert.DoesNotContain("new_string", tool.Description);
+        Assert.DoesNotContain("replace_all", tool.Description);
+        Assert.Contains("oldString", schemaArguments);
+        Assert.Contains("newString", schemaArguments);
+        Assert.Contains("replaceAll", schemaArguments);
+    }
+
+    [Fact]
+    public async Task ReplaceLinesTool_Description_KeepsExplicitJsonPropertyNamesAsync()
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(FileAccessProvider.ReplaceLinesToolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — line_number/new_line are mapped explicitly via JsonPropertyName, so the
+        // description must keep referencing them as-is instead of a camelCase rename.
+        Assert.Contains("line_number", tool.Description);
+        Assert.Contains("new_line", tool.Description);
+        Assert.Contains("line_number", schemaArguments);
+        Assert.Contains("new_line", schemaArguments);
+    }
+
+    private static async Task<AIFunction> GetToolAsync(string toolName)
+    {
+        // Arrange
+        var provider = new FileAccessProvider(new InMemoryAgentFileStore());
+        var agent = new Mock<AIAgent>().Object;
+        var session = new ChatClientAgentSession();
+#pragma warning disable MAAI001
+        var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());
+#pragma warning restore MAAI001
+
+        AIContext result = await provider.InvokingAsync(context);
+        return (AIFunction)result.Tools!.First(t => t is AIFunction f && f.Name == toolName);
+    }
+
+    private static List<string> GetSchemaArgumentNames(AIFunction tool)
+    {
+        var names = new List<string>();
+        if (tool.JsonSchema is JsonElement schema)
+        {
+            CollectPropertyNames(schema, names);
+        }
+
+        return names.Distinct().ToList();
+    }
+
+    private static void CollectPropertyNames(JsonElement element, List<string> names)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (property.Name == "properties")
+                {
+                    foreach (JsonProperty item in property.Value.EnumerateObject())
+                    {
+                        names.Add(item.Name);
+                        CollectPropertyNames(item.Value, names);
+                    }
+                }
+                else
+                {
+                    CollectPropertyNames(property.Value, names);
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                CollectPropertyNames(item, names);
+            }
+        }
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileMemory/FileMemoryToolDescriptionSchemaTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/Harness/FileMemory/FileMemoryToolDescriptionSchemaTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Moq;
+
+namespace Microsoft.Agents.AI.UnitTests.Harness.FileMemory;
+
+/// <summary>
+/// Verifies that each file memory tool's description refers to arguments by the same
+/// names that <see cref="AIFunctionFactory"/> exposes in the generated JSON schema.
+/// </summary>
+public class FileMemoryToolDescriptionSchemaTests
+{
+    [Theory]
+    [InlineData(FileMemoryProvider.LsToolName)]
+    [InlineData(FileMemoryProvider.GrepToolName)]
+    public async Task FilteringTool_Description_UsesSchemaArgumentNameAsync(string toolName)
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(toolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — the description and the generated schema agree on the filter argument name.
+        Assert.Contains("globPattern", tool.Description);
+        Assert.DoesNotContain("glob_pattern", tool.Description);
+        Assert.Contains("globPattern", schemaArguments);
+    }
+
+    [Fact]
+    public async Task ReplaceTool_Description_UsesSchemaArgumentNamesAsync()
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(FileMemoryProvider.ReplaceToolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — the description and the generated schema agree on the replace argument names.
+        Assert.Contains("oldString", tool.Description);
+        Assert.Contains("newString", tool.Description);
+        Assert.Contains("replaceAll", tool.Description);
+        Assert.DoesNotContain("old_string", tool.Description);
+        Assert.DoesNotContain("new_string", tool.Description);
+        Assert.DoesNotContain("replace_all", tool.Description);
+        Assert.Contains("oldString", schemaArguments);
+        Assert.Contains("newString", schemaArguments);
+        Assert.Contains("replaceAll", schemaArguments);
+    }
+
+    [Fact]
+    public async Task ReplaceLinesTool_Description_KeepsExplicitJsonPropertyNamesAsync()
+    {
+        // Arrange
+        AIFunction tool = await GetToolAsync(FileMemoryProvider.ReplaceLinesToolName);
+
+        // Act
+        List<string> schemaArguments = GetSchemaArgumentNames(tool);
+
+        // Assert — line_number/new_line are mapped explicitly via JsonPropertyName, so the
+        // description must keep referencing them as-is instead of a camelCase rename.
+        Assert.Contains("line_number", tool.Description);
+        Assert.Contains("new_line", tool.Description);
+        Assert.Contains("line_number", schemaArguments);
+        Assert.Contains("new_line", schemaArguments);
+    }
+
+    private static async Task<AIFunction> GetToolAsync(string toolName)
+    {
+        // Arrange
+        var provider = new FileMemoryProvider(new InMemoryAgentFileStore());
+        var agent = new Mock<AIAgent>().Object;
+        var session = new ChatClientAgentSession();
+#pragma warning disable MAAI001
+        var context = new AIContextProvider.InvokingContext(agent, session, new AIContext());
+#pragma warning restore MAAI001
+
+        AIContext result = await provider.InvokingAsync(context);
+        return (AIFunction)result.Tools!.First(t => t is AIFunction f && f.Name == toolName);
+    }
+
+    private static List<string> GetSchemaArgumentNames(AIFunction tool)
+    {
+        var names = new List<string>();
+        if (tool.JsonSchema is JsonElement schema)
+        {
+            CollectPropertyNames(schema, names);
+        }
+
+        return names.Distinct().ToList();
+    }
+
+    private static void CollectPropertyNames(JsonElement element, List<string> names)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (JsonProperty property in element.EnumerateObject())
+            {
+                if (property.Name == "properties")
+                {
+                    foreach (JsonProperty item in property.Value.EnumerateObject())
+                    {
+                        names.Add(item.Name);
+                        CollectPropertyNames(item.Value, names);
+                    }
+                }
+                else
+                {
+                    CollectPropertyNames(property.Value, names);
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                CollectPropertyNames(item, names);
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿### Motivation & Context

The `file_access` and `file_memory` tool descriptions refer to their arguments by snake_case names (`glob_pattern`, `old_string`, `new_string`, `replace_all`) while `AIFunctionFactory` generates the tool schema from the camelCase C# parameter names (`globPattern`, `oldString`, `newString`, `replaceAll`). A model that follows the description emits argument names that never bind, so `file_access_ls` runs without its filter and `file_access_replace` fails its own "old_string not found" check for reasons unrelated to the file.

### Description & Review Guide

- **What are the major changes?**
  Renamed the argument references in the `[Description]` text of the affected tools so they match the generated schema:
  - `file_access_ls`, `file_memory_ls`, `file_memory_grep`: `glob_pattern` → `globPattern`
  - `file_access_replace`, `file_memory_replace`: `old_string`/`new_string`/`replace_all` → `oldString`/`newString`/`replaceAll`
  The `replace_lines` descriptions are intentionally left alone: `line_number` and `new_line` are mapped explicitly via `[JsonPropertyName]` and are genuinely snake_case in the schema.
  Added `FileAccessToolDescriptionSchemaTests` and `FileMemoryToolDescriptionSchemaTests` asserting each affected description and its generated schema agree on argument names, plus a guard for the `replace_lines` names.

- **What is the impact of these changes?**
  Models that follow the descriptions will emit argument names that bind, so filtering and replace behave as described instead of silently dropping arguments.

- **What do you want reviewers to focus on?**
  That every affected tool is covered, and that the `replace_lines` `JsonPropertyName` names were intentionally kept as-is.

### Related Issue

Fixes #7672

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

