### PR TITLE
.NET: Fix duplicate Foundry AgentHost port binding

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
@@ -65,13 +65,14 @@ public static class FoundryHostingExtensions
     public static IServiceCollection AddFoundryResponses(this IServiceCollection services, Action<FoundryResponsesOptions>? configure = null)
     {
         _ = Throw.IfNull(services);
+        bool agentHostControlsListenPort = IsAgentHostBuilder(services);
         FoundryResponsesOptions configuredOptions = CreateFoundryResponsesOptions(configure);
         bool serverAdded = AddResponsesServerOnce(
             services,
             configuredOptions,
             configure is not null);
         services.AddHealthChecks();
-        ConfigureFoundryListenPort(services);
+        ConfigureFoundryListenPort(services, agentHostControlsListenPort);
         ConfigureFoundryResponsesOptions(
             services,
             configuredOptions,
@@ -121,13 +122,14 @@ public static class FoundryHostingExtensions
         _ = Throw.IfNull(services);
         _ = Throw.IfNull(agent);
 
+        bool agentHostControlsListenPort = IsAgentHostBuilder(services);
         FoundryResponsesOptions configuredOptions = CreateFoundryResponsesOptions(configure);
         bool serverAdded = AddResponsesServerOnce(
             services,
             configuredOptions,
             configure is not null);
         services.AddHealthChecks();
-        ConfigureFoundryListenPort(services);
+        ConfigureFoundryListenPort(services, agentHostControlsListenPort);
         ConfigureFoundryResponsesOptions(
             services,
             configuredOptions,
@@ -520,9 +522,10 @@ public static class FoundryHostingExtensions
     /// is resolved.
     /// </para>
     /// </remarks>
-    private static void ConfigureFoundryListenPort(IServiceCollection services)
+    private static void ConfigureFoundryListenPort(IServiceCollection services, bool agentHostControlsListenPort)
     {
-        if (services.Any(static d => d.ServiceType == typeof(FoundryListenPortMarker)))
+        if (agentHostControlsListenPort ||
+            services.Any(static d => d.ServiceType == typeof(FoundryListenPortMarker)))
         {
             return;
         }
@@ -539,6 +542,20 @@ public static class FoundryHostingExtensions
                 options.ListenAnyIP(ResolveListenPort(configuration));
             });
     }
+
+    /// <summary>
+    /// Detects the AgentServer builder, which configures its own Kestrel listener during
+    /// <c>AgentHostBuilder.Build()</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>AgentHostBuilder</c> registers its public <see cref="ServerVersionRegistry"/> instance
+    /// before callers add protocol services. A standalone <see cref="WebApplicationBuilder"/> does
+    /// not have that instance registration and still needs this package to configure the Foundry port.
+    /// </remarks>
+    private static bool IsAgentHostBuilder(IServiceCollection services) =>
+        services.Any(static descriptor =>
+            descriptor.ServiceType == typeof(ServerVersionRegistry) &&
+            descriptor.ImplementationInstance is ServerVersionRegistry);
 
     /// <summary>
     /// Reads the listen port from configuration, applying the same contract as

--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/ServiceCollectionExtensions.cs
@@ -12,9 +12,9 @@ using Azure.Core;
 using Azure.Identity;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,14 +65,13 @@ public static class FoundryHostingExtensions
     public static IServiceCollection AddFoundryResponses(this IServiceCollection services, Action<FoundryResponsesOptions>? configure = null)
     {
         _ = Throw.IfNull(services);
-        bool agentHostControlsListenPort = IsAgentHostBuilder(services);
         FoundryResponsesOptions configuredOptions = CreateFoundryResponsesOptions(configure);
         bool serverAdded = AddResponsesServerOnce(
             services,
             configuredOptions,
             configure is not null);
         services.AddHealthChecks();
-        ConfigureFoundryListenPort(services, agentHostControlsListenPort);
+        ConfigureFoundryListenPort(services);
         ConfigureFoundryResponsesOptions(
             services,
             configuredOptions,
@@ -122,14 +121,13 @@ public static class FoundryHostingExtensions
         _ = Throw.IfNull(services);
         _ = Throw.IfNull(agent);
 
-        bool agentHostControlsListenPort = IsAgentHostBuilder(services);
         FoundryResponsesOptions configuredOptions = CreateFoundryResponsesOptions(configure);
         bool serverAdded = AddResponsesServerOnce(
             services,
             configuredOptions,
             configure is not null);
         services.AddHealthChecks();
-        ConfigureFoundryListenPort(services, agentHostControlsListenPort);
+        ConfigureFoundryListenPort(services);
         ConfigureFoundryResponsesOptions(
             services,
             configuredOptions,
@@ -491,16 +489,14 @@ public static class FoundryHostingExtensions
     }
 
     /// <summary>
-    /// Binds Kestrel to the port the Foundry hosted runtime probes and routes to, so a plain
-    /// <c>WebApplication.CreateBuilder</c> host (Tier 3) works with no Dockerfile. Mirrors
-    /// <c>AgentHostBuilder</c>, which listens on the <c>PORT</c> value (default 8088).
+    /// Configures the URL used by a plain <c>WebApplication.CreateBuilder</c> host (Tier 3) so
+    /// it listens on the port the Foundry hosted runtime probes and routes to.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The listener is added only when configuration reports a Foundry container through
-    /// <see cref="FoundryHostingEnvironmentKey"/>. A listener configured in code overrides the
-    /// addresses a host resolves from configuration, so adding it everywhere would silently move
-    /// any non-Foundry app off its configured address.
+    /// The URL is configured only when configuration reports a Foundry container through
+    /// <see cref="FoundryHostingEnvironmentKey"/>. Outside Foundry the host keeps its configured
+    /// addresses.
     /// </para>
     /// <para>
     /// Both values come from <see cref="IConfiguration"/> rather than from
@@ -510,52 +506,42 @@ public static class FoundryHostingExtensions
     /// environment.
     /// </para>
     /// <para>
-    /// Inside a Foundry container the listener cannot be skipped based on <c>ASPNETCORE_URLS</c>:
-    /// the .NET base image always sets it to port 80, so such a guard would always trip and leave
-    /// the container failing the readiness probe with HTTP 424. It cannot key off the presence of
-    /// <c>PORT</c> either, because the platform sets that value only when it needs a port other
-    /// than the default.
+    /// Inside a Foundry container this replaces the URL inherited from the .NET base image. When
+    /// <c>AgentHostBuilder</c> is used, its code-configured Kestrel listener takes precedence over
+    /// this URL, so both hosting paths resolve to one listener without identifying the builder
+    /// from its service registrations.
     /// </para>
     /// <para>
-    /// Idempotent, and harmless when no Kestrel server is present (for example under
-    /// <c>TestServer</c>): the <see cref="KestrelServerOptions"/> callback only runs when Kestrel
-    /// is resolved.
+    /// The startup filter is resolved before ASP.NET reads the configured URLs and starts its
+    /// server. Registration is idempotent across repeated <c>AddFoundryResponses</c> calls.
     /// </para>
     /// </remarks>
-    private static void ConfigureFoundryListenPort(IServiceCollection services, bool agentHostControlsListenPort)
+    private static void ConfigureFoundryListenPort(IServiceCollection services)
     {
-        if (agentHostControlsListenPort ||
-            services.Any(static d => d.ServiceType == typeof(FoundryListenPortMarker)))
+        if (services.Any(static d => d.ServiceType == typeof(FoundryListenPortMarker)))
         {
             return;
         }
 
         services.AddSingleton<FoundryListenPortMarker>();
-        services.AddOptions<KestrelServerOptions>()
-            .Configure<IConfiguration>(static (options, configuration) =>
-            {
-                if (string.IsNullOrEmpty(configuration[FoundryHostingEnvironmentKey]))
-                {
-                    return;
-                }
-
-                options.ListenAnyIP(ResolveListenPort(configuration));
-            });
+        services.AddSingleton<IStartupFilter, FoundryListenPortStartupFilter>();
     }
 
-    /// <summary>
-    /// Detects the AgentServer builder, which configures its own Kestrel listener during
-    /// <c>AgentHostBuilder.Build()</c>.
-    /// </summary>
-    /// <remarks>
-    /// <c>AgentHostBuilder</c> registers its public <see cref="ServerVersionRegistry"/> instance
-    /// before callers add protocol services. A standalone <see cref="WebApplicationBuilder"/> does
-    /// not have that instance registration and still needs this package to configure the Foundry port.
-    /// </remarks>
-    private static bool IsAgentHostBuilder(IServiceCollection services) =>
-        services.Any(static descriptor =>
-            descriptor.ServiceType == typeof(ServerVersionRegistry) &&
-            descriptor.ImplementationInstance is ServerVersionRegistry);
+    private sealed class FoundryListenPortStartupFilter : IStartupFilter
+    {
+        public FoundryListenPortStartupFilter(IConfiguration configuration)
+        {
+            // GenericWebHostService resolves startup filters before it reads this URL and starts
+            // the server, while a code-configured AgentHost listener takes precedence over it.
+            if (!string.IsNullOrEmpty(configuration[FoundryHostingEnvironmentKey]))
+            {
+                configuration[WebHostDefaults.ServerUrlsKey] =
+                    $"http://+:{ResolveListenPort(configuration)}";
+            }
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => next;
+    }
 
     /// <summary>
     /// Reads the listen port from configuration, applying the same contract as

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/Program.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests.TestContainer/Program.cs
@@ -51,6 +51,17 @@ AIAgent agent = scenario switch
     _ => throw new InvalidOperationException($"Unknown IT_SCENARIO '{scenario}'.")
 };
 
+if (scenario == "happy-path")
+{
+    var agentHostBuilder = AgentHost.CreateBuilder(args);
+    agentHostBuilder.Services.AddFoundryResponses(agent);
+    agentHostBuilder.RegisterProtocol("responses", endpoints => endpoints.MapFoundryResponses());
+
+    var agentHostApp = agentHostBuilder.Build();
+    agentHostApp.Run();
+    return;
+}
+
 var builder = WebApplication.CreateBuilder(args);
 
 var port = Environment.GetEnvironmentVariable("PORT");

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/HappyPathHostedAgentTests.cs
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/HappyPathHostedAgentTests.cs
@@ -7,8 +7,9 @@ using Foundry.Hosting.IntegrationTests.Fixtures;
 namespace Foundry.Hosting.IntegrationTests;
 
 /// <summary>
-/// Basic round trip, streaming, and container-instruction behaviour for a hosted Responses agent.
-/// Store and session semantics live in <see cref="HostedResponsesStoreConfigTests"/>.
+/// Basic round trip, streaming, and container-instruction behaviour for a hosted Responses agent
+/// whose server is created by <c>AgentHost.CreateBuilder</c>. Store and session semantics live in
+/// <see cref="HostedResponsesStoreConfigTests"/>.
 /// </summary>
 [Trait("Category", "FoundryHostedAgents")]
 public sealed class HappyPathHostedAgentTests(HappyPathHostedAgentFixture fixture) : IClassFixture<HappyPathHostedAgentFixture>
@@ -16,7 +17,7 @@ public sealed class HappyPathHostedAgentTests(HappyPathHostedAgentFixture fixtur
     private readonly HappyPathHostedAgentFixture _fixture = fixture;
 
     [Fact]
-    public async Task RunAsync_ReturnsNonEmptyTextAsync()
+    public async Task AgentHostBuilder_StartsAndHandlesRequestAsync()
     {
         // Arrange
         var agent = this._fixture.Agent;
@@ -26,6 +27,7 @@ public sealed class HappyPathHostedAgentTests(HappyPathHostedAgentFixture fixtur
 
         // Assert
         Assert.False(string.IsNullOrWhiteSpace(response.Text));
+        Assert.Contains("CONTAINER-OK", response.Text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/dotnet/tests/Foundry.Hosting.IntegrationTests/README.md
+++ b/dotnet/tests/Foundry.Hosting.IntegrationTests/README.md
@@ -31,6 +31,11 @@ the agent definition by each fixture, drives a `switch` in the test container's
 `Program.cs` to wire up the scenario specific behavior (tools, toolbox, custom storage,
 etc.).
 
+The `happy-path` scenario creates the server with `AgentHost.CreateBuilder`. This covers
+the recommended AgentServer builder, including its port and readiness configuration. The
+remaining scenarios use `WebApplication.CreateBuilder`, so every live run covers both
+supported hosting paths.
+
 ### Session sticky and user-identity scenario
 
 `HostedSessionAndUserIdentityTests` (fixture `UserIdentityHostedAgentFixture`, agent

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryListenPortTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryListenPortTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,9 +16,9 @@ namespace Microsoft.Agents.AI.Foundry.Hosting.UnitTests;
 
 /// <summary>
 /// Verifies that <c>AddFoundryResponses</c> adds a Kestrel listener on the Foundry hosted-runtime
-/// port for a plain <c>WebApplication.CreateBuilder</c> (Tier 3) host, so a source (ZIP) deployed
-/// agent passes the platform readiness probe with no Dockerfile pinning the port, and that it
-/// leaves the addresses of a host running outside Foundry alone.
+/// port for a plain <c>WebApplication.CreateBuilder</c> (Tier 3) host, does not duplicate the
+/// listener owned by <c>AgentHost.CreateBuilder</c> (Tier 2), and leaves the addresses of a host
+/// running outside Foundry alone.
 /// </summary>
 /// <remarks>
 /// Every case supplies its values through an in-memory <see cref="IConfiguration"/>, so no test
@@ -137,6 +138,46 @@ public sealed class FoundryListenPortTests
         Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
     }
 
+    [Fact]
+    public void AddFoundryResponses_WithStandaloneAgentServerCore_ListensOnFoundryPortOnce()
+    {
+        // Arrange
+        var services = CreateServices();
+        services.AddAgentServerCore();
+
+        // Act
+        services.AddFoundryResponses();
+
+        // Assert
+        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+    }
+
+    [Fact]
+    public async Task AddFoundryResponses_WithAgentHostBuilder_ListensOnFoundryPortOnceAsync()
+    {
+        // Arrange
+        var builder = AgentHost.CreateBuilder(
+        [
+            $"--{FoundryHostingExtensions.FoundryHostingEnvironmentKey}=foundry",
+        ]);
+        var mockAgent = new Mock<AIAgent>();
+        mockAgent.SetupGet(a => a.Name).Returns("test-agent");
+
+        // Act
+        builder.Services.AddFoundryResponses(mockAgent.Object);
+        var app = builder.Build();
+
+        // Assert
+        try
+        {
+            Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(app.App.Services));
+        }
+        finally
+        {
+            await app.App.DisposeAsync();
+        }
+    }
+
     /// <summary>
     /// Builds a service collection whose <see cref="IConfiguration"/> carries the supplied values,
     /// marking the process as Foundry-hosted unless <paramref name="hosted"/> says otherwise.
@@ -162,6 +203,11 @@ public sealed class FoundryListenPortTests
     private static List<int> GetCodeBackedPorts(IServiceCollection services)
     {
         using var provider = services.BuildServiceProvider();
+        return GetCodeBackedPorts(provider);
+    }
+
+    private static List<int> GetCodeBackedPorts(IServiceProvider provider)
+    {
         var options = provider.GetRequiredService<IOptions<KestrelServerOptions>>().Value;
 
         var property = typeof(KestrelServerOptions).GetProperty(

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryListenPortTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/FoundryListenPortTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,8 +27,6 @@ namespace Microsoft.Agents.AI.Foundry.Hosting.UnitTests;
 /// </remarks>
 public sealed class FoundryListenPortTests
 {
-    private const string AspNetCoreUrlsKey = "ASPNETCORE_URLS";
-
     [Fact]
     public void AddFoundryResponses_WhenHosted_ListensOnFoundryPort()
     {
@@ -38,7 +37,7 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
 
         // Assert
-        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -53,7 +52,7 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses(mockAgent.Object);
 
         // Assert
-        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -67,7 +66,7 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
 
         // Assert
-        Assert.Empty(GetCodeBackedPorts(services));
+        Assert.Null(GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -79,14 +78,14 @@ public sealed class FoundryListenPortTests
         // and fail every invocation with HTTP 424 session_not_ready.
         var services = CreateServices(settings: new Dictionary<string, string?>
         {
-            [AspNetCoreUrlsKey] = "http://+:80",
+            [WebHostDefaults.ServerUrlsKey] = "http://+:80",
         });
 
         // Act
         services.AddFoundryResponses();
 
         // Assert
-        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -102,7 +101,7 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
 
         // Assert
-        Assert.Equal([9099], GetCodeBackedPorts(services));
+        Assert.Equal("http://+:9099", GetConfiguredListenUrl(services));
     }
 
     [Theory]
@@ -119,12 +118,12 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
 
         // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() => GetCodeBackedPorts(services));
+        var exception = Assert.Throws<InvalidOperationException>(() => GetConfiguredListenUrl(services));
         Assert.Contains(port, exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void AddFoundryResponses_CalledTwiceWhenHosted_ListensOnFoundryPortOnce()
+    public void AddFoundryResponses_CalledTwiceWhenHosted_ConfiguresFoundryUrlIdempotently()
     {
         // Arrange
         var services = CreateServices();
@@ -133,9 +132,8 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
         services.AddFoundryResponses();
 
-        // Assert: a duplicate ListenAnyIP on the same port fails Kestrel startup with
-        // "address already in use", so the listener must be added exactly once.
-        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+        // Assert
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -149,7 +147,22 @@ public sealed class FoundryListenPortTests
         services.AddFoundryResponses();
 
         // Assert
-        Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(services));
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
+    }
+
+    [Fact]
+    public void AddFoundryResponses_WithStandaloneAgentServerCoreInstance_ListensOnFoundryPortOnce()
+    {
+        // Arrange
+        var services = CreateServices();
+        services.AddSingleton(new ServerVersionRegistry());
+        services.AddAgentServerCore();
+
+        // Act
+        services.AddFoundryResponses();
+
+        // Assert
+        Assert.Equal("http://+:8088", GetConfiguredListenUrl(services));
     }
 
     [Fact]
@@ -170,6 +183,7 @@ public sealed class FoundryListenPortTests
         // Assert
         try
         {
+            Assert.Equal("http://+:8088", GetConfiguredListenUrl(app.App.Services));
             Assert.Equal([FoundryHostingExtensions.DefaultListenPort], GetCodeBackedPorts(app.App.Services));
         }
         finally
@@ -196,16 +210,22 @@ public sealed class FoundryListenPortTests
         return services;
     }
 
-    /// <summary>
-    /// Builds the service provider, resolves the applied <see cref="KestrelServerOptions"/>, and
-    /// returns the ports of every code-configured listener (those added via <c>ListenAnyIP</c>).
-    /// </summary>
-    private static List<int> GetCodeBackedPorts(IServiceCollection services)
+    private static string? GetConfiguredListenUrl(IServiceCollection services)
     {
         using var provider = services.BuildServiceProvider();
-        return GetCodeBackedPorts(provider);
+        return GetConfiguredListenUrl(provider);
     }
 
+    private static string? GetConfiguredListenUrl(IServiceProvider provider)
+    {
+        // ASP.NET resolves startup filters before reading this URL and starting the server.
+        _ = provider.GetServices<IStartupFilter>();
+        return provider.GetRequiredService<IConfiguration>()[WebHostDefaults.ServerUrlsKey];
+    }
+
+    /// <summary>
+    /// Returns the ports of every code-configured listener, which are added via <c>ListenAnyIP</c>.
+    /// </summary>
     private static List<int> GetCodeBackedPorts(IServiceProvider provider)
     {
         var options = provider.GetRequiredService<IOptions<KestrelServerOptions>>().Value;


### PR DESCRIPTION
### Motivation & Context

`Microsoft.Agents.AI.Foundry.Hosting` added automatic port configuration for hosted applications created with `WebApplication.CreateBuilder`. Applications created with the documented `AgentHost.CreateBuilder` path already receive a Kestrel listener from AgentServer. Registering both listeners on port 8088 causes every hosted container to fail during startup and the client to receive HTTP 424 `session_not_ready`.

This change restores the documented `AgentHost.CreateBuilder` path while preserving automatic port configuration for standalone ASP.NET applications.

### Description & Review Guide

- **What are the major changes?** `AddFoundryResponses` now initializes the Foundry server URL through an ASP.NET startup filter before the server reads its configured addresses. A code-configured `AgentHostBuilder` listener takes precedence over that URL and remains the only Kestrel endpoint. A standalone `WebApplicationBuilder` uses the URL as its only listener. This avoids inferring the builder type from public service registrations. Unit tests cover both paths, including a standalone host with an explicit `ServerVersionRegistry` instance. The live hosted integration suite runs its `happy-path` scenario with `AgentHost.CreateBuilder`, while the remaining scenarios continue to cover `WebApplication.CreateBuilder`.
- **What is the impact of these changes?** Both supported hosting paths configure exactly one effective listener. Hosted containers using `AgentHost.CreateBuilder` can start and pass the readiness probe without requiring application changes or a package downgrade. Standalone hosts continue to override the base image URL with the Foundry port.
- **What do you want reviewers to focus on?** Please review the startup filter timing, the Kestrel address precedence, and the decision to cover both host builders within the existing live integration image.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #7617

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.