### PR TITLE
Python: preserve unmapped Anthropic and Mistral finish reasons

### DIFF
--- a/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
+++ b/python/packages/anthropic/agent_framework_anthropic/_chat_client.py
@@ -16,6 +16,7 @@ from agent_framework import (
     ChatResponse,
     ChatResponseUpdate,
     Content,
+    FinishReason,
     FinishReasonLiteral,
     FunctionInvocationConfiguration,
     FunctionInvocationLayer,
@@ -213,6 +214,18 @@ FINISH_REASON_MAP: dict[str, FinishReasonLiteral] = {
     "refusal": "content_filter",
     "pause_turn": "stop",
 }
+
+
+def _map_finish_reason(stop_reason: str | None) -> FinishReason | None:
+    """Map an Anthropic stop reason onto a framework finish reason.
+
+    Stop reasons that are not in ``FINISH_REASON_MAP`` are passed through unchanged so that
+    values added by the Anthropic API, such as ``model_context_window_exceeded``, still reach
+    the caller instead of being reported as no finish reason at all.
+    """
+    if not stop_reason:
+        return None
+    return FinishReason(FINISH_REASON_MAP.get(stop_reason, stop_reason))
 
 
 class AnthropicSettings(TypedDict, total=False):
@@ -1095,7 +1108,7 @@ class RawAnthropicClient(
             ],
             usage_details=self._parse_usage_from_anthropic(message.usage),
             model=message.model,
-            finish_reason=FINISH_REASON_MAP.get(message.stop_reason) if message.stop_reason else None,
+            finish_reason=_map_finish_reason(message.stop_reason),
             response_format=options.get("response_format"),
             raw_representation=message,
         )
@@ -1131,9 +1144,7 @@ class RawAnthropicClient(
                         *usage_details,
                     ],
                     model=event.message.model,
-                    finish_reason=FINISH_REASON_MAP.get(event.message.stop_reason)
-                    if event.message.stop_reason
-                    else None,
+                    finish_reason=_map_finish_reason(event.message.stop_reason),
                     raw_representation=event,
                 )
             case "message_delta":
@@ -1147,7 +1158,7 @@ class RawAnthropicClient(
                     ]
                     if usage
                     else [],
-                    finish_reason=FINISH_REASON_MAP.get(event.delta.stop_reason) if event.delta.stop_reason else None,
+                    finish_reason=_map_finish_reason(event.delta.stop_reason),
                     raw_representation=event,
                 )
             case "message_stop":

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -1530,6 +1530,74 @@ def test_process_message_with_tool_use(mock_anthropic_client: MagicMock) -> None
     assert response.finish_reason == "tool_calls"
 
 
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("end_turn", "stop"),
+        ("stop_sequence", "stop"),
+        ("pause_turn", "stop"),
+        ("max_tokens", "length"),
+        ("tool_use", "tool_calls"),
+        ("refusal", "content_filter"),
+        # Not in FINISH_REASON_MAP: passed through instead of dropped.
+        ("model_context_window_exceeded", "model_context_window_exceeded"),
+        (None, None),
+    ],
+)
+def test_process_message_finish_reason(
+    mock_anthropic_client: MagicMock, stop_reason: str | None, expected: str | None
+) -> None:
+    """Known stop reasons map, unmapped ones are preserved, and an absent one stays absent."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    mock_message = MagicMock(spec=BetaMessage)
+    mock_message.id = "msg_123"
+    mock_message.model = "claude-3-5-sonnet-20241022"
+    mock_message.content = [BetaTextBlock(type="text", text="Hello there!")]
+    mock_message.usage = BetaUsage(input_tokens=10, output_tokens=5)
+    mock_message.stop_reason = stop_reason
+
+    response = client._process_message(mock_message, {})
+
+    assert response.finish_reason == expected
+
+
+def test_process_stream_event_preserves_unmapped_stop_reason(mock_anthropic_client: MagicMock) -> None:
+    """Streaming message_delta events pass an unmapped stop reason through unchanged."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    mock_event = MagicMock()
+    mock_event.type = "message_delta"
+    mock_event.usage = None
+    mock_event.delta.stop_reason = "model_context_window_exceeded"
+
+    result = client._process_stream_event(mock_event)
+
+    assert result is not None
+    assert result.finish_reason == "model_context_window_exceeded"
+
+
+def test_process_stream_event_message_start_preserves_unmapped_stop_reason(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Streaming message_start events pass an unmapped stop reason through unchanged."""
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    mock_event = MagicMock()
+    mock_event.type = "message_start"
+    mock_event.message.id = "msg_abc"
+    mock_event.message.role = "assistant"
+    mock_event.message.model = "claude-3-5-sonnet-20241022"
+    mock_event.message.content = []
+    mock_event.message.usage = None
+    mock_event.message.stop_reason = "model_context_window_exceeded"
+
+    result = client._process_stream_event(mock_event)
+
+    assert result is not None
+    assert result.finish_reason == "model_context_window_exceeded"
+
+
 def test_parse_usage_from_anthropic_basic(mock_anthropic_client: MagicMock) -> None:
     """Test _parse_usage_from_anthropic with basic usage."""
     client = create_test_anthropic_client(mock_anthropic_client)

--- a/python/packages/mistral/agent_framework_mistral/_chat_client.py
+++ b/python/packages/mistral/agent_framework_mistral/_chat_client.py
@@ -20,6 +20,7 @@ from agent_framework import (
     ChatResponse,
     ChatResponseUpdate,
     Content,
+    FinishReason,
     FinishReasonLiteral,
     FunctionInvocationConfiguration,
     FunctionInvocationLayer,
@@ -186,6 +187,20 @@ _FINISH_REASON_MAP: dict[str, FinishReasonLiteral] = {
     "model_length": "length",
     "tool_calls": "tool_calls",
 }
+
+
+def _map_finish_reason(reason: Any) -> FinishReason | None:
+    """Map a Mistral finish reason onto a framework finish reason.
+
+    Finish reasons that are not in ``_FINISH_REASON_MAP`` are passed through unchanged so that
+    values such as ``error`` still reach the caller instead of being reported as no finish
+    reason at all.
+    """
+    if not reason:
+        return None
+    raw = str(reason)
+    return FinishReason(_FINISH_REASON_MAP.get(raw, raw))
+
 
 # La Plateforme requires tool call IDs to be exactly 9 alphanumeric characters.
 _MISTRAL_TOOL_CALL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9]{9}$")
@@ -754,9 +769,7 @@ class RawMistralChatClient(
         choice: Mapping[str, Any] = choices[0] if choices else {}
         message: Mapping[str, Any] = choice.get("message") or {}
         contents = self._parse_message_contents(message)
-        finish_reason: FinishReasonLiteral | None = None
-        if reason := choice.get("finish_reason"):
-            finish_reason = _FINISH_REASON_MAP.get(str(reason))
+        finish_reason = _map_finish_reason(choice.get("finish_reason"))
         return ChatResponse(
             response_id=response.get("id"),
             messages=[Message(role="assistant", contents=contents, raw_representation=choice or None)],
@@ -775,7 +788,7 @@ class RawMistralChatClient(
         emitted as complete calls when their choice finishes.
         """
         contents: list[Content] = []
-        finish_reason: FinishReasonLiteral | None = None
+        finish_reason: FinishReason | None = None
         choices = cast("Sequence[Mapping[str, Any]]", chunk.get("choices") or ())
         for choice in choices:
             choice_index = index if isinstance(index := choice.get("index"), int) else 0
@@ -786,7 +799,7 @@ class RawMistralChatClient(
             if reason := choice.get("finish_reason"):
                 contents.extend(tool_calls.flush_choice(choice_index))
                 if finish_reason is None:
-                    finish_reason = _FINISH_REASON_MAP.get(str(reason))
+                    finish_reason = _map_finish_reason(reason)
         if usage := self._parse_usage(chunk.get("usage")):
             contents.append(Content.from_usage(usage_details=usage, raw_representation=chunk))
         return ChatResponseUpdate(

--- a/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
+++ b/python/packages/mistral/tests/mistral/test_mistral_chat_client.py
@@ -692,6 +692,30 @@ async def test_parse_finish_reason_model_length() -> None:
     assert response.finish_reason == "length"
 
 
+async def test_parse_finish_reason_unmapped_is_preserved() -> None:
+    """A Mistral finish reason with no framework equivalent is passed through unchanged."""
+    client, _ = make_client(json_response(make_response_payload(content="x", finish_reason="error")))
+
+    response = await client.get_response([Message("user", ["hi"])])
+
+    assert response.finish_reason == "error"
+
+
+async def test_parse_finish_reason_absent() -> None:
+    """A response without a finish reason still reports no finish reason."""
+    client, _ = make_client(
+        json_response(
+            make_response_payload(
+                choices=[{"index": 0, "message": {"role": "assistant", "content": "x"}}],
+            )
+        )
+    )
+
+    response = await client.get_response([Message("user", ["hi"])])
+
+    assert response.finish_reason is None
+
+
 async def test_function_invocation_loop() -> None:
     client, server = make_client(
         json_response(
@@ -753,6 +777,17 @@ async def test_streaming_response() -> None:
         "cache_read_input_token_count": 2,
     }
     assert server.last_request["stream"] is True
+
+
+async def test_streaming_finish_reason_unmapped_is_preserved() -> None:
+    """A streamed Mistral finish reason with no framework equivalent is passed through unchanged."""
+    client, _ = make_client(stream_response(make_chunk_payload(content="partial", finish_reason="error")))
+
+    stream = client.get_response([Message("user", ["hi"])], stream=True)
+    updates = [update async for update in stream]
+
+    assert [u.finish_reason for u in updates] == ["error"]
+    assert (await stream.get_final_response()).finish_reason == "error"
 
 
 async def test_streaming_tool_calls() -> None:


### PR DESCRIPTION
### Motivation & Context

`AnthropicChatClient` and `MistralChatClient` look their finish reason maps up without a default, so any provider value the map does not cover reaches the caller as `finish_reason=None` — indistinguishable from a response that carries no finish reason at all. Anthropic's `model_context_window_exceeded` and Mistral's `error` are both lost this way, silently: nothing is logged, no exception is raised, and the OTel `gen_ai` span records no finish reason for those turns.

#7105 already fixed this for `ag-ui`, `bedrock`, `claude`, `core`, `github_copilot`, `ollama`, and `openai`. These two packages were missed. (`gemini` has the same gap and is covered separately by #7836 / #7837.)

### Description & Review Guide

- **What are the major changes?**
  A module-level `_map_finish_reason` helper in each of the two clients that falls back to the raw provider value, wrapped in `FinishReason(...)` so it type-checks under each package's strict Pyright config. It replaces three inline lookups in the Anthropic client (`_process_message`, and the `message_start` and `message_delta` branches of `_process_stream_event`) and two in the Mistral client (`_parse_response`, `_parse_chunk`). Tests cover the unmapped value in both the non-streaming and streaming paths, plus regressions for the already-mapped values and the absent case.

- **What is the impact of these changes?**
  Callers that previously saw `finish_reason=None` for an unmapped provider value now see the raw provider string. That is the normalization #7105 established and it is the documented contract of the type: `FinishReasonLiteral` is the four known values, while `FinishReason` is a `NewType("FinishReason", str)` explicitly documented as accepting any string for extensibility, exactly as `bedrock`, `claude` and `ollama` already emit. Nothing in the repo branches on `finish_reason`, `ChatResponse` does not validate it, and `ChatTelemetryLayer` already filters non-standard values back out before they reach OTel. Every value currently in the two maps keeps mapping exactly as it does today, and an absent reason stays `None`, so no existing behavior narrows.

- **What do you want reviewers to focus on?**
  Whether the two new helpers should instead be instance methods, to match `bedrock`/`gemini`, rather than module-level functions next to their maps as they are here — and whether Anthropic's `model_context_window_exceeded` would be better mapped explicitly to `length` rather than passed through as the raw value.

Verified locally on both packages: `poe syntax`, `poe pyright`, `poe test-typing` (pyright, pyrefly, ty, mypy, zuban) and `poe test` are all clean. The new "unmapped is preserved" tests fail on `main` before the change.

### Related Issue

Fixes #7849

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
