### PR TITLE
Python: Clarify function-loop spec update guidance

### DIFF
--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -64,8 +64,9 @@ serialization, or transport result handling must follow
 [the function-calling loop specification](../docs/specs/004-python-function-calling-loop.md). This area requires
 extra validation because small changes can duplicate side effects, orphan call/result pairs, replay stale approval
 authority, or make streaming and non-streaming behavior diverge. Update the specification and its scenario-to-test
-mapping whenever coverage or behavior changes. External contributors must check with the Agent Framework core team
-before picking up issues in this area.
+mapping only when the documented contract, scenario inventory, or authoritative scenario-to-test mapping materially
+changes. Adding or modifying tests that preserve existing documented behavior does not require a specification update.
+External contributors must check with the Agent Framework core team before picking up issues in this area.
 
 ## Project Structure
 


### PR DESCRIPTION
### Motivation & Context

The Python agent guidance currently tells coding agents to update the function-calling-loop specification whenever coverage changes. This causes routine regression-test changes that preserve the documented contract to modify the specification unnecessarily.

This change narrows that instruction so the specification remains authoritative without accumulating edits for tests that only preserve existing documented behavior.

### Description & Review Guide

- **What are the major changes?** Clarify that the function-calling-loop specification and scenario-to-test mapping need updates only when the documented contract, scenario inventory, or authoritative mapping materially changes.
- **What is the impact of these changes?** Coding agents can add or modify tests for existing documented behavior without producing unrelated specification churn.
- **What do you want reviewers to focus on?** Whether the wording preserves the intended safety requirements while clearly distinguishing contract changes from coverage-only changes.

### Related Issue

No related issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
