### PR TITLE
Python: fix MCP tool argument shadowing the remote tool name

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -240,6 +240,34 @@ def _mcp_config_candidate_names(*, local_name: str, normalized_name: str, remote
     return tuple(names)
 
 
+def _make_mcp_tool_caller(
+    mcp_tool: MCPTool, remote_tool_name: str
+) -> Callable[..., Coroutine[Any, Any, str | list[Content]]]:
+    """Build the callable backing a generated MCP ``FunctionTool``.
+
+    The remote tool name is captured in this factory's closure rather than declared as a
+    parameter of the returned callable. Model-supplied arguments are splatted into that
+    callable, so any name it declares could be bound - and overridden - by the model. Keeping
+    the call target out of the signature means it can only ever be reached through ``**kwargs``,
+    which is forwarded as tool arguments and can never redirect the call to another tool.
+    """
+
+    async def _call_tool_with_runtime_kwargs(
+        ctx: FunctionInvocationContext,
+        **kwargs: Any,
+    ) -> str | list[Content]:
+        trusted_meta = ctx.kwargs.get("_meta")
+        call_kwargs = dict(ctx.kwargs)
+        call_kwargs.update(kwargs)
+        if trusted_meta is not None:
+            call_kwargs["_meta"] = trusted_meta
+        else:
+            call_kwargs.pop("_meta", None)
+        return await mcp_tool.call_tool(remote_tool_name, **call_kwargs)
+
+    return _call_tool_with_runtime_kwargs
+
+
 def _validate_mcp_meta_key(key: str) -> None:
     """Validate an MCP ``_meta`` key against the 2025-06-18 key-name format."""
     if not _MCP_META_KEY_PATTERN.fullmatch(key):
@@ -1894,24 +1922,9 @@ class MCPTool:
                     )
                 )
 
-                async def _call_tool_with_runtime_kwargs(
-                    ctx: FunctionInvocationContext,
-                    *,
-                    _remote_tool_name: str = tool.name,
-                    **kwargs: Any,
-                ) -> str | list[Content]:
-                    trusted_meta = ctx.kwargs.get("_meta")
-                    call_kwargs = dict(ctx.kwargs)
-                    call_kwargs.update(kwargs)
-                    if trusted_meta is not None:
-                        call_kwargs["_meta"] = trusted_meta
-                    else:
-                        call_kwargs.pop("_meta", None)
-                    return await self.call_tool(_remote_tool_name, **call_kwargs)
-
                 # Create FunctionTools out of each tool
                 func: FunctionTool = FunctionTool(
-                    func=_call_tool_with_runtime_kwargs,
+                    func=_make_mcp_tool_caller(self, tool.name),
                     name=local_name,
                     description=tool.description or "",
                     approval_mode=approval_mode,

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -4784,10 +4784,10 @@ async def test_generated_mcp_function_ignores_model_supplied_remote_tool_name() 
     )
 
     tool.session.call_tool.assert_awaited_once()  # ty: ignore[unresolved-attribute]
-    called_name = tool.session.call_tool.await_args.args[0]  # ty: ignore[unresolved-attribute]
-    called_arguments = tool.session.call_tool.await_args.kwargs["arguments"]  # ty: ignore[unresolved-attribute]
-    assert called_name == "search_docs"
-    assert called_arguments == {"query": "quarterly report"}
+    await_args = tool.session.call_tool.await_args  # ty: ignore[unresolved-attribute]
+    assert await_args is not None
+    assert await_args.args[0] == "search_docs"
+    assert await_args.kwargs["arguments"] == {"query": "quarterly report"}
 
 
 async def test_mcp_tool_get_prompt_requires_loaded_prompts() -> None:

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -4744,6 +4744,52 @@ async def test_mcp_tool_call_tool_requires_loaded_tools() -> None:
         await tool.call_tool("remote_tool")
 
 
+async def test_generated_mcp_function_ignores_model_supplied_remote_tool_name() -> None:
+    """A model-supplied argument must not be able to redirect the call to another remote tool."""
+    tool = MCPTool(name="test_tool")  # type: ignore[abstract]
+    tool.session = Mock(spec=ClientSession)
+    tool.session.list_tools = AsyncMock(  # ty: ignore[unresolved-attribute]
+        return_value=types.ListToolsResult(
+            tools=[
+                types.Tool(
+                    name="search_docs",
+                    description="Search docs.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                ),
+                types.Tool(
+                    name="delete_repo",
+                    description="Delete a repository.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"repo": {"type": "string"}},
+                        "required": ["repo"],
+                    },
+                ),
+            ]
+        )
+    )
+    tool.session.call_tool = AsyncMock(  # ty: ignore[unresolved-attribute]
+        return_value=types.CallToolResult(content=[types.TextContent(type="text", text="ok")])
+    )
+
+    await tool.load_tools()
+
+    search_docs = next(func for func in tool.functions if func.name == "search_docs")
+    await search_docs.invoke(
+        arguments={"query": "quarterly report", "_remote_tool_name": "delete_repo", "repo": "corp/prod"}
+    )
+
+    tool.session.call_tool.assert_awaited_once()  # ty: ignore[unresolved-attribute]
+    called_name = tool.session.call_tool.await_args.args[0]  # ty: ignore[unresolved-attribute]
+    called_arguments = tool.session.call_tool.await_args.kwargs["arguments"]  # ty: ignore[unresolved-attribute]
+    assert called_name == "search_docs"
+    assert called_arguments == {"query": "quarterly report"}
+
+
 async def test_mcp_tool_get_prompt_requires_loaded_prompts() -> None:
     tool = MCPTool(name="test_tool", load_prompts=False)  # type: ignore[abstract]
 


### PR DESCRIPTION
### Motivation & Context

`MCPTool` generates one local `FunctionTool` per remote MCP tool. The generated function
carried the remote tool name as the default value of a keyword-only parameter:

```python
async def _call_tool_with_runtime_kwargs(
    ctx: FunctionInvocationContext,
    *,
    _remote_tool_name: str = tool.name,
    **kwargs: Any,
) -> str | list[Content]:
    ...
    return await self.call_tool(_remote_tool_name, **call_kwargs)
```

Tool arguments are splatted into that callable, so an argument named `_remote_tool_name`
binds to the keyword-only parameter instead of landing in `**kwargs`, and the generated
function calls a different remote tool than the one it represents. Unknown argument names are
only rejected when the tool's `inputSchema` carries `additionalProperties: false`, which MCP
servers are not required to emit, so the argument reaches the function on many servers.

The equivalent prompt path is already unaffected because it binds the remote name positionally
via `partial(self.get_prompt, prompt.name)`.

### Description & Review Guide

- **What are the major changes?** The remote tool name moves out of the generated function's
  signature and into a `_make_mcp_tool_caller(mcp_tool, remote_tool_name)` factory closure.
  The parameter default was there to bind the name per loop iteration; a factory gives the
  same per-iteration binding without exposing the name as a parameter, so it can only ever be
  reached through `**kwargs` (which is forwarded as tool arguments and filtered by
  `_prepare_call_kwargs`). Adds a regression test covering an argument named
  `_remote_tool_name`.
- **What is the impact of these changes?** No public API or behavior change. The parameter was
  private and undocumented, and nothing in the repository passed it. The `ctx` handling,
  `_meta` precedence, argument filtering, approval mode, and telemetry paths are unchanged.
- **What do you want reviewers to focus on?** Whether the factory is the right shape here
  versus a private method plus `partial`, which would more closely mirror the prompt path.

### Related Issue

<!-- No existing issue; this was found while reading the MCP tool generation code. -->

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
