### PR TITLE
Python: Fix Agent Lightning installation link

### DIFF
--- a/python/packages/lab/lightning/README.md
+++ b/python/packages/lab/lightning/README.md
@@ -24,7 +24,7 @@ pip install -e ".[lightning,math]"
 pip install -e ".[lightning,tau2]"
 ```
 
-To prepare for RL training, you'll also need to install dependencies like PyTorch, Ray, and vLLM. See the [Agent-lightning setup instructions](https://microsoft.github.io/agent-lightning/stable/tutorials/installation/) for more details.
+To prepare for RL training, you'll also need to install dependencies like PyTorch, Ray, and vLLM. See the [Agent-lightning setup instructions](https://microsoft.github.io/agent-lightning/0.3.0/tutorials/installation/) for more details.
 
 ## Usage Patterns
 


### PR DESCRIPTION
### Motivation & Context

The Agent Framework Lab Lightning README links to an Agent Lightning installation path that now returns HTTP 404. The lab package supports Agent Lightning 0.2.x and 0.3.x, so the setup link should target the compatible 0.3.0 documentation instead of the current stable documentation for the redesigned 1.0 release.

### Description & Review Guide

- **What are the major changes?** Replaces the broken Agent Lightning installation URL with the versioned 0.3.0 installation guide.
- **What is the impact of these changes?** Readers can reach setup instructions compatible with the package dependency range.
- **What do you want reviewers to focus on?** Confirm the versioned documentation matches `agentlightning>=0.2.0,<0.4.0`.

### Related Issue

N/A. No tracking issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
