### PR TITLE
Python: FoundryEvals always emits arguments field for tool calls

### DIFF
--- a/python/packages/core/agent_framework/_evaluation.py
+++ b/python/packages/core/agent_framework/_evaluation.py
@@ -797,7 +797,7 @@ class AgentEvalConverter:
                     "tool_call_id": c.call_id or "",
                     "name": c.name or "",
                 }
-                tc["arguments"] = args if args else {}
+                tc["arguments"] = args if args is not None else {}
                 content_items.append(tc)
             elif c.type == "function_result":
                 result_val = c.result

--- a/python/packages/core/agent_framework/_evaluation.py
+++ b/python/packages/core/agent_framework/_evaluation.py
@@ -797,8 +797,7 @@ class AgentEvalConverter:
                     "tool_call_id": c.call_id or "",
                     "name": c.name or "",
                 }
-                if args:
-                    tc["arguments"] = args
+                tc["arguments"] = args if args else {}
                 content_items.append(tc)
             elif c.type == "function_result":
                 result_val = c.result

--- a/python/packages/foundry/tests/test_foundry_evals.py
+++ b/python/packages/foundry/tests/test_foundry_evals.py
@@ -153,6 +153,23 @@ class TestConvertMessage:
         assert tc["name"] == "get_weather"
         assert tc["arguments"] == {"location": "Seattle"}
 
+    def test_assistant_with_zero_argument_tool_call(self) -> None:
+        msg = Message(
+            "assistant",
+            [
+                Content.from_function_call(
+                    call_id="call_3",
+                    name="get_site_summary",
+                    arguments=None,
+                ),
+            ],
+        )
+        result = AgentEvalConverter.convert_message(msg)
+        tc = result[0]["content"][0]
+        assert tc["type"] == "tool_call"
+        assert "arguments" in tc
+        assert tc["arguments"] == {}
+
     def test_assistant_text_and_tool_call(self) -> None:
         msg = Message(
             "assistant",


### PR DESCRIPTION
### Motivation & Context

`AgentEvalConverter.convert_message` only set the `arguments` field on a `tool_call` content item when the parsed arguments were truthy, so tool calls with no model-supplied arguments were uploaded without an `arguments` field at all. Foundry's tool-aware evaluators (`task_adherence`, `tool_output_utilization`, `tool_call_accuracy`) require every `tool_call` item to have an `arguments` field, even if empty, and fail with `FAILED_EXECUTION` otherwise. This contributes to the `FoundryEvals` evaluation scenario for agents with zero-argument tools.

### Description & Review Guide

- **What are the major changes?** `python/packages/core/agent_framework/_evaluation.py`: `tc["arguments"]` is now always set, defaulting to `{}` only when the parsed arguments are `None` (an explicit `is not None` check, not a truthiness check, so valid-but-falsy arguments like `0`/`""`/`False` are preserved).
- **What is the impact of these changes?** Zero-argument tool calls now serialize with `"arguments": {}` instead of omitting the key, matching what Foundry's evaluators require. No behavior change for tool calls that already had arguments.
- **What do you want reviewers to focus on?** Whether defaulting to `{}` (vs. omitting the field) is the correct shape for all Foundry evaluators, and whether the `is not None` check should also apply to the existing `{"_raw_arguments": "[unparseable]"}` fallback path.

### Related Issue

Fixes #7714

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
