### PR TITLE
Python: fix Gemini finish reason fallback and usage-attach cascade

### DIFF
--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -19,6 +19,7 @@ from agent_framework import (
     ChatResponse,
     ChatResponseUpdate,
     Content,
+    FinishReason,
     FinishReasonLiteral,
     FunctionInvocationConfiguration,
     FunctionInvocationLayer,
@@ -1260,18 +1261,20 @@ class RawGeminiChatClient(
             details["reasoning_output_token_count"] = v
         return details or None
 
-    def _map_finish_reason(self, reason: str | None) -> FinishReasonLiteral | None:
+    def _map_finish_reason(self, reason: str | None) -> FinishReasonLiteral | FinishReason | None:
         """Map a Gemini finish reason string to the framework's FinishReasonLiteral.
 
         Args:
             reason: The finish reason name from the Gemini API (e.g. ``"STOP"``), or None.
 
         Returns:
-            The corresponding ``FinishReasonLiteral``, or None if the reason is absent or unmapped.
+            The corresponding ``FinishReasonLiteral`` for known reasons, the raw reason string for
+            values not yet mapped (so callers still see that the response terminated abnormally
+            instead of losing it), or None if the reason is absent or ``FINISH_REASON_UNSPECIFIED``.
         """
-        if not reason:
+        if not reason or reason == "FINISH_REASON_UNSPECIFIED":
             return None
-        return _FINISH_REASON_MAP.get(reason)
+        return _FINISH_REASON_MAP.get(reason, FinishReason(reason))
 
     # endregion
 

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -463,19 +463,39 @@ async def test_get_response_no_usage_when_metadata_absent() -> None:
 @pytest.mark.parametrize(
     ("gemini_reason", "expected"),
     [
+        # Currently-mapped values: must keep mapping to exactly what they map to today.
         ("STOP", "stop"),
         ("MAX_TOKENS", "length"),
         ("SAFETY", "content_filter"),
         ("RECITATION", "content_filter"),
+        ("LANGUAGE", "content_filter"),
         ("BLOCKLIST", "content_filter"),
         ("PROHIBITED_CONTENT", "content_filter"),
         ("SPII", "content_filter"),
+        ("IMAGE_SAFETY", "content_filter"),
+        ("IMAGE_PROHIBITED_CONTENT", "content_filter"),
+        ("IMAGE_RECITATION", "content_filter"),
         ("MALFORMED_FUNCTION_CALL", "tool_calls"),
-        ("OTHER", None),
+        ("UNEXPECTED_TOOL_CALL", "tool_calls"),
+        # Real google-genai FinishReason values with no entry in _FINISH_REASON_MAP: must now
+        # pass through as the raw string instead of being silently dropped to None.
+        ("OTHER", "OTHER"),
+        ("TOO_MANY_TOOL_CALLS", "TOO_MANY_TOOL_CALLS"),
+        ("NO_IMAGE", "NO_IMAGE"),
+        ("IMAGE_OTHER", "IMAGE_OTHER"),
+        # Absent / unspecified: must still yield None.
+        (None, None),
+        ("FINISH_REASON_UNSPECIFIED", None),
     ],
 )
-async def test_finish_reason_mapping(gemini_reason: str, expected: str | None) -> None:
-    """Maps Gemini finish reason strings to the correct FinishReasonLiteral values."""
+async def test_finish_reason_mapping(gemini_reason: str | None, expected: str | None) -> None:
+    """Maps Gemini finish reason strings to the correct FinishReasonLiteral values.
+
+    Unmapped-but-real provider values (e.g. TOO_MANY_TOOL_CALLS) must pass through as the raw
+    string rather than vanishing to None, mirroring the fallback PR #7105 added for the other
+    chat clients (bedrock, claude, core, github_copilot, ollama, openai) but not gemini.
+    FINISH_REASON_UNSPECIFIED and an absent reason remain the legitimate None cases.
+    """
     client, mock = _make_gemini_client()
     mock.aio.models.generate_content = AsyncMock(
         return_value=_make_response([_make_part(text="Hi")], finish_reason=gemini_reason)
@@ -484,6 +504,37 @@ async def test_finish_reason_mapping(gemini_reason: str, expected: str | None) -
     response = await client.get_response(messages=[Message(role="user", contents=[Content.from_text("Hi")])])
 
     assert response.finish_reason == expected
+
+
+async def test_unmapped_finish_reason_still_attaches_usage_on_streamed_final_chunk() -> None:
+    """An unmapped provider finish reason must not suppress the final chunk's usage/token accounting.
+
+    Before this fix, `_process_chunk` attached usage only when `_map_finish_reason` returned a
+    non-None value. Since TOO_MANY_TOOL_CALLS is a real google-genai FinishReason absent from
+    `_FINISH_REASON_MAP`, it mapped to None, which silently dropped both the finish reason and
+    the whole turn's usage/token accounting for the final streamed chunk.
+    """
+    client, mock = _make_gemini_client()
+    chunks = [
+        _make_response([_make_part(text="Hello ")], finish_reason=None, prompt_tokens=None, output_tokens=None),
+        _make_response(
+            [_make_part(text="world!")],
+            finish_reason="TOO_MANY_TOOL_CALLS",
+            prompt_tokens=10,
+            output_tokens=5,
+        ),
+    ]
+    mock.aio.models.generate_content_stream = AsyncMock(return_value=_async_iter(chunks))
+
+    stream = client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Hi")])],
+        stream=True,
+    )
+
+    updates = [update async for update in stream]
+
+    assert updates[-1].finish_reason == "TOO_MANY_TOOL_CALLS"
+    assert any(c.type == "usage" for c in updates[-1].contents)
 
 
 # message conversion


### PR DESCRIPTION
### Motivation & Context

#7105 gave chat clients a fallback so an unmapped provider finish reason value passes through as the raw string instead of vanishing to `None`. It touched `ag`, `bedrock`, `claude`, `core`, `github_copilot`, `ollama`, and `openai`. It did not touch `gemini`.

Bedrock's version of the same method after #7105:

```python
def _map_finish_reason(self, reason: str | None) -> str | None:
    if not reason:
        return None
    return FINISH_REASON_MAP.get(reason.lower(), reason)
```

Gemini's still has no fallback:

```python
def _map_finish_reason(self, reason: str | None) -> FinishReasonLiteral | None:
    if not reason:
        return None
    return _FINISH_REASON_MAP.get(reason)
```

`_FINISH_REASON_MAP` covers 13 of the 18 members of `google.genai.types.FinishReason` in the package's own pinned dependency range (`google-genai>=1.69.0,<3.0.0`). Missing: `OTHER`, `TOO_MANY_TOOL_CALLS`, `NO_IMAGE`, `IMAGE_OTHER` (plus `FINISH_REASON_UNSPECIFIED`, which is a legitimate absent case and correctly stays `None`).

The bug cascades. In `_process_chunk`:

```python
if finish_reason and (usage := self._parse_usage(chunk.usage_metadata)):
```

Usage is attached to a streamed chunk only when `finish_reason` is truthy, so an unmapped reason drops the finish reason **and** the whole turn's token/billing accounting. `ChatTelemetryLayer` in `observability.py` skips recording the terminal span state the same way.

Concrete scenario: a Gemini call inside an agentic tool loop trips Gemini's own tool-call-count guardrail and returns `finish_reason=TOO_MANY_TOOL_CALLS`. The caller sees `finish_reason=None`, no usage, and no way to tell the run stopped abnormally instead of completing normally.

### Description & Review Guide

- **What are the major changes?**
  - `_map_finish_reason` now falls back to the raw reason string, wrapped as `FinishReason(reason)`, instead of `None`. `FINISH_REASON_UNSPECIFIED` and an absent reason still map to `None`.
  - The return type widens from `FinishReasonLiteral | None` to `FinishReasonLiteral | FinishReason | None`. This is not the same pattern bedrock uses (`str | None` with no wrapping) — bedrock's file carries a blanket `# type: ignore` at the top of the module, gemini's does not, so a bare `str` fails this package's strict Pyright config. `FinishReason(reason)` is the same construct `ollama` and `openai` used for the same fallback in #7105.
- **What is the impact of these changes?**
  - An unmapped-but-real Gemini finish reason (currently `OTHER`, `TOO_MANY_TOOL_CALLS`, `NO_IMAGE`, `IMAGE_OTHER`) is now surfaced to the caller instead of silently disappearing, and the final streamed chunk's usage/token accounting is no longer dropped alongside it.
- **What do you want reviewers to focus on?**
  - Whether `FINISH_REASON_UNSPECIFIED` is the only value that should keep mapping to `None`, or whether other values should be excluded from the fallback too.

### Related Issue

Fixes #7836

### Testing

Ran the gemini package's unit test suite only (not the full monorepo suite):

```
python -m pytest packages/gemini/tests -m "not integration" -v
```

GREEN (with the fix): 157 passed, 8 deselected (integration tests, no credentials configured).

Reverted only the source change (kept the new/updated tests) to confirm RED:

```
5 failed, 152 passed, 8 deselected
FAILED test_finish_reason_mapping[OTHER-OTHER]
FAILED test_finish_reason_mapping[TOO_MANY_TOOL_CALLS-TOO_MANY_TOOL_CALLS]
FAILED test_finish_reason_mapping[NO_IMAGE-NO_IMAGE]
FAILED test_finish_reason_mapping[IMAGE_OTHER-IMAGE_OTHER]
FAILED test_unmapped_finish_reason_still_attaches_usage_on_streamed_final_chunk
```

Restored the fix, reran, back to GREEN (157 passed).

Also ran `pyright` and `ruff check`/`ruff format --check` against the changed files only; all clean. Did not run the .NET suite, the full Python monorepo test suite, or integration tests (no Gemini/Vertex credentials in this environment).

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
