### PR TITLE
Python: Add Foundry-Features header to toolbox requests

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_TOOLBOX_SCOPE = "https://ai.azure.com/.default"
 # Default timeout (seconds) for toolbox MCP requests.
 _DEFAULT_TIMEOUT = 120.0
+# Environment variable used to inject platform-provided toolbox feature flags.
+_TOOLSET_FEATURES_ENV_VAR = "FOUNDRY_AGENT_TOOLSET_FEATURES"
 # Mandatory preview feature flag for Foundry toolbox requests.
 _MANDATORY_TOOLBOX_FEATURE = "Toolboxes=V1Preview"
 
@@ -113,7 +115,8 @@ class _ToolboxAuth(httpx.Auth):
     def __init__(self, credential: AzureCredentialTypes, scope: str) -> None:
         self._credential = credential
         self._scope = scope
-        self._features_header = _build_toolbox_features_header(os.environ.get("FOUNDRY_AGENT_TOOLSET_FEATURES"))
+        # Feature flags are startup configuration, matching the .NET toolbox service.
+        self._features_header = _build_toolbox_features_header(os.environ.get(_TOOLSET_FEATURES_ENV_VAR))
 
     def _apply_headers(self, request: httpx.Request, token: AccessToken) -> None:
         request.headers["Authorization"] = f"Bearer {token.token}"

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_toolbox.py
@@ -42,6 +42,20 @@ logger = logging.getLogger(__name__)
 DEFAULT_TOOLBOX_SCOPE = "https://ai.azure.com/.default"
 # Default timeout (seconds) for toolbox MCP requests.
 _DEFAULT_TIMEOUT = 120.0
+# Mandatory preview feature flag for Foundry toolbox requests.
+_MANDATORY_TOOLBOX_FEATURE = "Toolboxes=V1Preview"
+
+
+def _build_toolbox_features_header(additional_features: str | None) -> str:
+    """Merge platform-provided features with the mandatory toolbox feature."""
+    if additional_features is None or not additional_features.strip():
+        return _MANDATORY_TOOLBOX_FEATURE
+    if any(
+        feature.strip().casefold() == _MANDATORY_TOOLBOX_FEATURE.casefold()
+        for feature in additional_features.split(",")
+    ):
+        return additional_features
+    return f"{_MANDATORY_TOOLBOX_FEATURE},{additional_features}"
 
 
 def _resolve_toolbox_endpoint() -> str:
@@ -81,7 +95,7 @@ def _toolbox_name_from_endpoint(endpoint: str) -> str:
 
 
 class _ToolboxAuth(httpx.Auth):
-    """Injects a fresh bearer token and the platform call-id on every request.
+    """Injects a fresh bearer token, feature flags, and the platform call-id on every request.
 
     Both the synchronous (``sync_auth_flow``) and asynchronous (``async_auth_flow``)
     httpx auth hooks are implemented, so the same auth works regardless of which
@@ -99,11 +113,13 @@ class _ToolboxAuth(httpx.Auth):
     def __init__(self, credential: AzureCredentialTypes, scope: str) -> None:
         self._credential = credential
         self._scope = scope
+        self._features_header = _build_toolbox_features_header(os.environ.get("FOUNDRY_AGENT_TOOLSET_FEATURES"))
 
     def _apply_headers(self, request: httpx.Request, token: AccessToken) -> None:
         request.headers["Authorization"] = f"Bearer {token.token}"
         for key, value in get_request_context().platform_headers().items():
             request.headers[key] = value
+        request.headers["Foundry-Features"] = self._features_header
 
     def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
         # azure-core credentials cache the token internally and only refresh near
@@ -138,7 +154,8 @@ class FoundryToolbox(MCPStreamableHTTPTool):
     ``MCPStreamableHTTPTool`` by hand it:
 
     - resolves the toolbox endpoint and tool name from the environment when not given,
-    - authenticates every request with a bearer token from ``credential``, and
+    - authenticates every request with a bearer token from ``credential``,
+    - sends the mandatory toolbox preview feature plus platform-provided feature flags, and
     - forwards the platform per-request call-id (``x-agent-foundry-call-id``) so the
       Foundry MCP proxy can resolve the caller context server-side.
 

--- a/python/packages/foundry_hosting/tests/test_toolbox.py
+++ b/python/packages/foundry_hosting/tests/test_toolbox.py
@@ -163,6 +163,32 @@ async def test_auth_flow_injects_bearer_token_async_credential() -> None:
     assert cred.scopes == ["https://ai.azure.com/.default"]
 
 
+@pytest.mark.parametrize(
+    ("additional_features", "expected"),
+    [
+        (None, "Toolboxes=V1Preview"),
+        ("   ", "Toolboxes=V1Preview"),
+        ("FeatureOne=Enabled,FeatureTwo=Enabled", "Toolboxes=V1Preview,FeatureOne=Enabled,FeatureTwo=Enabled"),
+        ("FeatureOne=Enabled, toolboxes=v1preview ", "FeatureOne=Enabled, toolboxes=v1preview "),
+    ],
+)
+async def test_auth_flow_injects_foundry_features_header(
+    monkeypatch: pytest.MonkeyPatch,
+    additional_features: str | None,
+    expected: str,
+) -> None:
+    if additional_features is None:
+        monkeypatch.delenv("FOUNDRY_AGENT_TOOLSET_FEATURES", raising=False)
+    else:
+        monkeypatch.setenv("FOUNDRY_AGENT_TOOLSET_FEATURES", additional_features)
+    auth = _ToolboxAuth(_FakeCredential(), "scope")  # type: ignore
+    request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
+
+    prepared = await anext(auth.async_auth_flow(request))
+
+    assert prepared.headers["Foundry-Features"] == expected
+
+
 def test_sync_auth_flow_injects_bearer_token() -> None:
     cred = _FakeCredential("sync123")
     auth = _ToolboxAuth(cred, "https://ai.azure.com/.default")  # type: ignore

--- a/python/packages/foundry_hosting/tests/test_toolbox.py
+++ b/python/packages/foundry_hosting/tests/test_toolbox.py
@@ -200,6 +200,16 @@ def test_sync_auth_flow_injects_bearer_token() -> None:
     assert cred.scopes == ["https://ai.azure.com/.default"]
 
 
+def test_sync_auth_flow_injects_foundry_features_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FOUNDRY_AGENT_TOOLSET_FEATURES", "FeatureOne=Enabled")
+    auth = _ToolboxAuth(_FakeCredential(), "scope")  # type: ignore
+    request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")
+
+    prepared = next(auth.sync_auth_flow(request))
+
+    assert prepared.headers["Foundry-Features"] == "Toolboxes=V1Preview,FeatureOne=Enabled"
+
+
 def test_sync_auth_flow_rejects_async_credential() -> None:
     auth = _ToolboxAuth(_FakeAsyncCredential(), "scope")  # type: ignore
     request = httpx.Request("POST", "https://h/toolboxes/tb/mcp")


### PR DESCRIPTION
### Motivation & Context

Python `FoundryToolbox` requests currently omit the mandatory `Foundry-Features: Toolboxes=V1Preview` header and ignore `FOUNDRY_AGENT_TOOLSET_FEATURES`. This can prevent platform-provided feature flags from reaching the toolbox service and leaves Python behavior inconsistent with .NET.

### Description & Review Guide

- **What are the major changes?** Build the toolbox features header when authentication is configured, always include the mandatory preview flag, merge platform-provided values, and avoid duplicating the mandatory flag. Add focused coverage for default, blank, merged, and pre-existing mandatory values across asynchronous and synchronous authentication flows.
- **What is the impact of these changes?** Every Python `FoundryToolbox` request now carries the expected feature header without changing the public API.
- **What do you want reviewers to focus on?** The feature-value merge behavior and parity with the .NET toolbox handler.

### Related Issue

Fixes #7689

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
