### PR TITLE
Python: Discard unsafe Content fields during deepcopy

### DIFF
--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -601,7 +601,7 @@ class Content:
         for k, v in self.__dict__.items():
             if k in shallow:
                 if v is not None:
-                    logger.warning("Discarding field '%s' while deep-copying Content.", k)
+                    logger.debug("Discarding field '%s' while deep-copying Content.", k)
                 object.__setattr__(result, k, None)
             else:
                 object.__setattr__(result, k, deepcopy(v, memo))

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -589,10 +589,10 @@ class Content:
         self.consent_link = consent_link
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Content:
-        """Create a deep copy, preserving ``_SHALLOW_COPY_FIELDS`` by reference.
+        """Create a deep copy, discarding non-empty ``_SHALLOW_COPY_FIELDS``.
 
         Fields listed in ``_SHALLOW_COPY_FIELDS`` may contain LLM SDK objects
-        (e.g., proto/gRPC responses) that are not safe to deep-copy.
+        (e.g., proto/gRPC responses) that are not safe to deep-copy or share.
         """
         cls = type(self)
         result = cls.__new__(cls)
@@ -600,7 +600,9 @@ class Content:
         shallow = cls._SHALLOW_COPY_FIELDS
         for k, v in self.__dict__.items():
             if k in shallow:
-                object.__setattr__(result, k, v)
+                if v is not None:
+                    logger.warning("Discarding field '%s' while deep-copying Content.", k)
+                object.__setattr__(result, k, None)
             else:
                 object.__setattr__(result, k, deepcopy(v, memo))
         return result

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -589,7 +589,7 @@ class Content:
         self.consent_link = consent_link
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Content:
-        """Create a deep copy, discarding non-empty ``_SHALLOW_COPY_FIELDS``.
+        """Create a deep copy, discarding non-``None`` ``_SHALLOW_COPY_FIELDS``.
 
         Fields listed in ``_SHALLOW_COPY_FIELDS`` may contain LLM SDK objects
         (e.g., proto/gRPC responses) that are not safe to deep-copy or share.

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -2501,13 +2501,13 @@ class _NonCopyableRaw:
 
 
 def test_content_deepcopy_discards_raw_representation(caplog: pytest.LogCaptureFixture) -> None:
-    """Test that deepcopy of Content discards raw_representation and logs a warning."""
+    """Test that deepcopy of Content discards raw_representation and logs at debug level."""
     import copy
 
     raw = _NonCopyableRaw()
     content = Content.from_text("hello", raw_representation=raw)
 
-    with caplog.at_level("WARNING", logger="agent_framework"):
+    with caplog.at_level("DEBUG", logger="agent_framework"):
         cloned = copy.deepcopy(content)
 
     assert cloned.text == "hello"
@@ -2619,14 +2619,14 @@ def test_nested_deepcopy_preserves_raw_representation():
     assert cloned.text == "hello"
 
 
-def test_content_deepcopy_does_not_warn_for_empty_shallow_copy_fields(caplog: pytest.LogCaptureFixture) -> None:
-    """Test that empty shallow-copy fields do not emit discard warnings."""
+def test_content_deepcopy_does_not_log_for_empty_shallow_copy_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that empty shallow-copy fields do not emit discard logs."""
     import copy
 
     content = Content.from_text("hello")
     content.additional_properties["key"] = "value"
 
-    with caplog.at_level("WARNING", logger="agent_framework"):
+    with caplog.at_level("DEBUG", logger="agent_framework"):
         cloned = copy.deepcopy(content)
 
     assert cloned.raw_representation is None

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -1197,7 +1197,7 @@ def test_chat_response_updates_to_chat_response_multiple_multiple():
     assert len(chat_response.messages) == 1
     assert isinstance(chat_response.messages[0], Message)
     assert chat_response.messages[0].message_id == "1"
-    assert chat_response.messages[0].contents[0].raw_representation is not None
+    assert chat_response.messages[0].contents[0].raw_representation is None
 
     assert len(chat_response.messages[0].contents) == 3
     assert chat_response.messages[0].contents[0].type == "text"
@@ -1796,17 +1796,17 @@ def test_response_update_propagates_fields_and_metadata():
     assert resp.messages[0].message_id == "mid"
 
 
-def test_text_coalescing_preserves_first_properties():
+def test_text_coalescing_preserves_first_serializable_properties():
     t1 = Content.from_text("A", raw_representation={"r": 1}, additional_properties={"p": 1})
     t2 = Content.from_text("B")
     upd1 = ChatResponseUpdate(contents=[t1], message_id="x")
     upd2 = ChatResponseUpdate(contents=[t2], message_id="x")
     resp = ChatResponse.from_updates([upd1, upd2])
-    # After coalescing there should be a single TextContent with merged text and preserved props from first
+    # After coalescing there should be a single TextContent with merged text and serializable props from first.
     items = [c for c in resp.messages[0].contents if c.type == "text"]
     assert len(items) >= 1
     assert items[0].text == "AB"
-    assert items[0].raw_representation == {"r": 1}
+    assert items[0].raw_representation is None
     assert items[0].additional_properties == {"p": 1}
 
 
@@ -2500,18 +2500,20 @@ class _NonCopyableRaw:
         raise TypeError("Cannot deepcopy this object")
 
 
-def test_content_deepcopy_preserves_raw_representation():
-    """Test that deepcopy of Content keeps raw_representation by reference."""
+def test_content_deepcopy_discards_raw_representation(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that deepcopy of Content discards raw_representation and logs a warning."""
     import copy
 
     raw = _NonCopyableRaw()
     content = Content.from_text("hello", raw_representation=raw)
 
-    cloned = copy.deepcopy(content)
+    with caplog.at_level("WARNING", logger="agent_framework"):
+        cloned = copy.deepcopy(content)
 
     assert cloned.text == "hello"
-    assert cloned.raw_representation is raw
+    assert cloned.raw_representation is None
     assert cloned.additional_properties is not content.additional_properties
+    assert caplog.messages == ["Discarding field 'raw_representation' while deep-copying Content."]
 
 
 def test_message_deepcopy_preserves_raw_representation():
@@ -2617,21 +2619,20 @@ def test_nested_deepcopy_preserves_raw_representation():
     assert cloned.text == "hello"
 
 
-def test_content_deepcopy_shallow_copy_fields_identity():
-    """Test that Content._SHALLOW_COPY_FIELDS fields are identity-preserved while others are deep-copied."""
+def test_content_deepcopy_does_not_warn_for_empty_shallow_copy_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that empty shallow-copy fields do not emit discard warnings."""
     import copy
 
-    raw = _NonCopyableRaw()
-    content = Content.from_text("hello", raw_representation=raw)
+    content = Content.from_text("hello")
     content.additional_properties["key"] = "value"
 
-    cloned = copy.deepcopy(content)
+    with caplog.at_level("WARNING", logger="agent_framework"):
+        cloned = copy.deepcopy(content)
 
-    # _SHALLOW_COPY_FIELDS (raw_representation) should be same object
-    assert cloned.raw_representation is raw
-    # Non-shallow fields should be independent deep copies
+    assert cloned.raw_representation is None
     assert cloned.additional_properties is not content.additional_properties
     assert cloned.additional_properties == {"key": "value"}
+    assert caplog.messages == []
 
 
 def test_chat_response_deepcopy_deep_copies_additional_properties():


### PR DESCRIPTION
### Motivation & Context

`Content.__deepcopy__` currently keeps fields listed in `_SHALLOW_COPY_FIELDS` by reference. This creates a partially deep-copied object that can still share mutable provider SDK state with the original. The issue proposes discarding designated unsafe data and logging the loss so deepcopy retains isolation without failing on opaque provider objects.

### Description & Review Guide

- **What are the major changes?**
  - Set every non-`None` `Content._SHALLOW_COPY_FIELDS` value to `None` in the clone and emit a warning.
  - Continue deep-copying all other `Content` fields normally.
  - Update direct deepcopy, response aggregation, and text-coalescing tests for the new contract.
- **What is the impact of these changes?**
  - Deep-copied `Content` objects no longer share provider-specific raw state with their source.
  - Callers that inspect `raw_representation` after a `Content` deepcopy will receive `None`; the original object remains unchanged.
  - `SerializationMixin` behavior is intentionally unchanged because #7851 is scoped to `Content`.
- **What do you want reviewers to focus on?**
  - Whether fields explicitly classified in `_SHALLOW_COPY_FIELDS` should always be discarded, rather than copied on a best-effort basis.


### Related Issue

Fixes #7851

This is an alternative to #7898. That PR first attempts to deepcopy marked values and discards them only on failure, and it also changes `SerializationMixin`. This PR applies the issue's narrower `Content` contract directly: every non-`None` designated unsafe value is discarded. Besides avoiding copies of values already classified as unsafe, this approach cannot leave partial entries in the shared deepcopy memo after a failed best-effort copy.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.