### PR TITLE
Python: resolve release tags against real package directories

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,10 +34,18 @@ jobs:
           # Configure a constant location for the uv cache
           UV_CACHE_DIR: /tmp/.uv-cache
       - name: Set environment variables
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           # Extract package name from tag (format: python-<package>-<version>)
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$TAG_NAME"
           PACKAGE=$(echo "$TAG" | sed 's/^python-\([^-]*\)-.*$/\1/')
+
+          # Validate the extracted package name is a plain identifier
+          if [[ ! "$PACKAGE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "Error: could not derive a valid package name from tag '$TAG'"
+            exit 1
+          fi
 
           # Validate package exists
           if [[ ! -d "packages/$PACKAGE" ]]; then
@@ -50,11 +58,13 @@ jobs:
           echo "Building package: $PACKAGE"
 
       - name: Check version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          echo "Building and uploading Python package version: ${{ github.event.release.tag_name }}"
-          echo "Package directory: packages/${{ env.PACKAGE }}"
+          echo "Building and uploading Python package version: $TAG_NAME"
+          echo "Package directory: packages/$PACKAGE"
       - name: Build the package
-        run: uv run poe --directory packages/${{ env.PACKAGE }} build
+        run: uv run poe --directory "packages/$PACKAGE" build
       - name: Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -45,17 +45,44 @@ jobs:
           # python-<package>-<version> for a single package. Package names may
           # themselves contain hyphens (hosting-a2a, azure-ai-search), so the
           # package part cannot be found by splitting on the first hyphen.
+          #
+          # Versions follow the lifecycle patterns in the python-package-management
+          # skill: X.Y.Z, X.Y.ZaYYMMDD, X.Y.ZbYYMMDD, X.Y.ZrcN, each optionally
+          # carrying a .N or .postN re-cut suffix.
+          VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)?(\.[0-9]+|\.post[0-9]+)?$'
+
           REST="${TAG#python-}"
 
-          if [[ "$REST" != *-* ]]; then
+          if [[ -z "$REST" ]]; then
+            echo "Error: tag '$TAG' has no version or package component"
+            exit 1
+          fi
+
+          if [[ "$REST" =~ $VERSION_PATTERN ]]; then
             # python-<version>: build every workspace package plus the root meta package.
             PACKAGE="all"
             echo "Resolved tag '$TAG' to the full workspace build"
           else
-            # Strip the trailing -<version> component, then resolve what is left
-            # against the real package directories. Tags use hyphens even where the
-            # directory uses underscores (python-github-copilot -> github_copilot).
+            # python-<package>-<version>: split off the trailing version component and
+            # require it to be a real version, so a malformed tag fails here rather
+            # than being mistaken for another kind of release.
             CANDIDATE="${REST%-*}"
+            VERSION="${REST##*-}"
+
+            if [[ "$CANDIDATE" == "$REST" || -z "$CANDIDATE" ]]; then
+              echo "Error: tag '$TAG' is neither python-<version> nor python-<package>-<version>"
+              exit 1
+            fi
+
+            if [[ ! "$VERSION" =~ $VERSION_PATTERN ]]; then
+              echo "Error: tag '$TAG' does not end in a supported version"
+              echo "Derived version: '$VERSION'"
+              exit 1
+            fi
+
+            # Resolve the package part against the real package directories. Tags use
+            # hyphens even where the directory uses underscores
+            # (python-github-copilot -> github_copilot).
             PACKAGE=""
 
             for dir in packages/*/; do

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -33,38 +33,70 @@ jobs:
         env:
           # Configure a constant location for the uv cache
           UV_CACHE_DIR: /tmp/.uv-cache
-      - name: Set environment variables
+      - name: Resolve the package to build
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          # Extract package name from tag (format: python-<package>-<version>)
+          set -euo pipefail
+
           TAG="$TAG_NAME"
-          PACKAGE=$(echo "$TAG" | sed 's/^python-\([^-]*\)-.*$/\1/')
 
-          # Validate the extracted package name is a plain identifier
-          if [[ ! "$PACKAGE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            echo "Error: could not derive a valid package name from tag '$TAG'"
-            exit 1
+          # Release tags are either python-<version> for the whole workspace, or
+          # python-<package>-<version> for a single package. Package names may
+          # themselves contain hyphens (hosting-a2a, azure-ai-search), so the
+          # package part cannot be found by splitting on the first hyphen.
+          REST="${TAG#python-}"
+
+          if [[ "$REST" != *-* ]]; then
+            # python-<version>: build every workspace package plus the root meta package.
+            PACKAGE="all"
+            echo "Resolved tag '$TAG' to the full workspace build"
+          else
+            # Strip the trailing -<version> component, then resolve what is left
+            # against the real package directories. Tags use hyphens even where the
+            # directory uses underscores (python-github-copilot -> github_copilot).
+            CANDIDATE="${REST%-*}"
+            PACKAGE=""
+
+            for dir in packages/*/; do
+              name="${dir#packages/}"
+              name="${name%/}"
+              if [[ "$name" == "$CANDIDATE" || "${name//_/-}" == "$CANDIDATE" ]]; then
+                PACKAGE="$name"
+                break
+              fi
+            done
+
+            if [[ -z "$PACKAGE" ]]; then
+              echo "Error: tag '$TAG' does not map to a directory in packages/"
+              echo "Derived package name: '$CANDIDATE'"
+              echo "Available packages: $(ls packages/)"
+              exit 1
+            fi
+
+            echo "Resolved tag '$TAG' to package '$PACKAGE'"
           fi
 
-          # Validate package exists
-          if [[ ! -d "packages/$PACKAGE" ]]; then
-            echo "Error: Package '$PACKAGE' not found in packages/ directory"
-            echo "Available packages: $(ls packages/)"
-            exit 1
-          fi
-
-          echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
-          echo "Building package: $PACKAGE"
+          echo "PACKAGE=$PACKAGE" >> "$GITHUB_ENV"
 
       - name: Check version
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          echo "Building and uploading Python package version: $TAG_NAME"
-          echo "Package directory: packages/$PACKAGE"
+          echo "Building and uploading Python release: $TAG_NAME"
+          if [[ "$PACKAGE" == "all" ]]; then
+            echo "Build scope: all workspace packages and the root meta package"
+          else
+            echo "Build scope: packages/$PACKAGE"
+          fi
       - name: Build the package
-        run: uv run poe --directory "packages/$PACKAGE" build
+        run: |
+          set -euo pipefail
+          if [[ "$PACKAGE" == "all" ]]; then
+            uv run poe build
+          else
+            uv run poe --directory "packages/$PACKAGE" build
+          fi
       - name: Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:


### PR DESCRIPTION
### Motivation & Context

`python-release.yml` builds the release assets for a release by deriving a package name
from the release tag. The extraction is a single `sed` that splits the tag on the first
hyphen:

```bash
PACKAGE=$(echo "$TAG" | sed 's/^python-\([^-]*\)-.*$/\1/')
```

That assumes package names never contain a hyphen and always match their directory name
exactly. Neither holds, so against the tags this repo actually produces:

| Tag | Extracted | Result |
| --- | --- | --- |
| `python-devui-1.0.0b260414` | `devui` | correct |
| `python-hosting-a2a-1.0.0a260723` | `hosting` | **builds the wrong package** — `packages/hosting` exists, so it succeeds silently |
| `python-github-copilot-1.0.0` | `github` | fails — the directory is `github_copilot` |
| `python-1.14.0` | `python-1.14.0` | fails — no match, the tag passes through unchanged |

The `hosting-a2a` case is the concerning one: the job attaches artifacts for a different
package to the release without any error.

Separately, the tag value was templated directly into the `run:` script text rather than
passed through the step `env:` block. Every other workflow in this repo already uses the
`env:` block for `github.event.*` values, so this one was the odd one out.

### Description & Review Guide

- **What are the major changes?**
  - Require the tag to end in a supported version before doing anything else. The pattern
    covers the lifecycle versions from the `python-package-management` skill plus the
    re-cut suffixes present in the tag history (`1.0.0b251105.1`, `1.0.0b251106.post1`):
    `^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)?(\.[0-9]+|\.post[0-9]+)?$`.
    Tags matching neither shape are rejected instead of being guessed at.
  - Resolve the package name against the real `packages/` listing instead of guessing the
    hyphen boundary. The trailing `-<version>` component is stripped, and the remainder is
    matched against each directory name both literally and with `_` normalized to `-`,
    which covers `hosting-a2a`, `azure-ai-search`, `github_copilot`, and `foundry_local`.
  - Handle the `python-<version>` workspace tag explicitly. It now runs the root
    `uv run poe build`, which builds every workspace package plus the `agent-framework`
    meta package into `python/dist/`, instead of failing on a nonsensical package name.
  - Fail with an explicit error naming the derived package or version, and the available
    packages, rather than falling through to a confusing later failure.
  - Pass the tag via the step `env:` block as `TAG_NAME` and reference it as a quoted shell
    variable, matching the pattern used elsewhere in `.github/workflows/`.
  - Add `set -euo pipefail` to the scripted steps.

- **What is the impact of these changes?**
  Single-package release tags now resolve to the correct directory, including the ones that
  previously resolved to the wrong package or failed outright. Workspace-level
  `python-X.Y.Z` tags now build assets instead of erroring. Malformed tags fail with a clear
  message instead of producing an arbitrary build. Renamed the first step from
  "Set environment variables" to "Resolve the package to build" to reflect what it does.

- **What do you want reviewers to focus on?**
  The `python-<version>` branch: it now invokes the root `poe build`, which builds all
  packages plus the meta package. Please confirm that is the intended asset set for a
  workspace-level release tag — that is the one behavior here that is a deliberate choice
  rather than a straightforward correction.

Verified against all 62 existing `python-*` tags in the repo (all resolve as expected), a
synthetic tag for each of the 35 directories under `python/packages/` (all round-trip to
the correct directory), and a set of malformed tags (`python-devui`, `python-typo`,
`python-`, `python-hosting-a2a`, `python-devui-notaversion`, `python-1.0`), which all
error out.

### Related Issue

N/A — no tracking issue; found while reading the release workflow.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
