### PR TITLE
Add moonbox3 as codeowner for Foundry hosting and local packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,8 +66,8 @@
 /python/packages/declarative/                                   @chetantoshniwal @moonbox3 @peibekwe
 /python/packages/devui/                                         @chetantoshniwal @eavanvalkenburg @moonbox3
 /python/packages/foundry/                                       @chetantoshniwal @eavanvalkenburg @TaoChenOSU @moonbox3 @giles17
-/python/packages/foundry_hosting/                               @chetantoshniwal @TaoChenOSU @eavanvalkenburg
-/python/packages/foundry_local/                                 @chetantoshniwal @eavanvalkenburg @giles17
+/python/packages/foundry_hosting/                               @chetantoshniwal @TaoChenOSU @eavanvalkenburg @moonbox3
+/python/packages/foundry_local/                                 @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/gemini/                                        @chetantoshniwal @giles17 @eavanvalkenburg @moonbox3
 /python/packages/github_copilot/                                @chetantoshniwal @giles17 @eavanvalkenburg @moonbox3
 /python/packages/hosting/                                       @chetantoshniwal @eavanvalkenburg @TaoChenOSU @moonbox3


### PR DESCRIPTION
### Motivation & Context

Add moonbox3 as codeowner for Foundry hosting and local packages

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

### Description & Review Guide

Add moonbox3 as codeowner for Foundry hosting and local packages

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
- **What is the impact of these changes?**
- **What do you want reviewers to focus on?**
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
