### PR TITLE
.NET: Python: Clarify PR review comment resolution

### DIFF
--- a/.github/skills/pull-requests/SKILL.md
+++ b/.github/skills/pull-requests/SKILL.md
@@ -74,9 +74,12 @@ code before the user has reviewed the plan**:
    approval or adjustments before implementing anything.
 4. **Implement.** Make the agreed changes.
 5. **Reply to every comment.** Add a reply to **all** comments explaining how it
-   was addressed (or the agreed outcome) — leave none unanswered.
-6. **Resolve resolved threads.** Mark a review thread as resolved only when the
-   comment has actually been addressed.
+   was addressed, preferably citing the commit containing the change. If the
+   feedback was not addressed, explain why. Leave no comment unanswered.
+6. **Resolve completed threads yourself.** After replying and completing any
+   necessary discussion, resolve the review thread. Do not wait for the reviewer
+   or a maintainer to resolve it. Leave a thread open only while it has an
+   unanswered question or active discussion.
 
 ### Useful commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,27 @@ We use and recommend the following workflow:
 7. Create a PR against the repository's **main** branch.
    - State in the description what issue or improvement your change is addressing.
    - Verify that all the Continuous Integration checks are passing.
-8. Wait for feedback or approval of your changes from the code maintainers.
+8. Address feedback from the code maintainers. Reply to every review comment with
+   the outcome and resolve each completed review conversation yourself before
+   requesting another review.
 9. When area owners have signed off, and all checks are green, your PR will be merged.
+
+### Resolving PR Review Comments
+
+PR authors are responsible for closing out all review conversations on their pull
+requests, including conversations opened by reviewers. Do not wait for the reviewer
+or a maintainer to resolve completed conversations for you.
+
+For every review comment:
+
+- If the feedback was addressed, reply with a brief explanation and, preferably,
+  the commit containing the change.
+- If the feedback was not addressed, reply with the reason why.
+
+After replying and completing any necessary discussion, **resolve the conversation
+yourself**. Leave a conversation open only while it has an unanswered question or
+active discussion. Reviewers may reopen a conversation if further changes or
+discussion are needed.
 
 ### Development Setup
 

--- a/dotnet/.github/skills/pull-requests/SKILL.md
+++ b/dotnet/.github/skills/pull-requests/SKILL.md
@@ -74,9 +74,12 @@ code before the user has reviewed the plan**:
    approval or adjustments before implementing anything.
 4. **Implement.** Make the agreed changes.
 5. **Reply to every comment.** Add a reply to **all** comments explaining how it
-   was addressed (or the agreed outcome) — leave none unanswered.
-6. **Resolve resolved threads.** Mark a review thread as resolved only when the
-   comment has actually been addressed.
+   was addressed, preferably citing the commit containing the change. If the
+   feedback was not addressed, explain why. Leave no comment unanswered.
+6. **Resolve completed threads yourself.** After replying and completing any
+   necessary discussion, resolve the review thread. Do not wait for the reviewer
+   or a maintainer to resolve it. Leave a thread open only while it has an
+   unanswered question or active discussion.
 
 ### Useful commands
 

--- a/python/.github/skills/pull-requests/SKILL.md
+++ b/python/.github/skills/pull-requests/SKILL.md
@@ -74,9 +74,12 @@ code before the user has reviewed the plan**:
    approval or adjustments before implementing anything.
 4. **Implement.** Make the agreed changes.
 5. **Reply to every comment.** Add a reply to **all** comments explaining how it
-   was addressed (or the agreed outcome) — leave none unanswered.
-6. **Resolve resolved threads.** Mark a review thread as resolved only when the
-   comment has actually been addressed.
+   was addressed, preferably citing the commit containing the change. If the
+   feedback was not addressed, explain why. Leave no comment unanswered.
+6. **Resolve completed threads yourself.** After replying and completing any
+   necessary discussion, resolve the review thread. Do not wait for the reviewer
+   or a maintainer to resolve it. Leave a thread open only while it has an
+   unanswered question or active discussion.
 
 ### Useful commands
 


### PR DESCRIPTION
### Motivation & Context

Review feedback can remain open after contributors have addressed it, leaving maintainers to close completed conversations.

### Description & Review Guide

- **What are the major changes?** Document that PR authors must reply to every review comment and resolve completed conversations themselves.
- **What is the impact of these changes?** Review status and outstanding feedback will be clearer for contributors and maintainers.
- **What do you want reviewers to focus on?** Whether the guidance clearly distinguishes completed conversations from active discussion.

### Related Issue

N/A — documentation policy clarification.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
