### PR TITLE
.NET: Remove AGUI history special cases from ChatClientAgent

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ChatClientAgent.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Agents.AI;
 /// </remarks>
 public sealed partial class ChatClientAgent : AIAgent
 {
-    private const string AGUIProviderName = "ag-ui";
-
     private readonly ChatClientAgentOptions? _agentOptions;
     private readonly HashSet<string> _aiContextProviderStateKeys;
     private readonly AIAgentMetadata _agentMetadata;
@@ -818,7 +816,7 @@ public sealed partial class ChatClientAgent : AIAgent
 
         if (!string.IsNullOrWhiteSpace(responseConversationId))
         {
-            if (!IsAGUIProviderName(this._agentMetadata.ProviderName) && this._agentOptions?.ChatHistoryProvider is not null)
+            if (this._agentOptions?.ChatHistoryProvider is not null)
             {
                 // The agent has a ChatHistoryProvider configured, but the service returned a conversation id,
                 // meaning the service manages chat history server-side. Both cannot be used simultaneously.
@@ -932,9 +930,6 @@ public sealed partial class ChatClientAgent : AIAgent
         }
     }
 
-    private static bool IsAGUIProviderName(string? providerName) =>
-        string.Equals(providerName, AGUIProviderName, StringComparison.Ordinal);
-
     /// <summary>
     /// Ensures that <see cref="AIAgent.CurrentRunContext"/> contains the resolved session.
     /// </summary>
@@ -994,7 +989,6 @@ public sealed partial class ChatClientAgent : AIAgent
         // the provider the decorator depends on.
         bool serviceStoresHistory =
             !this.RequiresPerServiceCallChatHistoryPersistence
-            && !IsAGUIProviderName(this._agentMetadata.ProviderName)
             && (!string.IsNullOrWhiteSpace(chatOptions?.ConversationId)
                 || !string.IsNullOrWhiteSpace(session.ConversationId));
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/BasicStreamingTests.cs
@@ -131,12 +131,12 @@ public sealed class BasicStreamingTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task MultiTurnConversationPreservesAllMessagesInSessionAsync()
+    public async Task AGUIChatClientBackedAgentUsesLocalChatHistoryAcrossTurnsAsync()
     {
         // Arrange
         await this.SetupTestServerAsync();
         var chatClient = new AGUIChatClient(new(this._client!, ""));
-        AIAgent agent = chatClient.AsAIAgent(instructions: null, name: "assistant", description: "Sample assistant", tools: []);
+        ChatClientAgent agent = new(chatClient, instructions: null, name: "assistant", description: "Sample assistant", tools: []);
         ChatClientAgentSession chatClientSession = (ChatClientAgentSession)await agent.CreateSessionAsync();
         ChatMessage firstUserMessage = new(ChatRole.User, "First question");
 
@@ -149,6 +149,8 @@ public sealed class BasicStreamingTests : IAsyncDisposable
 
         // Assert first turn completed
         firstTurnUpdates.Should().Contain(u => !string.IsNullOrEmpty(u.Text));
+        firstTurnUpdates.Should().AllSatisfy(u => u.AsChatResponseUpdate().ConversationId.Should().BeNull());
+        chatClientSession.ConversationId.Should().BeNull();
 
         // Act - Second turn with another message
         ChatMessage secondUserMessage = new(ChatRole.User, "Second question");
@@ -160,14 +162,29 @@ public sealed class BasicStreamingTests : IAsyncDisposable
 
         // Assert second turn completed
         secondTurnUpdates.Should().Contain(u => !string.IsNullOrEmpty(u.Text));
+        secondTurnUpdates.Should().AllSatisfy(u => u.AsChatResponseUpdate().ConversationId.Should().BeNull());
+        chatClientSession.ConversationId.Should().BeNull();
 
-        // Verify first turn assistant response
+        // Verify the local provider retained both turns.
+        InMemoryChatHistoryProvider historyProvider = agent.ChatHistoryProvider.Should().BeOfType<InMemoryChatHistoryProvider>().Subject;
+        List<ChatMessage> history = historyProvider.GetMessages(chatClientSession);
+        history.Should().HaveCount(4);
+        history[0].Role.Should().Be(ChatRole.User);
+        history[0].Text.Should().Be("First question");
+        history[1].Role.Should().Be(ChatRole.Assistant);
+        history[1].Text.Should().Be("Hello from fake agent!");
+        history[2].Role.Should().Be(ChatRole.User);
+        history[2].Text.Should().Be("Second question");
+        history[3].Role.Should().Be(ChatRole.Assistant);
+        history[3].Text.Should().Be("Hello from fake agent!");
+
+        // Verify first turn assistant response.
         AgentResponse firstResponse = firstTurnUpdates.ToAgentResponse();
         firstResponse.Messages.Should().HaveCount(1);
         firstResponse.Messages[0].Role.Should().Be(ChatRole.Assistant);
         firstResponse.Messages[0].Text.Should().Be("Hello from fake agent!");
 
-        // Verify second turn assistant response
+        // Verify second turn assistant response.
         AgentResponse secondResponse = secondTurnUpdates.ToAgentResponse();
         secondResponse.Messages.Should().HaveCount(1);
         secondResponse.Messages[0].Role.Should().Be(ChatRole.Assistant);


### PR DESCRIPTION
### Motivation & Context

`ChatClientAgent` contains provider-name checks that exempt AG-UI clients from the normal conversation ID and chat-history rules. Current `AGUI.Client` follows Microsoft.Extensions.AI service-managed-history semantics: it keeps AG-UI thread identity on protocol events and does not return a `ConversationId`. The framework no longer needs an AG-UI-specific workaround.

### Description & Review Guide

- **What are the major changes?** Removed the AG-UI provider constant and both AG-UI-specific branches from `ChatClientAgent`, restoring the normal provider-agnostic conversation ID and `ChatHistoryProvider` logic. Strengthened the real `AGUI.Client` two-turn integration test to verify that no service-managed `ConversationId` is exposed and that the default `InMemoryChatHistoryProvider` retains both turns.
- **What is the impact of these changes?** AG-UI-backed agents continue using local history because `AGUI.Client` returns no `ConversationId`, while any chat client that does return one now follows the same service-managed-history conflict and provider-disengagement behavior regardless of provider name. Validation passed for the focused AG-UI regression on `net8.0`, `net9.0`, and `net10.0`; the ChatClient history-management tests and the full `Microsoft.Agents.AI.UnitTests` project passed on `net10.0` and `net472` (2,039 and 1,903 tests respectively).
- **What do you want reviewers to focus on?** Confirm that removing the provider-name gates fully restores the intended provider-agnostic semantics and that the two-turn AG-UI test captures the service-managed-history contract.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #7299

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.