### PR TITLE
.NET: Fix JsonWireSerializedValue hash code contract

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/JsonWireSerializedValue.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/Checkpointing/JsonWireSerializedValue.cs
@@ -58,6 +58,9 @@ internal sealed class JsonWireSerializedValue(JsonMarshaller serializer, JsonEle
 
     public override int GetHashCode()
     {
-        return this.Data.GetHashCode();
+        // JsonElement does not provide a structural hash code. ValueKind is necessarily equal
+        // whenever DeepEquals returns true, preserving the equality contract without recursively
+        // reimplementing JsonElement.DeepEquals semantics.
+        return this.Data.ValueKind.GetHashCode();
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/JsonSerializationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/JsonSerializationTests.cs
@@ -34,6 +34,24 @@ public class JsonSerializationTests
 
     private static EdgeId TakeEdgeId() => new(Interlocked.Increment(ref s_nextEdgeId));
 
+    [Fact]
+    public void Test_JsonWireSerializedValue_EqualValuesHaveEqualHashCodes()
+    {
+        // Arrange
+        JsonMarshaller marshaller = new();
+        using JsonDocument firstDocument = JsonDocument.Parse("""{"a":1,"b":[true,null]}""");
+        using JsonDocument secondDocument = JsonDocument.Parse("""{"a":1,"b":[true,null]}""");
+        JsonWireSerializedValue first = new(marshaller, firstDocument.RootElement);
+        JsonWireSerializedValue second = new(marshaller, secondDocument.RootElement);
+
+        // Act
+        bool areEqual = first.Equals(second);
+
+        // Assert
+        areEqual.Should().BeTrue();
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
     internal static T RunJsonRoundtrip<T>(T value, JsonSerializerOptions? externalOptions = null, Expression<Func<T, bool>>? predicate = null)
     {
         JsonMarshaller marshaller = new(externalOptions);


### PR DESCRIPTION
### Motivation & Context

`JsonWireSerializedValue.Equals()` uses structural JSON equality, while its previous hash code came from `JsonElement.GetHashCode()`, which is not structural. Separately parsed equivalent JSON values could therefore compare equal but produce different hash codes.

### Description & Review Guide

- **What are the major changes?** Use `JsonValueKind` as the stable hash input and add a regression test for equivalent values parsed from separate JSON documents.
- **What is the impact of these changes?** Equal `JsonWireSerializedValue` instances now produce equal hash codes. Hash collisions between values of the same JSON kind are intentional to remain consistent with `JsonElement.DeepEquals()` without duplicating its semantics.
- **What do you want reviewers to focus on?** Whether the minimal `ValueKind`-based approach is appropriate for this internal delayed-deserialization wrapper.

### Related Issue

Fixes #7958

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and the title prefix in sync automatically.