### PR TITLE
Python: Avoid unchanged AG-UI predictive state snapshots

### DIFF
--- a/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
@@ -783,6 +783,7 @@ def _emit_tool_result_common(
     # in stream order instead of grouping B with A (moonbox3's replay concern).
     flow.snapshot_segments.append({"kind": "tool_results"})
 
+    predictive_state_updated = bool(predictive_handler and predictive_handler.pending_state_updates)
     if predictive_handler:
         predictive_handler.apply_pending_updates()
 
@@ -795,7 +796,7 @@ def _emit_tool_result_common(
         )
 
     # Emit a single coalesced snapshot when either mechanism updated state.
-    if (predictive_handler or state_update) and flow.current_state:
+    if (predictive_state_updated or state_update) and flow.current_state:
         events.append(StateSnapshotEvent(snapshot=flow.current_state))
 
     flow.tool_call_id = None

--- a/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_run_common.py
@@ -783,7 +783,7 @@ def _emit_tool_result_common(
     # in stream order instead of grouping B with A (moonbox3's replay concern).
     flow.snapshot_segments.append({"kind": "tool_results"})
 
-    predictive_state_updated = bool(predictive_handler and predictive_handler.pending_state_updates)
+    had_pending_predictive_updates = bool(predictive_handler and predictive_handler.pending_state_updates)
     if predictive_handler:
         predictive_handler.apply_pending_updates()
 
@@ -796,7 +796,7 @@ def _emit_tool_result_common(
         )
 
     # Emit a single coalesced snapshot when either mechanism updated state.
-    if (predictive_state_updated or state_update) and flow.current_state:
+    if (had_pending_predictive_updates or state_update) and flow.current_state:
         events.append(StateSnapshotEvent(snapshot=flow.current_state))
 
     flow.tool_call_id = None

--- a/python/packages/ag-ui/tests/ag_ui/test_run_common.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run_common.py
@@ -380,6 +380,37 @@ class TestEmitToolResultWithState:
         events = _emit_tool_result(content, flow)
         assert all(e.type != EventType.STATE_SNAPSHOT for e in events)
 
+    def test_predictive_handler_without_pending_updates_emits_no_snapshot(self):
+        """A configured predictive handler must not emit unchanged state for unrelated tools."""
+        flow = FlowState(current_state={"existing": "value"})
+        handler = PredictiveStateHandler(
+            predict_state_config={"draft": {"tool": "write_draft", "tool_argument": "body"}},
+            current_state=flow.current_state,
+        )
+        content = Content.from_function_result(call_id="c1", result="plain")
+
+        events = _emit_tool_result(content, flow, predictive_handler=handler)
+
+        assert all(e.type != EventType.STATE_SNAPSHOT for e in events)
+        assert flow.current_state == {"existing": "value"}
+
+    def test_predictive_handler_with_pending_updates_emits_snapshot(self):
+        """A pending predictive update is applied and emitted as one snapshot."""
+        flow = FlowState(current_state={"existing": "value"})
+        handler = PredictiveStateHandler(
+            predict_state_config={"draft": {"tool": "write_draft", "tool_argument": "body"}},
+            current_state=flow.current_state,
+        )
+        handler.pending_state_updates["draft"] = "updated"
+        content = Content.from_function_result(call_id="c1", result="plain")
+
+        events = _emit_tool_result(content, flow, predictive_handler=handler)
+
+        snapshots = [event for event in events if event.type == EventType.STATE_SNAPSHOT]
+        assert len(snapshots) == 1
+        assert snapshots[0].snapshot == {"existing": "value", "draft": "updated"}  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert flow.current_state == {"existing": "value", "draft": "updated"}
+
     def test_tool_result_content_text_unchanged(self):
         """The text sent to the LLM must not leak the state marker."""
         tool_return = state_update(text="Weather: 14°C", state={"weather": {"temp": 14}})

--- a/python/packages/ag-ui/tests/ag_ui/test_run_common.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run_common.py
@@ -5,7 +5,7 @@
 import logging
 
 import pytest
-from ag_ui.core import EventType
+from ag_ui.core import EventType, StateSnapshotEvent
 from ag_ui.core.events import (
     ReasoningMessageContentEvent,
     ReasoningMessageStartEvent,
@@ -401,14 +401,15 @@ class TestEmitToolResultWithState:
             predict_state_config={"draft": {"tool": "write_draft", "tool_argument": "body"}},
             current_state=flow.current_state,
         )
-        handler.pending_state_updates["draft"] = "updated"
+        deltas = handler.emit_streaming_deltas("write_draft", '{"body":"updated"}')
         content = Content.from_function_result(call_id="c1", result="plain")
 
         events = _emit_tool_result(content, flow, predictive_handler=handler)
 
-        snapshots = [event for event in events if event.type == EventType.STATE_SNAPSHOT]
+        assert len(deltas) == 1
+        snapshots = [event for event in events if isinstance(event, StateSnapshotEvent)]
         assert len(snapshots) == 1
-        assert snapshots[0].snapshot == {"existing": "value", "draft": "updated"}  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+        assert snapshots[0].snapshot == {"existing": "value", "draft": "updated"}
         assert flow.current_state == {"existing": "value", "draft": "updated"}
 
     def test_tool_result_content_text_unchanged(self):


### PR DESCRIPTION
### Motivation & Context

When `predict_state_config` is enabled, every tool result currently emits a full `StateSnapshotEvent`, even when the completed tool did not produce a predictive update. The handler object is truthy regardless of whether `pending_state_updates` is empty, so unrelated tools resend unchanged state and can trigger unnecessary client rendering.

### Description & Review Guide

- **What are the major changes?** Record whether predictive updates are pending before applying and clearing them, then use that signal when deciding whether to emit the coalesced state snapshot. Add regression tests for both the no-op and real-update paths.
- **What is the impact of these changes?** Unrelated tool results no longer emit unchanged full-state snapshots. Actual predictive updates and deterministic `state_update` results retain the existing single-snapshot behavior.
- **What do you want reviewers to focus on?** Whether checking the pending-update set before `apply_pending_updates()` is the preferred boundary for distinguishing configured prediction from an actual state change.

### Related Issue

Fixes #7490

No other open PR is linked to this issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.