### PR TITLE
Python: fix(python): project the per-call effective tool set on agent-hooks pre_model_call

### DIFF
--- a/python/packages/core/agent_framework/_agent_hooks.py
+++ b/python/packages/core/agent_framework/_agent_hooks.py
@@ -914,38 +914,26 @@ def _tool_description(item: Any) -> str | None:
 
 
 def _tool_names(context: AgentContext) -> list[str]:
-    """Project the registered tool names for ``agent_startup`` (spec ``tools_registered``).
+    """Project the run-start tool names for ``agent_startup`` (spec ``tools_registered``).
 
-    This is deliberately the run-start snapshot: the tools declared on the agent
-    (:class:`~agent_framework.Agent` stores them in ``default_options["tools"]``) plus
-    this invocation's run-level tools — whichever supported form they arrive in (the
-    ``tools=`` keyword, or a ``tools`` entry in the run's options dict; the run gives
-    the named parameter precedence). Tools registered dynamically during the run (for
-    example by context providers during run preparation, or by MCP servers whose
-    functions expand at connect time) cannot be known at ``agent_startup`` time; they
-    surface in each ``pre_model_call`` emission's ``tools`` projection (the completed
-    per-call set) and are bracketed by ``pre_tool_call``/``post_tool_call`` like any
-    other tool when invoked.
+    The framework owns the run-start resolution — ``AgentContext._resolve_run_start_tools``
+    returns the agent-declared tools plus this invocation's run-level tools (the named
+    ``tools`` parameter takes precedence over a ``tools`` entry in the options mapping),
+    already normalized — so this helper is projection only. This is deliberately the
+    run-start snapshot: tools registered dynamically during the run (for example by
+    context providers during run preparation, or by MCP servers whose functions expand
+    at connect time) cannot be known at ``agent_startup`` time; they surface in each
+    ``pre_model_call`` emission's ``tools`` projection (the completed per-call set) and
+    are bracketed by ``pre_tool_call``/``post_tool_call`` like any other tool when
+    invoked. An unresolvable set degrades to a warning and an empty snapshot rather
+    than aborting the emission.
     """
-    agent_options = getattr(context.agent, "default_options", None)
-    agent_tools: Any = (
-        cast("Mapping[str, Any]", agent_options).get("tools") if isinstance(agent_options, Mapping) else None
-    )
-    if agent_tools is None:
-        # Custom agent implementations (no default_options mapping, or one without a
-        # tools entry) keep exposing their declared tools through the legacy attribute.
-        agent_tools = getattr(context.agent, "tools", None)
-    run_tools: Any = context.tools
-    if run_tools is None and isinstance(context.options, Mapping):
-        # Run-level tools may also arrive inside the run's options dict; mirror the
-        # run's own precedence (`tools_ = tools if tools is not None else
-        # opts.pop("tools", None)`), where the named parameter wins.
-        run_tools = context.options.get("tools")
-    return [
-        _projected_tool_name(item)
-        for tools in (agent_tools, run_tools)
-        for item in _normalized_tools(tools, point="agent_startup")
-    ]
+    try:
+        resolved = context._resolve_run_start_tools()  # pyright: ignore[reportPrivateUsage]
+    except Exception:
+        logger.warning("agent-hooks could not resolve the run-start tools for the agent_startup projection.")
+        return []
+    return [_projected_tool_name(item) for item in resolved]
 
 
 def _pre_model_call_tools(options: Mapping[str, Any]) -> list[dict[str, Any]] | None:

--- a/python/packages/core/agent_framework/_agent_hooks.py
+++ b/python/packages/core/agent_framework/_agent_hooks.py
@@ -862,23 +862,82 @@ def _agent_updates_from_response(response: AgentResponse[Any]) -> list[AgentResp
     return updates
 
 
-def _tool_names(context: AgentContext) -> list[str]:
-    """Project the registered tool names for ``agent_startup`` (spec ``tools_registered``)."""
-    from ._tools import _get_tool_name, normalize_tools  # type: ignore[reportPrivateUsage]
+def _normalized_tools(tools: Any, *, point: str) -> list[Any]:
+    """Normalize a tools value for projection; empty (with a warning) when it cannot be."""
+    from ._tools import normalize_tools
 
-    tools: Any = context.tools if context.tools is not None else getattr(context.agent, "tools", None)
-    if tools is None:
+    if not tools:
         return []
     try:
-        normalized = normalize_tools(tools)
+        return list(normalize_tools(tools))
     except Exception:
-        logger.warning("agent-hooks could not normalize the run's tools for the agent_startup projection.")
+        logger.warning("agent-hooks could not normalize the tools for the %s projection.", point)
         return []
-    names: list[str] = []
-    for item in normalized:
-        name = _get_tool_name(item)
-        names.append(name if name else type(item).__name__)
-    return names
+
+
+def _projected_tool_name(item: Any) -> str:
+    from ._tools import _get_tool_name  # type: ignore[reportPrivateUsage]
+
+    name = _get_tool_name(item)
+    return name if name else type(item).__name__
+
+
+def _tool_description(item: Any) -> str | None:
+    """Extract a tool description from a tool object or dict tool definition."""
+    if isinstance(item, Mapping):
+        function = cast("Mapping[str, Any]", item).get("function")
+        if isinstance(function, Mapping):
+            description = cast("Mapping[str, Any]", function).get("description")
+            return description if isinstance(description, str) else None
+        return None
+    description = getattr(item, "description", None)
+    return description if isinstance(description, str) else None
+
+
+def _tool_names(context: AgentContext) -> list[str]:
+    """Project the registered tool names for ``agent_startup`` (spec ``tools_registered``).
+
+    This is deliberately the run-start snapshot: the tools declared on the agent
+    (:class:`~agent_framework.Agent` stores them in ``default_options["tools"]``) plus
+    this invocation's run-level tools. Tools registered dynamically during the run (for
+    example by context providers during run preparation, or by MCP servers whose
+    functions expand at connect time) cannot be known at ``agent_startup`` time; they
+    surface in each ``pre_model_call`` emission's ``tools`` projection (the completed
+    per-call set) and are bracketed by ``pre_tool_call``/``post_tool_call`` like any
+    other tool when invoked.
+    """
+    agent_options = getattr(context.agent, "default_options", None)
+    agent_tools: Any = (
+        cast("Mapping[str, Any]", agent_options).get("tools")
+        if isinstance(agent_options, Mapping)
+        else getattr(context.agent, "tools", None)
+    )
+    return [
+        _projected_tool_name(item)
+        for tools in (agent_tools, context.tools)
+        for item in _normalized_tools(tools, point="agent_startup")
+    ]
+
+
+def _pre_model_call_tools(options: Mapping[str, Any]) -> list[dict[str, Any]] | None:
+    """Project the per-call effective tool set for ``pre_model_call`` (spec ``tools``).
+
+    This is the completed set for this model call — the run-start tools plus anything
+    registered during the run (context-provider tools, connected MCP-server functions,
+    progressive tool exposure) — whereas ``agent_startup``'s ``tools_registered`` is the
+    run-start snapshot. Entries carry ``{"name", "description"?}`` (description omitted
+    when the tool has none). Returns ``None`` — the spec's optional field is omitted —
+    when the call offers no tools or the set cannot be projected, so an unprojectable
+    set is never misreported as "no tools".
+    """
+    projected: list[dict[str, Any]] = []
+    for item in _normalized_tools(options.get("tools"), point="pre_model_call"):
+        entry: dict[str, Any] = {"name": _projected_tool_name(item)}
+        description = _tool_description(item)
+        if description:
+            entry["description"] = description
+        projected.append(entry)
+    return projected or None
 
 
 def _is_host_error(record: InterceptionRecord) -> bool:
@@ -1269,7 +1328,7 @@ class _AgentHooksChatMiddleware(_AgentHooksMiddlewareBase, ChatMiddleware):
         model_id = str(options.get("model") or type(context.client).__name__)
         before = _ModelRequestCodec.to_wire(context.messages)
         outcome: EmitOutcome = await state.emitter.emit(
-            state.builder.pre_model_call(model_id=model_id, messages=before)
+            state.builder.pre_model_call(model_id=model_id, messages=before, tools=_pre_model_call_tools(options))
         )
         transformed_messages = _ModelRequestCodec.write_back(context.messages, before, outcome.target)
         if transformed_messages is not None:

--- a/python/packages/core/agent_framework/_agent_hooks.py
+++ b/python/packages/core/agent_framework/_agent_hooks.py
@@ -918,7 +918,9 @@ def _tool_names(context: AgentContext) -> list[str]:
 
     This is deliberately the run-start snapshot: the tools declared on the agent
     (:class:`~agent_framework.Agent` stores them in ``default_options["tools"]``) plus
-    this invocation's run-level tools. Tools registered dynamically during the run (for
+    this invocation's run-level tools — whichever supported form they arrive in (the
+    ``tools=`` keyword, or a ``tools`` entry in the run's options dict; the run gives
+    the named parameter precedence). Tools registered dynamically during the run (for
     example by context providers during run preparation, or by MCP servers whose
     functions expand at connect time) cannot be known at ``agent_startup`` time; they
     surface in each ``pre_model_call`` emission's ``tools`` projection (the completed
@@ -933,9 +935,15 @@ def _tool_names(context: AgentContext) -> list[str]:
         # Custom agent implementations (no default_options mapping, or one without a
         # tools entry) keep exposing their declared tools through the legacy attribute.
         agent_tools = getattr(context.agent, "tools", None)
+    run_tools: Any = context.tools
+    if run_tools is None and isinstance(context.options, Mapping):
+        # Run-level tools may also arrive inside the run's options dict; mirror the
+        # run's own precedence (`tools_ = tools if tools is not None else
+        # opts.pop("tools", None)`), where the named parameter wins.
+        run_tools = context.options.get("tools")
     return [
         _projected_tool_name(item)
-        for tools in (agent_tools, context.tools)
+        for tools in (agent_tools, run_tools)
         for item in _normalized_tools(tools, point="agent_startup")
     ]
 

--- a/python/packages/core/agent_framework/_agent_hooks.py
+++ b/python/packages/core/agent_framework/_agent_hooks.py
@@ -863,11 +863,14 @@ def _agent_updates_from_response(response: AgentResponse[Any]) -> list[AgentResp
 
 
 def _normalized_tools(tools: Any, *, point: str) -> list[Any]:
-    """Normalize a tools value for projection; empty (with a warning) when it cannot be."""
+    """Normalize a tools value for projection; empty (with a warning) when it cannot be.
+
+    Everything — including the emptiness check inside ``normalize_tools`` — runs under
+    the guard, so a tools container whose ``__bool__``/``__len__``/``__iter__`` raises
+    degrades to omitting the projection instead of aborting the emission mid-run.
+    """
     from ._tools import normalize_tools
 
-    if not tools:
-        return []
     try:
         return list(normalize_tools(tools))
     except Exception:
@@ -876,20 +879,36 @@ def _normalized_tools(tools: Any, *, point: str) -> list[Any]:
 
 
 def _projected_tool_name(item: Any) -> str:
+    """Project a tool's display name; hosted-tool mappings fall back to their ``type``."""
     from ._tools import _get_tool_name  # type: ignore[reportPrivateUsage]
 
+    fallback = type(item).__name__
     name = _get_tool_name(item)
-    return name if name else type(item).__name__
+    if name:
+        return name
+    if isinstance(item, Mapping):
+        # Hosted-tool mappings carry top-level fields (no nested "function"), e.g.
+        # {"type": "web_search"} or {"type": "web_search_20250305", "name": "web_search"}.
+        mapping = cast("Mapping[str, Any]", item)
+        for key in ("name", "type"):
+            value = mapping.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return fallback
 
 
 def _tool_description(item: Any) -> str | None:
     """Extract a tool description from a tool object or dict tool definition."""
     if isinstance(item, Mapping):
-        function = cast("Mapping[str, Any]", item).get("function")
-        if isinstance(function, Mapping):
-            description = cast("Mapping[str, Any]", function).get("description")
-            return description if isinstance(description, str) else None
-        return None
+        mapping = cast("Mapping[str, Any]", item)
+        function = mapping.get("function")
+        # Function-tool dicts nest the description; hosted-tool mappings keep it top-level.
+        description = (
+            cast("Mapping[str, Any]", function).get("description")
+            if isinstance(function, Mapping)
+            else mapping.get("description")
+        )
+        return description if isinstance(description, str) else None
     description = getattr(item, "description", None)
     return description if isinstance(description, str) else None
 
@@ -908,10 +927,12 @@ def _tool_names(context: AgentContext) -> list[str]:
     """
     agent_options = getattr(context.agent, "default_options", None)
     agent_tools: Any = (
-        cast("Mapping[str, Any]", agent_options).get("tools")
-        if isinstance(agent_options, Mapping)
-        else getattr(context.agent, "tools", None)
+        cast("Mapping[str, Any]", agent_options).get("tools") if isinstance(agent_options, Mapping) else None
     )
+    if agent_tools is None:
+        # Custom agent implementations (no default_options mapping, or one without a
+        # tools entry) keep exposing their declared tools through the legacy attribute.
+        agent_tools = getattr(context.agent, "tools", None)
     return [
         _projected_tool_name(item)
         for tools in (agent_tools, context.tools)

--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -32,6 +32,7 @@ from ._middleware import (
     MiddlewareTypes,
     _as_middleware_list,  # pyright: ignore[reportPrivateUsage]
     _copy_middleware_sequence,  # pyright: ignore[reportPrivateUsage]
+    _select_run_level_tools,  # pyright: ignore[reportPrivateUsage]
     categorize_middleware,
 )
 from ._serialization import SerializationMixin
@@ -1359,8 +1360,13 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):
         opts = dict(options) if options else {}
         existing_additional_args: dict[str, Any] = opts.pop("additional_function_arguments", None) or {}
 
-        # Get tools from options or named parameter (named param takes precedence)
-        tools_ = tools if tools is not None else opts.pop("tools", None)
+        # Run-level tools: the named parameter takes precedence over an options entry
+        # (_select_run_level_tools is the framework's single statement of that rule,
+        # shared with the middleware layer's run-start resolution). The options entry
+        # is consumed either way, so a losing options["tools"] can never ride the
+        # remaining options into the request and silently override the resolved list.
+        tools_ = _select_run_level_tools(tools, opts)
+        opts.pop("tools", None)
 
         input_messages = normalize_messages(messages)
 

--- a/python/packages/core/agent_framework/_middleware.py
+++ b/python/packages/core/agent_framework/_middleware.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterable, Awaitable, Callable, Collection, Mapping, Sequence
+from collections.abc import AsyncIterable, Awaitable, Callable, Collection, Iterable, Mapping, Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, cast, overload
 
@@ -151,6 +151,45 @@ class MiddlewareType(str, Enum):
     CHAT = "chat"
 
 
+def _select_run_level_tools(tools: Any, options: Mapping[str, Any] | None) -> Any:
+    """Select this invocation's run-level tool source.
+
+    The named ``tools`` parameter takes precedence over a ``tools`` entry in the
+    options mapping. This is the framework's single statement of that rule — the run-start
+    resolution (:meth:`AgentContext._resolve_run_start_tools`, projected into
+    ``agent_startup`` by observability middleware) and the run's own setup
+    (``Agent._prepare_run_context``) both consume it, so the run-start view can never
+    disagree with what the run executes.
+    """
+    if tools is not None:
+        return tools
+    if options is not None:
+        return options.get("tools")
+    return None
+
+
+def _materialize_tool_container(tools: Any) -> Any:
+    """Materialize a one-shot iterable tool container into a list, elements untouched.
+
+    ``normalize_tools`` flattens any iterable tool collection, so generators and other
+    single-pass iterables are supported containers — but each observer that iterates
+    one consumes it for everyone after it. Listing the outer container once (without
+    converting the elements: middleware must keep seeing the caller's original tool
+    objects, so identity-based policy checks still fire) makes the value safely
+    re-iterable for the middleware pipeline, the run-start resolution, and the run
+    itself. Re-iterable values (sequences) and the leaf or collection shapes
+    ``normalize_tools`` handles without directly iterating them (strings, mappings,
+    pydantic models, single tools/callables) pass through untouched.
+    """
+    from pydantic import BaseModel
+
+    if tools is None or isinstance(tools, (str, bytes, bytearray, Mapping, BaseModel, Sequence)):
+        return cast("Any", tools)
+    if isinstance(tools, Iterable):
+        return list(cast("Iterable[Any]", tools))
+    return tools
+
+
 class AgentContext:
     """Context object for agent middleware invocations.
 
@@ -291,9 +330,7 @@ class AgentContext:
         )
         if declared is None:
             declared = getattr(self.agent, "tools", None)
-        run_level: Any = self.tools
-        if run_level is None and self.options is not None:
-            run_level = self.options.get("tools")
+        run_level = _select_run_level_tools(self.tools, self.options)
         return [*normalize_tools(declared), *normalize_tools(run_level)]
 
 
@@ -1618,15 +1655,17 @@ class AgentMiddlewareLayer:
             )
 
         # Run-level tool containers may be one-shot iterables (normalize_tools flattens
-        # any iterable collection). Materialize them exactly once here, so the context
-        # the middleware observes and the run executed beneath it share the same list —
-        # a middleware reading the tools must never consume the run's tool source.
-        from ._tools import normalize_tools
-
-        if tools is not None:
-            tools = normalize_tools(tools)
+        # any iterable collection). Materialize only the outer container here — list()
+        # without converting the elements — so the context the middleware observes and
+        # the run executed beneath it share one re-iterable container of the caller's
+        # original tool objects: observation never consumes the run's tool source, and
+        # identity-based policy checks (for example rejecting one specific privileged
+        # callable) keep seeing exactly what the caller supplied.
+        tools = _materialize_tool_container(tools)
         if options is not None and (options_tools := options.get("tools")) is not None:
-            options = cast("ChatOptions[Any]", {**options, "tools": normalize_tools(options_tools)})
+            materialized_options_tools = _materialize_tool_container(options_tools)
+            if materialized_options_tools is not options_tools:
+                options = cast("ChatOptions[Any]", {**options, "tools": materialized_options_tools})
 
         context = AgentContext(
             agent=self,  # type: ignore[arg-type]

--- a/python/packages/core/agent_framework/_middleware.py
+++ b/python/packages/core/agent_framework/_middleware.py
@@ -171,32 +171,44 @@ def _select_run_level_tools(tools: Any, options: Mapping[str, Any] | None) -> An
 def _materialize_tool_container(tools: Any) -> Any:
     """Materialize one-shot iterable tool containers into lists, tools untouched.
 
-    ``normalize_tools`` recursively flattens any iterable tool collection, so
-    generators and other single-pass iterables are supported containers at every
-    nesting level — but each observer that iterates one consumes it for everyone
-    after it. This walks exactly the container shapes that flattening walks and lists
-    them once, without converting any tool: middleware must keep seeing the caller's
-    original tool objects, so identity-based policy checks still fire. Leaf shapes —
-    tools, dict specs, mapping-like collections (flattened via their re-iterable
-    ``.tools`` attribute), pydantic models, strings, callables — pass through
-    untouched, and an already re-iterable container whose elements needed no
-    materialization keeps its identity.
+    ``normalize_tools`` recursively flattens any iterable tool collection — including
+    the ``.tools`` collection of wrapper objects — so generators and other single-pass
+    iterables are supported containers at every nesting level; but each observer that
+    iterates one consumes it for everyone after it. This walks exactly the container
+    shapes that flattening walks (in flattening's own order) and lists them once,
+    without converting any tool: middleware must keep seeing the caller's original
+    tool objects, so identity-based policy checks still fire. Tool leaves pass through
+    untouched, and any container or wrapper whose contents needed no materialization
+    keeps its identity. A wrapper whose ``.tools`` collection is one-shot (or holds a
+    one-shot) cannot be preserved without mutating the caller's object, so exactly
+    that case is expanded into its materialized tools — the same contents flattening
+    would have produced from it.
     """
     from pydantic import BaseModel
 
     from ._mcp import MCPTool
     from ._tools import FunctionTool
 
-    def is_leaf(value: Any) -> bool:
-        # Mirror the shapes normalize_tools treats as non-container leaves (or
-        # flattens without directly iterating the value itself).
-        if value is None or isinstance(value, (FunctionTool, MCPTool, Mapping, BaseModel, str, bytes, bytearray)):
-            return True
-        return callable(value) or not isinstance(value, Iterable)
-
     def materialize(value: Any) -> Any:
-        if is_leaf(value):
-            return value
+        # Tool leaves flattening never iterates, in flattening's own order.
+        if value is None or isinstance(value, (FunctionTool, dict, MCPTool, str, bytes, bytearray)) or callable(value):
+            return cast("Any", value)
+        # Wrapper objects exposing an iterable ``.tools`` collection (mapping-like
+        # toolboxes, pydantic wrappers): flattening reads and iterates that attribute
+        # — before its Mapping/BaseModel exclusions — so its contents must be
+        # materialized here too.
+        collection = getattr(value, "tools", None)
+        if isinstance(collection, Iterable) and not isinstance(collection, (str, bytes, bytearray, Mapping)):
+            items = [materialize(item) for item in cast("Iterable[Any]", collection)]
+            if isinstance(collection, Collection) and all(
+                new is old for new, old in zip(items, cast("Collection[Any]", collection))
+            ):
+                # The collection is safely re-iterable and its contents needed no
+                # materialization: keep the wrapper itself.
+                return value
+            return items
+        if isinstance(value, (Mapping, BaseModel)) or not isinstance(value, Iterable):
+            return cast("Any", value)
         items = [materialize(item) for item in cast("Iterable[Any]", value)]
         if isinstance(value, Sequence) and all(new is old for new, old in zip(items, cast("Sequence[Any]", value))):
             return cast("Any", value)

--- a/python/packages/core/agent_framework/_middleware.py
+++ b/python/packages/core/agent_framework/_middleware.py
@@ -266,6 +266,36 @@ class AgentContext:
         # gate binds to that run's identity and never to middleware-initiated runs.
         self._run_persistence_gate: _RunPersistenceGate | None = None
 
+    def _resolve_run_start_tools(self) -> list[ToolTypes]:
+        """Resolve the run-start tool list for this invocation, normalized.
+
+        This is the framework's one statement of the run-start tool policy, kept next
+        to the run-option rules it mirrors so they evolve together (middleware such as
+        agent-hooks reads it instead of re-deriving the precedence): the agent's
+        declared tools (:class:`~agent_framework.Agent` keeps them in
+        ``default_options["tools"]``; other agent implementations may expose a
+        ``tools`` attribute) followed by this invocation's run-level tools, where the
+        named ``tools`` parameter takes precedence over a ``tools`` entry in the
+        options mapping — matching the run's own resolution in
+        ``Agent._prepare_run_context``. Tools registered later in the run (context
+        providers during run preparation, MCP servers expanding at connect time,
+        progressive tool exposure) are deliberately not part of the run-start view.
+
+        Normalization errors propagate; callers that must not fail should guard.
+        """
+        from ._tools import normalize_tools
+
+        declared_options = getattr(self.agent, "default_options", None)
+        declared: Any = (
+            cast("Mapping[str, Any]", declared_options).get("tools") if isinstance(declared_options, Mapping) else None
+        )
+        if declared is None:
+            declared = getattr(self.agent, "tools", None)
+        run_level: Any = self.tools
+        if run_level is None and self.options is not None:
+            run_level = self.options.get("tools")
+        return [*normalize_tools(declared), *normalize_tools(run_level)]
+
 
 class FunctionInvocationContext:
     """Context object for function middleware invocations.
@@ -1586,6 +1616,17 @@ class AgentMiddlewareLayer:
                 function_invocation_kwargs=effective_function_invocation_kwargs,
                 client_kwargs=effective_client_kwargs,
             )
+
+        # Run-level tool containers may be one-shot iterables (normalize_tools flattens
+        # any iterable collection). Materialize them exactly once here, so the context
+        # the middleware observes and the run executed beneath it share the same list —
+        # a middleware reading the tools must never consume the run's tool source.
+        from ._tools import normalize_tools
+
+        if tools is not None:
+            tools = normalize_tools(tools)
+        if options is not None and (options_tools := options.get("tools")) is not None:
+            options = cast("ChatOptions[Any]", {**options, "tools": normalize_tools(options_tools)})
 
         context = AgentContext(
             agent=self,  # type: ignore[arg-type]

--- a/python/packages/core/agent_framework/_middleware.py
+++ b/python/packages/core/agent_framework/_middleware.py
@@ -169,25 +169,40 @@ def _select_run_level_tools(tools: Any, options: Mapping[str, Any] | None) -> An
 
 
 def _materialize_tool_container(tools: Any) -> Any:
-    """Materialize a one-shot iterable tool container into a list, elements untouched.
+    """Materialize one-shot iterable tool containers into lists, tools untouched.
 
-    ``normalize_tools`` flattens any iterable tool collection, so generators and other
-    single-pass iterables are supported containers — but each observer that iterates
-    one consumes it for everyone after it. Listing the outer container once (without
-    converting the elements: middleware must keep seeing the caller's original tool
-    objects, so identity-based policy checks still fire) makes the value safely
-    re-iterable for the middleware pipeline, the run-start resolution, and the run
-    itself. Re-iterable values (sequences) and the leaf or collection shapes
-    ``normalize_tools`` handles without directly iterating them (strings, mappings,
-    pydantic models, single tools/callables) pass through untouched.
+    ``normalize_tools`` recursively flattens any iterable tool collection, so
+    generators and other single-pass iterables are supported containers at every
+    nesting level — but each observer that iterates one consumes it for everyone
+    after it. This walks exactly the container shapes that flattening walks and lists
+    them once, without converting any tool: middleware must keep seeing the caller's
+    original tool objects, so identity-based policy checks still fire. Leaf shapes —
+    tools, dict specs, mapping-like collections (flattened via their re-iterable
+    ``.tools`` attribute), pydantic models, strings, callables — pass through
+    untouched, and an already re-iterable container whose elements needed no
+    materialization keeps its identity.
     """
     from pydantic import BaseModel
 
-    if tools is None or isinstance(tools, (str, bytes, bytearray, Mapping, BaseModel, Sequence)):
-        return cast("Any", tools)
-    if isinstance(tools, Iterable):
-        return list(cast("Iterable[Any]", tools))
-    return tools
+    from ._mcp import MCPTool
+    from ._tools import FunctionTool
+
+    def is_leaf(value: Any) -> bool:
+        # Mirror the shapes normalize_tools treats as non-container leaves (or
+        # flattens without directly iterating the value itself).
+        if value is None or isinstance(value, (FunctionTool, MCPTool, Mapping, BaseModel, str, bytes, bytearray)):
+            return True
+        return callable(value) or not isinstance(value, Iterable)
+
+    def materialize(value: Any) -> Any:
+        if is_leaf(value):
+            return value
+        items = [materialize(item) for item in cast("Iterable[Any]", value)]
+        if isinstance(value, Sequence) and all(new is old for new, old in zip(items, cast("Sequence[Any]", value))):
+            return cast("Any", value)
+        return items
+
+    return materialize(tools)
 
 
 class AgentContext:
@@ -1640,6 +1655,32 @@ class AgentMiddlewareLayer:
         effective_function_invocation_kwargs = (
             dict(function_invocation_kwargs) if function_invocation_kwargs is not None else {}
         )
+        # Select the winning run-level tool route first, then materialize only that
+        # source: the losing route is never iterated — a losing one-shot options
+        # entry stays untouched for its owner and cannot raise or trigger side
+        # effects — and it is dropped from the forwarded options (on a copy), so no
+        # layer below (telemetry serialization, run setup) ever consumes or records a
+        # source the run will not use. Materialization covers the nested collection
+        # forms normalize_tools recursively flattens, so every observer of the run —
+        # middleware pipeline, telemetry, run setup — shares one re-iterable
+        # structure of the caller's original tool objects: observation never consumes
+        # the run's tool source, and identity-based policy checks (for example
+        # rejecting one specific privileged callable) keep seeing exactly what the
+        # caller supplied.
+        selected_tools = _select_run_level_tools(tools, options)
+        materialized_tools = _materialize_tool_container(selected_tools)
+        if tools is not None:
+            tools = materialized_tools
+            if options is not None and "tools" in options:
+                options = cast(
+                    "ChatOptions[Any]",
+                    {key: item for key, item in options.items() if key != "tools"},
+                )
+        elif materialized_tools is not selected_tools:
+            # The options mapping supplied the winner; swap the materialized value in
+            # on a copy (the caller's mapping is never mutated).
+            options = cast("ChatOptions[Any]", {**cast("Mapping[str, Any]", options), "tools": materialized_tools})
+
         # Execute with middleware if available
         if not pipeline.has_middlewares:
             return super().run(  # type: ignore[misc, no-any-return]
@@ -1653,19 +1694,6 @@ class AgentMiddlewareLayer:
                 function_invocation_kwargs=effective_function_invocation_kwargs,
                 client_kwargs=effective_client_kwargs,
             )
-
-        # Run-level tool containers may be one-shot iterables (normalize_tools flattens
-        # any iterable collection). Materialize only the outer container here — list()
-        # without converting the elements — so the context the middleware observes and
-        # the run executed beneath it share one re-iterable container of the caller's
-        # original tool objects: observation never consumes the run's tool source, and
-        # identity-based policy checks (for example rejecting one specific privileged
-        # callable) keep seeing exactly what the caller supplied.
-        tools = _materialize_tool_container(tools)
-        if options is not None and (options_tools := options.get("tools")) is not None:
-            materialized_options_tools = _materialize_tool_container(options_tools)
-            if materialized_options_tools is not options_tools:
-                options = cast("ChatOptions[Any]", {**options, "tools": materialized_options_tools})
 
         context = AgentContext(
             agent=self,  # type: ignore[arg-type]

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -623,6 +623,32 @@ async def test_one_shot_iterable_run_tools_survive_the_snapshot(
         assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
 
 
+@requires_sdk
+async def test_snapshot_and_per_call_agree_when_both_run_tool_routes_are_supplied(
+    chat_client_base: MockBaseChatClient,
+) -> None:
+    """With both ``tools=`` and ``options={"tools": ...}`` supplied, the named parameter
+    wins everywhere: ``tools_registered`` and the per-call ``tools`` projection report
+    the same set the run executes. (Previously the losing options entry silently
+    overrode the request's tools, so the run-start view and the executed set
+    disagreed.)"""
+
+    @tool(approval_mode="never_require")
+    def options_entry_tool(x: str) -> str:
+        """Arrives through the options dict and loses the precedence."""
+        return x
+
+    guard = AllowGuard()
+    agent = Agent(client=chat_client_base, middleware=[create_agent_hooks_middleware([guard])])
+
+    await agent.run("hello", tools=[weather_tool], options={"tools": [options_entry_tool]})
+
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool"]
+    pre_model = guard.contexts_for("pre_model_call")[0]
+    assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
+
+
 # endregion
 
 # region Deny-before-execution

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -647,6 +647,50 @@ async def test_nested_one_shot_collection_survives_the_snapshot(chat_client_base
 
 
 @requires_sdk
+@pytest.mark.parametrize("backing", ["one_shot", "reusable"])
+async def test_wrapper_tools_collections_survive_the_snapshot(
+    chat_client_base: MockBaseChatClient, backing: str
+) -> None:
+    """Wrapper objects' ``.tools`` collections survive observation.
+
+    ``normalize_tools`` flattens a wrapper object through its iterable ``.tools``
+    attribute, so a one-shot (generator-backed) collection is a supported shape the
+    boundary must materialize — otherwise the startup projection drains it and the
+    run executes without the tool. A wrapper whose collection is reusable passes
+    through untouched, keeping its identity for the middleware pipeline.
+    """
+
+    from types import SimpleNamespace
+
+    toolbox = SimpleNamespace(tools=(item for item in [weather_tool]) if backing == "one_shot" else [weather_tool])
+    seen: dict[str, Any] = {}
+
+    class CaptureToolsMiddleware(AgentMiddleware):
+        async def process(self, context: AgentContext, call_next: Callable[[], Awaitable[None]]) -> None:
+            seen["tools"] = context.tools
+            await call_next()
+
+    guard = AllowGuard()
+    chat_client_base.run_responses = [tool_call_response(), final_response()]
+    agent = Agent(
+        client=chat_client_base,
+        middleware=[create_agent_hooks_middleware([guard]), CaptureToolsMiddleware()],
+    )
+
+    response = await agent.run("Get weather for Seattle", tools=toolbox)
+
+    assert response.text == "Final response"
+    assert weather_tool_calls == ["Seattle"]
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool"]
+    for pre_model in guard.contexts_for("pre_model_call"):
+        assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
+    if backing == "reusable":
+        # A reusable wrapper keeps its identity through the pipeline.
+        assert seen["tools"] is toolbox
+
+
+@requires_sdk
 async def test_snapshot_and_per_call_agree_when_both_run_tool_routes_are_supplied(
     chat_client_base: MockBaseChatClient,
 ) -> None:

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -544,6 +544,17 @@ def test_tools_projection_survives_hostile_tools_container(caplog: pytest.LogCap
         assert _pre_model_call_tools({"tools": HostileTools()}) is None
     assert "could not normalize the tools" in caplog.text
 
+    # The startup snapshot degrades the same way when the run-start resolution raises.
+    from agent_framework._agent_hooks import _tool_names
+
+    class HostileAgent:
+        tools = HostileTools()
+
+    context = AgentContext(agent=cast("Any", HostileAgent()), messages=[])
+    with caplog.at_level("WARNING", logger="agent_framework._agent_hooks"):
+        assert _tool_names(context) == []
+    assert "could not resolve the run-start tools" in caplog.text
+
 
 @requires_sdk
 def test_startup_snapshot_falls_back_to_legacy_tools_attribute() -> None:
@@ -578,6 +589,38 @@ async def test_options_route_run_tools_appear_on_both_projections(chat_client_ba
     assert startup["agent_init"]["tools_registered"] == ["weather_tool", "options_route_tool"]
     pre_model = guard.contexts_for("pre_model_call")[0]
     assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool", "options_route_tool"]
+
+
+@requires_sdk
+@pytest.mark.parametrize("route", ["tools_kwarg", "options_dict"])
+async def test_one_shot_iterable_run_tools_survive_the_snapshot(
+    chat_client_base: MockBaseChatClient, route: str
+) -> None:
+    """Observing the tools never consumes them: one-shot iterables stay usable by the run.
+
+    ``normalize_tools`` flattens any iterable tool collection, so a generator is a
+    supported run-level container. The framework materializes it exactly once when it
+    builds the middleware context; snapshot, per-call projection, and the run itself
+    all see the same tools. (Previously the startup projection exhausted the iterable
+    and enabling agent-hooks silently removed every run-level tool it contained.)
+    """
+    guard = AllowGuard()
+    chat_client_base.run_responses = [tool_call_response(), final_response()]
+    agent = Agent(client=chat_client_base, middleware=[create_agent_hooks_middleware([guard])])
+
+    one_shot = (item for item in [weather_tool])
+    if route == "tools_kwarg":
+        response = await agent.run("Get weather for Seattle", tools=one_shot)
+    else:
+        response = await agent.run("Get weather for Seattle", options={"tools": one_shot})
+
+    # The run kept its tools: the tool call resolved and the loop completed.
+    assert response.text == "Final response"
+    assert weather_tool_calls == ["Seattle"]
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool"]
+    for pre_model in guard.contexts_for("pre_model_call"):
+        assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
 
 
 # endregion

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -559,6 +559,27 @@ def test_startup_snapshot_falls_back_to_legacy_tools_attribute() -> None:
     assert _tool_names(context) == ["weather_tool"]
 
 
+@requires_sdk
+async def test_options_route_run_tools_appear_on_both_projections(chat_client_base: MockBaseChatClient) -> None:
+    """Run-level tools passed as ``options={"tools": ...}`` (instead of the ``tools=``
+    keyword) appear in the run-start snapshot and the per-call projection alike."""
+
+    @tool(approval_mode="never_require")
+    def options_route_tool(city: str) -> str:
+        """Arrives through the options dict."""
+        return city
+
+    guard = AllowGuard()
+    agent = Agent(client=chat_client_base, tools=[weather_tool], middleware=[create_agent_hooks_middleware([guard])])
+
+    await agent.run("hello", options={"tools": [options_route_tool]})
+
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool", "options_route_tool"]
+    pre_model = guard.contexts_for("pre_model_call")[0]
+    assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool", "options_route_tool"]
+
+
 # endregion
 
 # region Deny-before-execution

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -368,6 +368,133 @@ async def test_tool_result_projection_preserves_canonical_values(chat_client_bas
     assert post_tool["target"] == value
 
 
+@requires_sdk
+async def test_pre_model_call_projects_per_call_effective_tools(chat_client_base: MockBaseChatClient) -> None:
+    """Every ``pre_model_call`` carries the effective tool set for that call (spec ``tools``).
+
+    Constructor-registered and run-level tools are both part of the effective set the
+    model is offered, so both must appear — a registration-time-only projection would
+    hide the run-level tools from auditors (the Python half of #7560; parity with the
+    .NET per-call ``ChatOptions.Tools`` projection).
+    """
+
+    @tool(approval_mode="never_require")
+    def run_only_tool(city: str) -> str:
+        """Look up a city."""
+        return city
+
+    guard = AllowGuard()
+    chat_client_base.run_responses = [tool_call_response(), final_response()]
+    agent = Agent(
+        client=chat_client_base,
+        tools=[weather_tool],
+        middleware=[create_agent_hooks_middleware([guard])],
+    )
+
+    await agent.run("Get weather for Seattle", tools=[run_only_tool])
+
+    pre_models = guard.contexts_for("pre_model_call")
+    assert len(pre_models) == 2
+    for pre_model in pre_models:
+        assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool", "run_only_tool"]
+    # Descriptions ride along ({name, description?}), so auditors see what the model saw.
+    assert pre_models[0]["tools"][0]["description"] == "Get the weather for a location."
+    # agent_startup's tools_registered is the run-start snapshot: both are known at run
+    # start here, so both appear (constructor tools were previously dropped entirely).
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool", "run_only_tool"]
+
+
+@requires_sdk
+async def test_agent_startup_projects_constructor_registered_tools(chat_client_base: MockBaseChatClient) -> None:
+    """Constructor-registered tools appear in ``tools_registered`` (#7560)."""
+    guard = AllowGuard()
+    agent = Agent(client=chat_client_base, tools=[weather_tool], middleware=[create_agent_hooks_middleware([guard])])
+
+    await agent.run("hello")
+
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool"]
+
+
+@requires_sdk
+async def test_pre_model_call_tools_include_provider_contributed_tools(chat_client_base: MockBaseChatClient) -> None:
+    """Tools registered during run preparation surface in the per-call ``tools`` projection.
+
+    Context providers contribute tools after ``agent_startup`` has been emitted, so the
+    run-start snapshot cannot know them — the per-call projection is where they become
+    visible to auditors (same contract as the .NET fix on #7564).
+    """
+    from agent_framework import ContextProvider
+
+    @tool(approval_mode="never_require")
+    def provider_tool(query: str) -> str:
+        """A tool contributed by a context provider."""
+        return query
+
+    class ToolContextProvider(ContextProvider):
+        def __init__(self) -> None:
+            super().__init__(source_id="tool-context")
+
+        async def before_run(self, *, agent: Any, session: Any, context: Any, state: Any) -> None:
+            context.extend_tools("tool-context", [provider_tool])
+
+    guard = AllowGuard()
+    agent = Agent(
+        client=chat_client_base,
+        context_providers=[ToolContextProvider()],
+        middleware=[create_agent_hooks_middleware([guard])],
+    )
+
+    await agent.run("hello")
+
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == []
+    pre_model = guard.contexts_for("pre_model_call")[0]
+    assert [entry["name"] for entry in pre_model["tools"]] == ["provider_tool"]
+
+
+@requires_sdk
+@pytest.mark.parametrize("max_iterations", [1], indirect=True)
+async def test_tools_disabled_final_call_still_projects_effective_tools(
+    chat_client_base: MockBaseChatClient,
+) -> None:
+    """The loop's ``tool_choice="none"`` final call projects its effective options' tools.
+
+    When the iteration budget is exhausted the function-invocation loop requests one
+    final response with ``tool_choice="none"`` but the tools still in the options —
+    the projection reflects exactly those effective options (parity with the .NET
+    per-call ``ChatOptions.Tools`` projection), not a guess about tool availability.
+    """
+    guard = AllowGuard()
+    chat_client_base.run_responses = [tool_call_response(), tool_call_response()]
+    agent = Agent(
+        client=chat_client_base,
+        tools=[weather_tool],
+        middleware=[create_agent_hooks_middleware([guard])],
+    )
+
+    response = await agent.run("Get weather for Seattle")
+
+    assert "broke out" in response.text
+    pre_models = guard.contexts_for("pre_model_call")
+    assert len(pre_models) == 2
+    for pre_model in pre_models:
+        assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
+
+
+@requires_sdk
+async def test_pre_model_call_omits_tools_when_call_has_none(chat_client_base: MockBaseChatClient) -> None:
+    """A call with no tools omits the optional ``tools`` field instead of claiming an empty set."""
+    guard = AllowGuard()
+    agent = Agent(client=chat_client_base, middleware=[create_agent_hooks_middleware([guard])])
+
+    await agent.run("hello")
+
+    pre_model = guard.contexts_for("pre_model_call")[0]
+    assert "tools" not in pre_model
+
+
 # endregion
 
 # region Deny-before-execution

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -624,6 +624,29 @@ async def test_one_shot_iterable_run_tools_survive_the_snapshot(
 
 
 @requires_sdk
+async def test_nested_one_shot_collection_survives_the_snapshot(chat_client_base: MockBaseChatClient) -> None:
+    """Nested one-shot containers are materialized too, at every level flattening walks.
+
+    ``normalize_tools`` flattens iterable collections recursively, so a generator
+    nested inside a list is a supported shape; the run-start materialization must
+    cover it, or the startup projection drains the inner iterator and the run loses
+    that tool (the same silent degradation one level down).
+    """
+    guard = AllowGuard()
+    chat_client_base.run_responses = [tool_call_response(), final_response()]
+    agent = Agent(client=chat_client_base, middleware=[create_agent_hooks_middleware([guard])])
+
+    response = await agent.run("Get weather for Seattle", tools=[(item for item in [weather_tool])])
+
+    assert response.text == "Final response"
+    assert weather_tool_calls == ["Seattle"]
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["weather_tool"]
+    for pre_model in guard.contexts_for("pre_model_call"):
+        assert [entry["name"] for entry in pre_model["tools"]] == ["weather_tool"]
+
+
+@requires_sdk
 async def test_snapshot_and_per_call_agree_when_both_run_tool_routes_are_supplied(
     chat_client_base: MockBaseChatClient,
 ) -> None:

--- a/python/packages/core/tests/core/test_agent_hooks.py
+++ b/python/packages/core/tests/core/test_agent_hooks.py
@@ -495,6 +495,70 @@ async def test_pre_model_call_omits_tools_when_call_has_none(chat_client_base: M
     assert "tools" not in pre_model
 
 
+@requires_sdk
+async def test_hosted_tool_mappings_project_top_level_name_and_description(
+    chat_client_base: MockBaseChatClient,
+) -> None:
+    """Hosted-tool mappings project their top-level fields, with ``type`` naming unnamed tools.
+
+    The provider factories return plain mappings without a nested ``function`` object
+    (e.g. OpenAI's ``{"type": "web_search"}``, Anthropic's ``{"type": "web_search_20250305",
+    "name": "web_search"}``); those must not be projected as ``{"name": "dict"}``.
+    """
+    guard = AllowGuard()
+    agent = Agent(
+        client=chat_client_base,
+        tools=[
+            {"type": "web_search"},
+            {"type": "web_search_20250305", "name": "web_search"},
+            {"type": "custom_hosted", "name": "lookup", "description": "Look things up."},
+        ],
+        middleware=[create_agent_hooks_middleware([guard])],
+    )
+
+    await agent.run("hello")
+
+    pre_model = guard.contexts_for("pre_model_call")[0]
+    assert pre_model["tools"] == [
+        {"name": "web_search"},
+        {"name": "web_search"},
+        {"name": "lookup", "description": "Look things up."},
+    ]
+    startup = guard.contexts_for("agent_startup")[0]
+    assert startup["agent_init"]["tools_registered"] == ["web_search", "web_search", "lookup"]
+
+
+@requires_sdk
+def test_tools_projection_survives_hostile_tools_container(caplog: pytest.LogCaptureFixture) -> None:
+    """A tools container whose ``__bool__`` raises degrades to omission, never an emission abort."""
+    from agent_framework._agent_hooks import _pre_model_call_tools
+
+    class HostileTools:
+        def __bool__(self) -> bool:
+            raise RuntimeError("hostile __bool__")
+
+        def __iter__(self) -> Any:
+            return iter([])
+
+    with caplog.at_level("WARNING", logger="agent_framework._agent_hooks"):
+        assert _pre_model_call_tools({"tools": HostileTools()}) is None
+    assert "could not normalize the tools" in caplog.text
+
+
+@requires_sdk
+def test_startup_snapshot_falls_back_to_legacy_tools_attribute() -> None:
+    """A custom agent whose ``default_options`` mapping has no tools entry keeps its
+    ``tools``-attribute projection (the pre-existing fallback for non-``Agent`` hosts)."""
+    from agent_framework._agent_hooks import _tool_names
+
+    class LegacyAgent:
+        default_options = {"temperature": 0.2}  # mapping-valued, but no "tools" key
+        tools = [weather_tool]
+
+    context = AgentContext(agent=cast("Any", LegacyAgent()), messages=[])
+    assert _tool_names(context) == ["weather_tool"]
+
+
 # endregion
 
 # region Deny-before-execution

--- a/python/packages/core/tests/core/test_middleware_with_agent.py
+++ b/python/packages/core/tests/core/test_middleware_with_agent.py
@@ -30,6 +30,7 @@ from agent_framework import (
     agent_middleware,
     chat_middleware,
     function_middleware,
+    tool,
 )
 from agent_framework._sessions import InMemoryHistoryProvider
 
@@ -3026,6 +3027,101 @@ class TestMiddlewareFailure:
         settlement = requests[-1]
         assert settlement["tool_choice"] == "none"
         assert [result.call_id for result in settlement["results"]] == ["call_1"]
+
+
+# endregion
+
+# region Run-level tools as observed by middleware
+
+
+async def test_agent_middleware_observes_and_controls_original_tool_objects() -> None:
+    """Agent middleware sees the caller's original tool objects, identity intact.
+
+    A guard that enforces policy by identity — for example rejecting one specific
+    privileged callable — must see exactly what the caller supplied. A one-shot
+    iterable container is materialized into a list before the pipeline (so observing
+    the tools does not consume the run's source), but its elements are never
+    converted, and an identity-based removal by the middleware governs what the run
+    executes.
+    """
+    invoked: list[str] = []
+
+    def delete_all_data(target: str) -> str:
+        """Privileged tool."""
+        invoked.append(target)
+        return f"deleted {target}"
+
+    observed: dict[str, Any] = {}
+
+    class IdentityGuard(AgentMiddleware):
+        async def process(self, context: AgentContext, call_next: Callable[[], Awaitable[None]]) -> None:
+            observed["bare_identity"] = context.tools is delete_all_data
+            if isinstance(context.tools, list):
+                tools_list = cast("list[Any]", context.tools)
+                observed["element_identity"] = any(item is delete_all_data for item in tools_list)
+                # Identity-based enforcement: strip the privileged callable from the run.
+                context.tools = [item for item in tools_list if item is not delete_all_data]
+            await call_next()
+
+    # A bare callable passes through to the pipeline untouched.
+    agent = Agent(client=MockBaseChatClient(), middleware=[IdentityGuard()])
+    await agent.run("hi", tools=delete_all_data)
+    assert observed["bare_identity"] is True
+
+    # A one-shot iterable is materialized (outer container only): the middleware sees
+    # the original callable, removes it by identity, and even though the model then
+    # requests it, the privileged tool is never invoked.
+    client = MockBaseChatClient()
+    client.run_responses = [
+        ChatResponse(
+            messages=[
+                Message(
+                    role="assistant",
+                    contents=[
+                        Content.from_function_call(
+                            call_id="call_del", name="delete_all_data", arguments='{"target": "prod"}'
+                        )
+                    ],
+                )
+            ]
+        ),
+        ChatResponse(messages=[Message(role="assistant", contents=["done"])]),
+    ]
+    agent2 = Agent(client=client, middleware=[IdentityGuard()])
+    await agent2.run("hi", tools=(item for item in [delete_all_data]))
+    assert observed["element_identity"] is True
+    assert invoked == []
+
+
+async def test_named_tools_parameter_wins_over_options_tools_entry() -> None:
+    """When both run-level routes are supplied, the named parameter wins end to end.
+
+    Previously the losing ``options["tools"]`` entry survived in the remaining options
+    and rode ``**opts`` into the request, silently overriding the resolved tool list —
+    the run executed one set while the run-start view reported another.
+    """
+
+    @tool(approval_mode="never_require")
+    def kw_tool(x: str) -> str:
+        """Named-parameter tool."""
+        return x
+
+    @tool(approval_mode="never_require")
+    def opt_tool(x: str) -> str:
+        """Options-entry tool."""
+        return x
+
+    captured: dict[str, Any] = {}
+
+    class CaptureChatMiddleware(ChatMiddleware):
+        async def process(self, context: ChatContext, call_next: Callable[[], Awaitable[None]]) -> None:
+            captured["tools"] = list((context.options or {}).get("tools") or [])
+            await call_next()
+
+    agent = Agent(client=MockBaseChatClient(), middleware=[CaptureChatMiddleware()])
+    await agent.run("hi", tools=[kw_tool], options={"tools": [opt_tool]})
+
+    assert [getattr(item, "name", None) for item in captured["tools"]] == ["kw_tool"]
 
 
 # endregion

--- a/python/packages/core/tests/core/test_middleware_with_agent.py
+++ b/python/packages/core/tests/core/test_middleware_with_agent.py
@@ -3124,4 +3124,42 @@ async def test_named_tools_parameter_wins_over_options_tools_entry() -> None:
     assert [getattr(item, "name", None) for item in captured["tools"]] == ["kw_tool"]
 
 
+async def test_losing_run_tool_route_is_never_iterated() -> None:
+    """Only the winning run-level route is materialized; the loser stays untouched.
+
+    A losing one-shot ``options["tools"]`` source must not be consumed (or allowed to
+    raise / trigger side effects) when the named parameter wins: the framework drops
+    the losing entry without iterating it, and its owner can still consume it after
+    the run.
+    """
+
+    @tool(approval_mode="never_require")
+    def winning_tool(x: str) -> str:
+        """Named-parameter tool."""
+        return x
+
+    @tool(approval_mode="never_require")
+    def losing_tool(x: str) -> str:
+        """Options-entry tool."""
+        return x
+
+    iterations: list[str] = []
+
+    def losing_source() -> Any:
+        iterations.append("iterated")
+        yield losing_tool
+
+    class Passthrough(AgentMiddleware):
+        async def process(self, context: AgentContext, call_next: Callable[[], Awaitable[None]]) -> None:
+            await call_next()
+
+    losing = losing_source()
+    agent = Agent(client=MockBaseChatClient(), middleware=[Passthrough()])
+    await agent.run("hi", tools=[winning_tool], options={"tools": losing})
+
+    assert iterations == []
+    # The source still belongs to its owner, un-drained.
+    assert list(losing) == [losing_tool]
+
+
 # endregion


### PR DESCRIPTION
### Motivation & Context

#7560 reported that constructor-registered tools never appear in the agent-hooks `agent_startup` projection: `_tool_names` falls back to `getattr(agent, "tools", None)`, but `Agent` stores constructor tools in `default_options["tools"]`, so the fallback is always `None`. The review thread on the .NET port (#7564, with @westey-m) surfaced the wider version of the same gap: tools registered dynamically during a run (context providers, MCP expansion, progressive tool exposure) can never be known at `agent_startup` time, so any startup-time projection is inherently a partial view of what each model call is actually offered.

The .NET feature resolved this on #7564 (commit `5ffe0fa58` there) by projecting the per-call effective `ChatOptions.Tools` into each `pre_model_call` emission's optional `tools` field and documenting `tools_registered` as the run-start snapshot. This PR mirrors that resolution in the Python feature so both languages carry the same AGENT-HOOKS-0.1 projection contract — the parity contract established in the #7444/#7515 discussions.

### Description & Review Guide

- **What are the major changes?**
  - `pre_model_call` now carries the spec's optional `tools` field, projected as `{name, description?}` from the call's effective `options["tools"]` — the completed set for that model call, including run-level tools, context-provider tools, connected MCP-server functions, and progressive tool exposure. The function-invocation loop's `tool_choice="none"` final/settlement calls project their effective options unchanged (the tools are still in the options for those calls), matching the .NET semantics. When the call offers no tools — or the set cannot be normalized — the optional field is omitted rather than misreported as an empty set.
  - `_tool_names` (the `agent_startup` `tools_registered` projection) now produces the honest run-start snapshot: agent-declared tools (`Agent.default_options["tools"]`, with the old `tools` attribute as a fallback for custom agent implementations) plus the invocation's run-level tools — the same two sources the .NET `ResolveToolNames` reads. Its docstring documents the snapshot semantics: dynamically registered tools surface per call in the `pre_model_call` projection and are bracketed by `pre_tool_call`/`post_tool_call` like any other tool when invoked.
- **What is the impact of these changes?** Purely additive to the emitted contexts (a new optional field on `pre_model_call`, and `tools_registered` entries that were previously silently dropped now present). No enforcement-path behavior changes; the fail-closed posture is untouched. Auditors and interceptors now see exactly which tools each model call was offered.
- **What do you want reviewers to focus on?** The projection sources: `context.options["tools"]` at the chat seam is the per-call effective set (the function-invocation layer normalizes it and shares the run-local mutable list per iteration), and `default_options["tools"]` + `context.tools` at the agent seam is the run-start snapshot. Also the deliberate choice to omit the optional `tools` field (instead of emitting `[]`) when a tool set cannot be projected.

Five new tests: per-call effective set across a multi-call tool run (constructor + run-level tools), the #7560 constructor-tools startup repro, context-provider-contributed tools (startup snapshot excludes, per-call projection includes), the loop's `tool_choice="none"` final call, and omission of the field on tool-less calls. Core suite, ruff, prek hooks, and pyright/mypy/ty/zuban/pyrefly all green.

Cross-reference for reviewers: the .NET counterpart is commit `5ffe0fa58` on #7564 — same field shape (`{name, description?}`), same snapshot-vs-per-call semantics, so the two implementations stay reviewable against one contract.

### Behavior note (edge case, from review)

Review follow-ups pulled the run-level tool resolution into one framework statement (`_select_run_level_tools`, consumed by both the run-start resolution and `Agent._prepare_run_context`). This fixes a pre-existing inconsistency: when **both** `tools=` and `options={"tools": [...]}` were supplied, the losing `options["tools"]` entry survived in the remaining options and rode `**opts` into the request, silently overriding the resolved list — the run executed the options set while the documented precedence (and now the run-start view) said the named parameter wins. With this PR, the named parameter wins end to end; the single-route behaviors are unchanged. Also per review: agent middleware now observes the caller's original tool objects (one-shot iterable containers are materialized outer-container-only), so identity-based tool policy checks keep working.

### Related Issue

Fixes #7560

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

