### PR TITLE
Python: send a Pydantic response_format to Gemini as response_schema

### DIFF
--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -936,7 +936,14 @@ class RawGeminiChatClient(
 
     @staticmethod
     def _extract_response_schema(response_format: Any) -> dict[str, Any] | None:
-        """Extract a Gemini response schema from supported mapping response_format shapes."""
+        """Extract a Gemini response schema from supported response_format shapes.
+
+        Handles Pydantic model classes and the mapping shapes (raw JSON schema,
+        ``json_schema`` envelopes, ``format`` envelopes).
+        """
+        if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+            return response_format.model_json_schema()
+
         if not isinstance(response_format, Mapping):
             return None
         mapping = cast("Mapping[str, Any]", response_format)

--- a/python/packages/gemini/agent_framework_gemini/_chat_client.py
+++ b/python/packages/gemini/agent_framework_gemini/_chat_client.py
@@ -938,8 +938,9 @@ class RawGeminiChatClient(
     def _extract_response_schema(response_format: Any) -> dict[str, Any] | None:
         """Extract a Gemini response schema from supported response_format shapes.
 
-        Handles Pydantic model classes and the mapping shapes (raw JSON schema,
-        ``json_schema`` envelopes, ``format`` envelopes).
+        Handles a Pydantic model class and, for mappings, a ``format`` envelope
+        (unwrapped recursively), a ``json_schema`` envelope, a bare ``schema``
+        envelope, and a raw JSON schema mapping. Anything else returns ``None``.
         """
         if isinstance(response_format, type) and issubclass(response_format, BaseModel):
             return response_format.model_json_schema()

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -1504,7 +1504,9 @@ async def test_response_schema_option_wins_over_pydantic_response_format() -> No
 
     await client.get_response(
         messages=[Message(role="user", contents=[Content.from_text("Hi")])],
-        options={"response_format": Reply, "response_schema": explicit},
+        # response_format binds the options TypedDict to Reply while response_schema only
+        # exists on GeminiChatOptions[None]; no get_response overload accepts the combination.
+        options=cast(Any, {"response_format": Reply, "response_schema": explicit}),
     )
 
     config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]

--- a/python/packages/gemini/tests/test_gemini_client.py
+++ b/python/packages/gemini/tests/test_gemini_client.py
@@ -1466,6 +1466,51 @@ async def test_response_format_sets_json_mime_type() -> None:
     assert config.response_mime_type == "application/json"
 
 
+async def test_response_format_pydantic_model_sets_response_schema() -> None:
+    """A Pydantic model response_format must reach Gemini as response_schema, not just JSON mode.
+
+    Without the schema, the model is asked for JSON but is not constrained by it, so it can
+    return arbitrary JSON that then fails to parse into the requested model - the failure mode
+    #5888 described for mapping-shaped schemas, on the shape #5893 left out of scope.
+    """
+    from pydantic import BaseModel
+
+    class Reply(BaseModel):
+        text: str
+
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="{}")]))
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Hi")])],
+        options={"response_format": Reply},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.response_mime_type == "application/json"
+    assert config.response_schema == Reply.model_json_schema()
+
+
+async def test_response_schema_option_wins_over_pydantic_response_format() -> None:
+    """An explicit response_schema still takes precedence, as it already does for mapping shapes."""
+    from pydantic import BaseModel
+
+    class Reply(BaseModel):
+        text: str
+
+    client, mock = _make_gemini_client()
+    mock.aio.models.generate_content = AsyncMock(return_value=_make_response([_make_part(text="{}")]))
+    explicit = {"type": "object", "properties": {"other": {"type": "string"}}}
+
+    await client.get_response(
+        messages=[Message(role="user", contents=[Content.from_text("Hi")])],
+        options={"response_format": Reply, "response_schema": explicit},
+    )
+
+    config: types.GenerateContentConfig = mock.aio.models.generate_content.call_args.kwargs["config"]
+    assert config.response_schema == explicit
+
+
 async def test_response_format_populates_value_on_chat_response() -> None:
     """When response_format is a Pydantic model, ChatResponse.value must be parsed from the response text."""
     from pydantic import BaseModel


### PR DESCRIPTION
### What

`response_format` accepts "a Pydantic model type or JSON schema mapping" per its own documentation, but only the mapping half reaches Gemini as a `response_schema`. A model class falls through `_extract_response_schema`, so the request goes out with `response_mime_type="application/json"` and no schema attached.

This converts the model class with `model_json_schema()`.

### Why it slipped through

#5893 fixed exactly this failure for mapping-shaped values, and said so explicitly — it extracts schemas from *"supported mapping-shaped `response_format` values"*. `_extract_response_schema` opens with `if not isinstance(response_format, Mapping): return None`, which is correct for that scope. The Pydantic class shape simply was not in it.

The existing tests sit either side of the gap without covering it:

- `test_response_format_sets_json_mime_type` passes a Pydantic model and asserts `response_mime_type`, but not `response_schema`.
- `test_response_format_populates_value_on_chat_response` asserts the inbound parse into that model, which works regardless.

So the outbound half is never checked for this shape, and the request has been going out unconstrained.

### Effect

Gemini is asked for JSON without being told what shape, and `_process_generate_response` then parses whatever comes back into the model the caller asked for. Depending on what the model returns, that is either a `ValidationError` the caller did not expect or — worse — JSON that happens to validate while ignoring the intent of the schema. It is #5888's failure mode on a different shape.

### Consistency with the other clients

`_prepare_response_format` in Mistral, `_prepare_output_config` in Bedrock, and the Anthropic equivalent all branch on `isinstance(x, type) and issubclass(x, BaseModel)` and call `model_json_schema()`. Gemini was the one client in that group without the branch. Ollama had the same gap and it was closed in #6782.

### Tests

Two added:

- `test_response_format_pydantic_model_sets_response_schema` — the regression. Verified red-before-green: with the source change reverted it fails with `assert None == {'properties': {'text': ...}, 'title': 'Reply', 'type': 'object'}`, `None` being `GenerateContentConfig(response_mime_type='application/json').response_schema`.
- `test_response_schema_option_wins_over_pydantic_response_format` — a guard that an explicit `response_schema` still takes precedence, as it already does for mapping shapes.

`ruff check` and `ruff format --check` are clean on the package.

**On the suite run:** `packages/gemini/tests/` hangs for me on the same test before and after this change — 146 tests pass then it stalls in an asyncio loop on `main`, 148 with these two added, no failures either way. It looks environmental on my machine rather than related to this diff, but flagging it rather than claiming a clean full-suite run I did not get.

### One question

The docstring already promised Pydantic support, so I treated this as a defect rather than a feature and kept the change to the one branch. If you would rather `_extract_response_schema` stay mapping-only and have the conversion happen upstream where the option is validated, say so and I will move it — I did not want to widen the surface without asking.
