### PR TITLE
Python: keep agent loop marker from provider SDKs

### DIFF
--- a/python/packages/core/agent_framework/_agents.py
+++ b/python/packages/core/agent_framework/_agents.py
@@ -1512,6 +1512,9 @@ class RawAgent(BaseAgent, Generic[OptionsCoT]):
         # _merge_options strips unset (None) options, so e.g. an unset `store` is not forwarded
         # and the service decides its own default.
         co = _merge_options(chat_options, run_opts)
+        # The loop marker must remain on SessionContext.options for after_run provider
+        # scoping, but it is framework-private metadata and must not reach the client.
+        co.pop(_LOOP_ITERATION_TOKEN_KEY, None)
 
         # Build session_messages from session context: context messages + input messages
         session_messages: list[Message] = session_context.get_messages(include_input=True)

--- a/python/packages/core/tests/core/test_harness_loop.py
+++ b/python/packages/core/tests/core/test_harness_loop.py
@@ -32,9 +32,9 @@ from agent_framework import (
     background_tasks_running,
     background_tasks_running_message,
     set_agent_mode,
-    tool,
     todos_remaining,
     todos_remaining_message,
+    tool,
 )
 from agent_framework._harness._loop import (
     DEFAULT_JUDGE_MAX_ITERATIONS,
@@ -1422,6 +1422,55 @@ class _RunScopedRecordingProvider(ContextProvider):
 
     async def after_run(self, *, agent: Any, session: Any, context: Any, state: dict[str, Any]) -> None:
         self.after_calls += 1
+
+
+class _StrictTransportChatClient(RecordingChatClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.received_provider_options: list[str] = []
+
+    def _inner_get_response(
+        self,
+        *,
+        messages: Sequence[Message],
+        stream: bool = False,
+        options: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> Awaitable[ChatResponse] | ResponseStream[ChatResponseUpdate, ChatResponse]:
+        self._strict_transport(**options)
+        return super()._inner_get_response(messages=messages, stream=stream, options=options, **kwargs)
+
+    def _strict_transport(self, *, tool_choice: Any, _provider_option: str) -> None:
+        self.received_provider_options.append(_provider_option)
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+async def test_loop_marker_is_not_forwarded_to_provider_transport(stream: bool) -> None:
+    client = _StrictTransportChatClient()
+    turn_scoped = _TurnScopedRecordingProvider()
+    agent = Agent(
+        client=client,
+        middleware=[AgentLoopMiddleware(always_continue, max_iterations=1)],
+        context_providers=[turn_scoped],
+    )
+    options = {"_provider_option": "kept"}
+
+    if stream:
+        response = agent.run(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]  # ty: ignore[no-matching-overload]
+            "start",
+            stream=True,
+            options=options,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+        )
+        _ = [update async for update in response]
+        await response.get_final_response()
+    else:
+        await agent.run(  # type: ignore[call-overload]  # pyrefly: ignore[no-matching-overload]  # ty: ignore[no-matching-overload]
+            "start",
+            options=options,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+        )
+
+    assert client.received_provider_options == ["kept"]
+    assert turn_scoped.after_calls == 1
 
 
 async def test_turn_scoped_after_run_fires_once_per_loop() -> None:


### PR DESCRIPTION
### Motivation & Context

Agent loop middleware stamps `_agent_loop_iteration` into run options so turn-scoped context providers can defer their `after_run` work to the loop boundary. Because remaining run options are also forwarded as provider-specific options, the private marker reached provider SDKs and caused real clients such as Ollama and Foundry to reject the unexpected keyword argument.

This change keeps the marker available for provider scoping while preventing framework-private metadata from crossing the chat-client transport boundary.

### Description & Review Guide

- **What are the major changes?** Remove `_agent_loop_iteration` from the final merged chat options passed to the client, without removing it from `SessionContext.options`. Add streaming and non-streaming regression coverage using a strict transport signature.
- **What is the impact of these changes?** Harness agents with an active loop predicate can call strict provider SDKs successfully, provider-specific options continue to pass through, and turn-scoped providers still run once at the loop boundary.
- **What do you want reviewers to focus on?** Confirm that filtering the single reserved key at the outbound options copy is the narrowest boundary and preserves the loop marker semantics introduced in #7289.


### Related Issue

Fixes #7821

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.