### PR TITLE
.NET: chore: promote shipped .NET APIs

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -565,6 +565,8 @@ Microsoft.Extensions.AI.ChatClientExtensions
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.BackgroundAgentsProviderOptions() -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.get -> string?
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.set -> void
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator.BackgroundTaskCompletionLoopEvaluator(Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions? options = null) -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -413,6 +413,8 @@ Microsoft.Extensions.AI.ChatClientExtensions
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.BackgroundAgentsProviderOptions() -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.get -> string?
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.set -> void
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator.BackgroundTaskCompletionLoopEvaluator(Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions? options = null) -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -565,6 +565,8 @@ Microsoft.Extensions.AI.ChatClientExtensions
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.BackgroundAgentsProviderOptions() -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.get -> string?
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.set -> void
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator.BackgroundTaskCompletionLoopEvaluator(Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions? options = null) -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -565,6 +565,8 @@ Microsoft.Extensions.AI.ChatClientExtensions
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.BackgroundAgentsProviderOptions() -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.get -> string?
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.set -> void
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator.BackgroundTaskCompletionLoopEvaluator(Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions? options = null) -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -413,6 +413,8 @@ Microsoft.Extensions.AI.ChatClientExtensions
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.BackgroundAgentsProviderOptions() -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.get -> string?
 [MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.Instructions.set -> void
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
+[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluator.BackgroundTaskCompletionLoopEvaluator(Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions? options = null) -> void
 [MAAI001]Microsoft.Agents.AI.BackgroundTaskCompletionLoopEvaluatorOptions

--- a/dotnet/src/Microsoft.Agents.AI/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/dotnet/src/Microsoft.Agents.AI/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.get -> System.TimeSpan
-[MAAI001]Microsoft.Agents.AI.BackgroundAgentsProviderOptions.WaitTimeout.set -> void


### PR DESCRIPTION
follow up to #7935 
Right now [the automation is failing](https://github.com/microsoft/agent-framework/actions/runs/33422435859/job/99587837382) because a setting is not enabled at the organization level, I've made a request:
- https://github.com/microsoft/github-operations/issues/1754