### PR TITLE
Python: Reject MCP servers passed as tools to Claude and Copilot agents

### DIFF
--- a/python/packages/claude/agent_framework_claude/_agent.py
+++ b/python/packages/claude/agent_framework_claude/_agent.py
@@ -29,6 +29,7 @@ from agent_framework import (
     normalize_messages,
     normalize_tools,
 )
+from agent_framework._mcp import MCPTool
 from agent_framework._telemetry import mark_feature_used
 from agent_framework.exceptions import AgentException, AgentInvalidRequestException
 from agent_framework.observability import AgentTelemetryLayer
@@ -71,6 +72,15 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("agent_framework.claude")
+
+_MCP_TOOL_MESSAGE = (
+    "MCP server '{name}' cannot be passed to ClaudeAgent as a tool: the Claude Agent SDK "
+    "connects to MCP servers itself, so a framework-managed MCPTool would keep none of its "
+    "framework behavior. Configure the server natively instead, for example "
+    "default_options={{'mcp_servers': {{'{name}': "
+    "{{'type': 'stdio', 'command': 'python', 'args': ['server.py']}}}}}}, or use a ChatAgent, "
+    "where the framework owns the connection."
+)
 
 FINISH_REASON_MAP: dict[str, str] = {
     "end_turn": "stop",
@@ -408,8 +418,9 @@ class RawClaudeAgent(BaseAgent, Generic[OptionsT]):
             return
 
         non_builtin_tools: ToolTypes | Callable[..., Any] | Sequence[ToolTypes | Callable[..., Any]] = []
-        if not isinstance(tools, list):
-            tools = [tools]
+        # Same wrapping rule as normalize_tools: any other Sequence is a collection of tools.
+        if isinstance(tools, (str, bytes, bytearray, Mapping)) or not isinstance(tools, Sequence):
+            tools = [tools]  # type: ignore[assignment]
         for tool in tools:  # type: ignore[reportUnknownVariableType]
             if isinstance(tool, str):
                 self._builtin_tools.append(tool)
@@ -417,7 +428,12 @@ class RawClaudeAgent(BaseAgent, Generic[OptionsT]):
                 non_builtin_tools.append(tool)  # type: ignore[union-attr, reportUnknownArgumentType]
         if not non_builtin_tools:
             return
-        self._custom_tools.extend(normalize_tools(non_builtin_tools))
+        # Check after normalizing: it flattens tool-collection wrappers, which can hide an MCPTool.
+        normalized = normalize_tools(non_builtin_tools)
+        for tool in normalized:
+            if isinstance(tool, MCPTool):
+                raise TypeError(_MCP_TOOL_MESSAGE.format(name=tool.name))
+        self._custom_tools.extend(normalized)
 
     async def __aenter__(self) -> RawClaudeAgent[OptionsT]:
         """Start the agent when entering async context."""

--- a/python/packages/claude/tests/test_claude_agent.py
+++ b/python/packages/claude/tests/test_claude_agent.py
@@ -1,10 +1,11 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agent_framework import AgentResponseUpdate, AgentSession, Content, Message, tool
+from agent_framework import AgentResponseUpdate, AgentSession, Content, MCPStdioTool, Message, tool
 from agent_framework._settings import load_settings
 from agent_framework.exceptions import AgentInvalidRequestException
 
@@ -173,6 +174,31 @@ class TestClaudeAgentLifecycle:
 
         agent = ClaudeAgent(tools=[greet, farewell])
         assert len(agent._custom_tools) == 2  # type: ignore[reportPrivateUsage]
+
+    def test_mcp_tool_is_rejected_with_the_native_configuration(self) -> None:
+        """An MCP server cannot keep its framework behavior here, so it is refused, not dropped."""
+        with pytest.raises(TypeError, match="mcp_servers"):
+            ClaudeAgent(tools=[MCPStdioTool(name="weather", command="python")])
+
+    def test_mcp_tool_in_a_tuple_is_rejected(self) -> None:
+        """``tools`` takes any sequence, so a tuple must not slip past the refusal."""
+        with pytest.raises(TypeError, match="mcp_servers"):
+            ClaudeAgent(tools=(MCPStdioTool(name="weather", command="python"),))
+
+    def test_mcp_tool_inside_a_tool_collection_is_rejected(self) -> None:
+        """normalize_tools flattens collection wrappers, so the refusal has to run after it."""
+
+        toolbox = SimpleNamespace(tools=[MCPStdioTool(name="weather", command="python")])
+
+        with pytest.raises(TypeError, match="mcp_servers"):
+            ClaudeAgent(tools=[toolbox])
+
+    def test_builtin_tools_in_a_tuple_are_recognized(self) -> None:
+        """A tuple of built-in names must classify like the list form, not fall through as custom tools."""
+        agent = ClaudeAgent(tools=("Read", "Bash"))
+
+        assert agent._builtin_tools == ["Read", "Bash"]  # type: ignore[reportPrivateUsage]
+        assert agent._custom_tools == []  # type: ignore[reportPrivateUsage]
 
     def test_no_tools(self) -> None:
         """Test agent without tools."""

--- a/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
+++ b/python/packages/github_copilot/agent_framework_github_copilot/_agent.py
@@ -30,6 +30,7 @@ from agent_framework import (
     add_usage_details,
     normalize_messages,
 )
+from agent_framework._mcp import MCPTool
 from agent_framework._settings import load_settings
 from agent_framework._telemetry import mark_feature_used
 from agent_framework._tools import FunctionTool, ToolTypes
@@ -178,6 +179,22 @@ async def _resolve_function_approval(
 
 
 logger = logging.getLogger("agent_framework.github_copilot")
+
+_MCP_TOOL_MESSAGE = (
+    "MCP server '{name}' cannot be passed to GitHubCopilotAgent as a tool: the Copilot SDK "
+    "connects to MCP servers itself, so a framework-managed MCPTool would keep none of its "
+    "framework behavior. Configure the server natively instead, for example "
+    "default_options={{'mcp_servers': {{'{name}': {{'type': 'stdio', 'command': 'python', "
+    "'args': ['server.py'], 'tools': ['*']}}}}}}, or use a ChatAgent, where the framework owns "
+    "the connection."
+)
+
+
+def _reject_mcp_tools(tools: Sequence[Any]) -> None:
+    """Refuse MCP servers handed in as tools, from whichever option carried them."""
+    for tool in tools:
+        if isinstance(tool, MCPTool):
+            raise TypeError(_MCP_TOOL_MESSAGE.format(name=tool.name))
 
 
 def _deny_all_permissions(
@@ -654,6 +671,7 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
         )
 
         self._tools = normalize_tools(tools)
+        _reject_mcp_tools(self._tools)
         self._permission_handler = on_permission_request
         self._on_pre_tool_use: PreToolUseHandler | None = on_pre_tool_use
         self._function_approval_handler: FunctionApprovalCallback | None = on_function_approval
@@ -1472,7 +1490,10 @@ class RawGitHubCopilotAgent(BaseAgent, Generic[OptionsT]):
 
         # Merge agent-level tools with any caller-supplied tools (from default_options
         # or per-run options, the latter winning) and convert to SDK tools.
-        all_tools = list(self._tools or []) + list(kwargs.get("tools") or [])
+        # Normalize the option-supplied tools the way the constructor does: it converts callables
+        # and flattens tool-collection wrappers, which can otherwise hide an MCPTool.
+        all_tools = normalize_tools(list(self._tools or []) + list(kwargs.get("tools") or []))
+        _reject_mcp_tools(all_tools)
         kwargs["tools"] = self._prepare_tools(all_tools) if all_tools else None
 
         kwargs["streaming"] = streaming

--- a/python/packages/github_copilot/tests/test_github_copilot_agent.py
+++ b/python/packages/github_copilot/tests/test_github_copilot_agent.py
@@ -9,6 +9,7 @@ import os
 import unittest.mock
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -24,6 +25,7 @@ from agent_framework import (
     Content,
     ContextProvider,
     HistoryProvider,
+    MCPStdioTool,
     Message,
     tool,
 )
@@ -1939,6 +1941,48 @@ class TestGitHubCopilotAgentOptionsPassthrough:
         config = mock_client.create_session.call_args.kwargs
         assert config["reasoning_effort"] == "high"
         assert config["context_tier"] == "large"
+
+    async def test_mcp_tool_is_rejected_with_the_native_configuration(
+        self,
+        mock_client: MagicMock,
+    ) -> None:
+        """An MCP server cannot keep its framework behavior here, so it is refused, not dropped."""
+        with pytest.raises(TypeError, match="mcp_servers"):
+            GitHubCopilotAgent(client=mock_client, tools=[MCPStdioTool(name="weather", command="python")])
+
+    async def test_mcp_tool_in_a_tuple_is_rejected(
+        self,
+        mock_client: MagicMock,
+    ) -> None:
+        """``tools`` takes any sequence, so a tuple must not slip past the refusal."""
+        with pytest.raises(TypeError, match="mcp_servers"):
+            GitHubCopilotAgent(client=mock_client, tools=(MCPStdioTool(name="weather", command="python"),))
+
+    async def test_mcp_tool_from_default_options_is_rejected(
+        self,
+        mock_client: MagicMock,
+    ) -> None:
+        """Tools reach the SDK from the options too, so the refusal cannot live in the constructor alone."""
+        agent = GitHubCopilotAgent(
+            client=mock_client,
+            default_options=cast(Any, {"tools": [MCPStdioTool(name="weather", command="python")]}),
+        )
+        await agent.start()
+
+        with pytest.raises(AgentException, match="mcp_servers"):
+            await agent._get_or_create_session(AgentSession())  # type: ignore[reportPrivateUsage]
+
+    async def test_mcp_tool_inside_a_tool_collection_from_options_is_rejected(
+        self,
+        mock_client: MagicMock,
+    ) -> None:
+        """Option-supplied tools are normalized too, so a wrapper cannot hide an MCP server."""
+        toolbox = SimpleNamespace(tools=[MCPStdioTool(name="weather", command="python")])
+        agent = GitHubCopilotAgent(client=mock_client, default_options=cast(Any, {"tools": [toolbox]}))
+        await agent.start()
+
+        with pytest.raises(AgentException, match="mcp_servers"):
+            await agent._get_or_create_session(AgentSession())  # type: ignore[reportPrivateUsage]
 
     async def test_tools_from_default_options_are_honored(
         self,


### PR DESCRIPTION
### Motivation & Context

An MCP server handed to `ClaudeAgent` or `GitHubCopilotAgent` is silently dropped: no error, no warning, and none of its tools reach the model.

```python
weather = MCPStdioTool(name="weather", command="python", args=["weather_server.py"])

agent = ClaudeAgent(tools=[weather])
await agent.run("What is the weather in Beijing?")   # "I have no tool for that"
```

The same code works on `ChatAgent`, so the failure looks like a model problem rather than a wiring one.

### Description & Review Guide

- **What are the major changes?**

Both provider agents convert tools themselves and only recognise `FunctionTool`; anything else is skipped, and an `MCPTool` -- a server connection rather than a callable tool -- fell into that branch.

Neither agent should be connecting to MCP servers in the first place: both SDKs run their own tool loop and take MCP servers as configuration (`ClaudeAgentOptions.mcp_servers`, `create_session(mcp_servers=...)`), which is what the existing samples use. What a framework-managed `MCPTool` promises on top of that -- middleware, tracing, approval routing, result parsing -- cannot survive a connection the framework does not own, so the agents now refuse it and quote the native configuration to write instead, filled in with the server's own name.

Both checks run on the normalized tool list, since `normalize_tools()` flattens tool-collection wrappers that would otherwise hide an `MCPTool`, and Copilot checks the option-supplied tools as well as the constructor's. Claude's tool classification was only treating `list` as a collection, so a tuple bypassed it -- it now follows the same rule as `normalize_tools()`, which also fixes built-in tool names passed as a tuple being mistaken for custom tools.

- **What is the impact of these changes?**

A configuration that silently did nothing now fails, at construction time where the tools are passed there. Nobody's working code changes behaviour: an `MCPTool` never contributed anything to these agents.

I first implemented this as a translation into each SDK's native `mcp_servers` config, so that `ChatAgent` code would port over unchanged, and dropped it. Rejection can only name the options an `MCPTool` carries explicitly; it cannot cover what the framework supplies ambiently -- middleware, tracing, approval routing -- because those are not options anyone passed. Ported code would have run and quietly behaved differently, which is a worse failure than the one this PR started from. Happy to revisit if the project does want `tools=` to accept `MCPTool` everywhere.

**Before / after**, the server from the snippet above:

```
no error; configured tools: [<agent_framework._mcp.MCPStdioTool object at 0x108990ad0>]
mcp_servers handed to the SDK: {}

TypeError: MCP server 'weather' cannot be passed to ClaudeAgent as a tool: the Claude
Agent SDK connects to MCP servers itself, so a framework-managed MCPTool would keep none of
its framework behavior. Configure the server natively instead, for example
default_options={'mcp_servers': {'weather': {'type': 'stdio', 'command': 'python',
'args': ['server.py']}}}, or use a ChatAgent, where the framework owns the connection.
```

### Related Issue

Fixes #3651

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

