### PR TITLE
Python: Surface mid-stream oauth_consent_request items in Foundry hosting

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -1736,6 +1736,18 @@ async def _to_outputs(
                 "Approval request was not saved to approval storage because the approval request ID "
                 "could not be extracted from the stream event."
             )
+    elif content.type == "oauth_consent_request" and content.consent_link:
+        # Mirrors the init-time consent path in `_handle_response` so consent requests raised
+        # mid-stream (e.g. OBO identity pass-through) reach the caller instead of being dropped.
+        oauth_item = OAuthConsentRequestOutputItem(
+            id=IdGenerator.new_id("oacr"),
+            type="oauth_consent_request",
+            consent_link=content.consent_link,
+            server_label=content.additional_properties.get("server_label", "agent_framework"),
+        )
+        builder = stream.add_output_item(oauth_item["id"])
+        yield builder.emit_added(oauth_item)
+        yield builder.emit_done(oauth_item)
     else:
         # Log a warning for unsupported content types instead of raising an error to avoid breaking the response stream.
         logger.warning(f"Content type '{content.type}' is not supported yet. This is usually safe to ignore.")

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -175,6 +175,43 @@ def consent_url_from_error(exc: BaseException) -> list[ConsentError] | None:
     return None
 
 
+def _emit_oauth_consent_item(
+    stream: ResponseEventStream,
+    *,
+    consent_link: str,
+    server_label: str,
+    response_id: str | None = None,
+) -> Generator[ResponseStreamEvent]:
+    """Emit the added/done event pair for one OAuth consent request output item.
+
+    Shared by the two paths that can surface a consent request so the item shape and ID
+    prefix stay in sync: consent errors raised while entering the agent, and consent
+    content produced while the agent is running.
+
+    Args:
+        stream: The ResponseEventStream to emit the output item on.
+
+    Keyword Args:
+        consent_link: The URL the user must visit to complete OAuth consent.
+        server_label: The label of the tool source requiring consent.
+        response_id: The response the item belongs to, when known.
+
+    Yields:
+        ResponseStreamEvent: The added and done events for the consent output item.
+    """
+    oauth_item = OAuthConsentRequestOutputItem(
+        id=IdGenerator.new_id("oacr"),
+        type="oauth_consent_request",
+        consent_link=consent_link,
+        server_label=server_label,
+    )
+    if response_id is not None:
+        oauth_item["response_id"] = response_id
+    builder = stream.add_output_item(oauth_item["id"])
+    yield builder.emit_added(oauth_item)
+    yield builder.emit_done(oauth_item)
+
+
 # endregion Foundry Toolbox Auth integration
 
 
@@ -361,16 +398,13 @@ class ResponsesHostServer(ResponsesAgentServerHost):
 
             for consent_error in consent_errors_to_emit:
                 logger.warning("Consent URL for tool '%s': %s", consent_error.name, consent_error.consent_url)
-                oauth_item = OAuthConsentRequestOutputItem(
-                    id=IdGenerator.new_id("oacr"),
-                    response_id=context.response_id,
-                    type="oauth_consent_request",
+                for event in _emit_oauth_consent_item(
+                    response_event_stream,
                     consent_link=consent_error.consent_url,
                     server_label=consent_error.name,
-                )
-                builder = response_event_stream.add_output_item(oauth_item["id"])
-                yield builder.emit_added(oauth_item)
-                yield builder.emit_done(oauth_item)
+                    response_id=context.response_id,
+                ):
+                    yield event
 
             yield response_event_stream.emit_incomplete(
                 reason=f"OAuth consent required for {len(consent_errors_to_emit)} tool(s)."
@@ -1737,17 +1771,14 @@ async def _to_outputs(
                 "could not be extracted from the stream event."
             )
     elif content.type == "oauth_consent_request" and content.consent_link:
-        # Mirrors the init-time consent path in `_handle_response` so consent requests raised
-        # mid-stream (e.g. OBO identity pass-through) reach the caller instead of being dropped.
-        oauth_item = OAuthConsentRequestOutputItem(
-            id=IdGenerator.new_id("oacr"),
-            type="oauth_consent_request",
+        # Consent raised while the agent runs (e.g. OBO identity pass-through) must reach the
+        # caller rather than falling through to the unsupported-content warning below.
+        for event in _emit_oauth_consent_item(
+            stream,
             consent_link=content.consent_link,
             server_label=content.additional_properties.get("server_label", "agent_framework"),
-        )
-        builder = stream.add_output_item(oauth_item["id"])
-        yield builder.emit_added(oauth_item)
-        yield builder.emit_done(oauth_item)
+        ):
+            yield event
     else:
         # Log a warning for unsupported content types instead of raising an error to avoid breaking the response stream.
         logger.warning(f"Content type '{content.type}' is not supported yet. This is usually safe to ignore.")

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -3758,6 +3758,40 @@ class TestOAuthConsentSurfacing:
         assert len(oauth_items) == 1
         assert oauth_items[0]["consent_link"] == "https://consent.example.com/obo"
 
+    async def test_mid_stream_consent_content_streams_oauth_output_item(self) -> None:
+        # Companion to the non-streaming case above: a streaming client must see the consent
+        # item as a proper added/done output item pair, not lose it to the unsupported-content
+        # warning in `_to_outputs`.
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_oauth_consent_request("https://consent.example.com/obo")],
+                    role="assistant",
+                )
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, input_text="list my tasks", stream=True)
+        assert resp.status_code == 200
+        events = _parse_sse_events(resp.text)
+
+        added = [e for e in events if e["event"] == "response.output_item.added"]
+        oauth_added = [e for e in added if e["data"]["item"]["type"] == "oauth_consent_request"]
+        assert len(oauth_added) == 1
+        assert oauth_added[0]["data"]["item"]["consent_link"] == "https://consent.example.com/obo"
+        assert oauth_added[0]["data"]["item"]["server_label"] == "agent_framework"
+
+        done = [e for e in events if e["event"] == "response.output_item.done"]
+        oauth_done = [e for e in done if e["data"]["item"]["type"] == "oauth_consent_request"]
+        assert len(oauth_done) == 1
+        assert oauth_done[0]["data"]["item"]["id"] == oauth_added[0]["data"]["item"]["id"]
+
+        # Unlike the initialization-time path, which ends the response as `response.incomplete`,
+        # consent surfaced mid-stream still terminates as `response.completed`: `_to_outputs` is
+        # a content converter with no authority over response-level status.
+        assert _sse_event_types(events)[-1] == "response.completed"
+
     async def test_streaming_consent_error_emits_oauth_output_item(self) -> None:
         agent = _make_agent(stream_updates=[AgentResponseUpdate(contents=[Content.from_text("hi")], role="assistant")])
         agent.__aenter__.side_effect = _make_consent_error("https://consent.example.com/auth")

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -3739,6 +3739,25 @@ class TestOAuthConsentSurfacing:
         # The agent must not be run when entry fails.
         agent.run.assert_not_called()
 
+    async def test_mid_stream_consent_content_emits_oauth_output_item(self) -> None:
+        # Consent raised while the agent runs (e.g. OBO identity pass-through) must reach
+        # the caller instead of being dropped as an unsupported content type.
+        agent = _make_agent(
+            stream_updates=[
+                AgentResponseUpdate(
+                    contents=[Content.from_oauth_consent_request("https://consent.example.com/obo")],
+                    role="assistant",
+                )
+            ]
+        )
+        server = _make_server(agent)
+
+        resp = await _post(server, input_text="list my tasks", stream=False)
+        assert resp.status_code == 200
+        oauth_items = [it for it in resp.json()["output"] if it["type"] == "oauth_consent_request"]
+        assert len(oauth_items) == 1
+        assert oauth_items[0]["consent_link"] == "https://consent.example.com/obo"
+
     async def test_streaming_consent_error_emits_oauth_output_item(self) -> None:
         agent = _make_agent(stream_updates=[AgentResponseUpdate(contents=[Content.from_text("hi")], role="assistant")])
         agent.__aenter__.side_effect = _make_consent_error("https://consent.example.com/auth")


### PR DESCRIPTION
### Motivation & Context

When a Foundry-hosted agent uses an OAuth identity pass-through (OBO) MCP toolbox, a user who has not yet consented triggers an `oauth_consent_request` content item **while the agent is running**. The hosting layer dropped it:

```
WARNING:agent_framework_foundry_hosting._responses:Content type
'oauth_consent_request' is not supported yet. This is usually safe to ignore.
```

The caller got a response with no output items at all — no text, no consent link, no way to complete the consent flow. The agent appears to silently do nothing.

Consent surfacing already worked for the *other* moment it can occur: when `__aenter__` fails during lazy agent initialization, `_handle_response` catches it, runs `consent_url_from_error`, and emits a proper `OAuthConsentRequestOutputItem` (`_responses.py:362-378`). Only the mid-stream path was missing.

### Description & Review Guide

- **What are the major changes?**

  One `elif` branch in `_to_outputs()` (`_responses.py`), plus a regression test.

  `_OutputItemTracker.handle()` was already correct — its catch-all `else` closes the active builder and sets `needs_async = True`, so `oauth_consent_request` content was correctly routed to `_to_outputs()`. `_to_outputs()` simply had no branch for it, so it fell through to the `else` that logs and discards. The new branch emits an `OAuthConsentRequestOutputItem` with `added` + `done` events, mirroring the initialization-time path.

  Note that the reverse direction already worked: `_output_items_to_messages` parses an inbound `oauth_consent_request` item into `Content` (`_responses.py:1420`). The type round-tripped *in* but not *out*, which is why the existing `test_oauth_consent_request` (inbound only) stayed green.

- **What is the impact of these changes?**

  Not a breaking change. Content that was previously discarded now produces an output item; no existing content type changes shape. Applies to both transports, since non-streaming responses are assembled from the same `ResponseEventStream`.

- **What do you want reviewers to focus on?**

  See the heads-up section below — particularly the response status question, which may warrant a follow-up.

### Heads-up for maintainers

1. **The response is still marked `completed`, not `incomplete`.** The initialization-time path emits `emit_incomplete(reason="OAuth consent required for N tool(s).")` after the consent item. This change does not, because `_to_outputs()` is a leaf content converter with no authority over response-level status — signalling it would mean threading state back up to `_handle_response`. **If Foundry clients branch on `status == "incomplete"` to render the consent prompt, this fix is incomplete and needs that follow-up.** Guidance welcome; happy to extend this PR or file a separate issue.

2. **`server_label` defaults to `"agent_framework"`**, read from `content.additional_properties`, matching the convention in the adjacent `function_approval_request` branch. The init-time path can use the real tool-source name because the MCP error carries it; mid-stream content does not, so providers must set it explicitly via `additional_properties`. If a different default is preferred, easy to change.

3. **`response_id` is omitted from the emitted item.** It is optional in the `OAuthConsentRequestOutputItem` TypedDict (only `id`, `type`, `consent_link`, `server_label` are `Required`), and `_to_outputs()` has no `ResponseContext` — the stream only exposes `_response_id` privately. Reaching into an Azure SDK private attribute did not seem worth it, but say the word if the field is expected downstream.

4. **`content.consent_link` falsiness falls through to the existing warning.** A consent item with no link would render as an unclickable dead end, so it is treated as unsupported rather than emitted empty.

5. **The `"This is usually safe to ignore"` wording in the fallback `else`** is what made this bug easy to miss for an auth-blocking handshake. Left as-is to keep the diff focused, but it may deserve a second look.

### Verification

`uv run poe check -P foundry_hosting` — clean:

- `fmt` / `lint` pass
- `pyright` 0 errors, 0 warnings; `mypy`, `ty`, `pyrefly`, `zuban` all pass
- 217 tests pass, 20 deselected (integration)

New test `TestOAuthConsentSurfacing::test_mid_stream_consent_content_emits_oauth_output_item` fails without the fix (response output is empty) and passes with it.

### Related Issue

Fixes #7725

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
