### PR TITLE
Fix DevFlow review command whitespace handling

### DIFF
--- a/.github/scripts/review_command.js
+++ b/.github/scripts/review_command.js
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+/**
+ * Check whether a comment contains only the DevFlow review command.
+ *
+ * @param {unknown} body - Issue comment body from the GitHub event payload.
+ * @returns {boolean} Whether the normalized comment is exactly `/review`.
+ */
+function isReviewCommand(body) {
+  return typeof body === 'string' && body.trim() === '/review';
+}
+
+module.exports = isReviewCommand;

--- a/.github/tests/test_review_command.js
+++ b/.github/tests/test_review_command.js
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+/**
+ * Tests for review_command.js.
+ *
+ * Run with: node --test .github/tests/test_review_command.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const isReviewCommand = require('../scripts/review_command.js');
+
+
+describe('review command validation', () => {
+  it('accepts the exact review command', () => {
+    assert.equal(isReviewCommand('/review'), true);
+  });
+
+  it('accepts surrounding whitespace', () => {
+    assert.equal(isReviewCommand('/review\r\n'), true);
+    assert.equal(isReviewCommand('  \n/review\t'), true);
+  });
+
+  it('rejects commands with additional content', () => {
+    assert.equal(isReviewCommand('/reviewer'), false);
+    assert.equal(isReviewCommand('/review please'), false);
+    assert.equal(isReviewCommand('/review\nadditional text'), false);
+    assert.equal(isReviewCommand('/Review'), false);
+  });
+
+  it('rejects missing or non-string comment bodies', () => {
+    assert.equal(isReviewCommand(''), false);
+    assert.equal(isReviewCommand(null), false);
+    assert.equal(isReviewCommand(undefined), false);
+  });
+});

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -34,17 +34,41 @@ env:
   MODEL_CONFIG_PATH: ${{ github.workspace }}/devflow/config.ci.yaml
 
 jobs:
-  team_check:
+  command_check:
     if: >-
       github.event_name != 'issue_comment' ||
       (
         github.event.issue.pull_request &&
-        github.event.comment.body == '/review' &&
         (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER'
         )
       )
+    runs-on: ubuntu-latest
+    outputs:
+      should_review: ${{ steps.check.outputs.should_review }}
+    steps:
+      - name: Checkout review command validation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: .github/scripts/review_command.js
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check review command
+        id: check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const isReviewCommand = require('./.github/scripts/review_command.js');
+            const shouldReview = context.eventName !== 'issue_comment' ||
+              isReviewCommand(context.payload.comment?.body);
+            core.setOutput('should_review', shouldReview ? 'true' : 'false');
+
+  team_check:
+    needs: command_check
+    if: ${{ needs.command_check.outputs.should_review == 'true' }}
     runs-on: ubuntu-latest
     environment: github-app-auth
     outputs:


### PR DESCRIPTION
### Motivation & Context

DevFlow PR review commands can be stored by GitHub with trailing whitespace, such as `/review\r\n`. The workflow currently compares the raw comment body to `/review`, causing valid commands to skip the review jobs without adding the expected eyes reaction.

### Description & Review Guide

- **What are the major changes?** Adds a tested review-command validator that trims surrounding whitespace and requires the normalized comment to equal `/review`. Adds a lightweight command-check job before the existing team-membership and review jobs.
- **What is the impact of these changes?** Valid `/review` comments with surrounding whitespace now trigger DevFlow review, while similar commands such as `/reviewer`, `/review please`, and comments with additional lines remain rejected.
- **What do you want reviewers to focus on?** The command-gating dependency flow and the strict normalization behavior.


### Related Issue

None.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
