### PR TITLE
Python: fix: preserve Agent additional_properties in HandoffBuilder clones

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -300,6 +300,7 @@ class HandoffAgentExecutor(AgentExecutor):
             middleware=agent.middleware,
             require_per_service_call_history_persistence=agent.require_per_service_call_history_persistence,
             default_options=cloned_options,  # type: ignore[assignment]
+            additional_properties=deepcopy(agent.additional_properties),
         )
 
     def _apply_auto_tools(self, agent: Agent, targets: Sequence[HandoffConfiguration]) -> None:

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from agent_framework import (
     Agent,
+    AgentContext,
     AgentResponse,
     AgentResponseUpdate,
     ChatOptions,
@@ -21,6 +22,7 @@ from agent_framework import (
     ResponseStream,
     WorkflowEvent,
     WorkflowRunState,
+    agent_middleware,
     function_middleware,
     resolve_agent_id,
     tool,
@@ -803,6 +805,52 @@ async def test_handoff_clone_preserves_all_middleware_types() -> None:
     assert isinstance(executor, HandoffAgentExecutor)
     cloned_middleware = cast(Agent, executor._agent).middleware or []
     assert tracking_middleware in cloned_middleware, "User function middleware should be preserved on cloned agent"
+
+
+async def test_handoff_clone_preserves_additional_properties() -> None:
+    """Handoff clones should preserve additional_properties from the original agent."""
+    tracked_properties: list[dict[str, Any]] = []
+
+    @agent_middleware
+    async def observe_properties(context: AgentContext, call_next):
+        agent = cast(Agent, context.agent)
+        tracked_properties.append(dict(agent.additional_properties))
+        await call_next()
+
+    coordinator = Agent(
+        id="coordinator",
+        name="coordinator",
+        client=MockChatClient(name="coordinator"),
+        additional_properties={"tenant": "contoso", "trace_tag": "triage"},
+        middleware=[observe_properties],
+        require_per_service_call_history_persistence=True,
+    )
+    specialist = Agent(
+        id="specialist",
+        name="specialist",
+        client=MockChatClient(name="specialist"),
+        require_per_service_call_history_persistence=True,
+    )
+
+    workflow = (
+        HandoffBuilder(
+            participants=_as_handoff_agents(coordinator, specialist),
+            termination_condition=lambda conversation: any(msg.role == "assistant" for msg in conversation),
+        )
+        .with_start_agent(_as_handoff_agent(coordinator))
+        .build()
+    )
+
+    await _drain(workflow.run("hello", stream=True))
+
+    assert tracked_properties == [{"tenant": "contoso", "trace_tag": "triage"}]
+
+    # The clone owns its own copy; the original agent's properties stay untouched.
+    executor = workflow.executors[resolve_agent_id(coordinator)]
+    assert isinstance(executor, HandoffAgentExecutor)
+    cloned_additional_properties = cast(Agent, executor.agent).additional_properties
+    assert cloned_additional_properties == {"tenant": "contoso", "trace_tag": "triage"}
+    assert cloned_additional_properties is not coordinator.additional_properties
 
 
 def test_clean_conversation_for_handoff_keeps_text_only_history() -> None:


### PR DESCRIPTION
### Motivation & Context

Agents configured with `additional_properties` lose those properties when executed through a handoff workflow. The same agent exposes its configured properties during a direct run, but middleware sees an empty dictionary when the agent runs through `HandoffBuilder` — silently breaking middleware and integrations that rely on agent metadata (tenant info, tracing tags, feature flags, etc.).

### Description & Review Guide

`HandoffAgentExecutor` clones each participant `Agent` in `_clone_chat_agent` (to attach handoff tools without mutating the caller's agent), but the clone's `Agent(...)` reconstruction did not forward `additional_properties`. PR #5220 previously fixed middleware preservation in this same clone path; `additional_properties` is a separate public field that remained unpreserved.

- **What are the major changes?**
  - In `_handoff.py`, pass `deepcopy(agent.additional_properties)` to the cloned `Agent` so the clone carries the full configured metadata while the original agent stays untouched.
  - Add `test_handoff_clone_preserves_additional_properties`, which observes `context.agent.additional_properties` from agent middleware during a handoff run and asserts the clone holds an equal, independently owned copy.
- **What is the impact of these changes?**
  Agents participating in handoff workflows retain their configured `additional_properties`; no API or behavioral changes for agents without them. Not a breaking change.
- **What do you want reviewers to focus on?**
  Whether a deep copy (vs. a shared reference) is the right ownership semantics for the cloned agent's metadata.

### Related Issue

Fixes #7750

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**