### PR TITLE
Python: Register built-in orchestration types for checkpoint restore

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
@@ -129,7 +129,6 @@ for _checkpoint_type in (
     MagenticPlanReviewResponse,
     MagenticProgressLedger,
     MagenticProgressLedgerItem,
-    _MagenticTaskLedger,
 ):
     register_checkpoint_type(_checkpoint_type)
 

--- a/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
@@ -17,10 +17,14 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
 
+from agent_framework import register_checkpoint_type
+
 from ._base_group_chat_orchestrator import (
     BaseGroupChatOrchestrator,
+    GroupChatParticipantMessage,
     GroupChatRequestMessage,
     GroupChatRequestSentEvent,
+    GroupChatResponseMessage,
     GroupChatResponseReceivedEvent,
     TerminationCondition,
 )
@@ -59,6 +63,7 @@ from ._magentic import (
     MagenticProgressLedgerItem,
     MagenticResetSignal,
     StandardMagenticManager,
+    _MagenticTaskLedger,
 )
 from ._orchestration_request_info import AgentRequestInfoResponse
 from ._orchestration_state import OrchestrationState
@@ -108,3 +113,24 @@ __all__ = [
     "clean_conversation_for_handoff",
     "create_completion_message",
 ]
+
+# Framework-owned types that cross a checkpoint boundary: executor-to-executor message
+# envelopes and request_info payloads/responses. Registering them here means built-in
+# orchestrations restore without users maintaining their own `allowed_checkpoint_types`
+# list of framework module paths.
+for _checkpoint_type in (
+    GroupChatRequestMessage,
+    GroupChatParticipantMessage,
+    GroupChatResponseMessage,
+    HandoffAgentUserRequest,
+    AgentRequestInfoResponse,
+    MagenticResetSignal,
+    MagenticPlanReviewRequest,
+    MagenticPlanReviewResponse,
+    MagenticProgressLedger,
+    MagenticProgressLedgerItem,
+    _MagenticTaskLedger,
+):
+    register_checkpoint_type(_checkpoint_type)
+
+del _checkpoint_type

--- a/python/packages/orchestrations/tests/test_checkpoint_types.py
+++ b/python/packages/orchestrations/tests/test_checkpoint_types.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from typing import Any
+
+import pytest
+from agent_framework import Message
+from agent_framework._workflows._checkpoint_encoding import (
+    _REGISTERED_CHECKPOINT_TYPE_KEYS,
+    decode_checkpoint_value,
+    encode_checkpoint_value,
+)
+
+from agent_framework_orchestrations._base_group_chat_orchestrator import (
+    GroupChatParticipantMessage,
+    GroupChatRequestMessage,
+    GroupChatResponseMessage,
+)
+from agent_framework_orchestrations._handoff import HandoffAgentUserRequest
+from agent_framework_orchestrations._magentic import (
+    MagenticPlanReviewRequest,
+    MagenticPlanReviewResponse,
+    MagenticResetSignal,
+)
+from agent_framework_orchestrations._orchestration_request_info import AgentRequestInfoResponse
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        GroupChatRequestMessage(additional_instruction="go"),
+        GroupChatParticipantMessage(messages=[Message(role="user", contents=[])]),
+        GroupChatResponseMessage(message=Message(role="assistant", contents=[])),
+        MagenticResetSignal(),
+    ],
+)
+def test_builtin_envelopes_restore_without_extra_allowed_types(value: Any) -> None:
+    """Framework-owned envelopes decode under a restricted allowlist (issue #7789)."""
+    restored = decode_checkpoint_value(encode_checkpoint_value(value), allowed_types=frozenset())
+
+    assert type(restored) is type(value)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        HandoffAgentUserRequest,
+        AgentRequestInfoResponse,
+        MagenticPlanReviewRequest,
+        MagenticPlanReviewResponse,
+    ],
+)
+def test_builtin_request_info_types_are_registered(cls: type) -> None:
+    """Request/response payloads that get persisted are trusted by default."""
+    assert f"{cls.__module__}:{cls.__qualname__}" in _REGISTERED_CHECKPOINT_TYPE_KEYS


### PR DESCRIPTION
### Motivation & Context

`GroupChatBuilder`, `HandoffBuilder`, and `MagenticBuilder` route framework-owned dataclasses as executor-to-executor messages and as `request_info` payloads/responses. Those types live in `agent_framework_orchestrations`, which is outside the `agent_framework.` module prefix that the restricted checkpoint unpickler auto-allows.

The result is that restoring a checkpoint from a built-in orchestration fails unless the user hand-maintains an allowlist of internal framework module paths:

```text
Failed to decode pickled checkpoint data: Checkpoint deserialization blocked for type
'agent_framework_orchestrations._base_group_chat_orchestrator:GroupChatParticipantMessage'.
```

Users should not have to track framework-internal module paths to restore a framework-provided orchestration.

### Description & Review Guide

- **What are the major changes?**
  - `agent_framework_orchestrations/__init__.py` registers the package's checkpoint-crossing types through the existing public `register_checkpoint_type` API at import time.
  - The registered set covers the three group chat envelopes from the issue plus the wider audit it asks for: `HandoffAgentUserRequest`, `AgentRequestInfoResponse`, `MagenticResetSignal`, `MagenticPlanReviewRequest`/`MagenticPlanReviewResponse`, and the ledger types nested inside the plan review request.
  - New `tests/test_checkpoint_types.py` round-trips the envelopes through `encode_checkpoint_value`/`decode_checkpoint_value` under a restricted allowlist (`allowed_types=frozenset()`), and asserts the `request_info` payload/response types are registered.

- **What is the impact of these changes?**
  - Built-in orchestrations restore from checkpoints without any `allowed_checkpoint_types` configuration. The previously documented workaround keeps working; it is now redundant.
  - No change to the allowlist mechanism itself, and no widening of the module-prefix rule in core — only these named types become trusted.

- **What do you want reviewers to focus on?**
  - Whether the registered set is complete. `GroupChatState`, `OrchestrationState`, and `MagenticContext` are deliberately excluded because they persist through `to_dict`/`from_dict` rather than pickle.
  - Whether package-import-time registration is the right hook, versus a documented explicit helper that callers invoke.

### Related Issue

Fixes #7789

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
