### PR TITLE
Python: Fix checkpoint state isolation

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
 import json
 import logging
 import os
@@ -15,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 from ..exceptions import WorkflowCheckpointException
+from ._checkpoint_encoding import isolate_checkpoint_value
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +127,19 @@ class WorkflowCheckpoint:
 
 
 class CheckpointStorage(Protocol):
-    """Protocol for checkpoint storage backends."""
+    """Protocol for checkpoint storage backends.
+
+    Ownership:
+        Checkpoints returned by ``load``, ``list_checkpoints`` and
+        ``get_latest`` are owned by the caller. Mutating a returned
+        checkpoint must not change stored state, and repeated reads must
+        return independent objects. Symmetrically, ``save`` snapshots the
+        checkpoint at call time, so mutating the caller's object
+        afterwards must not change what was stored. Backends that
+        serialize satisfy this implicitly, because decoding allocates a
+        fresh object graph; backends that retain live objects must copy
+        explicitly.
+    """
 
     async def save(self, checkpoint: WorkflowCheckpoint) -> CheckpointID:
         """Save a checkpoint and return its ID.
@@ -208,7 +220,7 @@ class InMemoryCheckpointStorage:
 
     async def save(self, checkpoint: WorkflowCheckpoint) -> CheckpointID:
         """Save a checkpoint and return its ID."""
-        self._checkpoints[checkpoint.checkpoint_id] = copy.deepcopy(checkpoint)
+        self._checkpoints[checkpoint.checkpoint_id] = isolate_checkpoint_value(checkpoint)
         logger.debug(f"Saved checkpoint {checkpoint.checkpoint_id} to memory")
         return checkpoint.checkpoint_id
 
@@ -217,12 +229,12 @@ class InMemoryCheckpointStorage:
         checkpoint = self._checkpoints.get(checkpoint_id)
         if checkpoint:
             logger.debug(f"Loaded checkpoint {checkpoint_id} from memory")
-            return checkpoint
+            return isolate_checkpoint_value(checkpoint)
         raise WorkflowCheckpointException(f"No checkpoint found with ID {checkpoint_id}")
 
     async def list_checkpoints(self, *, workflow_name: str) -> list[WorkflowCheckpoint]:
         """List checkpoint objects for a given workflow name."""
-        return [cp for cp in self._checkpoints.values() if cp.workflow_name == workflow_name]
+        return [isolate_checkpoint_value(cp) for cp in self._checkpoints.values() if cp.workflow_name == workflow_name]
 
     async def delete(self, checkpoint_id: CheckpointID) -> bool:
         """Delete a checkpoint by ID."""
@@ -239,7 +251,7 @@ class InMemoryCheckpointStorage:
             return None
         latest_checkpoint = max(checkpoints, key=lambda cp: datetime.fromisoformat(cp.timestamp))
         logger.debug(f"Latest checkpoint for workflow {workflow_name} is {latest_checkpoint.checkpoint_id}")
-        return latest_checkpoint
+        return isolate_checkpoint_value(latest_checkpoint)
 
     async def list_checkpoint_ids(self, *, workflow_name: str) -> list[CheckpointID]:
         """List checkpoint IDs. If workflow_id is provided, filter by that workflow."""

--- a/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
@@ -51,11 +51,29 @@ import io
 import logging
 import pickle  # nosec  # ruff:ignore[suspicious-pickle-import]
 from enum import EnumMeta
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from ..exceptions import WorkflowCheckpointException
 
 logger = logging.getLogger("agent_framework")
+
+T = TypeVar("T")
+
+
+def isolate_checkpoint_value(value: T) -> T:
+    """Return an independent copy of a checkpoint-safe value via pickle round-trip.
+
+    This matches the serialization boundary used by checkpoint persistence
+    backends and does not require ``__deepcopy__`` support.
+
+    Args:
+        value: A pickle-serializable value to isolate.
+
+    Returns:
+        An independent copy of the value.
+    """
+    return pickle.loads(pickle.dumps(value))  # nosec  # ruff:ignore[suspicious-pickle-usage]
+
 
 # Application-defined types registered for all restricted checkpoint decoders.
 _REGISTERED_CHECKPOINT_TYPE_KEYS: set[str] = set()

--- a/python/packages/core/agent_framework/_workflows/_state.py
+++ b/python/packages/core/agent_framework/_workflows/_state.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from ._checkpoint_encoding import isolate_checkpoint_value
+
 
 class State:
     """Manages shared state across executors within a workflow.
@@ -108,14 +110,14 @@ class State:
 
         Note: Does not include pending changes.
         """
-        return dict(self._committed)
+        return isolate_checkpoint_value(dict(self._committed))
 
     def import_state(self, state: dict[str, Any]) -> None:
         """Import state from a serialized dictionary.
 
         Merges into committed state. Does not affect pending changes.
         """
-        self._committed.update(state)
+        self._committed.update(isolate_checkpoint_value(state))
 
 
 class _DeleteSentinelType:

--- a/python/packages/core/tests/workflow/test_checkpoint_storage_conformance.py
+++ b/python/packages/core/tests/workflow/test_checkpoint_storage_conformance.py
@@ -1,0 +1,311 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Conformance tests for checkpoint storage backends.
+
+These tests verify that all checkpoint storage implementations satisfy the
+ownership contract defined in the CheckpointStorage Protocol.
+"""
+
+import copy
+import pickle
+from dataclasses import dataclass
+
+import pytest
+
+from agent_framework import (
+    FileCheckpointStorage,
+    InMemoryCheckpointStorage,
+    WorkflowCheckpoint,
+    WorkflowCheckpointException,
+    WorkflowEvent,
+    register_checkpoint_type,
+)
+from agent_framework._workflows._runner_context import WorkflowMessage
+
+
+# Test dataclass for pickle-serializable but not deepcopyable regression test
+@dataclass
+class _PickleableNotDeepcopyable:
+    """A class that is pickle-serializable but explicitly rejects deepcopy."""
+
+    value: str
+
+    def __deepcopy__(self, memo):
+        raise TypeError("This class explicitly rejects deepcopy for testing purposes")
+
+    def __reduce__(self):
+        # Custom pickle support that doesn't require deepcopy
+        return (_PickleableNotDeepcopyable, (self.value,))
+
+
+# Register the test type for restricted checkpoint deserialization
+register_checkpoint_type(_PickleableNotDeepcopyable)
+
+
+@pytest.fixture(params=["memory", "file"])
+def conformance_storage(request, tmp_path):
+    """Parametrized fixture returning both in-tree storage backends."""
+    if request.param == "memory":
+        return InMemoryCheckpointStorage()
+    return FileCheckpointStorage(tmp_path / "conformance")
+
+
+class TestCheckpointStorageOwnership:
+    """Tests for checkpoint ownership contract compliance."""
+
+    async def test_load_returns_caller_owned_copy(self, conformance_storage):
+        """Mutating a loaded checkpoint must not affect the stored checkpoint."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "original"},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        loaded.state["key"] = "mutated"
+
+        # Reload to verify the stored checkpoint is unchanged
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.state["key"] == "original"
+
+    async def test_repeated_load_returns_independent_objects(self, conformance_storage):
+        """Repeated load calls must return independent objects from each other."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "original"},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded1 = await conformance_storage.load(saved_id)
+        loaded2 = await conformance_storage.load(saved_id)
+
+        # Mutate the first loaded checkpoint
+        loaded1.state["key"] = "mutated"
+
+        # The second loaded checkpoint should be unaffected
+        assert loaded2.state["key"] == "original"
+
+    async def test_get_latest_returns_caller_owned_copy(self, conformance_storage):
+        """Mutating get_latest result must not affect the stored checkpoint."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "original"},
+        )
+        await conformance_storage.save(checkpoint)
+
+        latest = await conformance_storage.get_latest(workflow_name="test-workflow")
+        assert latest is not None
+        latest.state["key"] = "mutated"
+
+        # Reload to verify the stored checkpoint is unchanged
+        reloaded = await conformance_storage.get_latest(workflow_name="test-workflow")
+        assert reloaded is not None
+        assert reloaded.state["key"] == "original"
+
+    async def test_list_checkpoints_returns_caller_owned_copies(self, conformance_storage):
+        """Mutating list_checkpoints results must not affect stored checkpoints."""
+        checkpoint1 = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "checkpoint1"},
+        )
+        checkpoint2 = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "checkpoint2"},
+        )
+        await conformance_storage.save(checkpoint1)
+        await conformance_storage.save(checkpoint2)
+
+        checkpoints = await conformance_storage.list_checkpoints(workflow_name="test-workflow")
+        checkpoints[0].state["key"] = "mutated"
+
+        # Reload to verify stored checkpoints are unchanged
+        reloaded = await conformance_storage.list_checkpoints(workflow_name="test-workflow")
+        assert all(cp.state["key"] != "mutated" for cp in reloaded)
+
+    async def test_save_snapshots_at_call_time(self, conformance_storage):
+        """Mutating caller's object after save must not affect what was stored."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"key": "original"},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        # Mutate the original checkpoint object after save
+        checkpoint.state["key"] = "mutated"
+
+        # Reload to verify the stored checkpoint has the original value
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.state["key"] == "original"
+
+    async def test_save_snapshots_nested_mutation(self, conformance_storage):
+        """Mutating nested structures after save must not affect what was stored."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"nested": {"deep": {"value": "original"}}},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        # Mutate nested structure after save
+        checkpoint.state["nested"]["deep"]["value"] = "mutated"
+
+        # Reload to verify the stored checkpoint has the original value
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.state["nested"]["deep"]["value"] == "original"
+
+    async def test_list_checkpoints_filters_by_workflow_name(self, conformance_storage):
+        """list_checkpoints must correctly filter by workflow_name."""
+        checkpoint1 = WorkflowCheckpoint(
+            workflow_name="workflow-1",
+            graph_signature_hash="hash-1",
+        )
+        checkpoint2 = WorkflowCheckpoint(
+            workflow_name="workflow-2",
+            graph_signature_hash="hash-2",
+        )
+        checkpoint3 = WorkflowCheckpoint(
+            workflow_name="workflow-1",
+            graph_signature_hash="hash-3",
+        )
+
+        await conformance_storage.save(checkpoint1)
+        await conformance_storage.save(checkpoint2)
+        await conformance_storage.save(checkpoint3)
+
+        workflow1_checkpoints = await conformance_storage.list_checkpoints(workflow_name="workflow-1")
+        assert len(workflow1_checkpoints) == 2
+        assert all(cp.workflow_name == "workflow-1" for cp in workflow1_checkpoints)
+
+        workflow2_checkpoints = await conformance_storage.list_checkpoints(workflow_name="workflow-2")
+        assert len(workflow2_checkpoints) == 1
+        assert workflow2_checkpoints[0].workflow_name == "workflow-2"
+
+    async def test_get_latest_returns_none_for_unknown_workflow(self, conformance_storage):
+        """get_latest must return None for an unknown workflow, not raise."""
+        latest = await conformance_storage.get_latest(workflow_name="unknown-workflow")
+        assert latest is None
+
+    async def test_load_with_missing_id_raises_exception(self, conformance_storage):
+        """load with a missing checkpoint_id must raise WorkflowCheckpointException."""
+        with pytest.raises(WorkflowCheckpointException):
+            await conformance_storage.load("nonexistent-id")
+
+    async def test_save_returns_checkpoint_id(self, conformance_storage):
+        """save must return the checkpoint_id."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+        assert saved_id == checkpoint.checkpoint_id
+
+
+class TestCheckpointStorageNestedMutation:
+    """Tests for isolation of nested mutable structures."""
+
+    async def test_nested_state_mutation_isolated(self, conformance_storage):
+        """Mutating nested state structures must not affect stored checkpoint."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"nested": {"deep": {"value": "original"}}},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        loaded.state["nested"]["deep"]["value"] = "mutated"
+
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.state["nested"]["deep"]["value"] == "original"
+
+    async def test_messages_data_mutation_isolated(self, conformance_storage):
+        """Mutating WorkflowMessage.data must not affect stored checkpoint."""
+        message = WorkflowMessage(source_id="test", target_id="test", data="original")
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            messages={"executor1": [message]},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        loaded.messages["executor1"][0].data = "mutated"
+
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.messages["executor1"][0].data == "original"
+
+    async def test_pending_request_info_events_data_mutation_isolated(self, conformance_storage):
+        """Mutating pending_request_info_events.data must not affect stored checkpoint."""
+        event = WorkflowEvent(type="test", data="original")
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            pending_request_info_events={"req1": event},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        loaded.pending_request_info_events["req1"].data = "mutated"
+
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.pending_request_info_events["req1"].data == "original"
+
+    async def test_metadata_mutation_isolated(self, conformance_storage):
+        """Mutating metadata must not affect stored checkpoint."""
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            metadata={"nested": {"value": "original"}},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        loaded.metadata["nested"]["value"] = "mutated"
+
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.metadata["nested"]["value"] == "original"
+
+
+class TestPickleRoundtripRegression:
+    """Regression test for pickle-serializable but not deepcopyable values.
+
+    This test MUST FAIL against a deepcopy-based implementation and MUST PASS
+    against the pickle round-trip implementation, proving the regression is closed.
+    """
+
+    async def test_pickleable_not_deepcopyable_roundtrips(self, conformance_storage):
+        """Values that are pickle-serializable but not deepcopyable must roundtrip correctly."""
+        # This value would fail with copy.deepcopy but works with pickle round-trip
+        test_value = _PickleableNotDeepcopyable(value="test")
+
+        # Verify it's not deepcopyable (this should raise)
+        with pytest.raises(TypeError, match="explicitly rejects deepcopy"):
+            copy.deepcopy(test_value)
+
+        # But it should be pickle-serializable
+        pickled = pickle.dumps(test_value)
+        unpickled = pickle.loads(pickled)
+        assert unpickled.value == "test"
+
+        # Now test that it roundtrips through checkpoint storage
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            state={"custom": test_value},
+        )
+        saved_id = await conformance_storage.save(checkpoint)
+
+        loaded = await conformance_storage.load(saved_id)
+        assert isinstance(loaded.state["custom"], _PickleableNotDeepcopyable)
+        assert loaded.state["custom"].value == "test"
+
+        # Verify it's truly isolated
+        loaded.state["custom"].value = "mutated"
+        reloaded = await conformance_storage.load(saved_id)
+        assert reloaded.state["custom"].value == "test"

--- a/python/packages/core/tests/workflow/test_state.py
+++ b/python/packages/core/tests/workflow/test_state.py
@@ -2,9 +2,28 @@
 
 """Unit tests for the State class superstep caching behavior."""
 
+import copy
+import pickle
+from dataclasses import dataclass
+
 import pytest
 
 from agent_framework._workflows._state import State
+
+
+# Test dataclass for pickle-serializable but not deepcopyable regression test
+@dataclass
+class _PickleableNotDeepcopyable:
+    """A class that is pickle-serializable but explicitly rejects deepcopy."""
+
+    value: str
+
+    def __deepcopy__(self, memo):
+        raise TypeError("This class explicitly rejects deepcopy for testing purposes")
+
+    def __reduce__(self):
+        # Custom pickle support that doesn't require deepcopy
+        return (_PickleableNotDeepcopyable, (self.value,))
 
 
 class TestStateBasicOperations:
@@ -301,3 +320,101 @@ class TestExportImport:
         # Pending is still there
         assert state.get("pending_key") == "pending_value"
         assert "pending_key" in state._pending  # pyright: ignore[reportPrivateUsage]
+
+
+class TestExportImportIsolation:
+    """Tests for state export/import isolation via pickle round-trip."""
+
+    def test_export_returns_isolated_copy(self) -> None:
+        """export_state must return an isolated copy that doesn't alias committed state."""
+        state = State()
+        state.set("key", "original")
+        state.commit()
+
+        exported = state.export_state()
+        exported["key"] = "mutated"
+
+        # Committed state should be unchanged
+        assert state.get("key") == "original"
+
+    def test_export_isolates_nested_mutable_values(self) -> None:
+        """export_state must isolate nested mutable structures."""
+        state = State()
+        state.set("nested", {"deep": {"value": "original"}})
+        state.commit()
+
+        exported = state.export_state()
+        exported["nested"]["deep"]["value"] = "mutated"
+
+        # Committed state should be unchanged
+        assert state.get("nested")["deep"]["value"] == "original"
+
+    def test_import_isolates_incoming_state(self) -> None:
+        """import_state must isolate the incoming state before merging."""
+        state = State()
+        state.set("existing", "original")
+        state.commit()
+
+        incoming = {"key": "value"}
+        state.import_state(incoming)
+        incoming["key"] = "mutated"
+
+        # Committed state should have the original imported value
+        assert state.get("key") == "value"
+
+    def test_import_isolates_nested_mutable_values(self) -> None:
+        """import_state must isolate nested mutable structures in incoming state."""
+        state = State()
+        state.set("existing", "original")
+        state.commit()
+
+        incoming = {"nested": {"deep": {"value": "original"}}}
+        state.import_state(incoming)
+        incoming["nested"]["deep"]["value"] = "mutated"
+
+        # Committed state should have the original imported value
+        assert state.get("nested")["deep"]["value"] == "original"
+
+    def test_pickleable_not_deepcopyable_roundtrips(self) -> None:
+        """Values that are pickle-serializable but not deepcopyable must roundtrip correctly.
+
+        This test MUST FAIL against a deepcopy-based implementation and MUST PASS
+        against the pickle round-trip implementation, proving the regression is closed.
+        """
+        # This value would fail with copy.deepcopy but works with pickle round-trip
+        test_value = _PickleableNotDeepcopyable(value="test")
+
+        # Verify it's not deepcopyable (this should raise)
+        with pytest.raises(TypeError, match="explicitly rejects deepcopy"):
+            copy.deepcopy(test_value)
+
+        # But it should be pickle-serializable
+        pickled = pickle.dumps(test_value)
+        unpickled = pickle.loads(pickled)
+        assert unpickled.value == "test"
+
+        # Now test that it roundtrips through export/import
+        state = State()
+        state.set("custom", test_value)
+        state.commit()
+
+        exported = state.export_state()
+        assert isinstance(exported["custom"], _PickleableNotDeepcopyable)
+        assert exported["custom"].value == "test"
+
+        # Verify it's truly isolated from the original state
+        exported["custom"].value = "mutated"
+        reexported = state.export_state()
+        assert reexported["custom"].value == "test"
+
+        # Test import isolation - the incoming state is isolated during import
+        state2 = State()
+        state2.import_state(exported)
+        assert state2.get("custom").value == "mutated"
+
+        # Re-export from state2 to verify it has the imported value
+        exported2 = state2.export_state()
+        assert exported2["custom"].value == "mutated"
+
+        # The original state should still have the original value
+        assert state.get("custom").value == "test"


### PR DESCRIPTION
### Motivation & Context

Checkpoint state is currently not isolated at two boundaries:

1. `State.export_state()` / `State.import_state()` perform shallow copies, allowing
   nested mutable state to remain aliased between a checkpoint and live workflow
   state. A resumed workflow can therefore mutate the checkpoint it was restored
   from.

2. `InMemoryCheckpointStorage` deep-copies on `save()` but returns its internally
   stored checkpoint objects directly from `load()`, `list_checkpoints()`, and
   `get_latest()`. Callers can therefore mutate the storage backend's internal
   state through a returned checkpoint.

This can silently corrupt checkpoint snapshots without raising an exception.

This PR fixes both isolation gaps while preserving the existing checkpoint value
contract. Instead of `copy.deepcopy()`, it uses a pickle round-trip for isolation,
matching the serialization boundary already used by checkpoint persistence
backends. This is important because checkpoint values may be custom
pickle-serializable types that do not support `copy.deepcopy()`.

Fixes #7683.

### Description & Review Guide

#### What are the major changes?

- Added a shared `isolate_checkpoint_value()` helper using a pickle round-trip.
- Updated `State.export_state()` to isolate nested mutable values when creating
  checkpoint state.
- Updated `State.import_state()` to isolate incoming checkpoint state before
  merging it into live state.
- Updated `InMemoryCheckpointStorage.load()`,
  `list_checkpoints()`, and `get_latest()` to return caller-owned checkpoint
  objects.
- Preserved `save()` snapshot semantics by isolating the checkpoint at save time.
- Documented the ownership contract directly on the `CheckpointStorage` protocol.
- Added a parametrized checkpoint-storage conformance suite covering both
  `InMemoryCheckpointStorage` and `FileCheckpointStorage`.
- Added regression coverage for a value that is pickle-serializable but
  intentionally not deepcopyable, ensuring the fix does not reproduce the
  correctness regression identified during review of #7697.
- Added state-level tests covering nested mutable values across export/import.

#### What is the impact of these changes?

Checkpoint objects are now isolated from live workflow state and from storage
backend internals at the relevant ownership boundaries.

The change does not alter the checkpoint value contract to require
`__deepcopy__` support. Isolation uses the same pickle-serialization semantics
already supported by checkpoint persistence.

The pickle round-trip is only performed at checkpoint export/import and storage
save/read boundaries; normal `State.get()`, `set()`, and `commit()` operations
are unchanged.

#### What do you want reviewers to focus on?

Please focus on:

- Whether the ownership boundaries are correctly defined between `State`,
  `WorkflowCheckpoint`, and `CheckpointStorage`.
- Whether pickle round-trip isolation is the appropriate mechanism instead of
  `copy.deepcopy()`, particularly for custom pickle-serializable checkpoint
  values.
- Whether the storage conformance tests adequately verify caller ownership and
  repeated-read independence.
- Whether the protocol ownership contract accurately describes the expected
  behavior for all checkpoint storage backends.

This PR incorporates the useful ownership-contract and conformance-test
direction discussed in #7697 and #7712, while avoiding the `copy.deepcopy()`
approach that was identified during review of #7697 as potentially breaking
previously valid pickle-serializable checkpoint values.

### Related Issue

Fixes #7683 

An existing PR, #7697, addresses the same issue but uses `copy.deepcopy()` for
isolation. Review identified that approach as a potential correctness regression
because pickle-serializable checkpoint values are not necessarily
deepcopyable.

This PR takes a different implementation approach using pickle round-trip
isolation and incorporates the relevant ownership-contract and conformance-test
feedback from #7697 and #7712.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.