### PR TITLE
Python: fix declarative workflow DevUI message input

### DIFF
--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -1084,7 +1084,7 @@ class DeclarativeActionExecutor(Executor):
         Follows .NET's DefaultTransform pattern - accepts any input type:
         - dict/Mapping: Used directly as workflow.inputs
         - str: Converted to {"input": value}
-        - list[Message]: Treated as the agent-facing message contract
+        - Message or list[Message]: Treated as the agent-facing message contract
           (e.g. from WorkflowAgent / as_agent()). The prior conversation
           history is stored in ``Conversation.messages``/
           ``Conversation.history`` and mirrored to
@@ -1113,9 +1113,11 @@ class DeclarativeActionExecutor(Executor):
         if isinstance(trigger, dict):
             # Structured inputs - use directly
             state.initialize(trigger)  # type: ignore
-        elif isinstance(trigger, list) and all(isinstance(m, Message) for m in trigger):  # pyright: ignore[reportUnknownVariableType]
-            # list[Message] (e.g. from WorkflowAgent / as_agent()).
-            messages_list = cast(list[Message], trigger)
+        elif isinstance(trigger, Message) or (
+            isinstance(trigger, list) and all(isinstance(m, Message) for m in trigger)  # pyright: ignore[reportUnknownVariableType]
+        ):
+            # Message (e.g. from DevUI) or list[Message] (e.g. from WorkflowAgent / as_agent()).
+            messages_list = [trigger] if isinstance(trigger, Message) else cast(list[Message], trigger)
 
             # Detect continuation: if the workflow's shared state already
             # carries declarative data from a prior turn (because the host

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_declarative_base.py
@@ -1084,7 +1084,9 @@ class DeclarativeActionExecutor(Executor):
         Follows .NET's DefaultTransform pattern - accepts any input type:
         - dict/Mapping: Used directly as workflow.inputs
         - str: Converted to {"input": value}
-        - Message or list[Message]: Treated as the agent-facing message contract
+        - Message: Starts a fresh run (e.g. from DevUI), with text and ID
+          surfaced through Inputs.input and System.LastMessage*.
+        - list[Message]: Treated as the agent-facing message contract
           (e.g. from WorkflowAgent / as_agent()). The prior conversation
           history is stored in ``Conversation.messages``/
           ``Conversation.history`` and mirrored to
@@ -1119,22 +1121,12 @@ class DeclarativeActionExecutor(Executor):
             # Message (e.g. from DevUI) or list[Message] (e.g. from WorkflowAgent / as_agent()).
             messages_list = [trigger] if isinstance(trigger, Message) else cast(list[Message], trigger)
 
-            # Detect continuation: if the workflow's shared state already
-            # carries declarative data from a prior turn (because the host
-            # restored a checkpoint and dispatched this run with
-            # reset_context=False), we MUST NOT call state.initialize() -
-            # that would wipe Conversation.messages, Local.*, System.* etc.
-            # Instead, treat the trigger as the new turn's user input only:
-            # update Inputs.input, append the new user message to existing
-            # Conversation history, and refresh System.LastMessage*.
-            #
-            # Continuation = declarative state already exists in the workflow's
-            # shared state (either left over in-memory from a prior turn on
-            # the same instance, or restored from a checkpoint just before
-            # this run). In that case state.initialize() would wipe Local.*,
-            # System.*, Conversation.* etc., destroying the cross-turn
-            # context we're trying to preserve.
-            is_continuation = state.is_initialized()
+            # Preserve the existing list[Message] continuation contract used
+            # by WorkflowAgent. A bare Message starts a fresh run: DevUI can
+            # reuse this workflow instance across unrelated conversations.
+            # State left on the instance is not evidence of session ownership.
+            # Explicit checkpoint/HIL restores use the runner's resume path.
+            is_continuation = not isinstance(trigger, Message) and state.is_initialized()
 
             # Locate the trailing user message in the trigger.
             last_user_index = -1

--- a/python/packages/declarative/agent_framework_declarative/_workflows/_executors_control_flow.py
+++ b/python/packages/declarative/agent_framework_declarative/_workflows/_executors_control_flow.py
@@ -400,6 +400,7 @@ class JoinExecutor(DeclarativeActionExecutor):
         self,
         trigger: dict[str, Any]
         | str
+        | Message
         | list[Message]
         | ActionTrigger
         | ActionComplete

--- a/python/packages/declarative/tests/test_graph_coverage.py
+++ b/python/packages/declarative/tests/test_graph_coverage.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from agent_framework import Message
 
 from agent_framework_declarative._workflows import (
     ActionComplete,
@@ -1521,6 +1522,19 @@ class TestDeclarativeActionExecutorBase:
         state = DeclarativeWorkflowState(mock_state)
         inputs = state.get("Workflow.Inputs")
         assert inputs == {"input": "string trigger"}
+
+    async def test_ensure_state_initialized_with_message_input(self, mock_context, mock_state):
+        """Test _ensure_state_initialized with a single Message input."""
+        from agent_framework_declarative._workflows._executors_control_flow import JoinExecutor
+
+        executor = JoinExecutor({"kind": "Entry"})
+        message = Message(role="user", contents=["message trigger"], message_id="message-1")
+        await executor.handle_action(message, mock_context)
+
+        state = DeclarativeWorkflowState(mock_state)
+        assert state.get("Workflow.Inputs") == {"input": "message trigger"}
+        assert state.get("System.LastMessage") == {"Text": "message trigger", "Id": "message-1"}
+        assert state.get("System.LastMessageText") == "message trigger"
 
     async def test_ensure_state_initialized_with_custom_object(self, mock_context, mock_state):
         """Test _ensure_state_initialized with custom object converts to string."""

--- a/python/packages/declarative/tests/test_workflow_factory.py
+++ b/python/packages/declarative/tests/test_workflow_factory.py
@@ -2,10 +2,12 @@
 
 """Unit tests for WorkflowFactory."""
 
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
+from agent_framework import Message
 
 from agent_framework_declarative._feature_usage import FeatureIndex
 from agent_framework_declarative._workflows._errors import DeclarativeWorkflowError
@@ -85,6 +87,50 @@ actions:
             })
 
         mark_feature_used.assert_called_once_with(FeatureIndex.DECLARATIVE_WORKFLOW)
+
+
+class TestWorkflowFactoryMessageInput:
+    """Tests for declarative workflows started with a single Message."""
+
+    async def test_entry_join_executor_initializes_workflow_inputs_message(self):
+        """Regression test for #7285: Entry JoinExecutor must accept a single Message input."""
+        from agent_framework_declarative._workflows._declarative_base import DECLARATIVE_STATE_KEY
+
+        factory = WorkflowFactory()
+        workflow = factory.create_workflow_from_yaml("""
+name: entry-message-inputs-test
+actions:
+  - kind: SendActivity
+    activity:
+      text: received
+""")
+
+        result = await workflow.run(Message(role="user", contents=["25"], message_id="message-25"))
+        outputs = result.get_outputs()
+        assert any("received" in str(output) for output in outputs)
+
+        state_data = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
+        assert isinstance(state_data, dict)
+        assert state_data["Inputs"]["input"] == "25"
+        assert state_data["System"]["LastMessage"] == {"Text": "25", "Id": "message-25"}
+        assert state_data["System"]["LastMessageText"] == "25"
+
+    @pytest.mark.parametrize(
+        ("age", "category"),
+        [(8, "child"), (16, "teenager"), (25, "adult"), (70, "senior")],
+    )
+    @_requires_powerfx
+    async def test_devui_declarative_workflow_categorizes_message_input(self, age: int, category: str):
+        """Regression test for #7285: The DevUI sample must categorize chat message input by age."""
+        workflow_path = (
+            Path(__file__).parents[3] / "samples" / "02-agents" / "devui" / "workflow_declarative" / "workflow.yaml"
+        )
+        workflow = WorkflowFactory().create_workflow_from_yaml_path(workflow_path)
+
+        result = await workflow.run(Message(role="user", contents=[str(age)]))
+        outputs = result.get_outputs()
+
+        assert any(f"categorized as: {category}" in str(output) for output in outputs)
 
 
 @_requires_powerfx

--- a/python/packages/declarative/tests/test_workflow_factory.py
+++ b/python/packages/declarative/tests/test_workflow_factory.py
@@ -186,8 +186,10 @@ actions:
         first = await workflow.run(Message(role="user", contents=["first-secret"]), checkpoint_storage=first_storage)
         first_request_id = first.get_request_info_events()[0].request_id
         checkpoints = await first_storage.list_checkpoints(workflow_name=workflow.name)
-        checkpoint = max(checkpoints, key=lambda item: item.timestamp)
-        assert checkpoint.pending_request_info_events
+        # Wall-clock timestamps can tie on Windows. Select the checkpoint
+        # that actually contains this run's pending question, not an earlier step.
+        checkpoint = next(item for item in checkpoints if first_request_id in item.pending_request_info_events)
+        assert first_request_id in checkpoint.pending_request_info_events
         first_state = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
         assert isinstance(first_state, dict)
         first_conversation_id = first_state["System"]["ConversationId"]

--- a/python/packages/declarative/tests/test_workflow_factory.py
+++ b/python/packages/declarative/tests/test_workflow_factory.py
@@ -115,6 +115,111 @@ actions:
         assert state_data["System"]["LastMessage"] == {"Text": "25", "Id": "message-25"}
         assert state_data["System"]["LastMessageText"] == "25"
 
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_message_input_resets_prior_run_state(self, stream: bool) -> None:
+        """A fresh Message must not inherit state from a reused workflow instance."""
+        from agent_framework_declarative._workflows._declarative_base import DECLARATIVE_STATE_KEY
+
+        workflow = WorkflowFactory().create_workflow_from_yaml("""
+name: fresh-message-state-test
+actions:
+  - kind: SendActivity
+    activity:
+      text: received
+""")
+        await workflow.run(Message(role="user", contents=["first"]))
+        prior = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
+        assert isinstance(prior, dict)
+        prior_conversation_id = prior["System"]["ConversationId"]
+        # Model values persisted by actions during the preceding run.
+        for namespace in ("Local", "System", "Outputs", "Agent", "Custom"):
+            prior[namespace]["tenant_secret"] = "first-conversation-only"
+        prior["Conversation"]["messages"] = [Message(role="assistant", contents=["private history"])]
+        prior["Conversation"]["history"] = list(prior["Conversation"]["messages"])
+        workflow._runner.state.set(DECLARATIVE_STATE_KEY, prior)
+        workflow._runner.state.commit()
+
+        message = Message(role="user", contents=["second"], message_id="second-message")
+        if stream:
+            events = [event async for event in workflow.run(message, stream=True)]
+            assert any(event.type == "output" for event in events)
+        else:
+            result = await workflow.run(message)
+            assert result.get_outputs()
+
+        current = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
+        assert isinstance(current, dict)
+        for namespace in ("Local", "System", "Outputs", "Agent", "Custom"):
+            assert "tenant_secret" not in current[namespace], namespace
+        assert current["Conversation"] == {"messages": [], "history": []}
+        assert current["System"]["ConversationId"] != prior_conversation_id
+        assert prior_conversation_id not in current["System"]["conversations"]
+        assert current["Inputs"] == {"input": "second"}
+        assert current["System"]["LastMessage"] == {"Text": "second", "Id": "second-message"}
+        assert current["System"]["LastMessageText"] == "second"
+        assert current["System"]["LastMessageId"] == "second-message"
+
+    @pytest.mark.parametrize("restore_with_responses", [False, True])
+    @_requires_powerfx
+    async def test_message_input_checkpoint_restores_own_state(self, restore_with_responses: bool) -> None:
+        """Restoring a paused run must recover its state after another conversation ran."""
+        from agent_framework import InMemoryCheckpointStorage
+
+        from agent_framework_declarative._workflows import ExternalInputResponse
+        from agent_framework_declarative._workflows._declarative_base import DECLARATIVE_STATE_KEY
+
+        workflow = WorkflowFactory().create_workflow_from_yaml("""
+name: message-checkpoint-state-test
+actions:
+  - kind: SetValue
+    path: Local.tenant_secret
+    value: =System.LastMessageText
+  - kind: Question
+    question:
+      text: Continue?
+    variable: Local.answer
+  - kind: SendActivity
+    activity:
+      text: =Local.tenant_secret
+""")
+        first_storage = InMemoryCheckpointStorage()
+        first = await workflow.run(Message(role="user", contents=["first-secret"]), checkpoint_storage=first_storage)
+        first_request_id = first.get_request_info_events()[0].request_id
+        checkpoints = await first_storage.list_checkpoints(workflow_name=workflow.name)
+        checkpoint = max(checkpoints, key=lambda item: item.timestamp)
+        assert checkpoint.pending_request_info_events
+        first_state = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
+        assert isinstance(first_state, dict)
+        first_conversation_id = first_state["System"]["ConversationId"]
+        await workflow.run(
+            responses={first_request_id: ExternalInputResponse(user_input="finish first")},
+            checkpoint_storage=first_storage,
+        )
+
+        second_storage = InMemoryCheckpointStorage()
+        second = await workflow.run(Message(role="user", contents=["second-secret"]), checkpoint_storage=second_storage)
+        second_request_id = second.get_request_info_events()[0].request_id
+        await workflow.run(
+            responses={second_request_id: ExternalInputResponse(user_input="finish second")},
+            checkpoint_storage=second_storage,
+        )
+
+        responses = {first_request_id: ExternalInputResponse(user_input="restored answer")}
+        if restore_with_responses:
+            restored = await workflow.run(
+                checkpoint_id=checkpoint.checkpoint_id, checkpoint_storage=first_storage, responses=responses
+            )
+        else:
+            await workflow.run(checkpoint_id=checkpoint.checkpoint_id, checkpoint_storage=first_storage)
+            restored = await workflow.run(responses=responses, checkpoint_storage=first_storage)
+
+        assert restored.get_outputs() == ["first-secret"]
+        restored_state = workflow._runner.state.get(DECLARATIVE_STATE_KEY)
+        assert isinstance(restored_state, dict)
+        assert restored_state["Local"] == {"tenant_secret": "first-secret", "answer": "restored answer"}
+        assert restored_state["Inputs"] == {"input": "first-secret"}
+        assert restored_state["System"]["ConversationId"] == first_conversation_id
+
     @pytest.mark.parametrize(
         ("age", "category"),
         [(8, "child"), (16, "teenager"), (25, "adult"), (70, "senior")],

--- a/python/samples/02-agents/devui/workflow_declarative/workflow.yaml
+++ b/python/samples/02-agents/devui/workflow_declarative/workflow.yaml
@@ -1,52 +1,48 @@
 name: conditional-workflow
-description: Demonstrates conditional branching based on user input
-
-inputs:
-  age:
-    type: integer
-    description: The user's age in years
+description: Demonstrates conditional branching based on age entered in DevUI chat
 
 actions:
-  - kind: SetValue
+  - kind: ParseValue
     id: get_age
     displayName: Get user age
-    path: turn.age
-    value: =inputs.age
+    variable: Local.age
+    value: =System.LastMessage.Text
+    valueType: number
 
   - kind: If
     id: check_age
     displayName: Check age category
-    condition: =turn.age < 13
+    condition: =Local.age < 13
     then:
       - kind: SetValue
-        path: turn.category
+        path: Local.category
         value: child
       - kind: SendActivity
         activity:
           text: "Welcome, young one! Here are some fun activities for kids."
     else:
       - kind: If
-        condition: =turn.age < 20
+        condition: =Local.age < 20
         then:
           - kind: SetValue
-            path: turn.category
+            path: Local.category
             value: teenager
           - kind: SendActivity
             activity:
               text: "Hey there! Check out these cool things for teens."
         else:
           - kind: If
-            condition: =turn.age < 65
+            condition: =Local.age < 65
             then:
               - kind: SetValue
-                path: turn.category
+                path: Local.category
                 value: adult
               - kind: SendActivity
                 activity:
                   text: "Welcome! Here are our professional services."
             else:
               - kind: SetValue
-                path: turn.category
+                path: Local.category
                 value: senior
               - kind: SendActivity
                 activity:
@@ -56,9 +52,9 @@ actions:
     id: summary
     displayName: Send category summary
     activity:
-      text: '=Concat("You have been categorized as: ", turn.category)'
+      text: '=Concat("You have been categorized as: ", Local.category)'
 
   - kind: SetValue
     id: set_output
-    path: workflow.outputs.category
-    value: =turn.category
+    path: Workflow.Outputs.category
+    value: =Local.category


### PR DESCRIPTION
### Motivation & Context

The declarative DevUI sample receives chat input as a single `Message`, while the entry `JoinExecutor` only accepts `list[Message]`. The workflow state therefore does not populate `System.LastMessage.Text` from the DevUI input. The sample also reads a structured `inputs.age` value and uses expression namespaces that do not match the Python runtime, so every age follows the child branch.

### Description & Review Guide

- **What are the major changes?** Accept a single `Message` and initialize fresh per-run declarative state, even when DevUI reuses the workflow object across conversations. Preserve the existing `list[Message]` continuation and explicit checkpoint/HIL restoration paths. Update the sample to parse `System.LastMessage.Text` with the existing `ParseValue` action, store per-run values under `Local.*`, and write the result to `Workflow.Outputs.*`.
- **What is the impact of these changes?** DevUI chat input now reaches the workflow as the expected age value. Existing dict, string, and `list[Message]` inputs keep their current behavior.
- **What do you want reviewers to focus on?** Please check the single-message state initialization and the use of `ParseValue` for the sample. Regression coverage includes streaming/non-streaming fresh-run isolation, checkpoint restoration after another conversation has run, existing agent continuation, and the child, teenager, adult, and senior branches.

### Related Issue

Fixes #7285

#7206 attempted to fix the same issue but was closed with an unresolved concern about a global `Int()` fallback. This version uses the existing `ParseValue` action and does not add or override Power Fx conversion behavior.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix). A workflow keeps the label and title prefix in sync automatically.
