### PR TITLE
Python: clarify skill script argument guidance

### DIFF
--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1818,7 +1818,7 @@ SCRIPT_RUNNER_INSTRUCTIONS: Final[str] = (
     "- Pass named script arguments inside `args` as a JSON object, including for inline scripts"
     ' (e.g. `args: {"length": 24}`), not as top-level tool parameters.\n'
     "- For file-based scripts that document CLI-style positional arguments, pass `args` as an array of strings"
-    ' (e.g. `args: ["input.docx", "--output", "result.idx"]).\n'
+    ' (e.g. `args: ["input.docx", "--output", "result.idx"]`).\n'
 )
 
 # endregion

--- a/python/packages/core/agent_framework/_skills.py
+++ b/python/packages/core/agent_framework/_skills.py
@@ -1815,8 +1815,10 @@ RESOURCE_INSTRUCTIONS: Final[str] = (
 
 SCRIPT_RUNNER_INSTRUCTIONS: Final[str] = (
     "- Use `run_skill_script` to run referenced scripts, using the name exactly as listed.\n"
-    "- Pass script arguments inside `args` as a JSON object"
+    "- Pass named script arguments inside `args` as a JSON object, including for inline scripts"
     ' (e.g. `args: {"length": 24}`), not as top-level tool parameters.\n'
+    "- For file-based scripts that document CLI-style positional arguments, pass `args` as an array of strings"
+    ' (e.g. `args: ["input.docx", "--output", "result.idx"]).\n'
 )
 
 # endregion

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -682,8 +682,9 @@ class TestBuildSkillsInstructionPrompt:
         ]
         prompt = SkillsProvider._create_instructions(None, skills)
         assert prompt is not None
-        assert "JSON object, including for inline scripts" in prompt
-        assert "file-based scripts that document CLI-style positional arguments" in prompt
+        script_guidance = [line for line in prompt.splitlines() if "script" in line]
+        assert any("JSON object" in line and "inline scripts" in line for line in script_guidance)
+        assert any("array of strings" in line and "file-based scripts" in line for line in script_guidance)
         assert "not as top-level tool parameters" in prompt
 
     def test_skills_sorted_alphabetically(self) -> None:

--- a/python/packages/core/tests/core/test_skills.py
+++ b/python/packages/core/tests/core/test_skills.py
@@ -676,6 +676,16 @@ class TestBuildSkillsInstructionPrompt:
         assert "<description>Does stuff.</description>" in prompt
         assert "load_skill" in prompt
 
+    def test_default_prompt_distinguishes_script_argument_shapes(self) -> None:
+        skills = [
+            InlineSkill(frontmatter=SkillFrontmatter(name="my-skill", description="Does stuff."), instructions="Body"),
+        ]
+        prompt = SkillsProvider._create_instructions(None, skills)
+        assert prompt is not None
+        assert "JSON object, including for inline scripts" in prompt
+        assert "file-based scripts that document CLI-style positional arguments" in prompt
+        assert "not as top-level tool parameters" in prompt
+
     def test_skills_sorted_alphabetically(self) -> None:
         skills = [
             InlineSkill(frontmatter=SkillFrontmatter(name="zebra", description="Z skill."), instructions="Body"),


### PR DESCRIPTION
### Motivation & Context

`SCRIPT_RUNNER_INSTRUCTIONS` currently tells agents to pass `args` as an object, while the `run_skill_script` schema also accepts string arrays for file-based CLI scripts. That guidance can steer agents away from a supported argument shape. This change aligns the default prompt with the existing schema and runtime behavior.

### Description & Review Guide

- **What are the major changes?**
  - Clarify that named arguments, including inline scripts, use a JSON object inside `args`.
  - Clarify that string arrays are for file-based scripts that document CLI-style positional arguments.
  - Add a regression test for the generated default prompt.
  - Close the inline-code example correctly so the generated guidance renders as intended.
- **What is the impact of these changes?**
  - No runtime or API behavior changes; the default prompt now distinguishes the two supported argument forms.
  - The focused `test_skills.py` suite passes with 537 passed and 11 skipped; Ruff check and format checks pass.
  - `uv build` successfully produced the core sdist and wheel. The repository `poe build -P core` wrapper then stops at its `sh`-based dist move because `sh` is unavailable in this Windows environment.
- **What do you want reviewers to focus on?**
  - Whether the wording matches the file-based and inline script behavior.
  - Whether the test asserts the distinction without coupling to an entire sentence.

This PR was prepared with AI assistance; I reviewed the patch and verified the focused behavior locally.

### Related Issue

Fixes #7691

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix) — a workflow keeps the label and the title prefix in sync automatically.