### PR TITLE
.NET: expose pending tool approval requests from a restored AgentSession

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/ChatClient/ToolApprovalAgentSessionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI/ChatClient/ToolApprovalAgentSessionExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.AI;
+using Microsoft.Shared.Diagnostics;
+
+namespace Microsoft.Agents.AI;
+
+/// <summary>
+/// Provides extension methods for reading human-in-the-loop tool approval state from an <see cref="AgentSession"/>.
+/// </summary>
+public static class ToolApprovalAgentSessionExtensions
+{
+    /// <summary>
+    /// Attempts to retrieve the tool approval requests that the framework has surfaced for the specified session and
+    /// that have not yet been answered with a matching <see cref="ToolApprovalResponseContent"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A host with durable sessions can use this after deserializing a session to discover that the conversation is
+    /// paused on a pending approval, restore its approval UI, and submit the approval later using
+    /// the request id.
+    /// </para>
+    /// <para>
+    /// The returned requests are snapshots of the model-originated requests. Mutating them does not change the
+    /// recorded state used to bind an incoming approval response.
+    /// </para>
+    /// </remarks>
+    /// <param name="session">The agent session to read pending approval requests from.</param>
+    /// <param name="requests">When this method returns, contains the pending approval requests if any were found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if at least one pending approval request was found; <see langword="false"/> otherwise.</returns>
+    public static bool TryGetPendingToolApprovalRequests(
+        this AgentSession session,
+        [NotNullWhen(true)] out IReadOnlyList<ToolApprovalRequestContent>? requests)
+    {
+        _ = Throw.IfNull(session);
+
+        if (session.StateBag.TryGetValue<List<ToolApprovalRequestContent>>(
+                ApprovalResponseBindingChatClient.StateBagKey,
+                out var pending,
+                AgentJsonUtilities.DefaultOptions)
+            && pending is { Count: > 0 })
+        {
+            requests = pending;
+            return true;
+        }
+
+        requests = null;
+        return false;
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ApprovalResponseBindingChatClientTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/ChatClient/ApprovalResponseBindingChatClientTests.cs
@@ -270,6 +270,55 @@ public class ApprovalResponseBindingChatClientTests
         Assert.Contains(capture.Messages!.SelectMany(m => m.Contents), c => c is ToolApprovalResponseContent);
     }
 
+    [Fact]
+    public async Task TryGetPendingToolApprovalRequests_SurvivesSessionStateRoundTripAsync()
+    {
+        // Arrange — a run stops on an approval request, then the session is persisted and reloaded.
+        var session = new ChatClientAgentSession();
+        var call = new FunctionCallContent("call1", "get_weather", new Dictionary<string, object?> { ["location"] = "Beijing" });
+        await RecordRequestAsync(session, new ToolApprovalRequestContent(RequestId, call));
+
+        var restored = new ChatClientAgentSession(
+            stateBag: AgentSessionStateBag.Deserialize(session.StateBag.Serialize()));
+
+        // Act
+        var found = restored.TryGetPendingToolApprovalRequests(out var pending);
+
+        // Assert — the host can discover the pending approval without reading private state bag keys.
+        Assert.True(found);
+        var request = Assert.Single(pending!);
+        Assert.Equal(RequestId, request.RequestId);
+        var pendingCall = Assert.IsType<FunctionCallContent>(request.ToolCall);
+        Assert.Equal("get_weather", pendingCall.Name);
+        Assert.Equal("call1", pendingCall.CallId);
+    }
+
+    [Fact]
+    public async Task TryGetPendingToolApprovalRequests_AfterResponseIsConsumed_ReturnsFalseAsync()
+    {
+        // Arrange — record a request, then answer it.
+        var session = new ChatClientAgentSession();
+        await RecordRequestAsync(session, new ToolApprovalRequestContent(RequestId, new FunctionCallContent("call1", "toolA")));
+        Assert.True(session.TryGetPendingToolApprovalRequests(out _));
+
+        var decorator = new ApprovalResponseBindingChatClient(CreateCapturingChatClient(new Capture()));
+        var approval = new ToolApprovalResponseContent(RequestId, approved: true, new FunctionCallContent("call1", "toolA"));
+
+        // Act
+        await RunAsync(decorator, session, [new ChatMessage(ChatRole.User, [approval])]);
+
+        // Assert — the answered request is no longer pending.
+        Assert.False(session.TryGetPendingToolApprovalRequests(out var pending));
+        Assert.Null(pending);
+    }
+
+    [Fact]
+    public void TryGetPendingToolApprovalRequests_NoApprovalState_ReturnsFalse()
+    {
+        Assert.False(new ChatClientAgentSession().TryGetPendingToolApprovalRequests(out var pending));
+        Assert.Null(pending);
+    }
+
     private static async Task RecordRequestAsync(ChatClientAgentSession session, ToolApprovalRequestContent request)
     {
         var inner = CreateMockChatClient((_, _, _) =>


### PR DESCRIPTION
### Motivation & Context

A host application with durable sessions has no supported way to discover that a conversation is paused on a human-in-the-loop tool approval.

`ApprovalResponseBindingChatClient` already records every model-originated `ToolApprovalRequestContent` into the session state bag under the internal `_pendingApprovalRequests` key, and consumes the entry once a matching `ToolApprovalResponseContent` is bound. That state is correct and durable — it just isn't reachable through a public API.

So when a user closes or refreshes a conversation that stopped at an approval request and later reopens it, the host can only recover the pending approval by parsing that private state bag field out of serialized session metadata. Field names and shapes there are not a public contract, which makes the workaround fragile. Hosts also end up maintaining a duplicate mirror of the same state purely to have a stable request id to submit against.

Without that recovery the host renders message history only, misses the pending approval, and can let the user send a new message after an unresolved assistant tool call — producing a sequence strict chat-completions providers reject with `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.

### Description & Review Guide

- **What are the major changes?**

  Adds `ToolApprovalAgentSessionExtensions.TryGetPendingToolApprovalRequests`, an extension on `AgentSession` in `Microsoft.Agents.AI`:

  ```csharp
  public static bool TryGetPendingToolApprovalRequests(
      this AgentSession session,
      [NotNullWhen(true)] out IReadOnlyList<ToolApprovalRequestContent>? requests);
  ```

  It reads the same state `ApprovalResponseBindingChatClient` writes, returning `false` when there is no pending approval. It follows the shape of the existing `AgentSessionExtensions.TryGetInMemoryChatHistory`. Three unit tests are added to `ApprovalResponseBindingChatClientTests`, the primary one covering a state bag serialize/deserialize round trip so the reload scenario from the issue is exercised end to end.

- **What is the impact of these changes?**

  Purely additive and read-only. No behavioral change to approval binding, recording, or consumption, and no change to what gets persisted. A host can now, after `DeserializeSessionAsync`, detect the paused approval, restore its approval UI, and submit by request id — removing the need for a host-side mirror of the pending approval list.

  This addresses option 2 of the three remedies proposed in the issue. Option 1 (persisting `ToolApprovalRequestContent` into durable chat history rather than a bare `FunctionCallContent`) changes what goes into message history and affects replay across providers, so it is intentionally left out of this PR as a design decision for maintainers. I'm happy to follow up on it separately if you'd like it.

- **What do you want reviewers to focus on?**

  Whether the API name, placement, and return shape are what you'd want long term — in particular whether this belongs as an `AgentSession` extension in `Microsoft.Agents.AI` or somewhere more discoverable, and whether it should also expose a way to correlate a pending request back to the `FunctionCallContent` already present in message history.

### Related Issue

Fixes #7862

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
