### PR TITLE
.NET: Suppress false positive Zip Slip alert

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Mcp/Skills/Loaders/AgentMcpSkillArchiveExtractor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Mcp/Skills/Loaders/AgentMcpSkillArchiveExtractor.cs
@@ -159,7 +159,7 @@ internal static class AgentMcpSkillArchiveExtractor
                 throw new InvalidDataException($"Skill archive exceeds the maximum allowed file count ({maxFileCount}).");
             }
 
-            string? destination = ResolveDestination(fullTarget, entry.FullName);
+            string? destination = ResolveDestination(fullTarget, entry.FullName); // CodeQL [SM02729] ResolveDestination rejects paths outside fullTarget.
             if (destination is null)
             {
                 continue;

--- a/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -334,7 +335,7 @@ public sealed class FeatureRegistryTests
 
             foreach (EnumDeclarationSyntax featureIndex in enums)
             {
-                if (!featureIndex.Modifiers.Any(static modifier => modifier.RawKind == (int)SyntaxKind.InternalKeyword))
+                if (!featureIndex.Modifiers.Any(SyntaxKind.InternalKeyword))
                 {
                     errors.Add($"{filePath}: FeatureIndex must be internal.");
                 }

--- a/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
@@ -5,9 +5,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+#pragma warning disable IDE0005 // Required by Windows builds for Roslyn APIs.
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+#pragma warning restore IDE0005
 
 namespace Microsoft.Agents.AI.FeatureRegistry.UnitTests;
 

--- a/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -335,7 +334,7 @@ public sealed class FeatureRegistryTests
 
             foreach (EnumDeclarationSyntax featureIndex in enums)
             {
-                if (!featureIndex.Modifiers.Any(SyntaxKind.InternalKeyword))
+                if (!featureIndex.Modifiers.Any(static modifier => modifier.RawKind == (int)SyntaxKind.InternalKeyword))
                 {
                     errors.Add($"{filePath}: FeatureIndex must be internal.");
                 }

--- a/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.FeatureRegistry.UnitTests/FeatureRegistryTests.cs
@@ -431,5 +431,5 @@ public sealed class FeatureRegistryTests
 
     private sealed record RegistryEntry(int Index, string Id);
 
-    private sealed record FeatureDeclaration(string Owner, string MemberName, int Index, string FilePath);
+    private readonly record struct FeatureDeclaration(string Owner, string MemberName, int Index, string FilePath);
 }


### PR DESCRIPTION
### Motivation & Context

Suppresses the false-positive CodeQL Zip Slip finding SM02729.

### Description & Review Guide

- **What are the major changes?** Add an inline CodeQL suppression with justification.
- **What is the impact of these changes?** No runtime behavior changes.
- **What do you want reviewers to focus on?** The suppression justification.

### Related Issue

N/A - internal CodeQL finding SM02729.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.