### PR TITLE
Add es-metadata.yml for Engineering System inventory

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: 69587e29-ab55-4ccf-9e95-bff8d5a945fd
+    routing:
+      defaultAreaPath:
+        org: msdata
+        path: Vienna\Agent Framework Team


### PR DESCRIPTION
### Motivation & Context

The repository is not registered with Engineering System inventory, which requires
an `es-metadata.yml` file declaring the owning Service Tree service. Without it,
the repository is reported as missing inventory and compliance work items have no
routing target.

Adding the file at the repository root registers ownership and routes compliance
items to the owning team. This is standard practice for Microsoft-owned
repositories — `microsoft/aspire`, `microsoft/garnet`, `microsoft/STL`,
`microsoft/vstest` and many others carry the same file.

### Description & Review Guide

- **What are the major changes?**
  Adds a single new file, `es-metadata.yml`, at the repository root. It uses the
  `InventoryAsCode` provider (schema 1.0.0) to declare the accountable Service Tree
  service and the default area path for work item routing.

- **What is the impact of these changes?**
  No impact on source code, builds, tests, packaging or published artifacts. The
  file is consumed only by Microsoft engineering system tooling. Nothing in the
  repository reads it, and no workflow behaviour changes.

- **What do you want reviewers to focus on?**
  That the Service Tree service ID and area path are correct for this repository.

### Related Issue

Fixes #7739

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**