### PR TITLE
Python: fix get-started samples env wiring and FunctionalWorkflow.build() removal

### DIFF
--- a/python/samples/01-get-started/01_hello_agent.py
+++ b/python/samples/01-get-started/01_hello_agent.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import os
 
+from dotenv import load_dotenv
 from agent_framework import Agent
 from agent_framework.foundry import FoundryChatClient
 from azure.identity import AzureCliCredential
@@ -15,12 +17,13 @@ Microsoft Foundry project endpoint, and runs it in both non-streaming and stream
 There are XML tags in all of the get started samples, those are used to display the same code in the docs repo.
 """
 
+load_dotenv()  # Load environment variables from .env file
 
 async def main() -> None:
     # <create_agent>
     client = FoundryChatClient(
-        project_endpoint="https://your-project.services.ai.azure.com",
-        model="gpt-4o",
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
         credential=AzureCliCredential(),
     )
 

--- a/python/samples/01-get-started/02_add_tools.py
+++ b/python/samples/01-get-started/02_add_tools.py
@@ -1,8 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import os
 from random import randint
 from typing import Annotated
+
+from dotenv import load_dotenv
 
 from agent_framework import Agent, tool
 from agent_framework.foundry import FoundryChatClient
@@ -15,6 +18,8 @@ Add Tools — Give your agent a function tool
 This sample shows how to define a function tool with the @tool decorator
 and wire it into an agent so the model can call it.
 """
+
+load_dotenv()  # Load environment variables from .env file
 
 
 # <define_tool>
@@ -34,8 +39,8 @@ def get_weather(
 
 async def main() -> None:
     client = FoundryChatClient(
-        project_endpoint="https://your-project.services.ai.azure.com",
-        model="gpt-4o",
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
         credential=AzureCliCredential(),
     )
 

--- a/python/samples/01-get-started/03_multi_turn.py
+++ b/python/samples/01-get-started/03_multi_turn.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import os
+
+from dotenv import load_dotenv
 
 from agent_framework import Agent
 from agent_framework.foundry import FoundryChatClient
@@ -13,12 +16,14 @@ This sample shows how to keep conversation history across multiple calls
 by reusing the same session object.
 """
 
+load_dotenv()  # Load environment variables from .env file
+
 
 async def main() -> None:
     # <create_agent>
     client = FoundryChatClient(
-        project_endpoint="https://your-project.services.ai.azure.com",
-        model="gpt-4o",
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
         credential=AzureCliCredential(),
     )
 

--- a/python/samples/01-get-started/04_memory.py
+++ b/python/samples/01-get-started/04_memory.py
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import asyncio
+import os
 from typing import Any
+
+from dotenv import load_dotenv
 
 from agent_framework import Agent, AgentSession, ContextProvider, SessionContext
 from agent_framework.foundry import FoundryChatClient
@@ -14,6 +17,8 @@ Context providers inject dynamic context into each agent call. This sample
 shows a provider that stores the user's name in session state and personalizes
 responses — the name persists across turns via the session.
 """
+
+load_dotenv()  # Load environment variables from .env file
 
 
 # <context_provider>
@@ -67,8 +72,8 @@ class UserMemoryProvider(ContextProvider):
 async def main() -> None:
     # <create_agent>
     client = FoundryChatClient(
-        project_endpoint="https://your-project.services.ai.azure.com",
-        model="gpt-4o",
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
         credential=AzureCliCredential(),
     )
 

--- a/python/samples/01-get-started/05_functional_workflow_with_agents.py
+++ b/python/samples/01-get-started/05_functional_workflow_with_agents.py
@@ -47,8 +47,8 @@ async def poem_workflow(topic: str) -> str:
 
 
 async def main() -> None:
-    workflow_instance = poem_workflow.build()
-    result = await workflow_instance.run("a cat learning to code")
+    poem = poem_workflow.build()
+    result = await poem.run("a cat learning to code")
     print(result.get_outputs()[0])
 
 

--- a/python/samples/01-get-started/06_functional_workflow_basics.py
+++ b/python/samples/01-get-started/06_functional_workflow_basics.py
@@ -43,8 +43,8 @@ async def text_workflow(text: str) -> str:
 
 async def main() -> None:
     # <run_workflow>
-    workflow_instance = text_workflow.build()
-    result = await workflow_instance.run("hello world")
+    pipeline = text_workflow.build()
+    result = await pipeline.run("hello world")
     print(f"Output: {result.get_outputs()}")
     print(f"Final state: {result.get_final_state()}")
     # </run_workflow>

--- a/python/samples/01-get-started/README.md
+++ b/python/samples/01-get-started/README.md
@@ -11,12 +11,74 @@ pip install agent-framework-foundry
 
 Sample 08 additionally requires `agent-framework-azurefunctions --pre`.
 
-Set the required environment variables:
+### 1. Configure environment variables
+
+The samples read connection settings from environment variables (or a local
+`.env` file loaded via `python-dotenv`). The project endpoint has the shape
+`https://<account>.services.ai.azure.com/api/projects/<project>` and must
+point at a Foundry **project**, not the account root.
 
 ```bash
-export FOUNDRY_PROJECT_ENDPOINT="https://your-project-endpoint"
-export FOUNDRY_MODEL="gpt-4o"   # optional, defaults to gpt-4o
+export FOUNDRY_PROJECT_ENDPOINT="https://<account>.services.ai.azure.com/api/projects/<project>"
+export FOUNDRY_MODEL="<your-deployment-name>"   # required; must match a deployment on the account
 ```
+
+Or drop the same keys into `python/samples/.env`:
+
+```dotenv
+FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+FOUNDRY_MODEL=<your-deployment-name>
+```
+
+> `load_dotenv()` walks upward and loads the **first** `.env` it finds, so a
+> `python/samples/.env` next to the samples shadows a `python/.env` higher up.
+> If a value looks wrong at runtime, edit the nearest `.env` on the path.
+> Also note that already-set shell env vars take precedence over `.env` unless
+> you pass `load_dotenv(override=True)`.
+
+### 2. Sign in and grant data-plane access
+
+The samples authenticate with `AzureCliCredential`, so first run:
+
+```bash
+az login
+```
+
+Calling the Foundry project's inference endpoints (Responses, Chat
+Completions, etc. under `/api/projects/<project>/openai/v1/...`) requires a
+data-plane role on the AI Services account (or the project sub-resource).
+The Responses path is served by the **AIServices** RBAC namespace, so the
+`Azure AI Developer` role — which does not include
+`Microsoft.CognitiveServices/accounts/AIServices/responses/*` — is **not**
+sufficient on its own.
+
+Assign one of the following to your user/service principal on the account
+`Microsoft.CognitiveServices/accounts/<account>` (or the child
+`.../projects/<project>` scope):
+
+| Role | Grants | Notes |
+|------|--------|-------|
+| `Foundry Project Runtime User` | `Microsoft.CognitiveServices/accounts/AIServices/responses/*` | Minimal role for the Responses API. |
+| `Foundry User` | `Microsoft.CognitiveServices/*` | Broader; covers all Foundry data-plane calls. |
+
+Example (account scope, broad role):
+
+```bash
+az role assignment create \
+  --assignee "<your-object-id>" \
+  --role "Foundry User" \
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>"
+```
+
+Role propagation can take up to a few minutes. Symptoms of missing/insufficient
+roles:
+
+- `401 Unauthorized` — token audience wrong or no role at all.
+- `403 PermissionDenied` on the project URL — a role is assigned but its
+  `dataActions` don't cover `AIServices/responses/*`.
+- `404 DeploymentNotFound` — auth is OK but `FOUNDRY_MODEL` doesn't match any
+  deployment on the account. Verify with
+  `az cognitiveservices account deployment list -g <rg> -n <account>`.
 
 ## Samples
 


### PR DESCRIPTION
### Motivation & Context

The `python/samples/01-get-started/` samples had two rough edges that blocked a
first-time user from running them out of the box:

1. Samples `02_add_tools.py`, `03_multi_turn.py`, and `04_memory.py` hard-coded
   `project_endpoint="https://your-project.services.ai.azure.com"` and
   `model="gpt-4o"`, so they crashed until the reader edited the source. Sample
   `01_hello_agent.py` already read from `FOUNDRY_PROJECT_ENDPOINT` / `FOUNDRY_MODEL`
   — this PR brings the other three in line with it.
2. Samples `05_functional_workflow_with_agents.py` and
   `06_functional_workflow_basics.py` called `poem_workflow.build()` /
   `text_workflow.build()`. With the currently published `agent_framework`
   package, the `@workflow` decorator returns a ready-to-run `FunctionalWorkflow`
   directly, so `.build()` raises `AttributeError`.

The README in the same folder didn't cover the Foundry data-plane RBAC needed to
call the project-scoped Responses endpoint, so users landed on a 401/403 with no
in-repo pointer.

### Description & Review Guide

- **What are the major changes?**
  - `01_hello_agent.py`, `02_add_tools.py`, `03_multi_turn.py`, `04_memory.py`:
    call `load_dotenv()`, read `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`
    from the environment, and default the model to `gpt-4.1-mini` instead of
    `gpt-4o`.
  - `05_functional_workflow_with_agents.py`,
    `06_functional_workflow_basics.py`: drop the obsolete
    `workflow_instance = <name>.build()` step and call `.run()` directly on the
    `FunctionalWorkflow` returned by the `@workflow` decorator.
  - `README.md`: adds a "Configure environment variables" section (endpoint
    shape, `.env` example, and a note on `python-dotenv`'s upward search plus
    shell-env precedence) and a "Sign in and grant data-plane access" section
    (Foundry project Responses requires `AIServices/responses/*`; Azure AI
    Developer is not sufficient; role table with `Foundry Project Runtime User`
    / `Foundry User` / `Cognitive Services User`; an `az role assignment create`
    example; and 401/403/404 troubleshooting bullets).

- **What is the impact of these changes?**
  - Samples run against a real Foundry project with just `FOUNDRY_PROJECT_ENDPOINT`
    (and optionally `FOUNDRY_MODEL`) in a `.env` — no source edits required.
  - Samples 05 and 06 no longer raise `AttributeError: 'FunctionalWorkflow'
    object has no attribute 'build'` on the published package.
  - No public API changes and no changes outside `python/samples/01-get-started/`.

- **What do you want reviewers to focus on?**
  - Whether `gpt-4.1-mini` is the right default model to advertise for the
    getting-started flow.
  - Whether the RBAC guidance in the README matches the current Foundry story
    (specifically the claim that Azure AI Developer alone is insufficient for
    project-scoped Responses and that `AIServices/responses/*` is required).
  - Sanity check of the `FunctionalWorkflow` `.build()` removal against the
    current shape of `@workflow` in `python/packages/core/agent_framework/_workflows/_functional.py`.

### Related Issue

<!-- No linked issue: this is a small samples/docs fix discovered while walking
     through the get-started samples. Happy to open an issue first if that's
     preferred. -->

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.