### PR TITLE
.NET: Fix release build analyzer failures

### DIFF
--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.302",
+        "version": "10.0.303",
         "rollForward": "minor",
         "allowPrerelease": false
     },

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/AgentFrameworkResponseHandler.cs
@@ -514,9 +514,12 @@ public class AgentFrameworkResponseHandler : ResponseHandler
 
         if (notAllowedStoreUsageDetected)
         {
-            this._logger.LogError(
-                "Agent '{AgentName}' should not have server side storage enabled. This produced a new untracked conversation/response in the server while the hosted agent also generated a conversation for the request of the agent.",
-                agent.Name);
+            if (this._logger.IsEnabled(LogLevel.Error))
+            {
+                this._logger.LogError(
+                    "Agent '{AgentName}' should not have server side storage enabled. This produced a new untracked conversation/response in the server while the hosted agent also generated a conversation for the request of the agent.",
+                    agent.Name);
+            }
 
             throw HostedStoredOutputCompatibility.CreateMisconfiguredAgentError();
         }


### PR DESCRIPTION
### Motivation & Context

The .NET release solution build is blocked by CA1873 in Foundry Hosting and by a net9 ILLink analyzer crash when C# 14 extension members are analyzed under SDK 10.0.302. This restores release builds without suppressing diagnostics or changing the public API.

### Description & Review Guide

- **What are the major changes?** Guard the hosted-storage error log with `ILogger.IsEnabled(LogLevel.Error)` before evaluating `agent.Name`, and update the SDK pin from 10.0.302 to the servicing release 10.0.303.
- **What is the impact of these changes?** Release analysis no longer reports CA1873, and net9 builds use the serviced ILLink analyzer that handles C# 14 extension members without throwing AD0001.
- **What do you want reviewers to focus on?** Confirm that 10.0.303 is the preferred minimal SDK servicing baseline and that the logging guard is appropriately scoped.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #7720

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.