### PR TITLE
.NET: Rename CommunityToolkit.VectorData.CosmosNoSql to AzureCosmosDB

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -103,9 +103,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.8.2" />
     <!-- Vector Stores -->
-    <PackageVersion Include="CommunityToolkit.VectorData.CosmosNoSql" Version="1.0.0" />
+    <PackageVersion Include="CommunityToolkit.VectorData.AzureCosmosDB" Version="1.0.0" />
     <PackageVersion Include="CommunityToolkit.VectorData.InMemory" Version="1.0.0" />
     <PackageVersion Include="CommunityToolkit.VectorData.Qdrant" Version="1.0.0" />
     <!-- Agent SDKs -->

--- a/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/AgentWithMemory_Step08_MemoryUsingCosmosNoSql.csproj
+++ b/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/AgentWithMemory_Step08_MemoryUsingCosmosNoSql.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="CommunityToolkit.VectorData.CosmosNoSql" />
+    <PackageReference Include="CommunityToolkit.VectorData.AzureCosmosDB" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>

--- a/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/Program.cs
+++ b/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/Program.cs
@@ -6,7 +6,7 @@
 using System.Text.Json;
 using Azure.AI.Projects;
 using Azure.Identity;
-using CommunityToolkit.VectorData.CosmosNoSql;
+using CommunityToolkit.VectorData.AzureCosmosDB;
 using Microsoft.Agents.AI;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.AI;
@@ -40,9 +40,9 @@ using CosmosClient cosmosClient = new(
 
 DatabaseResponse databaseResponse = await cosmosClient.CreateDatabaseIfNotExistsAsync(cosmosDatabaseName);
 
-VectorStore vectorStore = new CosmosNoSqlVectorStore(
+VectorStore vectorStore = new CosmosVectorStore(
     databaseResponse.Database,
-    new CosmosNoSqlVectorStoreOptions
+    new CosmosVectorStoreOptions
     {
         JsonSerializerOptions = JsonSerializerOptions.Default,
         EmbeddingGenerator = aiProjectClient

--- a/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/README.md
+++ b/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step08_MemoryUsingCosmosNoSql/README.md
@@ -1,6 +1,6 @@
 ﻿# Agent with Memory Using Azure Cosmos DB for NoSQL
 
-This sample uses `ChatHistoryMemoryProvider` with `CosmosNoSqlVectorStore` to persist chat history in Azure Cosmos DB for NoSQL and recall relevant messages in a new agent session.
+This sample uses `ChatHistoryMemoryProvider` with `CosmosVectorStore` to persist chat history in Azure Cosmos DB for NoSQL and recall relevant messages in a new agent session.
 
 ## Features Demonstrated
 


### PR DESCRIPTION
CommunityToolkit renamed the `CommunityToolkit.VectorData.CosmosNoSql` package to `CommunityToolkit.VectorData.AzureCosmosDB` (see [CommunityToolkit/AI#48](https://github.com/CommunityToolkit/AI/pull/48)), which also renamed `CosmosNoSqlVectorStore` to `CosmosVectorStore`. This PR updates all references in the repo to track the new package and type names.