### PR TITLE
ci: adds dependabot cooldown for python and dotnet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     labels:
       - ".NET"
       - "dependencies"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for python.
   # TODO: Remove these Python Dependabot entries after we have confidence in the
@@ -43,6 +45,8 @@ updates:
     labels:
       - "python"
       - "dependencies"
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for github-actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
     labels:
       - "python"
       - "dependencies"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "uv"
     directory: "python/"
     schedule:


### PR DESCRIPTION
adds a delay for dependabot configurations so the dependencies don't get ahead of what the CFS offers, looking Microsoft contributors down