### PR TITLE
.NET: Suppress Swagger UI CodeQL alert in AgentWebChat sample

### DIFF
--- a/dotnet/samples/05-end-to-end/AgentWebChat/AgentWebChat.AgentHost/Program.cs
+++ b/dotnet/samples/05-end-to-end/AgentWebChat/AgentWebChat.AgentHost/Program.cs
@@ -165,7 +165,7 @@ knightsKnavesAgentBuilder.AddA2AServer();
 var app = builder.Build();
 
 app.MapOpenApi();
-app.UseSwaggerUI(options => options.SwaggerEndpoint("/openapi/v1.json", "Agents API"));
+app.UseSwaggerUI(options => options.SwaggerEndpoint("/openapi/v1.json", "Agents API")); // CodeQL [SM04686] Swagger UI is intentionally enabled because this is a sample application, not a production deployment.
 
 // Configure the HTTP request pipeline.
 app.UseExceptionHandler();


### PR DESCRIPTION
### Motivation & Context

CodeQL flags Swagger UI in AgentWebChat, but it is intentionally enabled in this end-to-end sample.

### Description & Review Guide

- **What are the major changes?** Suppress SM04686 with a sample-only justification.
- **What is the impact of these changes?** No behavior change.
- **What do you want reviewers to focus on?** The suppression and justification.

### Related Issue

N/A

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.