### PR TITLE
.NET: Remove Azure.AI.OpenAI dependency

### DIFF
--- a/.github/upgrades/prompts/SemanticKernelToAgentFramework.md
+++ b/.github/upgrades/prompts/SemanticKernelToAgentFramework.md
@@ -221,8 +221,8 @@ using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.Extensions.AI;
 using Microsoft.Agents.AI;
 // Provider-specific namespaces (add only if needed):
-using OpenAI; // For OpenAI provider
-using Azure.AI.OpenAI; // For Azure OpenAI provider
+using OpenAI; // For OpenAI and Azure OpenAI providers
+using System.ClientModel.Primitives; // For BearerTokenPolicy with Azure OpenAI
 using Azure.AI.Agents.Persistent; // For Microsoft Foundry provider
 using Azure.Identity; // For Azure authentication
 ```
@@ -545,9 +545,13 @@ AIAgent agent = new OpenAIClient(apiKey)
 
 **Azure OpenAI:**
 ```csharp
-AIAgent agent = new AzureOpenAIClient(endpoint, credential)
+Uri openAIEndpoint = new($"{endpoint.ToString().TrimEnd('/')}/openai/v1/");
+
+AIAgent agent = new OpenAIClient(
+        new BearerTokenPolicy(credential, "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = openAIEndpoint })
     .GetChatClient(deploymentName)
-    .CreateAIAgent(instructions: instructions);
+    .AsAIAgent(instructions: instructions);
 ```
 
 **Microsoft Foundry (New):**
@@ -571,9 +575,13 @@ AIAgent agent = new OpenAIClient(apiKey)
 
 **Azure OpenAI Responses:** *(Recommended for Azure OpenAI)*
 ```csharp
-AIAgent agent = new AzureOpenAIClient(endpoint, credential)
-    .GetOpenAIResponseClient(deploymentName)
-    .CreateAIAgent(instructions: instructions);
+Uri openAIEndpoint = new($"{endpoint.ToString().TrimEnd('/')}/openai/v1/");
+
+AIAgent agent = new OpenAIClient(
+        new BearerTokenPolicy(credential, "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = openAIEndpoint })
+    .GetResponsesClient()
+    .AsAIAgent(model: deploymentName, instructions: instructions);
 ```
 
 **A2A:**
@@ -979,11 +987,11 @@ AgentThread thread = agent.GetNewThread();
 **Add Agent Framework Packages:**
 ```xml
 <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
-<PackageReference Include="Azure.AI.OpenAI" />
+<PackageReference Include="OpenAI" />
 <PackageReference Include="Azure.Identity" />
 ```
 
-**Note**: If not using `AzureCliCredential`, you can use `ApiKeyCredential` instead without the `Azure.Identity` package.
+**Note**: If not using Entra ID (`AzureCliCredential` / `DefaultAzureCredential`), you can use `ApiKeyCredential` instead without the `Azure.Identity` package.
 </configuration_changes>
 
 **Before (Semantic Kernel):**
@@ -1005,13 +1013,18 @@ ChatCompletionAgent agent = new()
 
 **After (Agent Framework):**
 ```csharp
-using Microsoft.Agents.AI;
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
+using Microsoft.Agents.AI;
+using OpenAI;
+using OpenAI.Chat;
 
-AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new AzureCliCredential())
+var openAIEndpoint = $"{endpoint.TrimEnd('/')}/openai/v1/";
+AIAgent agent = new OpenAIClient(
+        new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = new Uri(openAIEndpoint) })
     .GetChatClient(deploymentName)
-    .CreateAIAgent(instructions: "You are a helpful assistant");
+    .AsAIAgent(instructions: "You are a helpful assistant");
 ```
 
 ### 3. OpenAI Assistants Migration
@@ -1273,14 +1286,15 @@ var result = await agent.RunAsync(userInput, thread);
 **Add Agent Framework Packages:**
 ```xml
 <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
-<PackageReference Include="Azure.AI.OpenAI" />
+<PackageReference Include="OpenAI" />
+<PackageReference Include="Azure.Identity" />
 ```
 </configuration_changes>
 
 <api_changes>
 **Replace this Semantic Kernel pattern:**
 
-Azure OpenAI Responses uses `AzureOpenAIClient` instead of `OpenAIClient`. The thread management is done manually where the thread needs to be passed to the `InvokeAsync` method and updated with the `item.Thread` from the response.
+Azure OpenAI Responses uses the OpenAI SDK with a custom endpoint and Entra token policy. The thread management is done manually where the thread needs to be passed to the `InvokeAsync` method and updated with the `item.Thread` from the response.
 
 ```csharp
 using Microsoft.SemanticKernel.Agents.OpenAI;
@@ -1311,21 +1325,28 @@ await foreach (AgentResponseItem<ChatMessageContent> responseItem in responseIte
 Agent Framework automatically manages the thread, so there's no need to manually update it.
 
 ```csharp
-using Microsoft.Agents.AI.OpenAI;
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using OpenAI;
+using OpenAI.Responses;
 
-AIAgent agent = new AzureOpenAIClient(endpoint, new AzureCliCredential())
-    .GetOpenAIResponseClient(modelId)
-    .CreateAIAgent(
+Uri openAIEndpoint = new($"{endpoint.ToString().TrimEnd('/')}/openai/v1/");
+AIAgent agent = new OpenAIClient(
+        new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = openAIEndpoint })
+    .GetResponsesClient()
+    .AsAIAgent(
+        model: modelId,
         name: "ResponseAgent",
         instructions: "Answer all queries in English and French.",
         tools: [/* AITools */]);
 
-AgentThread thread = agent.GetNewThread();
+AgentSession session = await agent.CreateSessionAsync();
 
-var result = await agent.RunAsync(userInput, thread);
+var result = await agent.RunAsync(userInput, session);
 
-// The thread will be automatically updated with the new response id from this point
+// The session is updated with the new response id.
 ```
 </api_changes>
 
@@ -1607,5 +1628,4 @@ var filteredAgent = originalAgent
     .Use(CustomAutoFunctionMiddleware)
     .Build();
 ```
-
 

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <!-- Enable central package management -->
     <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
@@ -29,7 +29,6 @@
     <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.4" />
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.10" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Azure.Core" Version="1.62.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -5,17 +5,21 @@
 ### Basic Agent - .NET
 
 ```c#
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using OpenAI;
 using OpenAI.Responses;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")!;
+// Use the Azure OpenAI v1 route with the OpenAI SDK (resource root + /openai/v1).
+var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")!; // e.g. https://YOUR.openai.azure.com/openai/v1/
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")!;
 
-var agent = new AzureOpenAIClient(new Uri(endpoint), new AzureCliCredential())
-    .GetResponsesClient(deploymentName)
-    .AsAIAgent(name: "HaikuBot", instructions: "You are an upbeat assistant that writes beautifully.");
+var agent = new OpenAIClient(
+        new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    .GetResponsesClient()
+    .AsAIAgent(model: deploymentName, name: "HaikuBot", instructions: "You are an upbeat assistant that writes beautifully.");
 
 Console.WriteLine(await agent.RunAsync("Write a haiku about Microsoft Agent Framework."));
 ```

--- a/dotnet/samples/02-agents/A2A/A2AAgent_PollingForTaskCompletion/A2AAgent_PollingForTaskCompletion.csproj
+++ b/dotnet/samples/02-agents/A2A/A2AAgent_PollingForTaskCompletion/A2AAgent_PollingForTaskCompletion.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="A2A" />
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/dotnet/samples/02-agents/A2A/A2AAgent_StreamReconnection/A2AAgent_StreamReconnection.csproj
+++ b/dotnet/samples/02-agents/A2A/A2AAgent_StreamReconnection/A2AAgent_StreamReconnection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="A2A" />
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Program.cs
@@ -17,13 +17,9 @@ builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -33,7 +29,7 @@ string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 ChatClient chatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName);
 
 AIAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Program.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+using OpenAI;
 using OpenAI.Chat;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -18,6 +19,11 @@ WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -25,9 +31,9 @@ string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient chatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+ChatClient chatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetChatClient(deploymentName);
 
 AIAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Server.csproj
+++ b/dotnet/samples/02-agents/AGUI/Step01_GettingStarted/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Program.cs
@@ -23,13 +23,9 @@ builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -90,7 +86,7 @@ AITool[] tools =
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 ChatClient chatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName);
 
 ChatClientAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Program.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
+using OpenAI;
 using OpenAI.Chat;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -24,6 +25,11 @@ WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -82,9 +88,9 @@ AITool[] tools =
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient chatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+ChatClient chatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetChatClient(deploymentName);
 
 ChatClientAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Server.csproj
+++ b/dotnet/samples/02-agents/AGUI/Step02_BackendTools/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Program.cs
@@ -17,13 +17,9 @@ builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -33,7 +29,7 @@ string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 ChatClient chatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName);
 
 AIAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Program.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+using OpenAI;
 using OpenAI.Chat;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -18,6 +19,11 @@ WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -25,9 +31,9 @@ string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient chatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+ChatClient chatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetChatClient(deploymentName);
 
 AIAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Server.csproj
+++ b/dotnet/samples/02-agents/AGUI/Step03_FrontendTools/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Program.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Chat;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -20,6 +21,11 @@ WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -41,9 +47,9 @@ AITool[] tools =
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient openAIChatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+ChatClient openAIChatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetChatClient(deploymentName);
 
 ChatClientAgent baseAgent = openAIChatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Program.cs
@@ -19,13 +19,9 @@ builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -49,7 +45,7 @@ AITool[] tools =
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 ChatClient openAIChatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName);
 
 ChatClientAgent baseAgent = openAIChatClient.AsAIAgent(

--- a/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Server.csproj
+++ b/dotnet/samples/02-agents/AGUI/Step04_HumanInLoop/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Program.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
 using AGUI.Server;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Chat;
 using RecipeAssistant;
 
@@ -27,6 +28,11 @@ WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -59,9 +65,9 @@ const string SharedStateSystemPrompt =
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-ChatClient chatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+ChatClient chatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetChatClient(deploymentName);
 
 AIAgent baseAgent = chatClient.AsAIAgent(new ChatClientAgentOptions

--- a/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Program.cs
+++ b/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Program.cs
@@ -26,13 +26,9 @@ builder.WebHost.UseUrls("http://localhost:8888");
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
     ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"]
     ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
@@ -67,7 +63,7 @@ const string SharedStateSystemPrompt =
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 ChatClient chatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName);
 
 AIAgent baseAgent = chatClient.AsAIAgent(new ChatClientAgentOptions

--- a/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Server.csproj
+++ b/dotnet/samples/02-agents/AGUI/Step05_StateManagement/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Agent_With_AzureOpenAIChatCompletion.csproj
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Agent_With_AzureOpenAIChatCompletion.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Program.cs
@@ -8,12 +8,9 @@ using Microsoft.Agents.AI;
 using OpenAI;
 using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
@@ -21,7 +18,7 @@ var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");
 

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/Program.cs
@@ -2,20 +2,26 @@
 
 // This sample shows how to create and use a simple AI agent with Azure OpenAI Chat Completion as the backend.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
+using OpenAI;
 using OpenAI.Chat;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");
 

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIChatCompletion/README.md
@@ -11,6 +11,8 @@ Before you begin, ensure you have the following prerequisites:
 Set the following environment variables:
 
 ```powershell
-$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/" # Replace with your Azure OpenAI resource endpoint
+# Resource root is fine (sample appends /openai/v1). You can also set the full v1 endpoint.
+$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+# or: $env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/openai/v1/"
 $env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-5.4-mini"  # Optional, defaults to gpt-5.4-mini
 ```

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Agent_With_AzureOpenAIResponses.csproj
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Agent_With_AzureOpenAIResponses.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Program.cs
@@ -2,22 +2,28 @@
 
 // This sample shows how to create and use a simple AI agent with Azure OpenAI Responses as the backend.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Responses;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 // You must dissable client side conversation storage for clients that support it
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetResponsesClient()
      .AsAIAgent(model: deploymentName, instructions: "You are good at telling jokes.", name: "Joker");
 
@@ -27,9 +33,9 @@ Console.WriteLine(await agent.RunAsync("Tell me a joke about a pirate."));
 // Create a responses based agent with "store"=false.
 // This means that chat history is managed locally by Agent Framework
 // instead of being stored in the service (default).
-AIAgent agentStoreFalse = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agentStoreFalse = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetResponsesClient()
      .AsIChatClientWithStoredOutputDisabled(model: deploymentName)
      .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/Program.cs
@@ -9,12 +9,9 @@ using Microsoft.Extensions.AI;
 using OpenAI;
 using OpenAI.Responses;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
@@ -23,7 +20,7 @@ var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT
 // You must dissable client side conversation storage for clients that support it
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetResponsesClient()
      .AsAIAgent(model: deploymentName, instructions: "You are good at telling jokes.", name: "Joker");
 
@@ -35,7 +32,7 @@ Console.WriteLine(await agent.RunAsync("Tell me a joke about a pirate."));
 // instead of being stored in the service (default).
 AIAgent agentStoreFalse = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetResponsesClient()
      .AsIChatClientWithStoredOutputDisabled(model: deploymentName)
      .AsAIAgent(instructions: "You are good at telling jokes.", name: "Joker");

--- a/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/azure/Agent_With_AzureOpenAIResponses/README.md
@@ -11,6 +11,8 @@ Before you begin, ensure you have the following prerequisites:
 Set the following environment variables:
 
 ```powershell
-$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/" # Replace with your Azure OpenAI resource endpoint
+# Resource root is fine (sample appends /openai/v1). You can also set the full v1 endpoint.
+$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+# or: $env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/openai/v1/"
 $env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-5.4-mini"  # Optional, defaults to gpt-5.4-mini
 ```

--- a/dotnet/samples/02-agents/AgentProviders/foundry/Agent_Step24_CodeInterpreterFileDownload/Program.cs
+++ b/dotnet/samples/02-agents/AgentProviders/foundry/Agent_Step24_CodeInterpreterFileDownload/Program.cs
@@ -38,8 +38,7 @@ foreach (TextContent textContent in response.Messages.SelectMany(x => x.Contents
 }
 
 // Extract container file citations from response annotations and download.
-// AIProjectClient.GetProjectOpenAIClient() returns a ProjectOpenAIClient (inherits from OpenAI.OpenAIClient)
-// which supports GetContainerClient(), unlike AzureOpenAIClient which does not.
+// AIProjectClient.GetProjectOpenAIClient() returns a ProjectOpenAIClient that supports GetContainerClient().
 var containerClient = aiProjectClient.GetProjectOpenAIClient().GetContainerClient();
 
 HashSet<string> downloadedFiles = [];

--- a/dotnet/samples/02-agents/AgentProviders/foundry/Agent_Step24_CodeInterpreterFileDownload/README.md
+++ b/dotnet/samples/02-agents/AgentProviders/foundry/Agent_Step24_CodeInterpreterFileDownload/README.md
@@ -17,14 +17,10 @@ These container files **cannot** be downloaded using the standard Files API (`Ge
 
 ### Getting the ContainerClient with Foundry
 
-`AzureOpenAIClient.GetContainerClient()` is not supported and throws `InvalidOperationException`. Instead, use the project's OpenAI client which inherits directly from `OpenAI.OpenAIClient`:
+Use the Foundry project OpenAI client from `AIProjectClient` to access the Containers API:
 
 ```csharp
-// ❌ AzureOpenAIClient does not support ContainerClient
-var azureClient = new AzureOpenAIClient(endpoint, credential);
-azureClient.GetContainerClient();  // Throws InvalidOperationException
-
-// ✅ Use AIProjectClient's project OpenAI client
+// Use AIProjectClient's project OpenAI client
 var containerClient = aiProjectClient.GetProjectOpenAIClient().GetContainerClient();
 await containerClient.DownloadContainerFileAsync("cntr_...", "cfile_...");
 ```

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Agent_Step07_SkillsAutoApproval.csproj
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Agent_Step07_SkillsAutoApproval.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Program.cs
@@ -17,12 +17,9 @@ using OpenAI;
 using OpenAI.Responses;
 
 // --- Configuration ---
-string endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 string deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // --- Skills Provider ---
@@ -36,7 +33,7 @@ var skillsProvider = new AgentSkillsProvider(
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+AIAgent agent = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = endpoint })
     .GetResponsesClient()
     .AsAIAgent(new ChatClientAgentOptions
     {

--- a/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Program.cs
+++ b/dotnet/samples/02-agents/AgentSkills/Agent_Step07_SkillsAutoApproval/Program.cs
@@ -9,14 +9,20 @@
 // All tools exposed by AgentSkillsProvider always require approval by default.
 // Auto-approval rules let you selectively bypass the approval prompt for safe operations.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Responses;
 
 // --- Configuration ---
 string endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // --- Skills Provider ---
@@ -30,7 +36,7 @@ var skillsProvider = new AgentSkillsProvider(
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetResponsesClient()
     .AsAIAgent(new ChatClientAgentOptions
     {

--- a/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/DeclarativeChatClientAgents.csproj
+++ b/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/DeclarativeChatClientAgents.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Microsoft.Agents.ObjectModel" />

--- a/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/Program.cs
+++ b/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/Program.cs
@@ -9,12 +9,9 @@ using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using OpenAI;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Create the chat client
@@ -23,7 +20,7 @@ var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 IChatClient chatClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetChatClient(deploymentName)
      .AsIChatClient();
 

--- a/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/Program.cs
+++ b/dotnet/samples/02-agents/DeclarativeAgents/ChatClient/Program.cs
@@ -2,22 +2,28 @@
 
 // This sample shows how to load an AI agent from a YAML file and process a prompt using Azure OpenAI as the backend.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Create the chat client
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-IChatClient chatClient = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+IChatClient chatClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetChatClient(deploymentName)
      .AsIChatClient();
 

--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/DevUI_Step01_BasicUsage.csproj
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/DevUI_Step01_BasicUsage.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
   </ItemGroup>

--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
@@ -2,14 +2,15 @@
 
 // This sample demonstrates basic usage of the DevUI in an ASP.NET Core application with AI agents.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.DevUI;
 using Microsoft.Agents.AI.Hosting;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
+using OpenAI;
 
 namespace DevUI_Step01_BasicUsage;
 
@@ -44,12 +45,17 @@ internal static class Program
 
         // Set up the Azure OpenAI client
         var endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+        // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+        if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+        {
+            endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+        }
         var deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? "gpt-5.4-mini";
 
         // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
         // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
         // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-        var chatClient = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+        var chatClient = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
             .GetChatClient(deploymentName)
             .AsIChatClient();
 

--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
@@ -44,18 +44,15 @@ internal static class Program
         var builder = WebApplication.CreateBuilder(args);
 
         // Set up the Azure OpenAI client
-        var endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-        // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-        if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-        {
-            endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-        }
+        Uri endpoint = AzureOpenAIEndpoint.From(
+            builder.Configuration["AZURE_OPENAI_ENDPOINT"])
+            ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
         var deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? "gpt-5.4-mini";
 
         // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
         // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
         // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-        var chatClient = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+        var chatClient = new OpenAIClient(new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"), new OpenAIClientOptions { Endpoint = endpoint })
             .GetChatClient(deploymentName)
             .AsIChatClient();
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Agent_MCP_LongRunningTask_Client.csproj
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Agent_MCP_LongRunningTask_Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Program.cs
@@ -20,8 +20,8 @@
 //
 // No application-level loop or continuation tokens are required in either mode.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Mcp;
@@ -33,6 +33,7 @@ using ModelContextProtocol.Client;
 using ModelContextProtocol.Extensions.Tasks;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using OpenAI;
 using OpenAI.Chat;
 
 if (args.Length > 0 && args[0] == "--server")
@@ -42,6 +43,11 @@ if (args.Length > 0 && args[0] == "--server")
 }
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Launch this same assembly as a stdio MCP server in a child process.
@@ -60,9 +66,9 @@ var mcpTools = await mcpClient.ListAgentToolsWithTasksAsync();
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetChatClient(deploymentName)
      .AsAIAgent(
         instructions: "You answer data-analysis questions by invoking the available tools. Always invoke a tool when one matches the request.",

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_LongRunningTask_Client/Program.cs
@@ -42,12 +42,9 @@ if (args.Length > 0 && args[0] == "--server")
     return;
 }
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Launch this same assembly as a stdio MCP server in a child process.
@@ -68,7 +65,7 @@ var mcpTools = await mcpClient.ListAgentToolsWithTasksAsync();
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetChatClient(deploymentName)
      .AsAIAgent(
         instructions: "You answer data-analysis questions by invoking the available tools. Always invoke a tool when one matches the request.",

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Agent_MCP_Server.csproj
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Agent_MCP_Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="ModelContextProtocol" />

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Program.cs
@@ -10,12 +10,9 @@ using ModelContextProtocol.Client;
 using OpenAI;
 using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Create an MCPClient for the GitHub server
@@ -34,7 +31,7 @@ var mcpTools = await mcpClient.ListToolsAsync().ConfigureAwait(false);
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You answer questions related to GitHub repositories only.", tools: [.. mcpTools.Cast<AITool>()]);
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server/Program.cs
@@ -2,14 +2,20 @@
 
 // This sample shows how to create and use a simple AI agent with tools from an MCP Server.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
+using OpenAI;
 using OpenAI.Chat;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // Create an MCPClient for the GitHub server
@@ -26,9 +32,9 @@ var mcpTools = await mcpClient.ListToolsAsync().ConfigureAwait(false);
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You answer questions related to GitHub repositories only.", tools: [.. mcpTools.Cast<AITool>()]);
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Agent_MCP_Server_Auth.csproj
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Agent_MCP_Server_Auth.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Program.cs
@@ -2,19 +2,25 @@
 
 // This sample shows how to create and use a simple AI agent with tools from an MCP Server that requires authentication.
 
+using System.ClientModel.Primitives;
 using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Web;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Authentication;
 using ModelContextProtocol.Client;
+using OpenAI;
 using OpenAI.Chat;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // We can customize a shared HttpClient with a custom handler if desired
@@ -53,9 +59,9 @@ var mcpTools = await mcpClient.ListToolsAsync().ConfigureAwait(false);
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You answer questions related to the weather.", tools: [.. mcpTools]);
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/Program.cs
@@ -15,12 +15,9 @@ using ModelContextProtocol.Client;
 using OpenAI;
 using OpenAI.Chat;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // We can customize a shared HttpClient with a custom handler if desired
@@ -61,7 +58,7 @@ var mcpTools = await mcpClient.ListToolsAsync().ConfigureAwait(false);
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetChatClient(deploymentName)
      .AsAIAgent(instructions: "You answer questions related to the weather.", tools: [.. mcpTools]);
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/README.md
+++ b/dotnet/samples/02-agents/ModelContextProtocol/Agent_MCP_Server_Auth/README.md
@@ -20,15 +20,29 @@ The sample shows:
 - .NET 10.0 or later
 - A running TestOAuthServer (for OAuth authentication), see [Start the Test OAuth Server](https://github.com/modelcontextprotocol/csharp-sdk/tree/main/samples/ProtectedMcpClient#step-1-start-the-test-oauth-server)
 - A running ProtectedMCPServer (for MCP services), see [Start the Protected MCP Server](https://github.com/modelcontextprotocol/csharp-sdk/tree/main/samples/ProtectedMcpClient#step-2-start-the-protected-mcp-server)
- 
+
+Clone the MCP .NET SDK if it is not already available locally:
+
+```powershell
+git clone https://github.com/modelcontextprotocol/csharp-sdk.git
+dotnet dev-certs https --trust
+```
+
 ## Configuring Environment Variables
 
 Set the following environment variables:
 
 ```powershell
-$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/" # Replace with your Azure OpenAI resource endpoint
-$env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-5.4-mini"  # Optional, defaults to gpt-5.4-mini
+# Azure OpenAI resource root (the sample appends /openai/v1 automatically):
+$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+$env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-5.4-mini"
+
+# A Foundry project OpenAI v1 endpoint also works:
+# $env:AZURE_OPENAI_ENDPOINT="https://your-resource.services.ai.azure.com/api/projects/your-project/openai/v1/"
 ```
+
+The OpenAI-compatible model is separate from MCP OAuth. MCP OAuth authenticates access to the weather
+tools. The model chooses when to call those tools.
 
 ## Setup and Running
 
@@ -100,11 +114,14 @@ sequenceDiagram
 ## OAuth Configuration
 
 The client is configured with:
-- **Client ID**: `demo-client`
-- **Client Secret**: `demo-secret` 
+- **Client registration**: Dynamic Client Registration performed automatically by the MCP client
+- **Client name**: `ProtectedMcpClient`
 - **Redirect URI**: `http://localhost:1179/callback`
 - **OAuth Server**: `https://localhost:7029`
 - **Protected Resource**: `http://localhost:7071`
+
+The test authorization endpoint immediately redirects back with an authorization code. No test username,
+password, client ID, or client secret needs to be entered.
 
 ## Available Tools
 

--- a/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/Program.cs
@@ -11,12 +11,9 @@ using Microsoft.Extensions.AI;
 using OpenAI;
 using OpenAI.Responses;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // **** MCP Tool with Auto Approval ****
@@ -38,7 +35,7 @@ var mcpTool = new HostedMcpServerTool(
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 AIAgent agent = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
      .GetResponsesClient()
      .AsAIAgent(
         model: deploymentName,
@@ -66,7 +63,7 @@ var mcpToolWithApproval = new HostedMcpServerTool(
 // Create an agent based on Azure OpenAI Responses as the backend.
 AIAgent agentWithRequiredApproval = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetResponsesClient()
     .AsAIAgent(
         model: deploymentName,

--- a/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/Program.cs
+++ b/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/Program.cs
@@ -4,13 +4,19 @@
 // In this case the OpenAI responses service will invoke any MCP tools as required. MCP tools are not invoked by the Agent Framework.
 // The sample first shows how to use MCP tools with auto approval, and then how to set up a tool that requires approval before it can be invoked and how to approve such a tool.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Responses;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 
 // **** MCP Tool with Auto Approval ****
@@ -30,9 +36,9 @@ var mcpTool = new HostedMcpServerTool(
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
      .GetResponsesClient()
      .AsAIAgent(
         model: deploymentName,
@@ -58,9 +64,9 @@ var mcpToolWithApproval = new HostedMcpServerTool(
 };
 
 // Create an agent based on Azure OpenAI Responses as the backend.
-AIAgent agentWithRequiredApproval = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+AIAgent agentWithRequiredApproval = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetResponsesClient()
     .AsAIAgent(
         model: deploymentName,

--- a/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/ResponseAgent_Hosted_MCP.csproj
+++ b/dotnet/samples/02-agents/ModelContextProtocol/ResponseAgent_Hosted_MCP/ResponseAgent_Hosted_MCP.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/03-workflows/Concurrent/MapReduce/MapReduce.csproj
+++ b/dotnet/samples/03-workflows/Concurrent/MapReduce/MapReduce.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
   </ItemGroup>

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/HostedWorkflowHandoff.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/HostedWorkflowHandoff.csproj
@@ -23,10 +23,11 @@
     <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="$(AgentFrameworkVersion)" />
     <PackageReference Include="Microsoft.Agents.AI.Foundry.Hosting" Version="$(AgentFrameworkVersion)" />
     <PackageReference Include="Microsoft.Agents.AI.Hosting" Version="$(AgentFrameworkVersion)" />
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="ModelContextProtocol" Version="2.1.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
+    <PackageReference Include="ModelContextProtocol" Version="2.1.0" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Web" />

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/Program.cs
@@ -35,13 +35,9 @@ var builder = WebApplication.CreateBuilder(args);
 // ---------------------------------------------------------------------------
 // 1. Create the shared Azure OpenAI chat client
 // ---------------------------------------------------------------------------
-var endpointValue = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpointValue).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpointValue = $"{endpointValue.TrimEnd('/')}/openai/v1";
-}
-var endpoint = new Uri(endpointValue);
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "gpt-4o";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/Program.cs
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/Program.cs
@@ -15,8 +15,8 @@
 //   - AZURE_OPENAI_ENDPOINT   - your Azure OpenAI endpoint
 //   - AZURE_OPENAI_DEPLOYMENT - the model deployment name (default: "gpt-4o")
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using DotNetEnv;
 using Microsoft.Agents.AI;
@@ -25,6 +25,7 @@ using Microsoft.Agents.AI.Hosting;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Client;
+using OpenAI;
 
 // Load .env file if present (for local development)
 Env.TraversePath().Load();
@@ -34,13 +35,21 @@ var builder = WebApplication.CreateBuilder(args);
 // ---------------------------------------------------------------------------
 // 1. Create the shared Azure OpenAI chat client
 // ---------------------------------------------------------------------------
-var endpoint = new Uri(System.Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set."));
-var deployment = System.Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "gpt-4o";
+var endpointValue = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpointValue).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpointValue = $"{endpointValue.TrimEnd('/')}/openai/v1";
+}
+var endpoint = new Uri(endpointValue);
+var deployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "gpt-4o";
 
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-var azureClient = new AzureOpenAIClient(endpoint, new DefaultAzureCredential());
+var azureClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = endpoint });
 IChatClient chatClient = azureClient.GetResponsesClient().AsIChatClient(deployment);
 
 // ---------------------------------------------------------------------------

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/README.md
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-Workflow-Handoff/README.md
@@ -10,7 +10,7 @@ This sample deploys to Foundry **directly from source (code / ZIP upload)**: the
 > deploying.
 
 > **The deployed agent needs its own role on that Azure OpenAI resource.** Because the workflow
-> builds its own `AzureOpenAIClient` (a data-plane client) instead of using the Foundry project's
+> builds its own `OpenAIClient` targeting the Azure OpenAI v1 endpoint instead of using the Foundry project's
 > hosted model, `azd deploy` does **not** grant it access automatically. `azd` only grants the agent
 > identity the `Foundry User` role on the project; it does not touch a separate Azure OpenAI account.
 > After the first deploy, grant the agent's managed identity the **`Cognitive Services OpenAI User`**

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/AGUIDojoServer.csproj
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/AGUIDojoServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
@@ -22,12 +22,9 @@ internal static class ChatClientAgentFactory
 
     public static void Initialize(IConfiguration configuration)
     {
-        string endpoint = configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-        // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-        if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-        {
-            endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-        }
+        Uri endpoint = AzureOpenAIEndpoint.From(
+            configuration["AZURE_OPENAI_ENDPOINT"])
+            ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
         s_deploymentName = configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
         // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
@@ -35,7 +32,7 @@ internal static class ChatClientAgentFactory
         // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
         s_azureOpenAIClient = new OpenAIClient(
             new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-            new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+            new OpenAIClientOptions { Endpoint = endpoint });
     }
 
     public static ChatClientAgent CreateAgenticChat()

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
@@ -1,35 +1,41 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.ClientModel.Primitives;
 using System.ComponentModel;
 using System.Text.Json;
 using AGUIDojoServer.AgenticUI;
 using AGUIDojoServer.BackendToolRendering;
 using AGUIDojoServer.PredictiveStateUpdates;
 using AGUIDojoServer.SharedState;
-using Azure.AI.OpenAI;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Chat;
 
 namespace AGUIDojoServer;
 
 internal static class ChatClientAgentFactory
 {
-    private static AzureOpenAIClient? s_azureOpenAIClient;
+    private static OpenAIClient? s_azureOpenAIClient;
     private static string? s_deploymentName;
 
     public static void Initialize(IConfiguration configuration)
     {
         string endpoint = configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+        // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+        if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+        {
+            endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+        }
         s_deploymentName = configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
         // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
         // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
         // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-        s_azureOpenAIClient = new AzureOpenAIClient(
-            new Uri(endpoint),
-            new DefaultAzureCredential());
+        s_azureOpenAIClient = new OpenAIClient(
+            new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+            new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
     }
 
     public static ChatClientAgent CreateAgenticChat()

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/AGUIServer.csproj
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/AGUIServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
@@ -16,6 +16,11 @@ builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.T
 builder.Services.AddAGUIServer();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
 const string AgentName = "AGUIAssistant";
@@ -30,9 +35,8 @@ IChatClient chatClient = new OpenAIClient(
     .GetResponsesClient()
     .AsIChatClientWithStoredOutputDisabled(model: deploymentName);
 
-// WARNING: When adding session persistence (e.g., WithInMemorySessionStore), or running in production,
-// make sure to also register an AgentIsolationKeyProvider to scope sessions by principal in multi-user
-// deployments, e.g.:
+// This local sample accepts anonymous requests, so it disables per-user session isolation below.
+// In production, authenticate callers and register an AgentIsolationKeyProvider, e.g.:
 // builder.Services.UseClaimsBasedAgentIsolation(new() { ClaimType = ClaimTypes.NameIdentifier });
 
 // Register the agent with the host and configure it to use an in-memory session store
@@ -58,7 +62,7 @@ builder
             name: "get_server_weather_forecast",
             description: "Gets the forecast for a specific location and date",
             AGUIServerSerializerContext.Default.Options))
-    .WithInMemorySessionStore();
+    .WithInMemorySessionStore(withIsolation: false);
 
 WebApplication app = builder.Build();
 

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
@@ -15,12 +15,9 @@ builder.Services.AddHttpClient().AddLogging();
 builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.TypeInfoResolverChain.Add(AGUIServerSerializerContext.Default));
 builder.Services.AddAGUIServer();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
 const string AgentName = "AGUIAssistant";
@@ -31,7 +28,7 @@ const string AgentName = "AGUIAssistant";
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 IChatClient chatClient = new OpenAIClient(
         new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-        new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+        new OpenAIClientOptions { Endpoint = endpoint })
     .GetResponsesClient()
     .AsIChatClientWithStoredOutputDisabled(model: deploymentName);
 

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/AGUIServer/Program.cs
@@ -35,8 +35,9 @@ IChatClient chatClient = new OpenAIClient(
     .GetResponsesClient()
     .AsIChatClientWithStoredOutputDisabled(model: deploymentName);
 
-// This local sample accepts anonymous requests, so it disables per-user session isolation below.
-// In production, authenticate callers and register an AgentIsolationKeyProvider, e.g.:
+// WARNING: When adding session persistence (e.g., WithInMemorySessionStore), or running in production,
+// make sure to also register an AgentIsolationKeyProvider to scope sessions by principal in multi-user
+// deployments, e.g.:
 // builder.Services.UseClaimsBasedAgentIsolation(new() { ClaimType = ClaimTypes.NameIdentifier });
 
 // Register the agent with the host and configure it to use an in-memory session store
@@ -62,7 +63,7 @@ builder
             name: "get_server_weather_forecast",
             description: "Gets the forecast for a specific location and date",
             AGUIServerSerializerContext.Default.Options))
-    .WithInMemorySessionStore(withIsolation: false);
+    .WithInMemorySessionStore();
 
 WebApplication app = builder.Build();
 

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/README.md
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/README.md
@@ -43,6 +43,17 @@ dotnet run --urls "http://localhost:5100"
 
 The server will start and listen on `http://localhost:5100`.
 
+The local server accepts anonymous requests and uses:
+
+```csharp
+.WithInMemorySessionStore(withIsolation: false);
+```
+
+`WithInMemorySessionStore()` enables per-user isolation by default. That default requires an
+`AgentIsolationKeyProvider`, normally backed by the authenticated caller's claims. This anonymous
+local sample has no user identity, so it disables isolation explicitly. In production, authenticate
+callers and register `UseClaimsBasedAgentIsolation(...)` instead.
+
 ### Step 2: Testing with the REST Client (Optional)
 
 Before running the client, you can test the server using the included `.http` file:
@@ -133,7 +144,7 @@ IChatClient chatClient = new OpenAIClient(
 builder
     .AddAIAgent("AGUIAssistant", "You are a helpful assistant.", chatClient)
     .WithAITool(new HostedWebSearchTool())
-    .WithInMemorySessionStore();
+    .WithInMemorySessionStore(withIsolation: false);
 
 app.MapAGUIServer("AGUIAssistant", "/");
 ```

--- a/dotnet/samples/05-end-to-end/AGUIClientServer/README.md
+++ b/dotnet/samples/05-end-to-end/AGUIClientServer/README.md
@@ -43,17 +43,6 @@ dotnet run --urls "http://localhost:5100"
 
 The server will start and listen on `http://localhost:5100`.
 
-The local server accepts anonymous requests and uses:
-
-```csharp
-.WithInMemorySessionStore(withIsolation: false);
-```
-
-`WithInMemorySessionStore()` enables per-user isolation by default. That default requires an
-`AgentIsolationKeyProvider`, normally backed by the authenticated caller's claims. This anonymous
-local sample has no user identity, so it disables isolation explicitly. In production, authenticate
-callers and register `UseClaimsBasedAgentIsolation(...)` instead.
-
 ### Step 2: Testing with the REST Client (Optional)
 
 Before running the client, you can test the server using the included `.http` file:
@@ -144,7 +133,7 @@ IChatClient chatClient = new OpenAIClient(
 builder
     .AddAIAgent("AGUIAssistant", "You are a helpful assistant.", chatClient)
     .WithAITool(new HostedWebSearchTool())
-    .WithInMemorySessionStore(withIsolation: false);
+    .WithInMemorySessionStore();
 
 app.MapAGUIServer("AGUIAssistant", "/");
 ```

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
@@ -67,14 +67,12 @@ The server (`Server/Program.cs`) creates a simple chat agent:
 
 ```csharp
 // Create OpenAI client targeting Azure OpenAI
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri openAIEndpoint = AzureOpenAIEndpoint.From(endpoint)
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 
 OpenAIClient openAIClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+    new OpenAIClientOptions { Endpoint = openAIEndpoint });
 
 ChatClient chatClient = openAIClient.GetChatClient(deploymentName);
 

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
@@ -66,12 +66,12 @@ Features:
 The server (`Server/Program.cs`) creates a simple chat agent:
 
 ```csharp
-// Create Azure OpenAI client
-AzureOpenAIClient azureOpenAIClient = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential());
+// Create OpenAI client targeting Azure OpenAI
+OpenAIClient openAIClient = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
 
-ChatClient chatClient = azureOpenAIClient.GetChatClient(deploymentName);
+ChatClient chatClient = openAIClient.GetChatClient(deploymentName);
 
 // Create AI agent
 ChatClientAgent agent = chatClient.AsAIAgent(

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/README.md
@@ -67,6 +67,11 @@ The server (`Server/Program.cs`) creates a simple chat agent:
 
 ```csharp
 // Create OpenAI client targeting Azure OpenAI
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
+
 OpenAIClient openAIClient = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
     new OpenAIClientOptions { Endpoint = new Uri(endpoint) });

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/Server/AGUIWebChatServer.csproj
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/Server/AGUIWebChatServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/Server/Program.cs
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/Server/Program.cs
@@ -2,10 +2,11 @@
 
 // This sample demonstrates a basic AG-UI server hosting a chat agent for the Blazor web client.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+using OpenAI;
 using OpenAI.Chat;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -20,15 +21,20 @@ builder.Services.AddAGUIServer();
 WebApplication app = builder.Build();
 
 string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
 // Create the AI agent
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-AzureOpenAIClient azureOpenAIClient = new(
-    new Uri(endpoint),
-    new DefaultAzureCredential());
+OpenAIClient azureOpenAIClient = new(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
 
 ChatClient chatClient = azureOpenAIClient.GetChatClient(deploymentName);
 

--- a/dotnet/samples/05-end-to-end/AGUIWebChat/Server/Program.cs
+++ b/dotnet/samples/05-end-to-end/AGUIWebChat/Server/Program.cs
@@ -20,12 +20,9 @@ builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
-string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"] ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    builder.Configuration["AZURE_OPENAI_ENDPOINT"])
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
 
 // Create the AI agent
@@ -34,7 +31,7 @@ string deploymentName = builder.Configuration["AZURE_OPENAI_DEPLOYMENT_NAME"] ??
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 OpenAIClient azureOpenAIClient = new(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+    new OpenAIClientOptions { Endpoint = endpoint });
 
 ChatClient chatClient = azureOpenAIClient.GetChatClient(deploymentName);
 

--- a/dotnet/samples/05-end-to-end/AgentWithPurview/AgentWithPurview.csproj
+++ b/dotnet/samples/05-end-to-end/AgentWithPurview/AgentWithPurview.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/dotnet/samples/05-end-to-end/AgentWithPurview/Program.cs
+++ b/dotnet/samples/05-end-to-end/AgentWithPurview/Program.cs
@@ -5,14 +5,20 @@
 // Authentication to Purview is done using an InteractiveBrowserCredential.
 // Any TokenCredential with Purview API permissions can be used here.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Purview;
 using Microsoft.Extensions.AI;
+using OpenAI;
 
 var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+{
+    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+}
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 var purviewClientAppId = Environment.GetEnvironmentVariable("PURVIEW_CLIENT_APP_ID") ?? throw new InvalidOperationException("PURVIEW_CLIENT_APP_ID is not set.");
 
@@ -27,9 +33,9 @@ TokenCredential browserCredential = new InteractiveBrowserCredential(
 // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
 // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-using IChatClient client = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new DefaultAzureCredential())
+using IChatClient client = new OpenAIClient(
+    new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
     .GetResponsesClient()
     .AsIChatClient(deploymentName)
     .AsBuilder()

--- a/dotnet/samples/05-end-to-end/AgentWithPurview/Program.cs
+++ b/dotnet/samples/05-end-to-end/AgentWithPurview/Program.cs
@@ -13,12 +13,9 @@ using Microsoft.Agents.AI.Purview;
 using Microsoft.Extensions.AI;
 using OpenAI;
 
-var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
-// OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-{
-    endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-}
+Uri endpoint = AzureOpenAIEndpoint.From(
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT"))
+    ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
 var purviewClientAppId = Environment.GetEnvironmentVariable("PURVIEW_CLIENT_APP_ID") ?? throw new InvalidOperationException("PURVIEW_CLIENT_APP_ID is not set.");
 
@@ -35,7 +32,7 @@ TokenCredential browserCredential = new InteractiveBrowserCredential(
 // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
 using IChatClient client = new OpenAIClient(
     new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-    new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetResponsesClient()
     .AsIChatClient(deploymentName)
     .AsBuilder()

--- a/dotnet/samples/05-end-to-end/AgentWithPurview/README.md
+++ b/dotnet/samples/05-end-to-end/AgentWithPurview/README.md
@@ -1,0 +1,58 @@
+# Agent with Purview
+
+This sample adds Microsoft Purview policy evaluation to an OpenAI-compatible chat client.
+
+## What is required
+
+The model endpoint and Purview authentication are separate:
+
+- The model endpoint generates the response.
+- Microsoft Graph Purview APIs evaluate the prompt and response against tenant policies.
+
+Set the model configuration:
+
+```powershell
+# Azure OpenAI resource root (the sample appends /openai/v1 automatically):
+$env:AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+$env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-5.4-mini"
+
+# A Foundry project OpenAI v1 endpoint also works:
+# $env:AZURE_OPENAI_ENDPOINT="https://your-resource.services.ai.azure.com/api/projects/your-project/openai/v1/"
+```
+
+Create or reuse a Microsoft Entra public client application and set:
+
+```powershell
+$env:PURVIEW_CLIENT_APP_ID="<application-client-id>"
+```
+
+The app requires these delegated Microsoft Graph permissions with tenant administrator consent:
+
+- `ProtectionScopes.Compute.All`
+- `Content.Process.All`
+- `ContentActivity.Write`
+
+Configure a localhost redirect URI for the public client application so `InteractiveBrowserCredential`
+can complete sign-in.
+
+## Tenant configuration
+
+A successful authentication only proves that the Graph permissions are configured. A real Purview block
+also requires:
+
+1. Microsoft Purview entitlement and consumptive billing.
+2. The Entra app registered in **Purview > Settings > AI app and agent locations**.
+3. A DLP or data collection policy targeting the app and signed-in user.
+4. The policy enabled outside test-only mode.
+
+## Run
+
+```powershell
+az login
+dotnet run
+```
+
+The sample opens a browser for the delegated Purview sign-in, then prompts for text to send to the model.
+
+For middleware options and policy behavior, see
+[`Microsoft.Agents.AI.Purview`](../../../src/Microsoft.Agents.AI.Purview/README.md).

--- a/dotnet/samples/05-end-to-end/M365Agent/M365Agent.csproj
+++ b/dotnet/samples/05-end-to-end/M365Agent/M365Agent.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" />
     <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />

--- a/dotnet/samples/05-end-to-end/M365Agent/Program.cs
+++ b/dotnet/samples/05-end-to-end/M365Agent/Program.cs
@@ -34,19 +34,15 @@ IChatClient chatClient;
 if (builder.Configuration.GetSection("AIServices").GetValue<bool>("UseAzureOpenAI"))
 {
     var deploymentName = builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("DeploymentName")!;
-    var endpoint = builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("Endpoint")!;
-    // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
-    if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
-    {
-        endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
-    }
+    Uri endpoint = AzureOpenAIEndpoint.From(builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("Endpoint"))
+        ?? throw new InvalidOperationException("AIServices:AzureOpenAI:Endpoint is not set.");
 
     // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
     // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
     // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
     chatClient = new OpenAIClient(
         new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
-        new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
+        new OpenAIClientOptions { Endpoint = endpoint })
          .GetChatClient(deploymentName)
          .AsIChatClient();
 }

--- a/dotnet/samples/05-end-to-end/M365Agent/Program.cs
+++ b/dotnet/samples/05-end-to-end/M365Agent/Program.cs
@@ -4,7 +4,7 @@
 // The agent can then be consumed from various M365 channels.
 // See the README.md for more information.
 
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Identity;
 using M365Agent;
 using M365Agent.Agents;
@@ -35,13 +35,18 @@ if (builder.Configuration.GetSection("AIServices").GetValue<bool>("UseAzureOpenA
 {
     var deploymentName = builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("DeploymentName")!;
     var endpoint = builder.Configuration.GetSection("AIServices:AzureOpenAI").GetValue<string>("Endpoint")!;
+    // OpenAI SDK needs the Azure OpenAI v1 route. Accept a resource root or a full /openai/v1 endpoint.
+    if (!new Uri(endpoint).AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+    {
+        endpoint = $"{endpoint.TrimEnd('/')}/openai/v1";
+    }
 
     // WARNING: DefaultAzureCredential is convenient for development but requires careful consideration in production.
     // In production, consider using a specific credential (e.g., ManagedIdentityCredential) to avoid
     // latency issues, unintended credential probing, and potential security risks from fallback mechanisms.
-    chatClient = new AzureOpenAIClient(
-        new Uri(endpoint),
-        new DefaultAzureCredential())
+    chatClient = new OpenAIClient(
+        new BearerTokenPolicy(new DefaultAzureCredential(), "https://ai.azure.com/.default"),
+        new OpenAIClientOptions { Endpoint = new Uri(endpoint) })
          .GetChatClient(deploymentName)
          .AsIChatClient();
 }

--- a/dotnet/samples/Directory.Build.props
+++ b/dotnet/samples/Directory.Build.props
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="SampleHelpers.AzureOpenAIEndpoint" Alias="AzureOpenAIEndpoint" />
     <Using Include="SampleHelpers.SampleEnvironment" Alias="Environment" />
   </ItemGroup>
 

--- a/dotnet/src/Microsoft.Agents.AI.Purview/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.Purview/README.md
@@ -28,14 +28,15 @@ Add Purview when you need to:
 ## Quick Start
 
 ``` csharp
-using Azure.AI.OpenAI;
+using System.ClientModel.Primitives;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Purview;
 using Microsoft.Extensions.AI;
+using OpenAI;
 
-Uri endpoint = new Uri("..."); // The endpoint of Azure OpenAI instance.
+Uri endpoint = new Uri("https://your-resource.openai.azure.com/openai/v1/");
 string deploymentName = "..."; // The deployment name of your Azure OpenAI instance ex: gpt-4o-mini
 string purviewClientAppId = "..."; // The client id of your entra app registration. 
 
@@ -47,11 +48,11 @@ TokenCredential browserCredential = new InteractiveBrowserCredential(
         ClientId = purviewClientAppId
     });
 
-IChatClient client = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new AzureCliCredential())
-    .GetResponsesClient(deploymentName)
-    .AsIChatClient()
+IChatClient client = new OpenAIClient(
+    new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = endpoint })
+    .GetResponsesClient()
+    .AsIChatClient(deploymentName)
     .AsBuilder()
     .WithPurview(browserCredential, new PurviewSettings("My Sample App"))
     .Build();
@@ -81,6 +82,17 @@ The plugin requires the following Graph permissions:
 - ProtectionScopes.Compute.All : [userProtectionScopeContainer](https://learn.microsoft.com/en-us/graph/api/userprotectionscopecontainer-compute)
 - Content.Process.All : [processContent](https://learn.microsoft.com/en-us/graph/api/userdatasecurityandgovernance-processcontent)
 - ContentActivity.Write : [contentActivity](https://learn.microsoft.com/en-us/graph/api/activitiescontainer-post-contentactivities)
+
+The Entra app must be configured as a public client application with a localhost redirect URI so
+`InteractiveBrowserCredential` can complete the delegated user sign-in. These permissions require tenant
+administrator consent.
+
+The client ID alone is not enough for a live Purview policy test. The tenant must also:
+
+1. Have Microsoft Purview entitlement and consumptive billing enabled.
+2. Register the Entra app as an integrated AI app in **Purview > Settings > AI app and agent locations**.
+3. Configure a DLP or data collection policy that applies to the signed-in user and the app.
+4. Turn the policy on. A policy in test mode does not produce an enforced block.
 
 Authentication with user tokens is preferred. When the configured credential resolves to a user token, that token's user id is used for Purview policy evaluation. If authenticating with app tokens, the token does not contain an end-user principal, so the agent-framework caller will need to provide an entra user id for each `ChatMessage` sent to the agent/client. This user id can be set using the `SetUserId` extension method, or by setting the `"userId"` field of the `AdditionalProperties` dictionary.
 
@@ -182,9 +194,9 @@ var settings = new PurviewSettings("My Sample App")
 Use the agent middleware when you already have / want the full agent pipeline:
 
 ``` csharp
-AIAgent agent = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new AzureCliCredential())
+AIAgent agent = new OpenAIClient(
+    new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = endpoint })
     .GetChatClient(deploymentName)
     .AsAIAgent("You are a helpful assistant.")
     .AsBuilder()
@@ -195,11 +207,11 @@ AIAgent agent = new AzureOpenAIClient(
 Use the chat middleware when you attach directly to a chat client (e.g. minimal agent shell or custom orchestration):
 
 ``` csharp
-IChatClient client = new AzureOpenAIClient(
-    new Uri(endpoint),
-    new AzureCliCredential())
-    .GetResponsesClient(deploymentName)
-    .AsIChatClient()
+IChatClient client = new OpenAIClient(
+    new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"),
+    new OpenAIClientOptions { Endpoint = endpoint })
+    .GetResponsesClient()
+    .AsIChatClient(deploymentName)
     .AsBuilder()
     .WithPurview(browserCredential, new PurviewSettings("Agent Framework Test App"))
     .Build();

--- a/dotnet/src/Shared/Demos/AzureOpenAIEndpoint.cs
+++ b/dotnet/src/Shared/Demos/AzureOpenAIEndpoint.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+#pragma warning disable IDE0005 // This file is shared by projects with and without implicit usings.
+
+using System;
+
+namespace SampleHelpers;
+
+internal static class AzureOpenAIEndpoint
+{
+    public static Uri? From(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return null;
+        }
+
+        Uri endpointUri = new(endpoint, UriKind.Absolute);
+        if (endpointUri.AbsolutePath.TrimEnd('/').EndsWith("/openai/v1", StringComparison.OrdinalIgnoreCase))
+        {
+            return endpointUri;
+        }
+
+        var endpointBuilder = new UriBuilder(endpointUri)
+        {
+            Path = $"{endpointUri.AbsolutePath.TrimEnd('/')}/openai/v1/",
+        };
+
+        return endpointBuilder.Uri;
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/Microsoft.Agents.AI.Foundry.UnitTests.csproj
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/Microsoft.Agents.AI.Foundry.UnitTests.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.ClientModel" />

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/PolicyPipelineInvestigationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.UnitTests/PolicyPipelineInvestigationTests.cs
@@ -10,8 +10,8 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.AI.OpenAI;
 using Microsoft.Extensions.AI;
+using OpenAI;
 using OpenAI.Chat;
 using OpenAI.Responses;
 
@@ -88,9 +88,9 @@ public sealed class PolicyPipelineInvestigationTests
 }
 
 /// <summary>
-/// Executable probes for caller-owned Azure OpenAI clients wrapped by Microsoft.Extensions.AI.
+/// Executable probes for caller-owned OpenAI clients targeting Azure OpenAI endpoints and wrapped by Microsoft.Extensions.AI.
 /// </summary>
-public sealed class AzureOpenAIRequestPoliciesInvestigationTests
+public sealed class OpenAIRequestPoliciesInvestigationTests
 {
     [Fact]
     public async Task CallerOwnedChatAndResponsesWrappers_HaveIsolatedPolicies_PreserveTransport_AndRunAfterBaseUserAgentAsync()
@@ -100,14 +100,12 @@ public sealed class AzureOpenAIRequestPoliciesInvestigationTests
 #pragma warning disable CA5399
         using var httpClient = new HttpClient(handler, disposeHandler: false);
 #pragma warning restore CA5399
-        var options = new AzureOpenAIClientOptions
+        var options = new OpenAIClientOptions
         {
+            Endpoint = new Uri("https://resource.openai.azure.com/openai/v1/"),
             Transport = new HttpClientPipelineTransport(httpClient),
         };
-        var azureClient = new AzureOpenAIClient(
-            new Uri("https://resource.openai.azure.com/"),
-            new ApiKeyCredential("test-key"),
-            options);
+        var azureClient = new OpenAIClient(new ApiKeyCredential("test-key"), options);
 
         ChatClient callerOwnedChatClient = azureClient.GetChatClient("deployment");
         ResponsesClient callerOwnedResponsesClient = azureClient.GetResponsesClient();
@@ -134,7 +132,6 @@ public sealed class AzureOpenAIRequestPoliciesInvestigationTests
         Assert.Contains(handler.Requests, static request => request.Marker == "chat-only");
         Assert.Equal(2, handler.Requests.Count(static request => request.Marker is null));
         Assert.Single(probe.ObservedUserAgents);
-        Assert.Contains("azsdk-net-AI.OpenAI/", probe.ObservedUserAgents[0]);
         Assert.Contains("MEAI/", probe.ObservedUserAgents[0]);
     }
 
@@ -168,11 +165,12 @@ public sealed class AzureOpenAIRequestPoliciesInvestigationTests
 
     private static IChatClient CreateChatWrapper(Uri endpoint, HttpClient httpClient)
     {
-        var options = new AzureOpenAIClientOptions
+        var options = new OpenAIClientOptions
         {
+            Endpoint = endpoint,
             Transport = new HttpClientPipelineTransport(httpClient),
         };
-        return new AzureOpenAIClient(endpoint, new ApiKeyCredential("test-key"), options)
+        return new OpenAIClient(new ApiKeyCredential("test-key"), options)
             .GetChatClient("deployment")
             .AsIChatClient();
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests.csproj
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests/Microsoft.Agents.AI.Hosting.AGUI.AspNetCore.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.AI.OpenAI" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />

--- a/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Microsoft.Agents.AI.OpenAI.UnitTests.csproj
+++ b/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/Microsoft.Agents.AI.OpenAI.UnitTests.csproj
@@ -5,10 +5,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\FeatureUsageAssert.cs" Link="FeatureUsageAssert.cs" />
     <ProjectReference Include="..\..\src\Microsoft.Agents.AI.Abstractions\Microsoft.Agents.AI.Abstractions.csproj" />
     <Using Include="Microsoft.Agents.AI.Testing" />

--- a/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/UserAgentPolicyTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.OpenAI.UnitTests/UserAgentPolicyTests.cs
@@ -9,10 +9,11 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.AI.OpenAI;
 using Microsoft.Extensions.AI;
 using OpenAI.Chat;
 using OpenAI.Responses;
+using OpenAIClient = OpenAI.OpenAIClient;
+using OpenAIClientOptions = OpenAI.OpenAIClientOptions;
 
 namespace Microsoft.Agents.AI.OpenAI.UnitTests;
 
@@ -58,7 +59,7 @@ public sealed class UserAgentPolicyTests : IDisposable
     {
         // Arrange
         using var handler = new RecordingHandler();
-        AzureOpenAIClient client = CreateAzureOpenAIClient(handler);
+        OpenAIClient client = CreateAzureOpenAIClient(handler);
         ChatClientAgent agent = client.GetChatClient("deployment").AsAIAgent();
         FeatureUsageAssert.Reset();
 
@@ -74,7 +75,7 @@ public sealed class UserAgentPolicyTests : IDisposable
     {
         // Arrange
         using var handler = new RecordingHandler();
-        AzureOpenAIClient client = CreateAzureOpenAIClient(handler);
+        OpenAIClient client = CreateAzureOpenAIClient(handler);
         ChatClientAgent agent = client.GetResponsesClient().AsAIAgent(model: "deployment");
         FeatureUsageAssert.Reset();
 
@@ -95,7 +96,7 @@ public sealed class UserAgentPolicyTests : IDisposable
             Environment.SetEnvironmentVariable(FeatureMaskDisabledEnvironmentVariable, "true");
             FeatureUsageAssert.Reset();
             using var handler = new RecordingHandler();
-            AzureOpenAIClient client = CreateAzureOpenAIClient(handler);
+            OpenAIClient client = CreateAzureOpenAIClient(handler);
             ChatClientAgent agent = client.GetChatClient("deployment").AsAIAgent();
 
             // Act
@@ -126,12 +127,12 @@ public sealed class UserAgentPolicyTests : IDisposable
 #pragma warning disable CA5399
         var httpClient = new HttpClient(handler, disposeHandler: false);
 #pragma warning restore CA5399
-        var options = new global::OpenAI.OpenAIClientOptions
+        var options = new OpenAIClientOptions
         {
             Endpoint = new Uri(endpoint),
             Transport = new HttpClientPipelineTransport(httpClient),
         };
-        var client = new global::OpenAI.OpenAIClient(new ApiKeyCredential("test-key"), options);
+        var client = new OpenAIClient(new ApiKeyCredential("test-key"), options);
         ChatClientAgent agent = client.GetChatClient("model").AsAIAgent();
         FeatureUsageAssert.Reset();
 
@@ -146,16 +147,16 @@ public sealed class UserAgentPolicyTests : IDisposable
 
     public void Dispose() => FeatureUsageAssert.Reset();
 
-    private static AzureOpenAIClient CreateAzureOpenAIClient(HttpMessageHandler handler)
+    private static OpenAIClient CreateAzureOpenAIClient(HttpMessageHandler handler)
     {
 #pragma warning disable CA5399
         var httpClient = new HttpClient(handler, disposeHandler: false);
 #pragma warning restore CA5399
-        return new AzureOpenAIClient(
-            new Uri("https://resource.openai.azure.com/"),
+        return new OpenAIClient(
             new ApiKeyCredential("test-key"),
-            new AzureOpenAIClientOptions
+            new OpenAIClientOptions
             {
+                Endpoint = new Uri("https://resource.openai.azure.com/openai/v1/"),
                 Transport = new HttpClientPipelineTransport(httpClient),
             });
     }


### PR DESCRIPTION
### Motivation & Context

The .NET tree still depends on `Azure.AI.OpenAI`, although the Azure SDK migration guidance recommends using the official `OpenAI` SDK directly for Azure OpenAI v1 endpoints. Keeping both packages adds an unnecessary dependency and leaves samples and tests with two client construction patterns.

This change removes the wrapper dependency while preserving Azure authentication, Azure OpenAI resource endpoint support, and the existing Agent Framework behavior.

### Description & Review Guide

- **What are the major changes?** Removes the centrally managed `Azure.AI.OpenAI` version and all direct package references. Azure OpenAI samples now construct `OpenAIClient` with `BearerTokenPolicy`, use the `https://ai.azure.com/.default` scope documented by the Azure SDK migration guide, and normalize resource roots to `/openai/v1/` by inspecting the URI path. Tests that previously constructed `AzureOpenAIClient` now use the direct OpenAI client. Related READMEs and the Semantic Kernel migration prompt were updated. `Aspire.Azure.AI.OpenAI` remains because it is a separate Aspire integration package.
- **What is the impact of these changes?** Consumers of these samples use one OpenAI SDK surface for OpenAI-compatible Azure endpoints. Existing resource root environment variables continue to work because the samples add the v1 path when needed. The anonymous AG-UI sample explicitly disables optional per-user session isolation for its local in-memory store, while the documentation retains the production guidance for authenticated deployments.
- **What do you want reviewers to focus on?** Please focus on the Azure OpenAI endpoint normalization, the Entra audience used by `BearerTokenPolicy`, the explicit dependency versions in the standalone Hosted Workflow Handoff sample, and the migrated policy and User-Agent tests.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #7985

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.