### PR TITLE
.NET: Stabilize Foundry recovery tests

### DIFF
--- a/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/ResilientWorkflowAgent.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/ResilientWorkflowAgent.cs
@@ -92,6 +92,9 @@ internal static class ResilientWorkflowAgent
             {
                 if (TryCreateCrashMarker(token, out string crashedProcessIncarnation))
                 {
+                    await Task.Delay(
+                        TimeSpan.FromSeconds(GetCrashDelaySeconds()),
+                        cancellationToken).ConfigureAwait(false);
                     Console.Out.Flush();
                     Console.Error.Flush();
                     Environment.Exit(70);
@@ -114,6 +117,21 @@ internal static class ResilientWorkflowAgent
             const int DefaultDelaySeconds = 20;
             string? value = Environment.GetEnvironmentVariable("IT_LONG_RUNNING_DELAY_SECONDS");
             return int.TryParse(value, out int seconds) && seconds > 0 ? seconds : DefaultDelaySeconds;
+        }
+
+        private static int GetCrashDelaySeconds()
+        {
+            const int DefaultDelaySeconds = 5;
+            string? value = Environment.GetEnvironmentVariable(
+                "IT_CRASH_DELAY_SECONDS");
+            return int.TryParse(
+                value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int seconds)
+                && seconds >= 0
+                    ? seconds
+                    : DefaultDelaySeconds;
         }
     }
 

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/ResilientWorkflowHostedAgentFixture.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/Fixtures/ResilientWorkflowHostedAgentFixture.cs
@@ -18,6 +18,7 @@ public sealed class ResilientWorkflowHostedAgentFixture : HostedAgentFixture
     protected override void ConfigureEnvironment(IDictionary<string, string> environment)
     {
         environment["IT_LONG_RUNNING_DELAY_SECONDS"] = "20";
+        environment["IT_CRASH_DELAY_SECONDS"] = "5";
         environment["IT_COUNTDOWN_DELAY_MILLISECONDS"] = "250";
         environment["IT_COUNTDOWN_CRASH_DELAY_SECONDS"] = "5";
     }

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/ResilientWorkflowHostedAgentTests.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/ResilientWorkflowHostedAgentTests.cs
@@ -67,7 +67,7 @@ public sealed class ResilientWorkflowHostedAgentTests(ResilientWorkflowHostedAge
         ResponseWaitResult waitResult = await WaitForTerminalAsync(responses, accepted.Id, s_completionTimeout);
 
         // Assert: this token is emitted only after a new process observes the crash marker written
-        // immediately before Environment.Exit.
+        // before Environment.Exit.
         Assert.True(accepted.Status is ResponseStatus.Queued or ResponseStatus.InProgress);
         Assert.True(
             waitResult.SawSessionNotReady
@@ -260,7 +260,7 @@ public sealed class ResilientWorkflowHostedAgentTests(ResilientWorkflowHostedAge
     }
 
     private static bool IsTransientRecoveryStatus(int status) =>
-        status is 404 or 424 or 500 or 502 or 503;
+        status is 404 or 409 or 424 or 500 or 502 or 503;
 
     private static int CountCountdownUpdates(IEnumerable<string> texts) =>
         texts.Count(text => text != "Countdown complete.");
@@ -293,6 +293,13 @@ public sealed class ResilientWorkflowHostedAgentTests(ResilientWorkflowHostedAge
             {
                 longestPollDuration = Max(longestPollDuration, pollStopwatch.Elapsed);
                 sawResponseNotFound = true;
+                await Task.Delay(TimeSpan.FromSeconds(2));
+                continue;
+            }
+            catch (ClientResultException ex) when (ex.Status == 409)
+            {
+                longestPollDuration = Max(longestPollDuration, pollStopwatch.Elapsed);
+                sawSessionNotReady = true;
                 await Task.Delay(TimeSpan.FromSeconds(2));
                 continue;
             }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ResilientTwoLifetimeIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ResilientTwoLifetimeIntegrationTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.AI.AgentServer.Responses;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Agents.AI.Workflows.Checkpointing;
 using Microsoft.AspNetCore.Builder;
@@ -18,6 +19,9 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using CreateResponse = Azure.AI.AgentServer.Responses.Models.CreateResponse;
+using ResponseStreamEvent = Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent;
 
 namespace Microsoft.Agents.AI.Foundry.Hosting.UnitTests;
 
@@ -148,7 +152,8 @@ public sealed class ResilientTwoLifetimeIntegrationTests
             {
                 WebApplication firstHost = await StartServerAsync(
                     BuildCountdownWorkflowAgent(coordinator, checkpointStore),
-                    new FoundryAgentSessionStore(storeName: sessionStoreName));
+                    new FoundryAgentSessionStore(storeName: sessionStoreName),
+                    coordinator);
                 try
                 {
                     using HttpClient firstClient = GetClient(firstHost);
@@ -158,11 +163,8 @@ public sealed class ResilientTwoLifetimeIntegrationTests
                         agentName: "countdown-workflow",
                         input: "Count down from 6");
                     await coordinator.Blocked.Task.WaitAsync(TimeSpan.FromSeconds(15));
-                    await WaitForPersistedResponseProgressAsync(
-                        stateRoot,
-                        responseId,
-                        ["6", "5", "4"],
-                        timeout: TimeSpan.FromSeconds(15));
+                    await coordinator.ExpectedCheckpointProcessed.Task.WaitAsync(
+                        TimeSpan.FromSeconds(15));
 
                     using CancellationTokenSource stopTimeout =
                         new(TimeSpan.FromSeconds(15));
@@ -223,7 +225,8 @@ public sealed class ResilientTwoLifetimeIntegrationTests
 
     private static async Task<WebApplication> StartServerAsync(
         AIAgent agent,
-        AgentSessionStore sessionStore)
+        AgentSessionStore sessionStore,
+        CountdownRecoveryCoordinator? recoveryCoordinator = null)
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -234,6 +237,15 @@ public sealed class ResilientTwoLifetimeIntegrationTests
         builder.Services.AddSingleton<HostedSessionIsolationKeyProvider>(
             new FakeHostedSessionIsolationKeyProvider());
         builder.Services.AddLogging();
+        if (recoveryCoordinator is not null)
+        {
+            builder.Services.RemoveAll<ResponseHandler>();
+            builder.Services.AddSingleton<ResponseHandler>(serviceProvider =>
+                new CheckpointObservingResponseHandler(
+                    ActivatorUtilities.CreateInstance<AgentFrameworkResponseHandler>(
+                        serviceProvider),
+                    recoveryCoordinator));
+        }
 
         WebApplication app = builder.Build();
         app.MapFoundryResponses();
@@ -307,47 +319,6 @@ public sealed class ResilientTwoLifetimeIntegrationTests
 
         throw new TimeoutException(
             $"Response '{responseId}' did not complete. Last response: {last}");
-    }
-
-    private static async Task WaitForPersistedResponseProgressAsync(
-        string stateRoot,
-        string responseId,
-        IReadOnlyList<string> expected,
-        TimeSpan timeout)
-    {
-        var deadline = DateTimeOffset.UtcNow + timeout;
-        List<string> last = [];
-        string path = GetPersistedResponsePath(stateRoot, responseId);
-        IOException? lastReadError = null;
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            if (File.Exists(path))
-            {
-                try
-                {
-                    JsonElement persisted = ReadPersistedResponse(stateRoot, responseId);
-                    lastReadError = null;
-                    last = GetOutputTexts(persisted);
-                    if (last.SequenceEqual(expected))
-                    {
-                        return;
-                    }
-                }
-                catch (IOException ex)
-                {
-                    lastReadError = ex;
-                }
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(25));
-        }
-
-        string message =
-            $"Response '{responseId}' did not persist the expected checkpointed output. " +
-            $"Expected: {string.Join(", ", expected)}. Last: {string.Join(", ", last)}.";
-        throw lastReadError is null
-            ? new TimeoutException(message)
-            : new TimeoutException(message, lastReadError);
     }
 
     private static JsonElement ReadPersistedResponse(
@@ -647,13 +618,53 @@ public sealed class ResilientTwoLifetimeIntegrationTests
     private sealed class CountdownRecoveryCoordinator(int target, int blockAt)
     {
         private int _blocked;
+        private int _processedCheckpoints;
 
         public int Target { get; } = target;
+
+        public int BlockAt { get; } = blockAt;
 
         public TaskCompletionSource Blocked { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public TaskCompletionSource ExpectedCheckpointProcessed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public bool ShouldBlock(int value) =>
-            value == blockAt && Interlocked.CompareExchange(ref this._blocked, 1, 0) == 0;
+            value == this.BlockAt && Interlocked.CompareExchange(ref this._blocked, 1, 0) == 0;
+
+        public void OnCheckpointProcessed()
+        {
+            int expectedCheckpointCount = this.Target - this.BlockAt + 1;
+            if (Interlocked.Increment(ref this._processedCheckpoints) == expectedCheckpointCount)
+            {
+                this.ExpectedCheckpointProcessed.TrySetResult();
+            }
+        }
+    }
+
+    private sealed class CheckpointObservingResponseHandler(
+        ResponseHandler inner,
+        CountdownRecoveryCoordinator coordinator) : ResponseHandler
+    {
+        public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
+            CreateResponse request,
+            ResponseContext context,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (ResponseStreamEvent responseEvent in inner
+                .CreateAsync(request, context, cancellationToken)
+                .WithCancellation(cancellationToken)
+                .ConfigureAwait(false))
+            {
+                bool isCheckpoint =
+                    responseEvent.GetType().Name == "ResponseCheckpointEvent";
+                yield return responseEvent;
+                if (isCheckpoint)
+                {
+                    coordinator.OnCheckpointProcessed();
+                }
+            }
+        }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ResilientTwoLifetimeIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/ResilientTwoLifetimeIntegrationTests.cs
@@ -158,11 +158,10 @@ public sealed class ResilientTwoLifetimeIntegrationTests
                         agentName: "countdown-workflow",
                         input: "Count down from 6");
                     await coordinator.Blocked.Task.WaitAsync(TimeSpan.FromSeconds(15));
-                    await WaitForResponseProgressAsync(
-                        firstClient,
+                    await WaitForPersistedResponseProgressAsync(
+                        stateRoot,
                         responseId,
                         ["6", "5", "4"],
-                        minimumOutputItems: 12,
                         timeout: TimeSpan.FromSeconds(15));
 
                     using CancellationTokenSource stopTimeout =
@@ -310,53 +309,64 @@ public sealed class ResilientTwoLifetimeIntegrationTests
             $"Response '{responseId}' did not complete. Last response: {last}");
     }
 
-    private static async Task WaitForResponseProgressAsync(
-        HttpClient client,
+    private static async Task WaitForPersistedResponseProgressAsync(
+        string stateRoot,
         string responseId,
         IReadOnlyList<string> expected,
-        int minimumOutputItems,
         TimeSpan timeout)
     {
         var deadline = DateTimeOffset.UtcNow + timeout;
         List<string> last = [];
+        string path = GetPersistedResponsePath(stateRoot, responseId);
+        IOException? lastReadError = null;
         while (DateTimeOffset.UtcNow < deadline)
         {
-            using HttpResponseMessage response = await client.GetAsync(
-                new Uri($"/responses/{responseId}", UriKind.Relative));
-            if (response.StatusCode == HttpStatusCode.OK)
+            if (File.Exists(path))
             {
-                using JsonDocument document = JsonDocument.Parse(
-                    await response.Content.ReadAsStringAsync());
-                JsonElement root = document.RootElement;
-                last = GetOutputTexts(root);
-                if (last.Count == expected.Count
-                    && last.SequenceEqual(expected)
-                    && root.GetProperty("output").GetArrayLength() >= minimumOutputItems)
+                try
                 {
-                    return;
+                    JsonElement persisted = ReadPersistedResponse(stateRoot, responseId);
+                    lastReadError = null;
+                    last = GetOutputTexts(persisted);
+                    if (last.SequenceEqual(expected))
+                    {
+                        return;
+                    }
+                }
+                catch (IOException ex)
+                {
+                    lastReadError = ex;
                 }
             }
 
             await Task.Delay(TimeSpan.FromMilliseconds(25));
         }
 
-        throw new TimeoutException(
-            $"Response '{responseId}' did not reach the expected checkpointed output. " +
-            $"Expected: {string.Join(", ", expected)}. Last: {string.Join(", ", last)}.");
+        string message =
+            $"Response '{responseId}' did not persist the expected checkpointed output. " +
+            $"Expected: {string.Join(", ", expected)}. Last: {string.Join(", ", last)}.";
+        throw lastReadError is null
+            ? new TimeoutException(message)
+            : new TimeoutException(message, lastReadError);
     }
 
     private static JsonElement ReadPersistedResponse(
         string stateRoot,
         string responseId)
     {
-        string path = Path.Combine(
+        string path = GetPersistedResponsePath(stateRoot, responseId);
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(path));
+        return document.RootElement.GetProperty("envelope").Clone();
+    }
+
+    private static string GetPersistedResponsePath(
+        string stateRoot,
+        string responseId) =>
+        Path.Combine(
             stateRoot,
             "responses",
             "envelopes",
             $"{responseId}.json");
-        using JsonDocument document = JsonDocument.Parse(File.ReadAllBytes(path));
-        return document.RootElement.GetProperty("envelope").Clone();
-    }
 
     private static string GetOutputText(JsonElement response)
     {


### PR DESCRIPTION
### Motivation & Context

Two Foundry recovery tests could observe state before the platform finished the durable operation they intended to verify.

The local two lifetime unit test stopped the host after the live HTTP response exposed new output, but before AgentServer had saved the matching checkpoint. The live integration test ended the process immediately after the workflow input stage, which could race the first durable recovery boundary and leave a completed response containing only workflow action items. During process replacement, response polling can also return HTTP 409 `session_updating` and explicitly ask the caller to retry.

### Description & Review Guide

- **What are the major changes?** The unit test now observes checkpoint processing through a test response handler before stopping the host. The live test waits five seconds before the intentional process exit, matching the existing countdown crash scenario. Recovery polling now treats HTTP 409 as transient alongside the existing replacement statuses.
- **What is the impact of these changes?** Test behavior becomes synchronized with the durable state it asserts. Production code and public APIs are unchanged.
- **What do you want reviewers to focus on?** Confirm that both tests wait for the operation they verify and that the new retry remains limited to the temporary hosted session update response.


### Related Issue

Fixes #7816

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix). A workflow keeps the label and title prefix in sync automatically.
