### PR TITLE
Add Python-wide code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,20 +50,20 @@
 
 # Python packages
 /python/packages/a2a/                                           @chetantoshniwal @giles17 @eavanvalkenburg @moonbox3
-/python/packages/ag-ui/                                         @chetantoshniwal @moonbox3 @giles17
+/python/packages/ag-ui/                                         @chetantoshniwal @eavanvalkenburg @moonbox3 @giles17
 /python/packages/anthropic/                                     @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/azure-ai-search/                               @chetantoshniwal @eavanvalkenburg @giles17
 /python/packages/azure-contentunderstanding/                    @chetantoshniwal @giles17 @eavanvalkenburg
 /python/packages/azure-cosmos/                                  @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/azure-cosmos-memory/                           @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/bedrock/                                       @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
-/python/packages/chatkit/                                       @chetantoshniwal @moonbox3 @giles17
+/python/packages/chatkit/                                       @chetantoshniwal @eavanvalkenburg @moonbox3 @giles17
 /python/packages/claude/                                        @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/copilotstudio/                                 @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/core/                                          @chetantoshniwal @eavanvalkenburg @moonbox3 @TaoChenOSU @giles17
-/python/packages/core/agent_framework/_workflows/               @chetantoshniwal @moonbox3 @TaoChenOSU
+/python/packages/core/agent_framework/_workflows/               @chetantoshniwal @eavanvalkenburg @moonbox3 @TaoChenOSU
 /python/packages/core/agent_framework/_harness/                 @chetantoshniwal @westey-m @eavanvalkenburg @moonbox3
-/python/packages/declarative/                                   @chetantoshniwal @moonbox3 @peibekwe
+/python/packages/declarative/                                   @chetantoshniwal @eavanvalkenburg @moonbox3 @peibekwe
 /python/packages/devui/                                         @chetantoshniwal @eavanvalkenburg @moonbox3
 /python/packages/foundry/                                       @chetantoshniwal @eavanvalkenburg @TaoChenOSU @moonbox3 @giles17
 /python/packages/foundry_hosting/                               @chetantoshniwal @TaoChenOSU @eavanvalkenburg @moonbox3
@@ -82,7 +82,7 @@
 /python/packages/monty/                                         @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/ollama/                                        @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/openai/                                        @chetantoshniwal @eavanvalkenburg @moonbox3 @TaoChenOSU @giles17
-/python/packages/orchestrations/                                @chetantoshniwal @moonbox3 @TaoChenOSU
+/python/packages/orchestrations/                                @chetantoshniwal @eavanvalkenburg @moonbox3 @TaoChenOSU
 /python/packages/purview/                                       @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/redis/                                         @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3
 /python/packages/tools/                                         @chetantoshniwal @eavanvalkenburg @giles17 @moonbox3


### PR DESCRIPTION
### Motivation & Context

Ensure Python ownership is consistent across the repository so `@eavanvalkenburg` is requested for reviews throughout the Python codebase, including paths with package-specific overrides.

### Description & Review Guide

- **What are the major changes?** Added `@eavanvalkenburg` to the five Python-specific CODEOWNERS rules that previously overrode the broader `/python` rule without including that owner.
- **What is the impact of these changes?** Changes under `ag-ui`, `chatkit`, core workflows, `declarative`, and `orchestrations` will now include `@eavanvalkenburg` as a code owner.
- **What do you want reviewers to focus on?** Confirm that every Python CODEOWNERS pattern now includes `@eavanvalkenburg`.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

N/A — repository ownership maintenance requested directly.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.