### PR TITLE
Python: return caller-owned checkpoints from InMemoryCheckpointStorage reads

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint.py
@@ -127,7 +127,13 @@ class WorkflowCheckpoint:
 
 
 class CheckpointStorage(Protocol):
-    """Protocol for checkpoint storage backends."""
+    """Protocol for checkpoint storage backends.
+
+    Reads return objects owned by the caller: mutating a checkpoint returned by ``load``,
+    ``list_checkpoints`` or ``get_latest`` must not change what a later read returns.
+    Backends that serialize their storage satisfy this by construction; backends that hold
+    checkpoints in memory must copy on read.
+    """
 
     async def save(self, checkpoint: WorkflowCheckpoint) -> CheckpointID:
         """Save a checkpoint and return its ID.
@@ -217,12 +223,12 @@ class InMemoryCheckpointStorage:
         checkpoint = self._checkpoints.get(checkpoint_id)
         if checkpoint:
             logger.debug(f"Loaded checkpoint {checkpoint_id} from memory")
-            return checkpoint
+            return copy.deepcopy(checkpoint)
         raise WorkflowCheckpointException(f"No checkpoint found with ID {checkpoint_id}")
 
     async def list_checkpoints(self, *, workflow_name: str) -> list[WorkflowCheckpoint]:
         """List checkpoint objects for a given workflow name."""
-        return [cp for cp in self._checkpoints.values() if cp.workflow_name == workflow_name]
+        return [copy.deepcopy(cp) for cp in self._checkpoints.values() if cp.workflow_name == workflow_name]
 
     async def delete(self, checkpoint_id: CheckpointID) -> bool:
         """Delete a checkpoint by ID."""
@@ -239,7 +245,7 @@ class InMemoryCheckpointStorage:
             return None
         latest_checkpoint = max(checkpoints, key=lambda cp: datetime.fromisoformat(cp.timestamp))
         logger.debug(f"Latest checkpoint for workflow {workflow_name} is {latest_checkpoint.checkpoint_id}")
-        return latest_checkpoint
+        return copy.deepcopy(latest_checkpoint)
 
     async def list_checkpoint_ids(self, *, workflow_name: str) -> list[CheckpointID]:
         """List checkpoint IDs. If workflow_id is provided, filter by that workflow."""

--- a/python/packages/core/tests/workflow/test_checkpoint.py
+++ b/python/packages/core/tests/workflow/test_checkpoint.py
@@ -1765,4 +1765,44 @@ async def test_file_checkpoint_storage_roundtrip_empty_collections():
         assert loaded.pending_request_info_events == {}
 
 
+async def test_memory_checkpoint_storage_load_returns_caller_owned_copy():
+    """Mutating a loaded checkpoint must not change what a later read returns."""
+    storage = InMemoryCheckpointStorage()
+    checkpoint = WorkflowCheckpoint(
+        workflow_name="test-workflow",
+        graph_signature_hash="test-hash",
+        state={"answer": "original"},
+    )
+    await storage.save(checkpoint)
+
+    loaded = await storage.load(checkpoint.checkpoint_id)
+    loaded.state["answer"] = "mutated"
+
+    reloaded = await storage.load(checkpoint.checkpoint_id)
+    assert reloaded.state["answer"] == "original"
+
+
+async def test_memory_checkpoint_storage_list_and_get_latest_return_caller_owned_copies():
+    """list_checkpoints and get_latest follow the same read-isolation contract as load."""
+    storage = InMemoryCheckpointStorage()
+    checkpoint = WorkflowCheckpoint(
+        workflow_name="test-workflow",
+        graph_signature_hash="test-hash",
+        state={"answer": "original"},
+    )
+    await storage.save(checkpoint)
+
+    listed = await storage.list_checkpoints(workflow_name="test-workflow")
+    listed[0].state["answer"] = "mutated-via-list"
+
+    latest = await storage.get_latest(workflow_name="test-workflow")
+    assert latest is not None
+    assert latest.state["answer"] == "original"
+
+    latest.state["answer"] = "mutated-via-get-latest"
+
+    reloaded = await storage.load(checkpoint.checkpoint_id)
+    assert reloaded.state["answer"] == "original"
+
+
 # endregion


### PR DESCRIPTION
### Motivation & Context

`InMemoryCheckpointStorage` handed out the checkpoint objects it stores, so a caller that mutated a loaded checkpoint also mutated the storage. The other two implementations of the same `CheckpointStorage` protocol, `FileCheckpointStorage` and the Azure Cosmos backend, rebuild every returned checkpoint from its serialized form, so their reads are isolated by construction.

That made the in-memory implementation the odd one out on a protocol three backends share, and it is the one tests and samples reach for first, so a workflow that mutates restored state could behave differently depending on which backend was configured.

The protocol itself did not say which behavior was correct, which is how the two were able to drift apart.

### Description & Review Guide

- **What are the major changes?**

  `InMemoryCheckpointStorage` now returns `copy.deepcopy` from its three read paths, `load`, `list_checkpoints` and `get_latest`, matching the deep copy that `save` already stored. Isolation on write was deliberate, and only the read side was missing.

  The `CheckpointStorage` protocol docstring now states the contract the fix restores: reads return objects owned by the caller, backends that serialize satisfy this by construction, and backends holding checkpoints in memory must copy on read.

- **What is the impact of these changes?**

  All three implementations now agree. Callers may treat a returned checkpoint as their own, which is what the file and Cosmos backends already allowed. No public signature changes, and no behavior changes for callers that do not mutate what they read.

  `get_latest` copies only the single checkpoint it returns rather than the whole candidate list, so listing cost is unchanged.

- **What do you want reviewers to focus on?**

  Whether the added protocol sentence states the intended contract. If the intended contract is instead that callers must copy defensively, then the file and Cosmos backends are the ones that diverge and this change should be reversed in favor of documenting that. I read the existing `copy.deepcopy` in `save` as evidence that caller isolation was already intended.

### Related Issue

Fixes #7685

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added the relevant documentation where applicable

Two tests were added to the workflow checkpoint suite:

- `test_memory_checkpoint_storage_load_returns_caller_owned_copy` — mutating a loaded checkpoint does not change what a later read returns.
- `test_memory_checkpoint_storage_list_and_get_latest_return_caller_owned_copies` — the same contract for the other two read paths.

Both fail without the fix. With it, `uv run poe test` over the workflow suite reports 926 passed, 2 skipped and 2 xfailed, while `ruff check` and `ruff format --check` are clean on both changed files.