### PR TITLE
Python: Bump package versions for 1.16.0 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-27
+
+### Added
+- **agent-framework-core**: Add configurable timeouts for waiting on the first background-agent task completion ([#7908](https://github.com/microsoft/agent-framework/pull/7908))
+- **agent-framework-core**: Allow programmatic OpenTelemetry service metadata, resource attributes, and OTLP exporter configuration ([#7703](https://github.com/microsoft/agent-framework/pull/7703))
+
+### Changed
+- **agent-framework-foundry-hosting**: Update Agent Server dependencies and expose parent `FoundryToolbox` constructor options ([#7921](https://github.com/microsoft/agent-framework/pull/7921))
+- **samples**: Apply ChatKit attachment lifecycle checks consistently in the end-to-end sample ([#7846](https://github.com/microsoft/agent-framework/pull/7846))
+
+### Fixed
+- **agent-framework-ag-ui**, **agent-framework-foundry-hosting**: Preserve backend-owned service-session snapshots and validate incremental provider continuation input ([#7770](https://github.com/microsoft/agent-framework/pull/7770))
+- **agent-framework-anthropic**, **agent-framework-mistral**: Preserve unmapped provider finish reasons ([#7850](https://github.com/microsoft/agent-framework/pull/7850))
+- **agent-framework-azure-ai-search**: Preserve the kinds of heterogeneous knowledge sources ([#7875](https://github.com/microsoft/agent-framework/pull/7875))
+- **agent-framework-core**: Prevent workflow checkpoints from being mutated outside storage implementations ([#7847](https://github.com/microsoft/agent-framework/pull/7847))
+- **agent-framework-core**: Discard unsafe `Content` fields during deep copy ([#7903](https://github.com/microsoft/agent-framework/pull/7903))
+- **agent-framework-core**: Avoid mutating caller input in `SerializationMixin.from_dict()` ([#7901](https://github.com/microsoft/agent-framework/pull/7901))
+- **agent-framework-core**: Keep the private agent-loop iteration marker out of provider SDK requests ([#7860](https://github.com/microsoft/agent-framework/pull/7860))
+- **agent-framework-gemini**: Preserve unmapped finish reasons and attach usage details to the correct response ([#7837](https://github.com/microsoft/agent-framework/pull/7837))
+- **agent-framework-openai**: Preserve streaming when GenAI instrumentation replaces the raw SDK response ([#7705](https://github.com/microsoft/agent-framework/pull/7705))
+
 ## [1.15.0] - 2026-08-21
 
 ### Added
@@ -1555,7 +1576,8 @@ Release candidate for **agent-framework-core** and **agent-framework-azure-ai** 
 
 For more information, see the [announcement blog post](https://devblogs.microsoft.com/foundry/introducing-microsoft-agent-framework-the-open-source-engine-for-agentic-ai-apps/).
 
-[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.15.0...HEAD
+[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.16.0...HEAD
+[1.16.0]: https://github.com/microsoft/agent-framework/compare/python-1.15.0...python-1.16.0
 [1.15.0]: https://github.com/microsoft/agent-framework/compare/python-1.14.0...python-1.15.0
 [1.14.0]: https://github.com/microsoft/agent-framework/compare/python-1.13.0...python-1.14.0
 [1.13.0]: https://github.com/microsoft/agent-framework/compare/python-1.12.1...python-1.13.0

--- a/python/packages/ag-ui/pyproject.toml
+++ b/python/packages/ag-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-framework-ag-ui"
-version = "1.2.0"
+version = "1.2.1"
 description = "AG-UI protocol integration for Agent Framework"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/python/packages/anthropic/pyproject.toml
+++ b/python/packages/anthropic/pyproject.toml
@@ -4,7 +4,7 @@ description = "Anthropic integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260827"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/azure-ai-search/pyproject.toml
+++ b/python/packages/azure-ai-search/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure AI Search integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.15.0"
+version = "1.16.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/foundry_hosting/pyproject.toml
+++ b/python/packages/foundry_hosting/pyproject.toml
@@ -4,7 +4,7 @@ description = "Foundry Hosting integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260827"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/gemini/pyproject.toml
+++ b/python/packages/gemini/pyproject.toml
@@ -4,7 +4,7 @@ description = "Google Gemini integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/mistral/pyproject.toml
+++ b/python/packages/mistral/pyproject.toml
@@ -4,7 +4,7 @@ description = "Mistral AI integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 license-files = ["LICENSE"]
 urls.homepage = "https://learn.microsoft.com/en-us/agent-framework/"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/openai/pyproject.toml
+++ b/python/packages/openai/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.14.0"
+version = "1.14.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.15.0"
+version = "1.16.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core[all]==1.15.0",
+    "agent-framework-core[all]==1.16.0",
 ]
 
 [dependency-groups]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.15.0"
+version = "1.16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"] },
@@ -206,7 +206,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-ag-ui"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "packages/ag-ui" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -248,7 +248,7 @@ test = [{ name = "agent-framework-orchestrations", editable = "packages/orchestr
 
 [[package]]
 name = "agent-framework-anthropic"
-version = "1.0.0b260821"
+version = "1.0.0b260827"
 source = { editable = "packages/anthropic" }
 dependencies = [
     { name = "agent-framework-core" },
@@ -263,7 +263,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azure-ai-search"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 source = { editable = "packages/azure-ai-search" }
 dependencies = [
     { name = "agent-framework-core" },
@@ -428,7 +428,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "msgspec" },
@@ -629,7 +629,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-foundry-hosting"
-version = "1.0.0b260821"
+version = "1.0.0b260827"
 source = { editable = "packages/foundry_hosting" }
 dependencies = [
     { name = "agent-framework-core" },
@@ -669,7 +669,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-gemini"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 source = { editable = "packages/gemini" }
 dependencies = [
     { name = "agent-framework-core" },
@@ -907,7 +907,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-mistral"
-version = "1.0.0b260813"
+version = "1.0.0b260827"
 source = { editable = "packages/mistral" }
 dependencies = [
     { name = "agent-framework-core" },
@@ -952,7 +952,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-openai"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "agent-framework-core" },


### PR DESCRIPTION
### Motivation & Context

The Python packages need a coordinated 1.16.0 release so the features and fixes merged since 1.15.0 can be published with consistent package metadata, release notes, and lockfile state.

### Description & Review Guide

- **What are the major changes?** Bumps the root package and core to 1.16.0; applies targeted patch bumps to AG-UI 1.2.1 and OpenAI 1.14.1; date-stamps the changed Anthropic, Azure AI Search, Foundry Hosting, Gemini, and Mistral beta packages; updates the CHANGELOG and comparison links; and minimally updates `uv.lock` for those package versions.
- **What is the impact of these changes?** Publishes only packages with shipping changes. Existing core dependency floors remain unchanged because the affected extensions do not consume new core 1.16 APIs, the unchanged beta cohort is not bumped, and Foundry remains unchanged because its only changes were tests. The release validator completed 16 of 18 aggregate probes; the two aggregate failures did not select the required `azure-ai-agentserver-responses==2.2.0b1` prerelease, while both direct Foundry Hosting lower and upper probes resolved that exact version successfully.
- **What do you want reviewers to focus on?** Confirm the CHANGELOG-to-package bump mapping, the intentionally retained compatibility floors, the Foundry tests-only exclusion, and the minimal lockfile delta.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No linked issue; this is scheduled Python release preparation. No competing Python 1.16.0 release PR was open when this PR was created.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
