### PR TITLE
CI: Prevent ineligible DevFlow runs from canceling reviews

### DIFF
--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -22,10 +22,6 @@ permissions:
   issues: write
   pull-requests: write
 
-concurrency:
-  group: devflow-pr-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
-  cancel-in-progress: true
-
 env:
   DEVFLOW_REPOSITORY: ${{ vars.DF_REPO }}
   DEVFLOW_REF: main
@@ -175,6 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: team_check
     if: ${{ needs.team_check.outputs.is_team_member == 'true' }}
+    concurrency:
+      group: devflow-pr-review-${{ github.repository }}-${{ needs.team_check.outputs.pr_number }}
+      cancel-in-progress: true
     permissions:
       copilot-requests: write
       contents: read

--- a/.github/workflows/devflow-pr-review.yml
+++ b/.github/workflows/devflow-pr-review.yml
@@ -22,6 +22,38 @@ permissions:
   issues: write
   pull-requests: write
 
+# Keep likely review-capable requests ordered from the moment they are created,
+# while bounding other per-PR events in a separate lane. Team membership is
+# still verified before review work begins.
+concurrency:
+  group: >-
+    devflow-pr-review-${{ github.repository }}-${{
+      github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id
+    }}-${{
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'OWNER'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          github.event.comment.body == '/review' &&
+          (
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'OWNER'
+          )
+        ) ||
+        github.event_name == 'workflow_dispatch'
+      )
+      && 'review'
+      || 'gate'
+    }}
+  cancel-in-progress: true
+
 env:
   DEVFLOW_REPOSITORY: ${{ vars.DF_REPO }}
   DEVFLOW_REF: main
@@ -133,7 +165,12 @@ jobs:
         id: check
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          MEMBERSHIP_USER: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || '' }}
+          MEMBERSHIP_USER: >-
+            ${{
+              github.event_name == 'issue_comment' && github.event.comment.user.login ||
+              github.event_name == 'workflow_dispatch' && github.actor ||
+              ''
+            }}
           TEAM_NAME: ${{ secrets.DEVELOPER_TEAM }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         with:
@@ -171,9 +208,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: team_check
     if: ${{ needs.team_check.outputs.is_team_member == 'true' }}
-    concurrency:
-      group: devflow-pr-review-${{ github.repository }}-${{ needs.team_check.outputs.pr_number }}
-      cancel-in-progress: true
     permissions:
       copilot-requests: write
       contents: read


### PR DESCRIPTION
### Motivation & Context

PR lifecycle events can supersede an authorized `/review` run even when the new event is ineligible to execute DevFlow, leaving the PR without a review.

### Description & Review Guide

- **What are the major changes?** Partition workflow-level concurrency into per-PR `review` and `gate` lanes, and authorize manual dispatches using the dispatching actor.
- **What is the impact of these changes?** Review-capable requests retain trigger ordering, while external or ineligible events are bounded separately and cannot cancel active reviews.
- **What do you want reviewers to focus on?** Confirm the lane classification preserves latest-review behavior without allowing external event churn to consume unbounded resources.

### Related Issue

None.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
