### PR TITLE
Python: Fix input mutation in SerializationMixin.from_dict

### DIFF
--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -569,7 +569,7 @@ class SerializationMixin:
                             and param_name in kwargs
                             and isinstance(kwargs[param_name], dict)
                         ):
-                            kwargs[param_name].update(param_value)
+                            kwargs[param_name] = {**kwargs[param_name], **param_value}
                         else:
                             kwargs[param_name] = param_value
             else:
@@ -581,7 +581,7 @@ class SerializationMixin:
                     )
                 # Handle dict parameters - merge if both are dicts
                 if isinstance(dep_value, dict) and dep_key in kwargs and isinstance(kwargs[dep_key], dict):
-                    kwargs[dep_key].update(dep_value)
+                    kwargs[dep_key] = {**kwargs[dep_key], **dep_value}
                 else:
                     kwargs[dep_key] = dep_value
 

--- a/python/packages/core/tests/core/test_serializable_mixin.py
+++ b/python/packages/core/tests/core/test_serializable_mixin.py
@@ -2,6 +2,7 @@
 
 """Tests for SerializationMixin functionality."""
 
+import copy
 import logging
 from typing import Any
 
@@ -570,3 +571,113 @@ class TestSerializationMixin:
         # Normal field: deep-copied
         assert cloned.items is not obj.items
         assert cloned.items == ["a"]
+
+    def test_dependency_dict_merge_does_not_mutate_input(self):
+        """Test that dict dependency merging does not mutate the caller's input dictionary."""
+
+        class TestClass(SerializationMixin):
+            INJECTABLE = {"config"}
+
+            def __init__(self, name: str, config: dict | None = None):
+                self.name = name
+                self.config = config or {}
+
+        # Create input with nested dict
+        input_data = {"type": "test_class", "name": "test", "config": {"base": True}}
+        original_input = copy.deepcopy(input_data)
+
+        # Call from_dict with dict-shaped dependency
+        dependencies = {"test_class": {"config": {"injected": True}}}
+        obj = TestClass.from_dict(input_data, dependencies=dependencies)
+
+        # Verify the object received the merged values
+        assert obj.config["base"] is True
+        assert obj.config["injected"] is True
+
+        # Verify the input was NOT mutated
+        assert input_data == original_input
+        assert input_data["config"] == {"base": True}
+        assert "injected" not in input_data["config"]
+
+    def test_dependency_dict_merge_preserves_override_semantics(self):
+        """Test that dict dependency merging preserves existing override behavior."""
+
+        class TestClass(SerializationMixin):
+            INJECTABLE = {"options"}
+
+            def __init__(self, name: str, options: dict | None = None):
+                self.name = name
+                self.options = options or {}
+
+        # Existing options in data
+        data = {"type": "test_class", "name": "test", "options": {"timeout": 10, "name": "original"}}
+        # Dependency with conflicting and new keys
+        dependencies = {"test_class": {"options": {"timeout": 20, "new_key": "value"}}}
+
+        obj = TestClass.from_dict(data, dependencies=dependencies)
+
+        # Dependency values should override existing values
+        assert obj.options["timeout"] == 20  # Overridden by dependency
+        assert obj.options["name"] == "original"  # Preserved from original
+        assert obj.options["new_key"] == "value"  # Added from dependency
+
+    def test_repeated_from_dict_calls_do_not_leak_state(self):
+        """Test that reusing the same input dictionary across calls does not leak state."""
+
+        class TestClass(SerializationMixin):
+            INJECTABLE = {"config"}
+
+            def __init__(self, name: str, config: dict | None = None):
+                self.name = name
+                self.config = config or {}
+
+        # Shared input specification
+        spec = {"type": "test_class", "name": "test", "config": {"base": True}}
+        original_spec = copy.deepcopy(spec)
+
+        # First call with first dependency
+        first = TestClass.from_dict(spec, dependencies={"test_class": {"config": {"first": True}}})
+
+        # Verify first result
+        assert first.config["base"] is True
+        assert first.config["first"] is True
+        assert "second" not in first.config
+
+        # Second call with second dependency (reusing same spec)
+        second = TestClass.from_dict(spec, dependencies={"test_class": {"config": {"second": True}}})
+
+        # Verify second result does NOT leak state from first call
+        assert second.config["base"] is True
+        assert second.config["second"] is True
+        assert "first" not in second.config
+
+        # Verify the original spec was never mutated
+        assert spec == original_spec
+        assert spec["config"] == {"base": True}
+
+    def test_instance_specific_dict_merge_does_not_mutate_input(self):
+        """Test that instance-specific dict dependency merging does not mutate input."""
+
+        class TestClass(SerializationMixin):
+            INJECTABLE = {"config"}
+
+            def __init__(self, name: str, config: dict | None = None):
+                self.name = name
+                self.config = config or {}
+
+        # Create input with nested dict
+        input_data = {"type": "test_class", "name": "special_instance", "config": {"base": True}}
+        original_input = copy.deepcopy(input_data)
+
+        # Call from_dict with instance-specific dict-shaped dependency
+        dependencies = {"test_class": {"name:special_instance": {"config": {"injected": True}}}}
+        obj = TestClass.from_dict(input_data, dependencies=dependencies)
+
+        # Verify the object received the merged values
+        assert obj.config["base"] is True
+        assert obj.config["injected"] is True
+
+        # Verify the input was NOT mutated
+        assert input_data == original_input
+        assert input_data["config"] == {"base": True}
+        assert "injected" not in input_data["config"]


### PR DESCRIPTION
### Motivation & Context

`SerializationMixin.from_dict()` can unexpectedly mutate nested dictionaries in the caller-provided input when dictionary-shaped dependencies are merged during deserialization.

The method creates a shallow copy of the input dictionary, so nested dictionaries remain shared with the original input. The subsequent in-place `.update()` operations therefore modify the caller's input.

This can cause unexpected state to persist when the same serialized specification is reused across multiple `from_dict()` calls. In particular, dependency data injected during one reconstruction can leak into subsequent reconstructions.

This change fixes that behavior while preserving the existing dictionary dependency merge semantics and dependency precedence.

### Description & Review Guide

* **What are the major changes?**

  * Replaced the two in-place dictionary `.update()` operations in `SerializationMixin.from_dict()` with non-mutating dictionary merges.
  * Added regression tests covering both dictionary dependency merge paths.
  * Added coverage to verify that repeated `from_dict()` calls using the same input do not leak dependency state.
  * Added coverage to verify that existing dependency override/merge behavior is preserved.

* **What is the impact of these changes?**

  * The caller-provided input dictionary is no longer modified by dictionary dependency merging.
  * Existing dictionary merge behavior remains unchanged, including dependency values overriding conflicting keys.
  * No public API or serialization format is changed.
  * This is a focused bug fix with no intended impact on unrelated serialization or dependency-injection behavior.

* **What do you want reviewers to focus on?**

  * Whether the non-mutating dictionary merge is the appropriate way to preserve the existing dependency merge semantics.
  * Whether the regression tests adequately cover both dependency merge paths and prevent cross-call state leakage.

### Related Issue

Fixes #7899

### Contribution Checklist

* [x] The code builds clean without any errors or warnings
* [x] All unit tests pass, and I have added new tests where possible
* [x] The PR follows the [[Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
* [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
* [x] **This is not a breaking change.**