### PR TITLE
Python: Give a hosted Foundry agent a single source of conversation history

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -336,6 +336,7 @@ class ResponsesHostServer(ResponsesAgentServerHost):
         agent_session_store_provider: StoreProvider[SessionStore] | None = None,
         checkpoint_store_provider: ContextScopedStoreProvider[CheckpointStorage] | None = None,
         function_approval_store_provider: StoreProvider[FunctionApprovalStore] | None = None,
+        allow_stored_output_enabled: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize a ResponsesHostServer.
@@ -351,6 +352,12 @@ class ResponsesHostServer(ResponsesAgentServerHost):
                 If not provided, a default `CheckpointStoreProvider` will be used.
             function_approval_store_provider: Optional provider for function approval storage.
                 If not provided, a default `FunctionApprovalStoreProvider` will be used.
+            allow_stored_output_enabled: Whether the agent's own chat client may store the
+                conversation server-side. Defaults to False, which turns storage off for every
+                run and fails the request if the client stored the turn anyway. Set to True to
+                leave the client exactly as the container configured it; nothing is then
+                overridden or checked, and reconciling the two records is the container's
+                responsibility.
             **kwargs: Additional keyword arguments.
 
         Note:
@@ -416,6 +423,7 @@ class ResponsesHostServer(ResponsesAgentServerHost):
                 )
 
         self._agent: SupportsAgentRun = agent
+        self._allow_stored_output_enabled = allow_stored_output_enabled
 
         # Storage providers
         self._checkpoint_storage_provider = (
@@ -630,6 +638,12 @@ class ResponsesHostServer(ResponsesAgentServerHost):
                 "session": session,
             }
             chat_options, are_options_set = _to_chat_options(request)
+            if self._uses_hosted_responses_history and not self._allow_stored_output_enabled:
+                # The platform records this conversation and serves it back through
+                # `context.get_history()` above. Letting the agent's own service store it too would
+                # give the model the same transcript twice -- once as input, once as the resumed
+                # service thread -- compounding every turn.
+                chat_options["store"] = False
 
             if are_options_set and not isinstance(self._agent, RawAgent):
                 logger.warning("Agent doesn't support runtime options. They will be ignored.")
@@ -662,8 +676,30 @@ class ResponsesHostServer(ResponsesAgentServerHost):
         finally:
             if self._uses_hosted_responses_history:
                 session.state.pop(_HOSTED_RESPONSES_HISTORY_SOURCE_ID, None)
+
+            # A service session id on the session means the agent's chat client kept the turn
+            # despite `store=False`, so a second record of this conversation now exists that
+            # nothing here reconciles. Leave the session unsaved so later turns do not resume onto
+            # it, and report it: a container configured this way is a server fault, not a bad request.
+            stored_output_violation = (
+                self._uses_hosted_responses_history
+                and not self._allow_stored_output_enabled
+                and session.service_session_id is not None
+            )
+            if stored_output_violation:
+                misconfigured = RuntimeError(
+                    "The agent's chat client stored this turn server-side while the hosting service "
+                    "is managing the conversation, which would feed the model a duplicated transcript. "
+                    "Configure the chat client so the underlying service does not store responses, or "
+                    "construct ResponsesHostServer with allow_stored_output_enabled=True to own that "
+                    "reconciliation yourself."
+                )
+                logger.error("%s", misconfigured)
+                if request_failure is None and not request_interrupted:
+                    request_failure = misconfigured
             try:
-                await session_storage.set(session_save_id, session)
+                if not stored_output_violation:
+                    await session_storage.set(session_save_id, session)
             except Exception as save_error:
                 save_failure = save_error
                 if request_interrupted:

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_responses.py
@@ -625,6 +625,13 @@ class ResponsesHostServer(ResponsesAgentServerHost):
         try:
             if self._uses_hosted_responses_history:
                 session.state.pop(_HOSTED_RESPONSES_HISTORY_SOURCE_ID, None)
+                if not self._allow_stored_output_enabled:
+                    # A service session id on a loaded session points at a thread that already holds
+                    # this conversation, written before storage was turned off. Core resumes it ahead
+                    # of anything in the options, so it would duplicate the transcript the platform
+                    # already supplies. Dropping it also makes the check in `finally` exact: an id
+                    # present by then can only have been set by this run.
+                    session.service_session_id = None
 
             input_items = await context.get_input_items()
             input_messages = await _items_to_messages(input_items, approval_storage=approval_storage)
@@ -677,10 +684,11 @@ class ResponsesHostServer(ResponsesAgentServerHost):
             if self._uses_hosted_responses_history:
                 session.state.pop(_HOSTED_RESPONSES_HISTORY_SOURCE_ID, None)
 
-            # A service session id on the session means the agent's chat client kept the turn
-            # despite `store=False`, so a second record of this conversation now exists that
-            # nothing here reconciles. Leave the session unsaved so later turns do not resume onto
-            # it, and report it: a container configured this way is a server fault, not a bad request.
+            # The session started this run without a service session id, so one now means the
+            # agent's chat client kept the turn despite `store=False`, and a second record of this
+            # conversation exists that nothing here reconciles. Leave the session unsaved so later
+            # turns do not resume onto it, and report it: a container configured this way is a
+            # server fault, not a bad request.
             stored_output_violation = (
                 self._uses_hosted_responses_history
                 and not self._allow_stored_output_enabled

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -809,6 +809,41 @@ class TestAgentSessionPersistence:
         assert stored is not None
         assert stored.service_session_id is None
 
+    async def test_session_carrying_a_pre_fix_service_thread_id_heals_instead_of_failing(self) -> None:
+        """A conversation started before storage was disabled continues cleanly after an upgrade.
+
+        Its persisted session still names the service thread that holds the whole transcript, and
+        core resumes that thread ahead of anything in the options. Left in place it duplicates the
+        turn and trips the storage violation, and since a failed turn is never re-saved the same
+        stale session would load again on every later turn.
+        """
+        client = _ServiceStorageRecordingClient()
+        agent = Agent(client=client, name="Upgraded Agent")
+        store = SessionStore()
+        server = _make_server(agent, session_store=store)
+
+        first = await _post(server, input_text="first")
+        # What a pre-fix version left behind: the service thread that already holds turn 1.
+        upgraded = await store.get(first.json()["id"])
+        assert upgraded is not None
+        upgraded.service_session_id = "svc-thread-1"
+        await store.set(first.json()["id"], upgraded)
+
+        second = await _post(server, input_text="second", previous_response_id=first.json()["id"])
+
+        assert second.status_code == 200
+        assert second.json()["status"] == "completed"
+        # The stale thread is neither resumed nor mistaken for a client that stored the turn.
+        assert client.conversation_ids == [None, None]
+        assert [[message.text for message in call] for call in client.calls] == [
+            ["first"],
+            ["first", "recorded", "second"],
+        ]
+
+        stored = await store.get(second.json()["id"])
+        assert stored is not None
+        assert stored.service_session_id is None
+
     async def test_client_that_stores_despite_disabled_storage_fails_and_leaves_session_unsaved(
         self,
         caplog: pytest.LogCaptureFixture,

--- a/python/packages/foundry_hosting/tests/test_responses.py
+++ b/python/packages/foundry_hosting/tests/test_responses.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -260,6 +261,44 @@ class _FunctionLoopRecordingClient(
 @tool(name="lookup_weather", approval_mode="never_require")
 def _lookup_weather(location: str) -> str:
     return f"Weather in {location}: sunny"
+
+
+class _ServiceStorageRecordingClient(BaseChatClient):
+    """A chat client whose service keeps the conversation, as OpenAI Responses does with ``store`` on."""
+
+    STORES_BY_DEFAULT = True
+
+    def __init__(self, *, honours_store: bool = True) -> None:
+        super().__init__()
+        self._honours_store = honours_store
+        self.calls: list[list[Message]] = []
+        self.store_options: list[Any] = []
+        self.conversation_ids: list[Any] = []
+
+    def _inner_get_response(
+        self,
+        *,
+        messages: Sequence[Message],
+        stream: bool,
+        options: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> Awaitable[ChatResponse] | ResponseStream[ChatResponseUpdate, ChatResponse]:
+        del kwargs
+        assert stream is True, "The inner agent only runs in stream mode in Foundry Hosted Agents."
+        self.calls.append(list(messages))
+        self.store_options.append(options.get("store"))
+        self.conversation_ids.append(options.get("conversation_id"))
+        storing = options.get("store") is not False if self._honours_store else True
+        conversation_id = "svc-thread-1" if storing else None
+
+        async def stream_response() -> AsyncIterator[ChatResponseUpdate]:
+            yield ChatResponseUpdate(
+                contents=[Content.from_text("recorded")],
+                role="assistant",
+                conversation_id=conversation_id,
+            )
+
+        return ResponseStream(stream_response(), finalizer=ChatResponse.from_updates)
 
 
 class _FailingSessionStore(SessionStore):
@@ -738,6 +777,69 @@ class TestAgentSessionPersistence:
         assert stored is not None
         assert InMemoryHistoryProvider.DEFAULT_SOURCE_ID not in stored.state
         assert "_foundry_responses_history" not in stored.state
+
+    async def test_responses_history_is_not_duplicated_when_the_client_stores_service_side(self) -> None:
+        """The platform transcript is the only history the model sees, even for a storing client.
+
+        Without turning storage off downstream the session keeps a service session id, the next run
+        resumes that thread, and the model receives the transcript both as input and as the resumed
+        thread -- twice on the second turn and three times on the third.
+        """
+        client = _ServiceStorageRecordingClient()
+        agent = Agent(client=client, name="Service Storage Agent")
+        store = SessionStore()
+        server = _make_server(agent, session_store=store)
+
+        first = await _post(server, input_text="first")
+        second = await _post(server, input_text="second", previous_response_id=first.json()["id"])
+        third = await _post(server, input_text="third", previous_response_id=second.json()["id"])
+
+        assert third.status_code == 200
+        assert third.json()["status"] == "completed"
+        assert [[message.text for message in call] for call in client.calls] == [
+            ["first"],
+            ["first", "recorded", "second"],
+            ["first", "recorded", "second", "recorded", "third"],
+        ]
+        # Storage is off downstream, so no service thread is ever resumed alongside that input.
+        assert client.store_options == [False, False, False]
+        assert client.conversation_ids == [None, None, None]
+
+        stored = await store.get(first.json()["id"])
+        assert stored is not None
+        assert stored.service_session_id is None
+
+    async def test_client_that_stores_despite_disabled_storage_fails_and_leaves_session_unsaved(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        client = _ServiceStorageRecordingClient(honours_store=False)
+        agent = Agent(client=client, name="Ignores Store Agent")
+        store = SessionStore()
+        server = _make_server(agent, session_store=store)
+
+        with caplog.at_level(logging.ERROR):
+            response = await _post(server, input_text="first")
+
+        assert response.json()["status"] == "failed"
+        assert "stored this turn server-side" in caplog.text
+        # The session is not saved, so a later turn cannot resume onto the duplicated thread.
+        assert await store.get(response.json()["id"]) is None
+
+    async def test_allow_stored_output_enabled_leaves_the_client_configuration_untouched(self) -> None:
+        client = _ServiceStorageRecordingClient()
+        agent = Agent(client=client, name="Container Managed Storage Agent")
+        store = SessionStore()
+        server = _make_server(agent, session_store=store, allow_stored_output_enabled=True)
+
+        response = await _post(server, input_text="first")
+
+        assert response.json()["status"] == "completed"
+        assert client.store_options == [None]
+
+        stored = await store.get(response.json()["id"])
+        assert stored is not None
+        assert stored.service_session_id == "svc-thread-1"
 
     async def test_per_service_call_persistence_preserves_function_loop_history(self) -> None:
         provider = _PerServiceCallHistoryProvider()


### PR DESCRIPTION
### Motivation & Context

A hosted `/responses` agent feeds the model the conversation transcript more than once per request, and the duplication compounds every turn. With a real model the agent visibly repeats its replies, getting worse as the conversation grows, plus the matching token overspend. In the reporter's repro, by turn 3 the model sees turn 1 three times (23 messages instead of 9).

`_handle_inner_agent` gives `agent.run(...)` two sources of history at once: `run_kwargs["messages"]`, the full platform transcript from `context.get_history()` plus the new input, and `run_kwargs["session"]`, the session loaded from the session store. The existing guard pops the transient history buffer (`_HOSTED_RESPONSES_HISTORY_SOURCE_ID`) out of `session.state`, but the session's top-level `service_session_id` survives and core resumes it. The run therefore continues a service-side thread that already holds the whole transcript while `messages` carries that transcript again. The service appends the duplicated request to the thread, so the next turn's thread contains it twice, hence the superlinear growth.

This is rarely seen because the default `FoundryAgentSessionStore`'s reads currently fail and return `None`, so the service thread is never resumed. Any working session store exposes it.

.NET fixed this class of bug in #7525 and refined it in #7572; this is the Python counterpart.

### Description & Review Guide

- **What are the major changes?**

  Server-side storage is turned off for the run, so the platform record is the only history in play:

  - `chat_options["store"] = False` when hosting manages history. The chat client then keeps nothing of its own and reports no conversation id, so no second thread exists to resume. This removes the cause rather than cleaning up after it, and avoids creating a downstream thread per turn.
  - If a service session id lands on the session anyway, the client stored the turn despite that setting and a second unreconciled record now exists. The request fails and the session is left unsaved, so later turns cannot resume onto the duplicated thread. A container configured this way is a server fault, not a bad request.
  - New `allow_stored_output_enabled` keyword on `ResponsesHostServer`, defaulting to `False`. Setting it to `True` leaves the chat client exactly as the container configured it; nothing is overridden or checked, and reconciling the two records is the container's responsibility.

  Three regression tests in `TestAgentSessionPersistence` cover the duplicated transcript, the client that stores despite `store=False`, and the opt-in. Each fails without the source change.

- **What is the impact of these changes?**

  Hosted agents whose chat client stores conversation state service-side (the default for `FoundryChatClient` and OpenAI Responses when `store` is not `False`) now send each message to the model exactly once.

  Behaviour changes for those agents: the downstream service is asked not to store, and an agent that stores anyway now fails loudly instead of silently duplicating. `allow_stored_output_enabled=True` restores the previous hands-off behaviour. The constructor keyword is additive and defaulted, so no signature breaks.

  Note that #7487, the ~5s streaming delay seen with the Foundry project endpoint and `store: False`, was closed as not caused by the SDK and not reproduced as consistent. This change makes `store: False` the default path for hosted agents, so if that delay is real it would become more visible; `allow_stored_output_enabled=True` is the escape hatch.

- **What do you want reviewers to focus on?**

  Whether disabling downstream storage by default is the direction you want for Python, matching #7572, versus neutralizing `service_session_id` on the hosted session. Also whether the misconfigured-client check belongs in the `finally` block as written, and whether a readiness-time probe like the .NET one is wanted here as a follow-up.

### Related Issue

Fixes #7955

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
