### PR TITLE
Python: preserve message roles in ClaudeAgent._format_prompt

### DIFF
--- a/python/packages/claude/agent_framework_claude/_agent.py
+++ b/python/packages/claude/agent_framework_claude/_agent.py
@@ -733,6 +733,14 @@ class RawClaudeAgent(BaseAgent, Generic[OptionsT]):
     def _format_prompt(self, messages: list[Message] | None) -> str:
         """Format messages into a prompt string.
 
+        The Claude Agent SDK's streaming-input protocol only accepts ``user``-role
+        turns (it generates its own ``assistant`` turns), so a multi-message,
+        multi-role ``messages`` list can't be forwarded with real per-message
+        roles. Instead, when more than a single plain user turn is given (e.g. an
+        agent receiving prior turns from other agents and the user in a
+        multi-agent orchestration), each message is prefixed with its role so
+        Claude can still tell the turns apart from the text itself.
+
         Args:
             messages: List of chat messages.
 
@@ -741,7 +749,9 @@ class RawClaudeAgent(BaseAgent, Generic[OptionsT]):
         """
         if not messages:
             return ""
-        return "\n".join([msg.text or "" for msg in messages])
+        if len(messages) == 1 and messages[0].role == "user":
+            return messages[0].text or ""
+        return "\n".join(f"[{msg.role}]: {msg.text or ''}" for msg in messages)
 
     @property
     def default_options(self) -> dict[str, Any]:

--- a/python/packages/claude/tests/test_claude_agent.py
+++ b/python/packages/claude/tests/test_claude_agent.py
@@ -1026,6 +1026,29 @@ class TestFormatPrompt:
         assert "Hello!" in result
         assert "How are you?" in result
 
+    def test_format_multiple_messages_preserves_roles(self) -> None:
+        """Multi-message input (e.g. multi-agent orchestration history) must keep
+        each message's role visible in the text, since the Claude Agent SDK's
+        streaming-input protocol only accepts user-role turns and can't carry
+        per-message roles on the wire."""
+        agent = ClaudeAgent()
+        messages = [
+            Message(role="assistant", contents=[Content.from_text(text="Researcher: Paris is the capital.")]),
+            Message(role="user", contents=[Content.from_text(text="Critic: verify that.")]),
+            Message(role="assistant", contents=[Content.from_text(text="Researcher: confirmed.")]),
+        ]
+        result = agent._format_prompt(messages)  # type: ignore[reportPrivateUsage]
+        assert "[assistant]: Researcher: Paris is the capital." in result
+        assert "[user]: Critic: verify that." in result
+        assert "[assistant]: Researcher: confirmed." in result
+
+    def test_format_single_user_message_has_no_role_label(self) -> None:
+        """The common single-turn case is left unlabeled for backward compatibility."""
+        agent = ClaudeAgent()
+        msg = Message(role="user", contents=[Content.from_text(text="Hello")])
+        result = agent._format_prompt([msg])  # type: ignore[reportPrivateUsage]
+        assert result == "Hello"
+
 
 # region Test Build Options
 


### PR DESCRIPTION
### Motivation & Context

`ClaudeAgent._format_prompt()` joins every message's text together with no role information at all, so a multi-agent orchestration (`SequentialBuilder`/`ConcurrentBuilder`) that hands an agent the accumulated conversation — including other agents' and the user's turns — loses all of that structure by the time Claude sees it. Everything reads as one undifferentiated blob sent as a single `user`-role turn, making it impossible for the agent to tell who said what.

Fixes #7894.

### Description & Review Guide

- **What are the major changes?** When there's more than a single plain user turn, `_format_prompt()` now labels each message with its role as visible text (`[user]: ...` / `[assistant]: ...`) before flattening. The common single-user-message case is left exactly as it was, to avoid changing behavior for the overwhelming majority of calls.
- **What is the impact of these changes?** Multi-agent orchestration scenarios that pass `ClaudeAgent` accumulated conversation history now let Claude distinguish prior turns by role, instead of seeing an undifferentiated blob.
- **What do you want reviewers to focus on?** I originally proposed sending real per-message roles through the SDK's async-iterable `query()` input (see the issue discussion), but testing that against the actual CLI showed the streaming-input protocol rejects any role other than `user` outright (`Error: Expected message role 'user', got 'assistant'`) — it generates its own assistant turns and won't accept synthetic ones. The text-label approach here is what the CLI actually allows.

### Related Issue

Fixes #7894

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

---

Verification:
- Added two tests: one confirming multi-message input keeps role labels, one confirming the single-user-turn case is unchanged. Confirmed the new multi-role test fails on unpatched code and passes after the fix (`git stash` isolation).
- Full `packages/claude/tests/` suite passes (72 tests).
- `ruff check` / `ruff format --check` clean on both changed files.
- `mypy` on the changed file shows the same 2 pre-existing, unrelated errors present on a clean `main` checkout (confirmed via `git stash`) — nothing introduced by this change.
