### PR TITLE
.NET: Avoid duplicate AG-UI conversation history

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -146,10 +146,11 @@ public static class AGUIEndpointRouteBuilderExtensions
             ctx.Input.ThreadId = threadId;
 
             var session = await hostAgent.GetOrCreateSessionAsync(threadId, cancellationToken).ConfigureAwait(false);
+            var messages = GetMessagesForRun(aiAgent, session, ctx.Messages);
 
             var events = hostAgent
                 .RunStreamingAsync(
-                    ctx.Messages,
+                    messages,
                     session: session,
                     options: new ChatClientAgentRunOptions { ChatOptions = ctx.ChatOptions },
                     cancellationToken: cancellationToken)
@@ -173,6 +174,92 @@ public static class AGUIEndpointRouteBuilderExtensions
 
         MarkFeatureUsed();
         return endpoint;
+    }
+
+    internal static IReadOnlyList<ChatMessage> GetMessagesForRun(
+        AIAgent agent,
+        AgentSession session,
+        List<ChatMessage> incomingMessages)
+    {
+        var chatClientAgent = agent.GetService<ChatClientAgent>();
+        var chatClientSession = session.GetService<ChatClientAgentSession>();
+        if (chatClientAgent is null || chatClientSession is null)
+        {
+            return incomingMessages;
+        }
+
+        if (chatClientAgent.ChatHistoryProvider is InMemoryChatHistoryProvider historyProvider &&
+            session.TryGetInMemoryChatHistory(out List<ChatMessage>? storedMessages, historyProvider.StateKeys[0]) &&
+            storedMessages.Count > 0)
+        {
+            return RemoveStoredHistory(incomingMessages, storedMessages);
+        }
+
+        if (!string.IsNullOrWhiteSpace(chatClientSession.ConversationId))
+        {
+            return GetCurrentTurnMessages(incomingMessages);
+        }
+
+        return incomingMessages;
+    }
+
+    private static List<ChatMessage> RemoveStoredHistory(
+        List<ChatMessage> incomingMessages,
+        List<ChatMessage> storedMessages)
+    {
+        string? lastStoredMessageId = storedMessages[^1].MessageId;
+        if (string.IsNullOrEmpty(lastStoredMessageId))
+        {
+            return incomingMessages;
+        }
+
+        // Leave at least one incoming message as the new turn, then match the preceding
+        // history backwards against the end of the stored conversation.
+        for (int historyEnd = incomingMessages.Count - 2; historyEnd >= 0; historyEnd--)
+        {
+            if (!string.Equals(lastStoredMessageId, incomingMessages[historyEnd].MessageId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int incomingIndex = historyEnd;
+            int storedIndex = storedMessages.Count - 1;
+            while (incomingIndex >= 0 && storedIndex >= 0)
+            {
+                string? storedMessageId = storedMessages[storedIndex].MessageId;
+                string? incomingMessageId = incomingMessages[incomingIndex].MessageId;
+                if (string.IsNullOrEmpty(storedMessageId) ||
+                    !string.Equals(storedMessageId, incomingMessageId, StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                incomingIndex--;
+                storedIndex--;
+            }
+
+            if (incomingIndex < 0)
+            {
+                int newMessagesStart = historyEnd + 1;
+                return incomingMessages.GetRange(newMessagesStart, incomingMessages.Count - newMessagesStart);
+            }
+        }
+
+        return incomingMessages;
+    }
+
+    private static List<ChatMessage> GetCurrentTurnMessages(List<ChatMessage> incomingMessages)
+    {
+        for (int i = incomingMessages.Count - 1; i >= 0; i--)
+        {
+            if (incomingMessages[i].Role == ChatRole.Assistant)
+            {
+                int newMessagesStart = i + 1;
+                return incomingMessages.GetRange(newMessagesStart, incomingMessages.Count - newMessagesStart);
+            }
+        }
+
+        return incomingMessages;
     }
 
     private static void MarkFeatureUsed()

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore/AGUIEndpointRouteBuilderExtensions.cs
@@ -207,45 +207,24 @@ public static class AGUIEndpointRouteBuilderExtensions
         List<ChatMessage> incomingMessages,
         List<ChatMessage> storedMessages)
     {
-        string? lastStoredMessageId = storedMessages[^1].MessageId;
-        if (string.IsNullOrEmpty(lastStoredMessageId))
+        if (incomingMessages.Count <= storedMessages.Count)
         {
             return incomingMessages;
         }
 
-        // Leave at least one incoming message as the new turn, then match the preceding
-        // history backwards against the end of the stored conversation.
-        for (int historyEnd = incomingMessages.Count - 2; historyEnd >= 0; historyEnd--)
+        // AG-UI sends the complete conversation in chronological order. Only remove
+        // stored history when it is an exact prefix of the incoming transcript.
+        for (int i = storedMessages.Count - 1; i >= 0; i--)
         {
-            if (!string.Equals(lastStoredMessageId, incomingMessages[historyEnd].MessageId, StringComparison.Ordinal))
+            string? storedMessageId = storedMessages[i].MessageId;
+            if (string.IsNullOrEmpty(storedMessageId) ||
+                !string.Equals(storedMessageId, incomingMessages[i].MessageId, StringComparison.Ordinal))
             {
-                continue;
-            }
-
-            int incomingIndex = historyEnd;
-            int storedIndex = storedMessages.Count - 1;
-            while (incomingIndex >= 0 && storedIndex >= 0)
-            {
-                string? storedMessageId = storedMessages[storedIndex].MessageId;
-                string? incomingMessageId = incomingMessages[incomingIndex].MessageId;
-                if (string.IsNullOrEmpty(storedMessageId) ||
-                    !string.Equals(storedMessageId, incomingMessageId, StringComparison.Ordinal))
-                {
-                    break;
-                }
-
-                incomingIndex--;
-                storedIndex--;
-            }
-
-            if (incomingIndex < 0)
-            {
-                int newMessagesStart = historyEnd + 1;
-                return incomingMessages.GetRange(newMessagesStart, incomingMessages.Count - newMessagesStart);
+                return incomingMessages;
             }
         }
 
-        return incomingMessages;
+        return incomingMessages.GetRange(storedMessages.Count, incomingMessages.Count - storedMessages.Count);
     }
 
     private static List<ChatMessage> GetCurrentTurnMessages(List<ChatMessage> incomingMessages)

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
@@ -252,7 +252,7 @@ public sealed class AGUIEndpointRouteBuilderExtensionsTests
     }
 
     [Fact]
-    public async Task GetMessagesForRun_WithTruncatedStoredHistoryOverlap_ReturnsOnlyNewMessagesAsync()
+    public async Task GetMessagesForRun_WithNonPrefixHistory_ReturnsMessagesUnchangedAsync()
     {
         // Arrange
         ChatClientAgent agent = new(new Mock<IChatClient>().Object);
@@ -275,8 +275,7 @@ public sealed class AGUIEndpointRouteBuilderExtensionsTests
             incomingMessages);
 
         // Assert
-        ChatMessage message = Assert.Single(messages);
-        Assert.Equal("user-2", message.MessageId);
+        Assert.Same(incomingMessages, messages);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
@@ -222,6 +222,150 @@ public sealed class AGUIEndpointRouteBuilderExtensionsTests
             endpointsMock.Object.MapAGUIServer((IHostedAgentBuilder)null!, "/api/agent"));
     }
 
+    [Fact]
+    public async Task GetMessagesForRun_WithStoredHistory_ReturnsOnlyNewMessagesAsync()
+    {
+        // Arrange
+        ChatClientAgent agent = new(new Mock<IChatClient>().Object);
+        AgentSession session = await agent.CreateSessionAsync();
+        session.SetInMemoryChatHistory(
+        [
+            new ChatMessage(ChatRole.User, "First question") { MessageId = "user-1" },
+            new ChatMessage(ChatRole.Assistant, "First answer") { MessageId = "assistant-1" },
+        ]);
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.User, "First question") { MessageId = "user-1" },
+            new ChatMessage(ChatRole.Assistant, "First answer") { MessageId = "assistant-1" },
+            new ChatMessage(ChatRole.User, "Second question") { MessageId = "user-2" },
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        ChatMessage message = Assert.Single(messages);
+        Assert.Equal("user-2", message.MessageId);
+    }
+
+    [Fact]
+    public async Task GetMessagesForRun_WithTruncatedStoredHistoryOverlap_ReturnsOnlyNewMessagesAsync()
+    {
+        // Arrange
+        ChatClientAgent agent = new(new Mock<IChatClient>().Object);
+        AgentSession session = await agent.CreateSessionAsync();
+        session.SetInMemoryChatHistory(
+        [
+            new ChatMessage(ChatRole.User, "First question") { MessageId = "user-1" },
+            new ChatMessage(ChatRole.Assistant, "First answer") { MessageId = "assistant-1" },
+        ]);
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.Assistant, "First answer") { MessageId = "assistant-1" },
+            new ChatMessage(ChatRole.User, "Second question") { MessageId = "user-2" },
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        ChatMessage message = Assert.Single(messages);
+        Assert.Equal("user-2", message.MessageId);
+    }
+
+    [Fact]
+    public async Task GetMessagesForRun_WithIncrementalMessage_ReturnsMessageUnchangedAsync()
+    {
+        // Arrange
+        ChatClientAgent agent = new(new Mock<IChatClient>().Object);
+        AgentSession session = await agent.CreateSessionAsync();
+        session.SetInMemoryChatHistory(
+        [
+            new ChatMessage(ChatRole.User, "Repeat") { MessageId = "user-1" },
+            new ChatMessage(ChatRole.Assistant, "Okay") { MessageId = "assistant-1" },
+        ]);
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.User, "Repeat") { MessageId = "user-2" },
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        Assert.Same(incomingMessages, messages);
+    }
+
+    [Fact]
+    public async Task GetMessagesForRun_WithProviderConversation_ReturnsCurrentTurnMessagesAsync()
+    {
+        // Arrange
+        ChatClientAgent agent = new(new Mock<IChatClient>().Object);
+        JsonElement serializedSession = JsonSerializer.SerializeToElement(new
+        {
+            conversationId = "provider-conversation",
+        });
+        AgentSession session = await agent.DeserializeSessionAsync(serializedSession);
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.User, "First question") { MessageId = "user-1" },
+            new ChatMessage(ChatRole.Assistant, "Call tools")
+            {
+                MessageId = "assistant-1",
+                Contents =
+                [
+                    new FunctionCallContent("call-1", "tool1"),
+                    new FunctionCallContent("call-2", "tool2"),
+                ],
+            },
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-1", "result-1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-2", "result-2")]),
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        Assert.Equal(2, messages.Count);
+        Assert.All(messages, message => Assert.Equal(ChatRole.Tool, message.Role));
+    }
+
+    [Fact]
+    public async Task GetMessagesForRun_WithUnknownAgent_ReturnsMessagesUnchangedAsync()
+    {
+        // Arrange
+        AIAgent agent = new TestAgent();
+        ChatClientAgent sessionAgent = new(new Mock<IChatClient>().Object);
+        AgentSession session = await sessionAgent.CreateSessionAsync();
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.User, "First question"),
+            new ChatMessage(ChatRole.Assistant, "First answer"),
+            new ChatMessage(ChatRole.User, "Second question"),
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        Assert.Same(incomingMessages, messages);
+    }
+
     private sealed class TestAgent : AIAgent
     {
         protected override Task<AgentResponse> RunCoreAsync(IEnumerable<ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.UnitTests/AGUIEndpointRouteBuilderExtensionsTests.cs
@@ -305,6 +305,52 @@ public sealed class AGUIEndpointRouteBuilderExtensionsTests
     }
 
     [Fact]
+    public async Task GetMessagesForRun_WithStoredToolCalls_ReturnsAllNewClientToolResultsAsync()
+    {
+        // Arrange
+        ChatClientAgent agent = new(new Mock<IChatClient>().Object);
+        AgentSession session = await agent.CreateSessionAsync();
+        session.SetInMemoryChatHistory(
+        [
+            new ChatMessage(ChatRole.User, "Call tools") { MessageId = "user-1" },
+            new ChatMessage(
+                ChatRole.Assistant,
+                [
+                    new FunctionCallContent("call-1", "tool1"),
+                    new FunctionCallContent("call-2", "tool2"),
+                ])
+            {
+                MessageId = "assistant-1",
+            },
+        ]);
+        List<ChatMessage> incomingMessages =
+        [
+            new ChatMessage(ChatRole.User, "Call tools") { MessageId = "user-1" },
+            new ChatMessage(
+                ChatRole.Assistant,
+                [
+                    new FunctionCallContent("call-1", "tool1"),
+                    new FunctionCallContent("call-2", "tool2"),
+                ])
+            {
+                MessageId = "assistant-1",
+            },
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-1", "result-1")]),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-2", "result-2")]),
+        ];
+
+        // Act
+        IReadOnlyList<ChatMessage> messages = AGUIEndpointRouteBuilderExtensions.GetMessagesForRun(
+            agent,
+            session,
+            incomingMessages);
+
+        // Assert
+        Assert.Equal(2, messages.Count);
+        Assert.All(messages, message => Assert.Equal(ChatRole.Tool, message.Role));
+    }
+
+    [Fact]
     public async Task GetMessagesForRun_WithProviderConversation_ReturnsCurrentTurnMessagesAsync()
     {
         // Arrange


### PR DESCRIPTION
### Motivation & Context

AG-UI clients send the complete conversation transcript on each turn. When `MapAGUIServer` restores a `ChatClientAgent` session, that prior history is already available through either the local `ChatHistoryProvider` or a provider-managed conversation. Forwarding the full transcript again duplicates earlier messages, increasing token usage and potentially degrading model responses.

### Description & Review Guide

- **What are the major changes?** The endpoint now detects history-backed `ChatClientAgent` sessions and narrows incoming AG-UI transcripts to the new suffix. For readable in-memory history, it verifies in one backward pass that stored message IDs are an ordered prefix of the incoming transcript; for provider-managed conversations, it keeps messages after the final assistant boundary. First turns, incremental-only requests, reordered/non-prefix history, and unknown custom agents remain unchanged. Regression tests cover complete ordered history, non-prefix history, repeated user text, local and provider client-tool-result continuations, and custom agents.
- **What is the impact of these changes?** Subsequent AG-UI turns no longer replay conversation messages already managed by Agent Framework or the provider. Client tool results in the new turn remain available to the agent. No public API changes are introduced.
- **What do you want reviewers to focus on?** Please focus on the conservative ordered-prefix matching and the final-assistant boundary used when provider history is not locally readable.


### Related Issue

Fixes #7930

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.