### PR TITLE
Python: clear service_session_id on full-history replay

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -206,6 +206,8 @@ class AgentExecutor(Executor):
         run the agent and emit an AgentExecutorResponse downstream.
         """
         self._cache.extend(request.messages)
+        if self._replays_full_history(request.messages):
+            self._session.service_session_id = None
 
         if request.should_respond:
             await self._run_agent_and_emit(ctx)
@@ -259,7 +261,10 @@ class AgentExecutor(Executor):
                 "which causes the full conversation context to be lost.",
                 self.id,
             )
-        self._cache.extend(normalize_messages_input(text))
+        messages = normalize_messages_input(text)
+        self._cache.extend(messages)
+        if self._replays_full_history(messages):
+            self._session.service_session_id = None
         await self._run_agent_and_emit(ctx)
 
     @handler
@@ -272,7 +277,10 @@ class AgentExecutor(Executor):
 
         The new message will be added to the cache which is used as the conversation context for the agent run.
         """
-        self._cache.extend(normalize_messages_input(message))
+        messages = normalize_messages_input(message)
+        self._cache.extend(messages)
+        if self._replays_full_history(messages):
+            self._session.service_session_id = None
         await self._run_agent_and_emit(ctx)
 
     @handler
@@ -285,7 +293,10 @@ class AgentExecutor(Executor):
 
         The new messages will be added to the cache which is used as the conversation context for the agent run.
         """
-        self._cache.extend(normalize_messages_input(messages))
+        normalized_messages = normalize_messages_input(messages)
+        self._cache.extend(normalized_messages)
+        if self._replays_full_history(normalized_messages):
+            self._session.service_session_id = None
         await self._run_agent_and_emit(ctx)
 
     @response_handler
@@ -315,6 +326,20 @@ class AgentExecutor(Executor):
             self._cache = normalize_messages_input(Message(role=role, contents=self._pending_responses_to_agent))
             self._pending_responses_to_agent.clear()
             await self._run_agent_and_emit(ctx)
+
+    @staticmethod
+    def _replays_full_history(messages: list[Message]) -> bool:
+        """Return True when the input explicitly replays prior conversation turns.
+
+        A full-history replay contains assistant and/or tool messages that carry
+        server-issued response items (function calls, reasoning, results). Running
+        such a replay while the session still holds a service_session_id makes
+        the provider receive both the previous_response_id pointer and the same
+        items inline, which the Responses API rejects with a "Duplicate item found"
+        error. Incremental turns (user messages only) keep the pointer so providers
+        can continue the conversation via previous_response_id.
+        """
+        return any(message.role in ("assistant", "tool") for message in messages)
 
     @override
     async def on_checkpoint_save(self) -> dict[str, Any]:

--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -329,15 +329,15 @@ class AgentExecutor(Executor):
 
     @staticmethod
     def _replays_full_history(messages: list[Message]) -> bool:
-        """Return True when the input explicitly replays prior conversation turns.
+        """Return True when the input replays prior conversation turns.
 
-        A full-history replay contains assistant and/or tool messages that carry
-        server-issued response items (function calls, reasoning, results). Running
-        such a replay while the session still holds a service_session_id makes
-        the provider receive both the previous_response_id pointer and the same
-        items inline, which the Responses API rejects with a "Duplicate item found"
-        error. Incremental turns (user messages only) keep the pointer so providers
-        can continue the conversation via previous_response_id.
+        A full-history replay includes assistant and/or tool messages — the turns a
+        previous run produced. Replaying them while the session still holds a
+        service_session_id makes the provider receive both the previous_response_id
+        pointer and the same turns inline, which the Responses API rejects with a
+        "Duplicate item found" error. Incremental turns (user messages only) keep
+        the pointer so providers can continue the conversation via
+        previous_response_id.
         """
         return any(message.role in ("assistant", "tool") for message in messages)
 

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -411,12 +411,14 @@ class _SessionIdCapturingAgent(BaseAgent):
 
 
 class _FullHistoryReplayCoordinator(Executor):
-    """Coordinator that pre-sets service_session_id on a target executor then replays the full
-    conversation (including function calls) back to it via AgentExecutorRequest."""
+    """Coordinator that pre-sets service_session_id on a target executor then sends it
+    an AgentExecutorRequest carrying either the full conversation (including function
+    calls) or just a new user turn."""
 
-    def __init__(self, *, target_exec: AgentExecutor, **kwargs: Any) -> None:
+    def __init__(self, *, target_exec: AgentExecutor, include_history: bool = True, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._target_exec = target_exec
+        self._include_history = include_history
 
     @handler
     async def handle(
@@ -424,7 +426,10 @@ class _FullHistoryReplayCoordinator(Executor):
         response: AgentExecutorResponse,
         ctx: WorkflowContext[AgentExecutorRequest, Any],
     ) -> None:
-        full_conv = list(response.full_conversation or response.agent_response.messages)
+        if self._include_history:
+            full_conv = list(response.full_conversation or response.agent_response.messages)
+        else:
+            full_conv = []
         full_conv.append(Message(role="user", contents=["follow-up"]))
         # Simulate a prior run: the target executor has a stored previous_response_id.
         self._target_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
@@ -434,15 +439,6 @@ class _FullHistoryReplayCoordinator(Executor):
         )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Tracks the executor-layer half of #3295: AgentExecutor should clear service_session_id "
-        "when handed a full prior conversation. The wire-level 'Duplicate item' API error is "
-        "already closed by the chat-client strip in #3295; this xfail covers the defense-in-depth "
-        "follow-up that makes the executor wiring reflect intent."
-    ),
-    strict=True,
-)
 async def test_run_request_with_full_history_clears_service_session_id() -> None:
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
@@ -470,6 +466,31 @@ async def test_run_request_with_full_history_clears_service_session_id() -> None
     # "Duplicate item found" because the same function-call IDs appear in both
     # previous_response_id (server-stored) and the explicit input messages.
     assert spy_agent._captured_service_session_id is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_run_request_with_new_turn_preserves_service_session_id() -> None:
+    """A new user turn (no replayed history) must keep service_session_id so the provider
+    can continue the conversation via previous_response_id."""
+    tool_agent = _ToolHistoryAgent(id="tool_agent_new_turn", name="ToolAgent", summary_text="Done.")
+    tool_exec = AgentExecutor(tool_agent, id="tool_agent_new_turn")
+
+    spy_agent = _SessionIdCapturingAgent(id="spy_agent_new_turn", name="SpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="spy_agent_new_turn")
+
+    coordinator = _FullHistoryReplayCoordinator(id="coord_new_turn", target_exec=spy_exec, include_history=False)
+
+    wf = (
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
+        .add_edge(tool_exec, coordinator)
+        .add_edge(coordinator, spy_exec)
+        .build()
+    )
+
+    result = await wf.run("initial prompt")
+    assert result.get_outputs() is not None
+
+    # The spy agent must still see the stored pointer: only a full-history replay clears it.
+    assert spy_agent._captured_service_session_id == "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_from_response_preserves_service_session_id() -> None:

--- a/python/packages/core/tests/workflow/test_full_conversation.py
+++ b/python/packages/core/tests/workflow/test_full_conversation.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-from collections.abc import AsyncIterable, Awaitable
+from collections.abc import AsyncIterable, Awaitable, Callable
 from typing import Any, Literal, overload
 
 import pytest
@@ -439,6 +439,32 @@ class _FullHistoryReplayCoordinator(Executor):
         )
 
 
+class _PayloadReplayCoordinator(Executor):
+    """Coordinator that pre-sets service_session_id on a target executor and sends it
+    a payload derived from the upstream response. The payload type selects the
+    executor's input handler (from_messages, from_message, from_str, or run)."""
+
+    def __init__(
+        self,
+        *,
+        target_exec: AgentExecutor,
+        payload_factory: Callable[[AgentExecutorResponse], Any],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._target_exec = target_exec
+        self._payload_factory = payload_factory
+
+    @handler
+    async def handle(
+        self,
+        response: AgentExecutorResponse,
+        ctx: WorkflowContext[str | Message | list[Message], Any],
+    ) -> None:
+        self._target_exec._session.service_session_id = "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
+        await ctx.send_message(self._payload_factory(response), target_id=self._target_exec.id)
+
+
 async def test_run_request_with_full_history_clears_service_session_id() -> None:
     """Replaying a full conversation (including function calls) via AgentExecutorRequest must
     clear service_session_id so the API does not receive both previous_response_id and the
@@ -490,6 +516,110 @@ async def test_run_request_with_new_turn_preserves_service_session_id() -> None:
     assert result.get_outputs() is not None
 
     # The spy agent must still see the stored pointer: only a full-history replay clears it.
+    assert spy_agent._captured_service_session_id == "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_from_messages_with_full_history_clears_service_session_id() -> None:
+    """from_messages with a full-history list must clear service_session_id."""
+    tool_agent = _ToolHistoryAgent(id="tool_agent_fm", name="ToolAgent", summary_text="Done.")
+    tool_exec = AgentExecutor(tool_agent, id="tool_agent_fm")
+
+    spy_agent = _SessionIdCapturingAgent(id="spy_agent_fm", name="SpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="spy_agent_fm")
+
+    coordinator = _PayloadReplayCoordinator(
+        id="coord_fm",
+        target_exec=spy_exec,
+        payload_factory=lambda response: list(response.full_conversation or response.agent_response.messages),
+    )
+
+    wf = (
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
+        .add_edge(tool_exec, coordinator)
+        .add_edge(coordinator, spy_exec)
+        .build()
+    )
+
+    result = await wf.run("initial prompt")
+    assert result.get_outputs() is not None
+    assert spy_agent._captured_service_session_id is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_from_messages_with_new_turn_preserves_service_session_id() -> None:
+    """from_messages with only a user turn must keep service_session_id."""
+    tool_agent = _ToolHistoryAgent(id="tool_agent_fm2", name="ToolAgent", summary_text="Done.")
+    tool_exec = AgentExecutor(tool_agent, id="tool_agent_fm2")
+
+    spy_agent = _SessionIdCapturingAgent(id="spy_agent_fm2", name="SpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="spy_agent_fm2")
+
+    coordinator = _PayloadReplayCoordinator(
+        id="coord_fm2",
+        target_exec=spy_exec,
+        payload_factory=lambda _: [Message(role="user", contents=["follow-up"])],
+    )
+
+    wf = (
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
+        .add_edge(tool_exec, coordinator)
+        .add_edge(coordinator, spy_exec)
+        .build()
+    )
+
+    result = await wf.run("initial prompt")
+    assert result.get_outputs() is not None
+    assert spy_agent._captured_service_session_id == "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_from_message_replays_prior_turn_clears_service_session_id() -> None:
+    """A single replayed assistant message via from_message must clear service_session_id."""
+    tool_agent = _ToolHistoryAgent(id="tool_agent_msg", name="ToolAgent", summary_text="Done.")
+    tool_exec = AgentExecutor(tool_agent, id="tool_agent_msg")
+
+    spy_agent = _SessionIdCapturingAgent(id="spy_agent_msg", name="SpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="spy_agent_msg")
+
+    coordinator = _PayloadReplayCoordinator(
+        id="coord_msg",
+        target_exec=spy_exec,
+        payload_factory=lambda response: list(response.full_conversation or response.agent_response.messages)[-1],
+    )
+
+    wf = (
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
+        .add_edge(tool_exec, coordinator)
+        .add_edge(coordinator, spy_exec)
+        .build()
+    )
+
+    result = await wf.run("initial prompt")
+    assert result.get_outputs() is not None
+    assert spy_agent._captured_service_session_id is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_from_str_with_user_prompt_preserves_service_session_id() -> None:
+    """from_str (a plain user prompt) must keep service_session_id."""
+    tool_agent = _ToolHistoryAgent(id="tool_agent_str", name="ToolAgent", summary_text="Done.")
+    tool_exec = AgentExecutor(tool_agent, id="tool_agent_str")
+
+    spy_agent = _SessionIdCapturingAgent(id="spy_agent_str", name="SpyAgent")
+    spy_exec = AgentExecutor(spy_agent, id="spy_agent_str")
+
+    coordinator = _PayloadReplayCoordinator(
+        id="coord_str",
+        target_exec=spy_exec,
+        payload_factory=lambda _: "follow-up",
+    )
+
+    wf = (
+        WorkflowBuilder(start_executor=tool_exec, output_from=[coordinator])
+        .add_edge(tool_exec, coordinator)
+        .add_edge(coordinator, spy_exec)
+        .build()
+    )
+
+    result = await wf.run("initial prompt")
+    assert result.get_outputs() is not None
     assert spy_agent._captured_service_session_id == "resp_PREVIOUS_RUN"  # pyright: ignore[reportPrivateUsage]
 
 


### PR DESCRIPTION
### Motivation & Context

When a workflow coordinator sends an `AgentExecutorRequest` that replays a prior conversation — including the function calls and results from an earlier run — the executor's session still carries the previous run's `service_session_id`. The provider then receives both the `previous_response_id` pointer and the same items inline, which the Responses API rejects with `Duplicate item found`.

The chat client already strips server-issued response items from the wire input when service-side storage is in play (#3295), but the executor wiring still forwarded a stale continuation pointer for full-history replays. This closes that gap so the two layers agree.

### Description & Review Guide

- **What are the major changes?**
  - `AgentExecutor` now clears `session.service_session_id` before running when an explicit input replays prior conversation turns (messages that include `assistant` or `tool` roles). This applies to the `run`, `from_str`, `from_message`, and `from_messages` handlers.
  - `from_response` is untouched: chained executors keep their pointer so the API can continue via `previous_response_id`.
  - A single new user turn also keeps the pointer — only full-history replays are cleared.
  - The strict `xfail` covering the executor-layer half of #3295 is removed and now passes, and a new test pins the incremental-turn boundary.
- **What is the impact of these changes?**
  - Replaying a full conversation to an `AgentExecutor` no longer risks a `Duplicate item found` provider error, and multi-turn continuation via `service_session_id` keeps working for plain new turns.
- **What do you want reviewers to focus on?**
  - The role-based detection of a full-history replay (`assistant`/`tool` messages) and whether the explicit-input handlers are the right places for it.

### Related Issue

Fixes #4292

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
