### PR TITLE
.NET: Set AgentResponse.CreatedAt from the A2A task status timestamp

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.A2A/A2AAgent.cs
@@ -430,6 +430,7 @@ public sealed class A2AAgent : AIAgent
         {
             AgentId = this.Id,
             ResponseId = task.Id,
+            CreatedAt = task.Status.Timestamp,
             FinishReason = MapTaskStateToFinishReason(task.Status.State),
             RawRepresentation = task,
             Messages = task.ToChatMessages() ?? [],
@@ -459,6 +460,7 @@ public sealed class A2AAgent : AIAgent
         {
             AgentId = this.Id,
             ResponseId = task.Id,
+            CreatedAt = task.Status.Timestamp,
             FinishReason = MapTaskStateToFinishReason(task.Status.State),
             RawRepresentation = task,
             Role = ChatRole.Assistant,
@@ -474,6 +476,7 @@ public sealed class A2AAgent : AIAgent
         {
             AgentId = this.Id,
             ResponseId = statusUpdateEvent.TaskId,
+            CreatedAt = statusUpdateEvent.Status.Timestamp,
             RawRepresentation = statusUpdateEvent,
             Role = ChatRole.Assistant,
             MessageId = statusUpdateEvent.Status.Message?.MessageId,

--- a/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.A2A.UnitTests/A2AAgentTests.cs
@@ -531,6 +531,55 @@ public sealed class A2AAgentTests : IDisposable
     }
 
     [Fact]
+    public async Task RunAsync_WithTaskResponse_SetsCreatedAtFromTaskStatusTimestampAsync()
+    {
+        // Arrange - an explicit timestamp distinct from "now", so the assertion cannot pass
+        // by accident against AgentTaskStatus.Timestamp's DateTimeOffset.UtcNow default.
+        var statusTimestamp = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        this._handler.AgentTaskToReturn = new AgentTask
+        {
+            Id = "task-created-at",
+            ContextId = "context-created-at",
+            Status = new() { State = TaskState.Completed, Timestamp = statusTimestamp }
+        };
+
+        var options = new AgentRunOptions { ContinuationToken = new A2AContinuationToken("task-created-at") };
+
+        // Act
+        var response = await this._agent.RunAsync([], options: options);
+
+        // Assert
+        Assert.Equal(statusTimestamp, response.CreatedAt);
+    }
+
+    [Fact]
+    public async Task RunStreamingAsync_WithTaskResponse_SetsCreatedAtFromTaskStatusTimestampAsync()
+    {
+        // Arrange
+        var statusTimestamp = new DateTimeOffset(2026, 2, 20, 8, 15, 0, TimeSpan.Zero);
+        this._handler.StreamingErrorCodeToReturn = A2AErrorCode.UnsupportedOperation;
+        this._handler.AgentTaskToReturn = new AgentTask
+        {
+            Id = "streaming-created-at",
+            ContextId = "context-streaming-created-at",
+            Status = new() { State = TaskState.Completed, Timestamp = statusTimestamp }
+        };
+
+        var options = new AgentRunOptions { ContinuationToken = new A2AContinuationToken("streaming-created-at") };
+
+        // Act
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in this._agent.RunStreamingAsync([], null, options))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        Assert.Single(updates);
+        Assert.Equal(statusTimestamp, updates[0].CreatedAt);
+    }
+
+    [Fact]
     public async Task RunAsync_WithTaskInSessionAndMessage_AddTaskAsReferencesToMessageAsync()
     {
         // Arrange


### PR DESCRIPTION
### What

`A2AAgent` never sets `AgentResponse.CreatedAt` / `AgentResponseUpdate.CreatedAt`, so every response it produces reports a null creation time. `CopilotStudioAgent` and `GitHubCopilotAgent` both populate it, so the metadata surface is inconsistent across agent implementations.

This sets `CreatedAt` from the A2A task status timestamp in the three converters whose input actually carries one.

### Why the value is available

`AgentTaskStatus` in the A2A SDK declares:

```csharp
/// ISO 8601 datetime string when the status was recorded.
public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
```

The surrounding code already reads `Status.State` from the same object on adjacent lines, so nothing new is fetched or plumbed through — the timestamp is one property away at every site that now uses it.

### Scope: three of six converters

`A2AAgent` has six response converters. Only three can be fixed; the other three are a data limitation rather than an oversight, so I left them alone:

| Converter | Input | Set `CreatedAt`? |
|---|---|---|
| `ConvertToAgentResponse(AgentTask)` | `task.Status` | ✅ |
| `ConvertToAgentResponseUpdate(AgentTask)` | `task.Status` | ✅ |
| `ConvertToAgentResponseUpdate(TaskStatusUpdateEvent)` | `statusUpdateEvent.Status` | ✅ |
| `ConvertToAgentResponse(Message)` | `Message` | ❌ `AgentMessage` exposes no timestamp |
| `ConvertToAgentResponseUpdate(Message)` | `Message` | ❌ same |
| `ConvertToAgentResponseUpdate(TaskArtifactUpdateEvent)` | — | ❌ type carries only `Artifact` / `Append` / `LastChunk` |

### Behaviour change worth calling out

Consumers that previously saw `CreatedAt == null` from an A2A agent will now see a value on the task-backed paths. That is the intent, but it is observable, so flagging it rather than burying it. The message-backed paths still return null, which is accurate — there is no timestamp to report there.

### Tests

Two regression tests in `A2AAgentTests`, covering the non-streaming and streaming task paths. Both use an explicit timestamp distinct from "now", so they cannot pass by accident against `AgentTaskStatus.Timestamp`'s `DateTimeOffset.UtcNow` default.

Verified red-before-green: with the source change reverted and the tests kept, both fail with `Assert.Equal() Failure: Values differ`; with the change applied, `Microsoft.Agents.AI.A2A.UnitTests` is 90/90 on `net10.0`. `dotnet format --verify-no-changes` is clean on both changed projects.

**Not covered by a test:** the `TaskStatusUpdateEvent` path. Driving a status-update event stream through the existing stub handler was more setup than the one-line change seemed to warrant, so I would rather say so than imply coverage I do not have. Happy to add it if you would prefer the path tested before merge.

### One question

`#6790` cited `A2AAgent` and `GitHubCopilotAgent` as the reference for a complete metadata surface while `CopilotStudioAgent` was the outlier. After #6791 that has inverted — `CopilotStudioAgent` now sets all four of `CreatedAt` / `FinishReason` / `RawRepresentation` / `AdditionalProperties`, and the two references have gaps of their own. This PR closes the `A2AAgent` one. `GitHubCopilotAgent` looks like it may be missing `FinishReason` and `AdditionalProperties` on its update path — worth a separate pass, or would you rather have the remaining gaps swept in one PR? Happy to do either; I would just rather ask than guess at the scope you want.
