### PR TITLE
Python: Include arguments for zero-argument Foundry eval tool calls

### DIFF
--- a/python/packages/core/agent_framework/_evaluation.py
+++ b/python/packages/core/agent_framework/_evaluation.py
@@ -796,9 +796,8 @@ class AgentEvalConverter:
                     "type": "tool_call",
                     "tool_call_id": c.call_id or "",
                     "name": c.name or "",
+                    "arguments": args if args is not None else {},
                 }
-                if args:
-                    tc["arguments"] = args
                 content_items.append(tc)
             elif c.type == "function_result":
                 result_val = c.result

--- a/python/packages/foundry/tests/test_foundry_evals.py
+++ b/python/packages/foundry/tests/test_foundry_evals.py
@@ -153,6 +153,26 @@ class TestConvertMessage:
         assert tc["name"] == "get_weather"
         assert tc["arguments"] == {"location": "Seattle"}
 
+    def test_assistant_with_zero_argument_tool_call(self) -> None:
+        msg = Message(
+            "assistant",
+            [Content.from_function_call(call_id="call_1", name="get_site_summary", arguments=None)],
+        )
+
+        result = AgentEvalConverter.convert_message(msg)
+
+        assert result[0]["content"][0]["arguments"] == {}
+
+    def test_assistant_with_empty_argument_object_tool_call(self) -> None:
+        msg = Message(
+            "assistant",
+            [Content.from_function_call(call_id="call_1", name="get_site_summary", arguments={})],
+        )
+
+        result = AgentEvalConverter.convert_message(msg)
+
+        assert result[0]["content"][0]["arguments"] == {}
+
     def test_assistant_text_and_tool_call(self) -> None:
         msg = Message(
             "assistant",


### PR DESCRIPTION
### Motivation & Context

Foundry evaluation conversion currently omits the `arguments` field when a function call has `None` or an empty object for its arguments. This produces an incomplete tool-call record for valid zero-argument tools. The converter should emit an empty object so the evaluation payload remains schema-consistent.

### Description & Review Guide

- **What are the major changes?** The converter now always includes `arguments`, using an empty object when the source value is `None`. Regression tests cover both `None` and an explicitly empty argument object.
- **What is the impact of these changes?** Zero-argument tool calls can be evaluated by Foundry without losing the required argument shape. Calls with populated arguments are unchanged.
- **What do you want reviewers to focus on?** Whether normalizing missing arguments to an empty object is the expected representation for Foundry evaluation tool calls.

### Related Issue

Fixes #7714

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.