### PR TITLE
.NET: Track and update A2A task state

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -57,11 +57,13 @@ internal sealed class A2AAgentHandler : IAgentHandler
         // Handle messages received via streaming endpoint
         if (context.StreamingResponse)
         {
-            return this.HandleNewMessageStreamingAsync(context, eventQueue, aggregateTaskUpdates: false, cancellationToken);
+            return this.HandleNewMessageAsync(context, eventQueue, aggregateTaskUpdates: false, cancellationToken);
         }
 
         // Handle new messages received via non-streaming endpoint
-        return this.HandleNewMessageAsync(context, eventQueue, cancellationToken);
+        // Aggregate task updates unless the caller requests an immediate response.
+        bool aggregateTaskUpdates = context.Configuration?.ReturnImmediately is not true;
+        return this.HandleNewMessageAsync(context, eventQueue, aggregateTaskUpdates, cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -69,36 +71,6 @@ internal sealed class A2AAgentHandler : IAgentHandler
     {
         var taskUpdater = new TaskUpdater(eventQueue, context.TaskId, context.ContextId);
         await taskUpdater.CancelAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Handles a new message received via the non-streaming <c>message/send</c> endpoint.
-    /// </summary>
-    /// <remarks>
-    /// A non-streaming caller receives exactly one response event, so the shape of that event depends on
-    /// both the server configuration and the client request:
-    /// <list type="bullet">
-    /// <item><description>
-    /// Server allows background responses and the client asked for an immediate response
-    /// (<c>ReturnImmediately = true</c>): the initial task is returned right away and the remaining updates
-    /// are streamed into the task by the server, so the client polls for the rest.
-    /// </description></item>
-    /// <item><description>
-    /// Server allows background responses and the client did not ask for an immediate response
-    /// (<c>ReturnImmediately = false</c>): the agent run is aggregated first and a single completed task is returned.
-    /// </description></item>
-    /// <item><description>
-    /// Server disallows background responses: a single aggregated message is returned regardless of
-    /// <c>ReturnImmediately</c>, because a message response cannot be produced incrementally.
-    /// </description></item>
-    /// </list>
-    /// </remarks>
-    private async Task HandleNewMessageAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
-    {
-        // Aggregate task updates unless the client requests an immediate response.
-        bool aggregateTaskUpdates = context.Configuration?.ReturnImmediately is not true;
-
-        await this.HandleNewMessageStreamingAsync(context, eventQueue, aggregateTaskUpdates, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -146,7 +118,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// </description></item>
     /// </list>
     /// </remarks>
-    private async Task HandleNewMessageStreamingAsync(RequestContext context, AgentEventQueue eventQueue, bool aggregateTaskUpdates, CancellationToken cancellationToken)
+    private async Task HandleNewMessageAsync(RequestContext context, AgentEventQueue eventQueue, bool aggregateTaskUpdates, CancellationToken cancellationToken)
     {
         var contextId = context.ContextId ?? Guid.NewGuid().ToString("N");
         var session = await this._hostAgent.GetOrCreateSessionAsync(contextId, cancellationToken).ConfigureAwait(false);
@@ -162,6 +134,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
         List<ChatMessage> chatMessages = context.Message is not null ? [context.Message.ToChatMessage()] : [];
 
         var options = CreateRunOptions(context);
+
         // Decide whether to run in background based on user preferences and agent capabilities
         var decisionContext = new A2ARunDecisionContext(context);
         var returnTask = await this._runMode.ShouldRunInBackgroundAsync(decisionContext, cancellationToken).ConfigureAwait(false);

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using A2A;
@@ -387,8 +386,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
         {
             if (response.Messages.ToParts() is { Count: > 0 } parts)
             {
-                await AddArtifactAsync(
-                    eventQueue,
+                await eventQueue.AddArtifactAsync(
                     updater,
                     parts,
                     metadata: response.AdditionalProperties?.ToA2AMetadata(),
@@ -408,41 +406,6 @@ internal sealed class A2AAgentHandler : IAgentHandler
             throw;
         }
     }
-
-    /// <summary>
-    /// Adds an artifact with metadata until the minimum A2A package version provides this capability on
-    /// <see cref="TaskUpdater.AddArtifactAsync"/>.
-    /// </summary>
-    /// <remarks>
-    /// Remove this method and call <see cref="TaskUpdater.AddArtifactAsync"/> directly after upgrading to an A2A
-    /// package version whose overload accepts artifact metadata.
-    /// </remarks>
-    private static ValueTask AddArtifactAsync(
-        AgentEventQueue eventQueue,
-        TaskUpdater updater,
-        IReadOnlyList<Part> parts,
-        string? artifactId = null,
-        string? name = null,
-        string? description = null,
-        bool lastChunk = true,
-        bool append = false,
-        Dictionary<string, JsonElement>? metadata = null,
-        CancellationToken cancellationToken = default) =>
-        eventQueue.EnqueueArtifactUpdateAsync(new TaskArtifactUpdateEvent
-        {
-            TaskId = updater.TaskId,
-            ContextId = updater.ContextId,
-            Artifact = new Artifact
-            {
-                ArtifactId = artifactId ?? Guid.NewGuid().ToString("N"),
-                Name = name,
-                Description = description,
-                Parts = [.. parts],
-                Metadata = metadata,
-            },
-            Append = append,
-            LastChunk = lastChunk,
-        }, cancellationToken);
 
     /// <summary>
     /// Consumes the agent updates and emits the aggregated result as a single message.

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -374,6 +374,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// <c>ReturnImmediately = false</c>, meaning it wants the final result in the response rather than a task
     /// it has to poll. No task event is emitted until the agent stream finishes, because the server returns on the
     /// first task event; emitting early would hand the caller an in-progress task instead of a completed one.
+    /// If emitting the result fails after the task has been submitted, the task is transitioned to
+    /// <c>Canceled</c>/<c>Failed</c> so it is never left in a non-terminal state.
     /// </remarks>
     private static async Task AggregateTaskUpdatesAsync(IAsyncEnumerable<AgentResponseUpdate> updates, TaskUpdater updater, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
@@ -381,17 +383,30 @@ internal sealed class A2AAgentHandler : IAgentHandler
 
         await updater.SubmitAsync(cancellationToken).ConfigureAwait(false);
 
-        if (response.Messages.ToParts() is { Count: > 0 } parts)
+        try
         {
-            await AddArtifactAsync(
-                eventQueue,
-                updater,
-                parts,
-                metadata: response.AdditionalProperties?.ToA2AMetadata(),
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
+            if (response.Messages.ToParts() is { Count: > 0 } parts)
+            {
+                await AddArtifactAsync(
+                    eventQueue,
+                    updater,
+                    parts,
+                    metadata: response.AdditionalProperties?.ToA2AMetadata(),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
 
-        await updater.CompleteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            await updater.CompleteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await updater.CancelAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception)
+        {
+            await updater.FailAsync(CreateFailureMessage(updater.ContextId, updater.TaskId), CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using A2A;
@@ -57,7 +58,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
         // Handle messages received via streaming endpoint
         if (context.StreamingResponse)
         {
-            return this.HandleNewMessageStreamingAsync(context, eventQueue, cancellationToken);
+            return this.HandleNewMessageStreamingAsync(context, eventQueue, aggregateTaskUpdates: false, cancellationToken);
         }
 
         // Handle new messages received via non-streaming endpoint
@@ -71,62 +72,82 @@ internal sealed class A2AAgentHandler : IAgentHandler
         await taskUpdater.CancelAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Handles a new message received via the non-streaming <c>message/send</c> endpoint.
+    /// </summary>
+    /// <remarks>
+    /// A non-streaming caller receives exactly one response event, so the shape of that event depends on
+    /// both the server configuration and the client request:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Server allows background responses and the client asked for an immediate response
+    /// (<c>ReturnImmediately = true</c>): the initial task is returned right away and the remaining updates
+    /// are streamed into the task by the server, so the client polls for the rest.
+    /// </description></item>
+    /// <item><description>
+    /// Server allows background responses and the client did not ask for an immediate response
+    /// (<c>ReturnImmediately = false</c>): the agent run is aggregated first and a single completed task is returned.
+    /// </description></item>
+    /// <item><description>
+    /// Server disallows background responses: a single aggregated message is returned regardless of
+    /// <c>ReturnImmediately</c>, because a message response cannot be produced incrementally.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
     private async Task HandleNewMessageAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
-        var contextId = context.ContextId ?? Guid.NewGuid().ToString("N");
-        var session = await this._hostAgent.GetOrCreateSessionAsync(contextId, cancellationToken).ConfigureAwait(false);
+        // Aggregate task updates unless the client requests an immediate response.
+        bool aggregateTaskUpdates = context.Configuration?.ReturnImmediately is not true;
 
-        // AIAgent does not support resuming from arbitrary prior tasks.
-        // Throw explicitly so the client gets a clear error rather than a response
-        // that silently ignores the referenced task context.
-        if (context.Message?.ReferenceTaskIds is { Count: > 0 })
-        {
-            throw new NotSupportedException("ReferenceTaskIds is not supported. AIAgent cannot resume from arbitrary prior task context.");
-        }
-
-        List<ChatMessage> chatMessages = context.Message is not null ? [context.Message.ToChatMessage()] : [];
-
-        // Decide whether to run in background based on user preferences and agent capabilities
-        var decisionContext = new A2ARunDecisionContext(context);
-        var allowBackgroundResponses = await this._runMode.ShouldRunInBackgroundAsync(decisionContext, cancellationToken).ConfigureAwait(false);
-
-        var options = CreateRunOptions(context, allowBackgroundResponses);
-
-        AgentResponse response;
-        try
-        {
-            response = await this._hostAgent.RunAsync(
-                chatMessages,
-                session: session,
-                options: options,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            await this._hostAgent.SaveSessionAsync(contextId, session, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        if (response.ContinuationToken is null)
-        {
-            // Return a lightweight message response (no task lifecycle needed).
-            var message = CreateMessageFromResponse(contextId, response);
-            await eventQueue.EnqueueMessageAsync(message, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            // Long-running operation: emit task lifecycle events.
-            var taskUpdater = new TaskUpdater(eventQueue, context.TaskId, contextId);
-            await taskUpdater.SubmitAsync(cancellationToken).ConfigureAwait(false);
-
-            Message? progressMessage = response.Messages.Count > 0
-                ? CreateMessageFromResponse(contextId, response)
-                : null;
-
-            await taskUpdater.StartWorkAsync(progressMessage, cancellationToken).ConfigureAwait(false);
-        }
+        await this.HandleNewMessageStreamingAsync(context, eventQueue, aggregateTaskUpdates, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task HandleNewMessageStreamingAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    /// <summary>
+    /// Runs the agent for a new message and emits the response events, shared by the streaming and non-streaming endpoints.
+    /// </summary>
+    /// <param name="context">The request context of the incoming message.</param>
+    /// <param name="eventQueue">The queue the response events are written to.</param>
+    /// <param name="aggregateTaskUpdates">
+    /// <see langword="true"/> to run the agent to completion before emitting a single completed task;
+    /// <see langword="false"/> to emit task updates as they are produced. Ignored when the server disallows
+    /// background responses, because a message response is always aggregated.
+    /// </param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
+    /// <remarks>
+    /// The response shape is decided by two independent inputs:
+    /// <list type="number">
+    /// <item><description>
+    /// Whether the server allows background responses. This is configured per agent registration, for example:
+    /// <code>
+    /// builder.AddA2AServer(agent, (A2AServerRegistrationOptions options) =>
+    ///     options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported);
+    /// </code>
+    /// Use <c>AgentRunMode.DisallowBackground</c> to always respond with a message instead of a task.
+    /// </description></item>
+    /// <item><description>
+    /// Whether the client asked for an immediate response. In the A2A protocol this is the
+    /// <c>MessageSendConfiguration.ReturnImmediately</c> flag on the request; from the Agent Framework side, an
+    /// <c>A2AAgent</c> sets it by passing <c>AgentRunOptions.AllowBackgroundResponses = true</c> to the run call.
+    /// </description></item>
+    /// </list>
+    /// The resulting combinations are:
+    /// <list type="bullet">
+    /// <item><description>
+    /// Server allows background responses and <c>ReturnImmediately = true</c>: returns the initial task, then the
+    /// rest of the updates piece by piece.
+    /// </description></item>
+    /// <item><description>
+    /// Server allows background responses and <c>ReturnImmediately = false</c>: returns a single completed task.
+    /// </description></item>
+    /// <item><description>
+    /// Server disallows background responses and <c>ReturnImmediately = true</c>: returns a message.
+    /// </description></item>
+    /// <item><description>
+    /// Server disallows background responses and <c>ReturnImmediately = false</c>: returns a message.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    private async Task HandleNewMessageStreamingAsync(RequestContext context, AgentEventQueue eventQueue, bool aggregateTaskUpdates, CancellationToken cancellationToken)
     {
         var contextId = context.ContextId ?? Guid.NewGuid().ToString("N");
         var session = await this._hostAgent.GetOrCreateSessionAsync(contextId, cancellationToken).ConfigureAwait(false);
@@ -142,7 +163,6 @@ internal sealed class A2AAgentHandler : IAgentHandler
         List<ChatMessage> chatMessages = context.Message is not null ? [context.Message.ToChatMessage()] : [];
 
         var options = CreateRunOptions(context);
-
         // Decide whether to run in background based on user preferences and agent capabilities
         var decisionContext = new A2ARunDecisionContext(context);
         var returnTask = await this._runMode.ShouldRunInBackgroundAsync(decisionContext, cancellationToken).ConfigureAwait(false);
@@ -153,13 +173,24 @@ internal sealed class A2AAgentHandler : IAgentHandler
         {
             if (returnTask)
             {
-                // Stream progress and output through the A2A task lifecycle.
                 var taskUpdater = new TaskUpdater(eventQueue, context.TaskId, contextId);
-                await StreamTaskUpdatesAsync(updates, taskUpdater, cancellationToken).ConfigureAwait(false);
+                if (aggregateTaskUpdates)
+                {
+                    // The server allows background responses, but the non-streaming client request has
+                    // ReturnImmediately disabled, so collect all updates and return a completed task.
+                    await AggregateTaskUpdatesAsync(updates, taskUpdater, eventQueue, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // The server allows background responses and this is either a streaming request or a
+                    // non-streaming request with ReturnImmediately enabled, so emit task updates as they arrive.
+                    await StreamTaskUpdatesAsync(updates, taskUpdater, cancellationToken).ConfigureAwait(false);
+                }
             }
             else
             {
-                // A2A permits only one message in a message-only stream, so aggregate all updates.
+                // The server disallows background responses, so return one aggregated message regardless
+                // of the client request's ReturnImmediately value.
                 await StreamMessageUpdatesAsync(contextId, updates, eventQueue, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -287,6 +318,16 @@ internal sealed class A2AAgentHandler : IAgentHandler
         return chatMessages;
     }
 
+    /// <summary>
+    /// Emits a task and streams the agent updates into it as artifacts as they are produced.
+    /// </summary>
+    /// <remarks>
+    /// Handles the case where the server allows background responses and the response is delivered incrementally:
+    /// either a streaming (<c>message/stream</c>) request, or a non-streaming request with
+    /// <c>ReturnImmediately = true</c>. In the latter case the caller receives the initial task immediately and
+    /// obtains the remaining updates by polling the task.
+    /// The task transitions <c>Submitted</c> to <c>Working</c> to <c>Completed</c>, or to <c>Canceled</c>/<c>Failed</c> on error.
+    /// </remarks>
     private static async Task StreamTaskUpdatesAsync(IAsyncEnumerable<AgentResponseUpdate> updates, TaskUpdater updater, CancellationToken cancellationToken)
     {
         var artifactWriter = new ArtifactStreamWriter(updater);
@@ -325,14 +366,81 @@ internal sealed class A2AAgentHandler : IAgentHandler
         }
     }
 
+    /// <summary>
+    /// Consumes the agent updates without emitting them and then returns a single completed task.
+    /// </summary>
+    /// <remarks>
+    /// Handles the case where the server allows background responses and a non-streaming client sent
+    /// <c>ReturnImmediately = false</c>, meaning it wants the final result in the response rather than a task
+    /// it has to poll. No task event is emitted until the agent stream finishes, because the server returns on the
+    /// first task event; emitting early would hand the caller an in-progress task instead of a completed one.
+    /// </remarks>
+    private static async Task AggregateTaskUpdatesAsync(IAsyncEnumerable<AgentResponseUpdate> updates, TaskUpdater updater, AgentEventQueue eventQueue, CancellationToken cancellationToken)
+    {
+        AgentResponse response = await updates.ToAgentResponseAsync(cancellationToken).ConfigureAwait(false);
+
+        await updater.SubmitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (response.Messages.ToParts() is { Count: > 0 } parts)
+        {
+            await AddArtifactAsync(
+                eventQueue,
+                updater,
+                parts,
+                metadata: response.AdditionalProperties?.ToA2AMetadata(),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        await updater.CompleteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds an artifact with metadata until the minimum A2A package version provides this capability on
+    /// <see cref="TaskUpdater.AddArtifactAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Remove this method and call <see cref="TaskUpdater.AddArtifactAsync"/> directly after upgrading to an A2A
+    /// package version whose overload accepts artifact metadata.
+    /// </remarks>
+    private static ValueTask AddArtifactAsync(
+        AgentEventQueue eventQueue,
+        TaskUpdater updater,
+        IReadOnlyList<Part> parts,
+        string? artifactId = null,
+        string? name = null,
+        string? description = null,
+        bool lastChunk = true,
+        bool append = false,
+        Dictionary<string, JsonElement>? metadata = null,
+        CancellationToken cancellationToken = default) =>
+        eventQueue.EnqueueArtifactUpdateAsync(new TaskArtifactUpdateEvent
+        {
+            TaskId = updater.TaskId,
+            ContextId = updater.ContextId,
+            Artifact = new Artifact
+            {
+                ArtifactId = artifactId ?? Guid.NewGuid().ToString("N"),
+                Name = name,
+                Description = description,
+                Parts = [.. parts],
+                Metadata = metadata,
+            },
+            Append = append,
+            LastChunk = lastChunk,
+        }, cancellationToken);
+
+    /// <summary>
+    /// Consumes the agent updates and emits the aggregated result as a single message.
+    /// </summary>
+    /// <remarks>
+    /// Handles the case where the server disallows background responses, which applies regardless of the client's
+    /// <c>ReturnImmediately</c> value: a message is not a long-running entity, so there is nothing to return early
+    /// or poll for and the full agent run is always aggregated into one message. An empty message is emitted when
+    /// the agent produces no messages.
+    /// </remarks>
     private static async Task StreamMessageUpdatesAsync(string contextId, IAsyncEnumerable<AgentResponseUpdate> responseUpdates, AgentEventQueue eventQueue, CancellationToken cancellationToken)
     {
         AgentResponse response = await responseUpdates.ToAgentResponseAsync(cancellationToken).ConfigureAwait(false);
-
-        if (response.Messages.Count == 0)
-        {
-            return;
-        }
 
         var message = CreateMessageFromResponse(contextId, response);
 

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentEventQueueExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentEventQueueExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using A2A;
+
+namespace Microsoft.Agents.AI.Hosting.A2A;
+
+/// <summary>
+/// Provides extensions for writing A2A events to an <see cref="AgentEventQueue"/>.
+/// </summary>
+internal static class AgentEventQueueExtensions
+{
+    /// <summary>
+    /// Adds an artifact with metadata until the minimum A2A package version provides this capability on
+    /// <see cref="TaskUpdater.AddArtifactAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Remove this method and call <see cref="TaskUpdater.AddArtifactAsync"/> directly after upgrading to an A2A
+    /// package version whose overload accepts artifact metadata.
+    /// </remarks>
+    public static ValueTask AddArtifactAsync(
+        this AgentEventQueue eventQueue,
+        TaskUpdater updater,
+        IReadOnlyList<Part> parts,
+        string? artifactId = null,
+        string? name = null,
+        string? description = null,
+        bool lastChunk = true,
+        bool append = false,
+        Dictionary<string, JsonElement>? metadata = null,
+        CancellationToken cancellationToken = default) =>
+        eventQueue.EnqueueArtifactUpdateAsync(new TaskArtifactUpdateEvent
+        {
+            TaskId = updater.TaskId,
+            ContextId = updater.ContextId,
+            Artifact = new Artifact
+            {
+                ArtifactId = artifactId ?? Guid.NewGuid().ToString("N"),
+                Name = name,
+                Description = description,
+                Parts = [.. parts],
+                Metadata = metadata,
+            },
+            Append = append,
+            LastChunk = lastChunk,
+        }, cancellationToken);
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -849,6 +849,97 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
+    /// Verifies that cancellation while emitting an aggregated task transitions the submitted task to Canceled.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenAggregatedTaskEmissionIsCanceled_CancelsTaskAsync()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "result")
+            {
+                ResponseId = "r1",
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    ["responseKey"] = new CallbackMetadataValue(cts.Cancel)
+                }
+            }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.AllowBackgroundIfSupported);
+        var events = new EventCollector();
+        var eventQueue = new AgentEventQueue();
+        var readerTask = ReadEventsAsync(eventQueue, events);
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            handler.ExecuteAsync(
+                new RequestContext
+                {
+                    StreamingResponse = false,
+                    TaskId = "task-1",
+                    ContextId = "ctx",
+                    Configuration = new SendMessageConfiguration { ReturnImmediately = false },
+                    Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+                },
+                eventQueue,
+                cts.Token));
+        eventQueue.Complete(null);
+        await readerTask;
+
+        // Assert
+        Assert.Equal(TaskState.Submitted, Assert.Single(events.Tasks).Status.State);
+        Assert.Equal(TaskState.Canceled, Assert.Single(events.StatusUpdates).Status.State);
+        Assert.Empty(events.ArtifactUpdates);
+    }
+
+    /// <summary>
+    /// Verifies that a failure while emitting an aggregated task transitions the submitted task to Failed.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenAggregatedTaskEmissionFails_FailsTaskAsync()
+    {
+        // Arrange
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "result")
+            {
+                ResponseId = "r1",
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    ["responseKey"] = new CallbackMetadataValue(
+                        () => throw new InvalidOperationException("Metadata serialization failed"))
+                }
+            }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.AllowBackgroundIfSupported);
+
+        // Act
+        var events = await CollectEventsForThrowingExecuteAsync<InvalidOperationException>(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = false },
+            Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+        });
+
+        // Assert
+        Assert.Equal(TaskState.Submitted, Assert.Single(events.Tasks).Status.State);
+        TaskStatusUpdateEvent statusUpdate = Assert.Single(events.StatusUpdates);
+        Assert.Equal(TaskState.Failed, statusUpdate.Status.State);
+        Assert.Equal(
+            "The agent encountered an unexpected error and could not complete the request.",
+            Assert.Single(statusUpdate.Status.Message!.Parts!).Text);
+        Assert.Empty(events.ArtifactUpdates);
+    }
+
+    /// <summary>
     /// Verifies that an immediate request returns one aggregated message when background responses are disabled.
     /// </summary>
     [Fact]
@@ -2641,6 +2732,18 @@ public sealed class A2AAgentHandlerTests
         public List<AgentTask> Tasks { get; } = [];
         public List<TaskStatusUpdateEvent> StatusUpdates { get; } = [];
         public List<TaskArtifactUpdateEvent> ArtifactUpdates { get; } = [];
+    }
+
+    private sealed class CallbackMetadataValue(Action callback)
+    {
+        public string Value
+        {
+            get
+            {
+                callback();
+                return "value";
+            }
+        }
     }
 
     private sealed class TestAgentSession : AgentSession;

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -24,11 +24,10 @@ public sealed class A2AAgentHandlerTests
     private const string ConfigurationPropertyKey = "a2a.configuration";
 
     /// <summary>
-    /// Verifies that when metadata is null, the options passed to RunAsync have
-    /// AllowBackgroundResponses disabled and no AdditionalProperties.
+    /// Verifies that when there is no request data to forward, null options are passed to RunStreamingAsync.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenMetadataIsNull_PassesOptionsWithNoAdditionalPropertiesToRunAsync()
+    public async Task ExecuteAsync_WhenMetadataIsNull_PassesNullOptionsToRunStreamingAsync()
     {
         // Arrange
         AgentRunOptions? capturedOptions = null;
@@ -41,14 +40,12 @@ public sealed class A2AAgentHandlerTests
         });
 
         // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.False(capturedOptions.AllowBackgroundResponses);
-        Assert.Null(capturedOptions.AdditionalProperties);
+        Assert.Null(capturedOptions);
     }
 
     /// <summary>
-    /// Verifies that when metadata is non-empty, the options passed to RunAsync have
-    /// AdditionalProperties populated with the converted metadata values.
+    /// Verifies that when metadata is non-empty, the options passed to RunStreamingAsync have
+    /// AllowBackgroundResponses unset and AdditionalProperties populated with the converted metadata values.
     /// </summary>
     [Fact]
     public async Task ExecuteAsync_WhenMetadataIsNonEmpty_PassesOptionsWithAdditionalPropertiesToRunAsync()
@@ -71,7 +68,7 @@ public sealed class A2AAgentHandlerTests
 
         // Assert
         Assert.NotNull(capturedOptions);
-        Assert.False(capturedOptions.AllowBackgroundResponses);
+        Assert.Null(capturedOptions.AllowBackgroundResponses);
         Assert.NotNull(capturedOptions.AdditionalProperties);
         Assert.Equal(2, capturedOptions.AdditionalProperties.Count);
         Assert.Equal("value1", capturedOptions.AdditionalProperties["key1"]?.ToString());
@@ -140,10 +137,10 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that the caller supplied configuration does not override the run mode configured on the server.
+    /// Verifies that the caller supplied configuration does not set AllowBackgroundResponses for a streaming run.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenConfigurationRequestsImmediateReturn_DoesNotOverrideRunModeAsync()
+    public async Task ExecuteAsync_WhenConfigurationRequestsImmediateReturn_DoesNotSetAllowBackgroundResponsesAsync()
     {
         // Arrange
         AgentRunOptions? capturedOptions = null;
@@ -161,7 +158,7 @@ public sealed class A2AAgentHandlerTests
 
         // Assert
         Assert.NotNull(capturedOptions);
-        Assert.False(capturedOptions.AllowBackgroundResponses);
+        Assert.Null(capturedOptions.AllowBackgroundResponses);
     }
 
     /// <summary>
@@ -245,111 +242,71 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that when runMode is DisallowBackground, AllowBackgroundResponses is false.
+    /// Verifies that a custom run-mode delegate returning false produces a message.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_DisallowBackgroundMode_SetsAllowBackgroundResponsesFalseAsync()
+    public async Task ExecuteAsync_DynamicMode_WithFalseCallback_ReturnsMessageAsync()
     {
         // Arrange
-        AgentRunOptions? capturedOptions = null;
         A2AAgentHandler handler = CreateHandler(
-            CreateAgentMock(options => capturedOptions = options),
-            runMode: AgentRunMode.DisallowBackground);
-
-        // Act
-        await InvokeExecuteAsync(handler, new RequestContext
-        {
-            TaskId = "", ContextId = "ctx", StreamingResponse = false, Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
-        });
-
-        // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.False(capturedOptions.AllowBackgroundResponses);
-    }
-
-    /// <summary>
-    /// Verifies that in AllowBackgroundIfSupported mode, AllowBackgroundResponses is true.
-    /// </summary>
-    [Fact]
-    public async Task ExecuteAsync_AllowBackgroundIfSupportedMode_SetsAllowBackgroundResponsesTrueAsync()
-    {
-        // Arrange
-        AgentRunOptions? capturedOptions = null;
-        A2AAgentHandler handler = CreateHandler(
-            CreateAgentMock(options => capturedOptions = options),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
-
-        // Act
-        await InvokeExecuteAsync(handler, new RequestContext
-        {
-            TaskId = "", ContextId = "ctx", StreamingResponse = false, Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
-        });
-
-        // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.True(capturedOptions.AllowBackgroundResponses);
-    }
-
-    /// <summary>
-    /// Verifies that a custom Dynamic delegate returning false sets AllowBackgroundResponses to false.
-    /// </summary>
-    [Fact]
-    public async Task ExecuteAsync_DynamicMode_WithFalseCallback_SetsAllowBackgroundResponsesFalseAsync()
-    {
-        // Arrange
-        AgentRunOptions? capturedOptions = null;
-        A2AAgentHandler handler = CreateHandler(
-            CreateAgentMock(options => capturedOptions = options),
+            CreateAgentMock(_ => { }),
             runMode: AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(false)));
 
         // Act
-        await InvokeExecuteAsync(handler, new RequestContext
+        var events = await CollectEventsAsync(handler, new RequestContext
         {
             TaskId = "", ContextId = "ctx", StreamingResponse = false, Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
         });
 
         // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.False(capturedOptions.AllowBackgroundResponses);
+        Assert.Single(events.Messages);
+        Assert.Empty(events.Tasks);
     }
 
     /// <summary>
-    /// Verifies that a custom Dynamic delegate returning true sets AllowBackgroundResponses to true.
+    /// Verifies that a custom run-mode delegate returning true produces a task.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_DynamicMode_WithTrueCallback_SetsAllowBackgroundResponsesTrueAsync()
+    public async Task ExecuteAsync_DynamicMode_WithTrueCallback_ReturnsTaskAsync()
     {
         // Arrange
-        AgentRunOptions? capturedOptions = null;
         A2AAgentHandler handler = CreateHandler(
-            CreateAgentMock(options => capturedOptions = options),
+            CreateAgentMock(_ => { }),
             runMode: AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(true)));
 
         // Act
-        await InvokeExecuteAsync(handler, new RequestContext
+        var events = await CollectEventsAsync(handler, new RequestContext
         {
             TaskId = "", ContextId = "ctx", StreamingResponse = false, Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
         });
 
         // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.True(capturedOptions.AllowBackgroundResponses);
+        Assert.Empty(events.Messages);
+        Assert.Single(events.Tasks);
     }
 
 #pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
-    /// Verifies that when the agent returns a ContinuationToken, task status events are emitted.
+    /// Verifies that an immediate request emits the initial task and streams subsequent updates when background responses are allowed.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenResponseHasContinuationToken_EmitsTaskStatusEventsAsync()
+    public async Task ExecuteAsync_WhenBackgroundResponsesAllowedAndReturnImmediatelyTrue_StreamsTaskUpdatesAsync()
     {
         // Arrange
-        AgentResponse response = new([new ChatMessage(ChatRole.Assistant, "Starting work...")])
-        {
-            ContinuationToken = CreateTestContinuationToken()
-        };
-        A2AAgentHandler handler = CreateHandler(CreateAgentMockWithResponse(response));
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" },
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 2")
+            {
+                ResponseId = "r1",
+                MessageId = "m1",
+                ContinuationToken = CreateTestContinuationToken()
+            },
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.AllowBackgroundIfSupported);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -357,12 +314,31 @@ public sealed class A2AAgentHandlerTests
             StreamingResponse = false,
             TaskId = "task-1",
             ContextId = "ctx-1",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = true },
             Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
         });
 
-        // Assert - should have emitted status update events (Submitted + Working)
-        Assert.True(events.StatusUpdates.Count >= 1);
+        // Assert
         Assert.Empty(events.Messages);
+        Assert.Equal(TaskState.Submitted, Assert.Single(events.Tasks).Status.State);
+        Assert.Collection(
+            events.StatusUpdates,
+            update => Assert.Equal(TaskState.Working, update.Status.State),
+            update => Assert.Equal(TaskState.Completed, update.Status.State));
+        Assert.Collection(
+            events.ArtifactUpdates,
+            update =>
+            {
+                Assert.Equal("chunk 1", Assert.Single(update.Artifact.Parts!).Text);
+                Assert.False(update.Append);
+                Assert.False(update.LastChunk);
+            },
+            update =>
+            {
+                Assert.Equal("chunk 2", Assert.Single(update.Artifact.Parts!).Text);
+                Assert.True(update.Append);
+                Assert.True(update.LastChunk);
+            });
     }
 
     /// <summary>
@@ -800,6 +776,142 @@ public sealed class A2AAgentHandlerTests
                 Assert.False(update.Append);
                 Assert.True(update.LastChunk);
             });
+    }
+
+    /// <summary>
+    /// Verifies that a non-immediate request aggregates all updates into a completed task.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenBackgroundResponsesAllowedAndReturnImmediatelyFalse_ReturnsCompletedTaskAsync()
+    {
+        // Arrange
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" },
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 2") { ResponseId = "r1", MessageId = "m1" }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.AllowBackgroundIfSupported);
+
+        // Act
+        var events = await CollectEventsAsync(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = false },
+            Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+        });
+
+        // Assert
+        Assert.Empty(events.Messages);
+        Assert.Equal(TaskState.Submitted, Assert.Single(events.Tasks).Status.State);
+        Assert.Equal(TaskState.Completed, Assert.Single(events.StatusUpdates).Status.State);
+        Assert.Equal("chunk 1chunk 2", Assert.Single(Assert.Single(events.ArtifactUpdates).Artifact.Parts!).Text);
+    }
+
+    /// <summary>
+    /// Verifies that an aggregated task artifact preserves response metadata.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenAggregatingTaskUpdates_PreservesArtifactMetadataAsync()
+    {
+        // Arrange
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "result")
+            {
+                ResponseId = "r1",
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    ["responseKey"] = "responseValue"
+                }
+            }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.AllowBackgroundIfSupported);
+
+        // Act
+        var events = await CollectEventsAsync(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = false },
+            Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+        });
+
+        // Assert
+        Artifact artifact = Assert.Single(events.ArtifactUpdates).Artifact;
+        Assert.Equal("responseValue", artifact.Metadata!["responseKey"].GetString());
+    }
+
+    /// <summary>
+    /// Verifies that an immediate request returns one aggregated message when background responses are disabled.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenBackgroundResponsesDisallowedAndReturnImmediatelyTrue_ReturnsMessageAsync()
+    {
+        // Arrange
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" },
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 2") { ResponseId = "r1", MessageId = "m1" }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.DisallowBackground);
+
+        // Act
+        var events = await CollectEventsAsync(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = true },
+            Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+        });
+
+        // Assert
+        Assert.Empty(events.Tasks);
+        Assert.Empty(events.StatusUpdates);
+        Assert.Empty(events.ArtifactUpdates);
+        Assert.Equal("chunk 1chunk 2", Assert.Single(Assert.Single(events.Messages).Parts!).Text);
+    }
+
+    /// <summary>
+    /// Verifies that a non-immediate request aggregates all updates into one message when background responses are disabled.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_WhenBackgroundResponsesDisallowedAndReturnImmediatelyFalse_ReturnsMessageAsync()
+    {
+        // Arrange
+        AgentResponseUpdate[] updates =
+        [
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" },
+            new AgentResponseUpdate(ChatRole.Assistant, "chunk 2") { ResponseId = "r1", MessageId = "m1" }
+        ];
+        A2AAgentHandler handler = CreateHandler(
+            CreateStreamingAgentMock(updates),
+            runMode: AgentRunMode.DisallowBackground);
+
+        // Act
+        var events = await CollectEventsAsync(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx",
+            Configuration = new SendMessageConfiguration { ReturnImmediately = false },
+            Message = new Message { MessageId = "test-id", Role = Role.User, Parts = [new Part { Text = "Hello" }] }
+        });
+
+        // Assert
+        Assert.Empty(events.Tasks);
+        Assert.Empty(events.StatusUpdates);
+        Assert.Empty(events.ArtifactUpdates);
+        Assert.Equal("chunk 1chunk 2", Assert.Single(Assert.Single(events.Messages).Parts!).Text);
     }
 
     /// <summary>
@@ -1627,10 +1739,10 @@ public sealed class A2AAgentHandlerTests
 
     /// <summary>
     /// Verifies that in streaming mode, when RunStreamingAsync yields no updates,
-    /// no messages are enqueued and the session is still saved.
+    /// an empty message is enqueued and the session is still saved.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_Streaming_WhenNoUpdates_EnqueuesNoMessagesAndSavesSessionAsync()
+    public async Task ExecuteAsync_Streaming_WhenNoUpdates_EnqueuesEmptyMessageAndSavesSessionAsync()
     {
         // Arrange
         var mockSessionStore = new Mock<AgentSessionStore>();
@@ -1660,7 +1772,7 @@ public sealed class A2AAgentHandlerTests
         });
 
         // Assert
-        Assert.Empty(events.Messages);
+        Assert.Empty(Assert.Single(events.Messages).Parts!);
         mockSessionStore.Verify(
             x => x.SaveSessionAsync(
                 It.IsAny<AIAgent>(),
@@ -1837,12 +1949,13 @@ public sealed class A2AAgentHandlerTests
             .ReturnsAsync(sessionInstance);
         agentMock
             .Protected()
-            .Setup<Task<AgentResponse>>("RunCoreAsync",
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
                 ItExpr.IsAny<IEnumerable<ChatMessage>>(),
                 ItExpr.IsAny<AgentSession?>(),
                 ItExpr.IsAny<AgentRunOptions?>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new AgentResponse([new ChatMessage(ChatRole.Assistant, "Reply")]));
+            .Returns(() => ToAsyncEnumerableAsync(
+                new AgentResponse([new ChatMessage(ChatRole.Assistant, "Reply")]).ToAgentResponseUpdates()));
 
         A2AAgentHandler handler = CreateHandler(agentMock, agentSessionStore: null);
 
@@ -1953,11 +2066,11 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that in the non-streaming path, SaveSessionAsync is called with
-    /// CancellationToken.None even when RunAsync throws an exception.
+    /// Verifies that in the non-streaming endpoint path, SaveSessionAsync is called with
+    /// CancellationToken.None even when RunStreamingAsync throws an exception.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_NonStreaming_WhenRunAsyncThrows_SavesSessionWithUncancelledTokenAsync()
+    public async Task ExecuteAsync_NonStreaming_WhenRunStreamingAsyncThrows_SavesSessionWithUncancelledTokenAsync()
     {
         // Arrange
         var mockSessionStore = new Mock<AgentSessionStore>();
@@ -1974,12 +2087,12 @@ public sealed class A2AAgentHandlerTests
             .Setup<ValueTask<AgentSession>>("CreateSessionCoreAsync", ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new TestAgentSession());
         agentMock.Protected()
-            .Setup<Task<AgentResponse>>("RunCoreAsync",
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
                 ItExpr.IsAny<IEnumerable<ChatMessage>>(),
                 ItExpr.IsAny<AgentSession?>(),
                 ItExpr.IsAny<AgentRunOptions?>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Agent failed"));
+            .Returns(() => ToThrowingAsyncEnumerableAsync(new InvalidOperationException("Agent failed")));
 
         using var cts = new CancellationTokenSource();
         A2AAgentHandler handler = CreateHandler(agentMock, agentSessionStore: mockSessionStore.Object);
@@ -2286,6 +2399,17 @@ public sealed class A2AAgentHandlerTests
             .Callback<IEnumerable<ChatMessage>, AgentSession?, AgentRunOptions?, CancellationToken>(
                 (_, _, options, _) => optionsCallback(options))
             .ReturnsAsync(new AgentResponse([new ChatMessage(ChatRole.Assistant, "Test response")]));
+        agentMock
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<IEnumerable<ChatMessage>, AgentSession?, AgentRunOptions?, CancellationToken>(
+                (_, _, options, _) => optionsCallback(options))
+            .Returns(() => ToAsyncEnumerableAsync(
+                new AgentResponse([new ChatMessage(ChatRole.Assistant, "Test response")]).ToAgentResponseUpdates()));
 
         return agentMock;
     }
@@ -2306,6 +2430,14 @@ public sealed class A2AAgentHandlerTests
                 ItExpr.IsAny<AgentRunOptions?>(),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
+        agentMock
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() => ToAsyncEnumerableAsync(response.ToAgentResponseUpdates()));
 
         return agentMock;
     }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
@@ -485,6 +485,79 @@ public sealed class A2AServerServiceCollectionExtensionsTests
         Assert.NotNull(response.Message);
     }
 
+    /// <summary>
+    /// Verifies that a non-immediate request waits for all streaming updates and returns a completed task.
+    /// </summary>
+    [Fact]
+    public async Task AddA2AServer_WithBackgroundResponsesAndNonImmediateRequest_ReturnsCompletedTaskAsync()
+    {
+        // Arrange
+        const string AgentName = "completed-task-request";
+        var services = new ServiceCollection();
+        Mock<AIAgent> agentMock = CreateAgentMockForRequests(AgentName);
+        agentMock
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() => ToAsyncEnumerableAsync(
+            [
+                new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" },
+                new AgentResponseUpdate(ChatRole.Assistant, "chunk 2") { ResponseId = "r1", MessageId = "m1" }
+            ]));
+        services.AddKeyedSingleton(AgentName, (_, _) => agentMock.Object);
+        services.AddA2AServer(
+            AgentName,
+            options => options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported);
+        await using var provider = services.BuildServiceProvider();
+        var server = provider.GetRequiredKeyedService<A2AServer>(AgentName);
+        SendMessageRequest request = CreateTestSendMessageRequest();
+        request.Configuration = new SendMessageConfiguration { ReturnImmediately = false };
+
+        // Act
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        SendMessageResponse response = await server.SendMessageAsync(request, cts.Token);
+
+        // Assert
+        Assert.Equal(SendMessageResponseCase.Task, response.PayloadCase);
+        Assert.Equal(TaskState.Completed, response.Task!.Status.State);
+        Assert.Equal("chunk 1chunk 2", Assert.Single(Assert.Single(response.Task.Artifacts!).Parts!).Text);
+    }
+
+    /// <summary>
+    /// Verifies that a non-streaming request returns an empty message when the agent produces no updates.
+    /// </summary>
+    [Fact]
+    public async Task AddA2AServer_WithEmptyAgentResponse_ReturnsEmptyMessageAsync()
+    {
+        // Arrange
+        const string AgentName = "empty-response-request";
+        var services = new ServiceCollection();
+        Mock<AIAgent> agentMock = CreateAgentMockForRequests(AgentName);
+        agentMock
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() => ToAsyncEnumerableAsync<AgentResponseUpdate>([]));
+        services.AddKeyedSingleton(AgentName, (_, _) => agentMock.Object);
+        services.AddA2AServer(AgentName);
+        await using var provider = services.BuildServiceProvider();
+        var server = provider.GetRequiredKeyedService<A2AServer>(AgentName);
+
+        // Act
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        SendMessageResponse response = await server.SendMessageAsync(CreateTestSendMessageRequest(), cts.Token);
+
+        // Assert
+        Assert.Equal(SendMessageResponseCase.Message, response.PayloadCase);
+        Assert.Empty(response.Message!.Parts!);
+    }
+
     private static SendMessageRequest CreateTestSendMessageRequest() =>
         new()
         {
@@ -512,6 +585,15 @@ public sealed class A2AServerServiceCollectionExtensionsTests
                 ItExpr.IsAny<AgentRunOptions?>(),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new AgentResponse([new ChatMessage(ChatRole.Assistant, "Test response")]));
+        agentMock
+            .Protected()
+            .Setup<IAsyncEnumerable<AgentResponseUpdate>>("RunCoreStreamingAsync",
+                ItExpr.IsAny<IEnumerable<ChatMessage>>(),
+                ItExpr.IsAny<AgentSession?>(),
+                ItExpr.IsAny<AgentRunOptions?>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns(() => ToAsyncEnumerableAsync(
+                new AgentResponse([new ChatMessage(ChatRole.Assistant, "Test response")]).ToAgentResponseUpdates()));
 
         return agentMock;
     }
@@ -532,6 +614,15 @@ public sealed class A2AServerServiceCollectionExtensionsTests
             .ReturnsAsync(JsonDocument.Parse("{}").RootElement);
 
         return agentMock;
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerableAsync<T>(IEnumerable<T> items)
+    {
+        await Task.Yield();
+        foreach (T item in items)
+        {
+            yield return item;
+        }
     }
 
     private sealed class TestAgentSession : AgentSession;


### PR DESCRIPTION
### Motivation & Context

A2A hosting can return either a message or a task. Previously, when it returned a background task, subsequent agent updates were not applied, leaving the task indefinitely in the `Working` state.

This change uses the agent streaming API for both response types. The server either aggregates updates into a message, returns an initial task and continues updating it, or waits for the stream to finish and returns the completed task.

### Description & Review Guide

- **What are the major changes?** New A2A messages now run through the streaming agent API. Background-enabled registrations either stream task updates after returning the initial task or aggregate them into a completed task, depending on `ReturnImmediately`. Background-disabled registrations aggregate the stream into a message. The task aggregation path also preserves response metadata on artifacts, and the four server/client response combinations have dedicated coverage.
- **What is the impact of these changes?** A2A tasks receive status and artifact updates instead of remaining indefinitely in Working state, while message responses and non-immediate task responses retain their expected response shapes.
- **What do you want reviewers to focus on?** Please focus on the response routing across `AgentRunMode` and `ReturnImmediately`, and on task artifact construction in the aggregate path.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #5362

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.