### PR TITLE
.NET: Annotate DevUI aggregator static-analysis false positives

### DIFF
--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
@@ -167,6 +167,7 @@ internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
             }
 
             context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
+            // CodeQL [SM04598] False positive: The Location is always /devui/?<query>. Since it is relative, the client re-requests the same host; the query cannot change the destination.
             context.Response.Headers.Location = redirect;
             return;
         }

--- a/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
+++ b/dotnet/src/Aspire.Hosting.AgentFramework.DevUI/DevUIAggregatorHostedService.cs
@@ -725,8 +725,8 @@ internal sealed class DevUIAggregatorHostedService : IAsyncDisposable
             ? HttpCompletionOption.ResponseHeadersRead
             : HttpCompletionOption.ResponseContentRead;
 
-        using var response = await client.SendAsync( // CodeQL [SM03781] False positive: ValidateProxyTarget confirms the target host, scheme, and port match the configured backend, so the user-supplied path and query cannot change the destination.
-            request, completionOption, context.RequestAborted).ConfigureAwait(false);
+        // CodeQL [SM03781] False positive: ValidateProxyTarget confirms the target host, scheme, and port match the configured backend, so the user-supplied path and query cannot change the destination.
+        using var response = await client.SendAsync(request, completionOption, context.RequestAborted).ConfigureAwait(false);
 
         if (streaming && response.Content.Headers.ContentType?.MediaType == "text/event-stream")
         {


### PR DESCRIPTION
### Motivation & Context

Static analysis reports two findings in the Aspire DevUI aggregator that are false positives — the existing guards already constrain both destinations, but the analyzer does not model them. This records the reasoning inline, using the repo's existing suppression pattern, so the alerts stop adding noise.

### Description & Review Guide

- **What are the major changes?** Move the proxy send suppression onto the reported line (and collapse the call to one line), and add a justified suppression for the DevUI trailing-slash redirect.
- **What is the impact of these changes?** None at runtime — comments and formatting only. Builds clean with no warnings.
- **What do you want reviewers to focus on?** Whether the justifications accurately describe the existing guards.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

No tracking issue; small static-analysis triage follow-up to #6771 and #7505. No other open PR covers these findings.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.