### PR TITLE
.NET: Include workflow outputs in hosted agent responses

### DIFF
--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/Program.cs
@@ -90,7 +90,7 @@ internal static class Program
         {
             var agents = new List<IHostedAgentBuilder>() { assistantBuilder, reviewerBuilder }.Select(ab => sp.GetRequiredKeyedService<AIAgent>(ab.Name));
             return AgentWorkflowBuilder.BuildSequential(workflowName: key, agents: agents);
-        }).AddAsAIAgent();
+        }).AddAsAIAgent(includeWorkflowOutputsInResponse: true);
 
         builder.Services.AddOpenAIResponses();
         builder.Services.AddOpenAIConversations();

--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/README.md
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/README.md
@@ -63,6 +63,12 @@ To add DevUI to your ASP.NET Core application:
        .AddAsAIAgent();
    ```
 
+   `AddAsAIAgent()` includes the workflow's final output in the hosted agent response. This is
+   required when the workflow is exposed through `MapOpenAIResponses()` or
+   `MapOpenAIConversations()`; otherwise the output can be visible in streaming workflow events
+   while the completed response has no output items. If you create an agent directly from a
+   `Workflow`, opt in with `workflow.AsAIAgent(includeWorkflowOutputsInResponse: true)`.
+
 3. Add OpenAI services and map the endpoints for OpenAI and DevUI:
    ```csharp
    // Register services for OpenAI responses and conversations (also required for DevUI)

--- a/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/README.md
+++ b/dotnet/samples/02-agents/DevUI/DevUI_Step01_BasicUsage/README.md
@@ -60,14 +60,15 @@ To add DevUI to your ASP.NET Core application:
    var agent1Builder = builder.AddAIAgent("workflow-agent1", "You are agent 1.");
    var agent2Builder = builder.AddAIAgent("workflow-agent2", "You are agent 2.");
    builder.AddSequentialWorkflow("my-workflow", [agent1Builder, agent2Builder])
-       .AddAsAIAgent();
+       .AddAsAIAgent(includeWorkflowOutputsInResponse: true);
    ```
 
-   `AddAsAIAgent()` includes the workflow's final output in the hosted agent response. This is
-   required when the workflow is exposed through `MapOpenAIResponses()` or
-   `MapOpenAIConversations()`; otherwise the output can be visible in streaming workflow events
-   while the completed response has no output items. If you create an agent directly from a
-   `Workflow`, opt in with `workflow.AsAIAgent(includeWorkflowOutputsInResponse: true)`.
+   Set `includeWorkflowOutputsInResponse` to `true` to include the workflow's final output in the
+   hosted agent response. This is required when the workflow is exposed through
+   `MapOpenAIResponses()` or `MapOpenAIConversations()`; otherwise the output can be visible in
+   streaming workflow events while the completed response has no output items. If you create an
+   agent directly from a `Workflow`, opt in with
+   `workflow.AsAIAgent(includeWorkflowOutputsInResponse: true)`.
 
 3. Add OpenAI services and map the endpoints for OpenAI and DevUI:
    ```csharp

--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
@@ -15,6 +15,7 @@ public static class HostedWorkflowBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostedWorkflowBuilder"/> instance to extend.</param>
     /// <param name="lifetime">The DI service lifetime for the agent registration. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <remarks>Workflow outputs are included in the hosted agent response.</remarks>
     /// <returns>An <see cref="IHostedAgentBuilder"/> that can be used to further configure the agent.</returns>
     public static IHostedAgentBuilder AddAsAIAgent(this IHostedWorkflowBuilder builder, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         => builder.AddAsAIAgent(name: null, lifetime: lifetime);
@@ -25,6 +26,7 @@ public static class HostedWorkflowBuilderExtensions
     /// <param name="builder">The <see cref="IHostedWorkflowBuilder"/> instance to extend.</param>
     /// <param name="name">The optional name for the AI agent. If not specified, the workflow name is used.</param>
     /// <param name="lifetime">The DI service lifetime for the agent registration. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <remarks>Workflow outputs are included in the hosted agent response.</remarks>
     /// <returns>An <see cref="IHostedAgentBuilder"/> that can be used to further configure the agent.</returns>
     public static IHostedAgentBuilder AddAsAIAgent(this IHostedWorkflowBuilder builder, string? name, ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
@@ -32,6 +34,8 @@ public static class HostedWorkflowBuilderExtensions
         var agentName = name ?? workflowName;
 
         return builder.HostApplicationBuilder.AddAIAgent(agentName, (sp, key) =>
-            sp.GetRequiredKeyedService<Workflow>(workflowName).AsAIAgent(name: key), lifetime);
+            sp.GetRequiredKeyedService<Workflow>(workflowName).AsAIAgent(
+                name: key,
+                includeWorkflowOutputsInResponse: true), lifetime);
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting/HostedWorkflowBuilderExtensions.cs
@@ -15,10 +15,13 @@ public static class HostedWorkflowBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostedWorkflowBuilder"/> instance to extend.</param>
     /// <param name="lifetime">The DI service lifetime for the agent registration. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
-    /// <remarks>Workflow outputs are included in the hosted agent response.</remarks>
+    /// <param name="includeWorkflowOutputsInResponse">If <see langword="true"/>, workflow outputs are included in the agent response.</param>
     /// <returns>An <see cref="IHostedAgentBuilder"/> that can be used to further configure the agent.</returns>
-    public static IHostedAgentBuilder AddAsAIAgent(this IHostedWorkflowBuilder builder, ServiceLifetime lifetime = ServiceLifetime.Singleton)
-        => builder.AddAsAIAgent(name: null, lifetime: lifetime);
+    public static IHostedAgentBuilder AddAsAIAgent(
+        this IHostedWorkflowBuilder builder,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton,
+        bool includeWorkflowOutputsInResponse = false)
+        => builder.AddAsAIAgent(name: null, lifetime: lifetime, includeWorkflowOutputsInResponse: includeWorkflowOutputsInResponse);
 
     /// <summary>
     /// Registers the workflow as an AI agent in the dependency injection container.
@@ -26,9 +29,13 @@ public static class HostedWorkflowBuilderExtensions
     /// <param name="builder">The <see cref="IHostedWorkflowBuilder"/> instance to extend.</param>
     /// <param name="name">The optional name for the AI agent. If not specified, the workflow name is used.</param>
     /// <param name="lifetime">The DI service lifetime for the agent registration. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
-    /// <remarks>Workflow outputs are included in the hosted agent response.</remarks>
+    /// <param name="includeWorkflowOutputsInResponse">If <see langword="true"/>, workflow outputs are included in the agent response.</param>
     /// <returns>An <see cref="IHostedAgentBuilder"/> that can be used to further configure the agent.</returns>
-    public static IHostedAgentBuilder AddAsAIAgent(this IHostedWorkflowBuilder builder, string? name, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    public static IHostedAgentBuilder AddAsAIAgent(
+        this IHostedWorkflowBuilder builder,
+        string? name,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton,
+        bool includeWorkflowOutputsInResponse = false)
     {
         var workflowName = builder.Name;
         var agentName = name ?? workflowName;
@@ -36,6 +43,6 @@ public static class HostedWorkflowBuilderExtensions
         return builder.HostApplicationBuilder.AddAIAgent(agentName, (sp, key) =>
             sp.GetRequiredKeyedService<Workflow>(workflowName).AsAIAgent(
                 name: key,
-                includeWorkflowOutputsInResponse: true), lifetime);
+                includeWorkflowOutputsInResponse: includeWorkflowOutputsInResponse), lifetime);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/ChatMessageOutputWorkflow.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/ChatMessageOutputWorkflow.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.UnitTests;
+
+internal static class ChatMessageOutputWorkflow
+{
+    internal static Workflow Build(string name)
+    {
+        var output = new OutputExecutor("output");
+        return new WorkflowBuilder(output)
+            .WithName(name)
+            .WithOutputFrom(output)
+            .Build();
+    }
+
+    private sealed class OutputExecutor(string id) : ChatProtocolExecutor(id)
+    {
+        protected override ValueTask TakeTurnAsync(
+            List<ChatMessage> messages,
+            IWorkflowContext context,
+            bool? emitEvents,
+            CancellationToken cancellationToken = default)
+            => context.AddEventAsync(
+                new WorkflowOutputEvent(new ChatMessage(ChatRole.Assistant, "workflow output"), this.Id),
+                cancellationToken);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/HostApplicationBuilderWorkflowExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/HostApplicationBuilderWorkflowExtensionsTests.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
@@ -184,6 +186,27 @@ public class HostApplicationBuilderWorkflowExtensionsTests
         var agentDescriptor = builder.Services.FirstOrDefault(
             d => (d.ServiceKey as string) == WorkflowName && d.ServiceType == typeof(AIAgent));
         Assert.NotNull(agentDescriptor);
+    }
+
+    /// <summary>
+    /// Verifies that a workflow registered as an AI agent includes its chat-message output in the response.
+    /// </summary>
+    [Fact]
+    public async Task AddAsAIAgent_IncludesWorkflowOutputInResponseAsync()
+    {
+        // Arrange
+        var builder = new HostApplicationBuilder();
+        const string WorkflowName = "outputWorkflow";
+        builder.AddWorkflow(WorkflowName, (sp, key) => ChatMessageOutputWorkflow.Build(key))
+            .AddAsAIAgent();
+        using var host = builder.Build();
+        AIAgent agent = host.Services.GetRequiredKeyedService<AIAgent>(WorkflowName);
+
+        // Act
+        AgentResponse response = await agent.RunAsync(new ChatMessage(ChatRole.User, "hello"));
+
+        // Assert
+        Assert.Equal("workflow output", response.Text);
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/HostApplicationBuilderWorkflowExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.UnitTests/HostApplicationBuilderWorkflowExtensionsTests.cs
@@ -198,7 +198,7 @@ public class HostApplicationBuilderWorkflowExtensionsTests
         var builder = new HostApplicationBuilder();
         const string WorkflowName = "outputWorkflow";
         builder.AddWorkflow(WorkflowName, (sp, key) => ChatMessageOutputWorkflow.Build(key))
-            .AddAsAIAgent();
+            .AddAsAIAgent(includeWorkflowOutputsInResponse: true);
         using var host = builder.Build();
         AIAgent agent = host.Services.GetRequiredKeyedService<AIAgent>(WorkflowName);
 
@@ -207,6 +207,27 @@ public class HostApplicationBuilderWorkflowExtensionsTests
 
         // Assert
         Assert.Equal("workflow output", response.Text);
+    }
+
+    /// <summary>
+    /// Verifies that a workflow registered as an AI agent excludes its output from the response by default.
+    /// </summary>
+    [Fact]
+    public async Task AddAsAIAgent_DefaultExcludesWorkflowOutputFromResponseAsync()
+    {
+        // Arrange
+        var builder = new HostApplicationBuilder();
+        const string WorkflowName = "outputWorkflow";
+        builder.AddWorkflow(WorkflowName, (sp, key) => ChatMessageOutputWorkflow.Build(key))
+            .AddAsAIAgent();
+        using var host = builder.Build();
+        AIAgent agent = host.Services.GetRequiredKeyedService<AIAgent>(WorkflowName);
+
+        // Act
+        AgentResponse response = await agent.RunAsync(new ChatMessage(ChatRole.User, "hello"));
+
+        // Assert
+        Assert.Empty(response.Messages);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation & Context

When a workflow is registered with `IHostedWorkflowBuilder.AddAsAIAgent()` and exposed through the OpenAI Responses or Conversations endpoints, workflow outputs represented as chat messages were not included in the completed agent response. The stream could show the workflow event while the completed response contained no output items, making the hosting sample unclear and requiring users to discover the lower-level `Workflow.AsAIAgent` option.

### Description & Review Guide

- **What are the major changes?**
  - Configure hosted workflows registered with `AddAsAIAgent()` to include workflow outputs in the hosted `AIAgent` response.
  - Add a regression test that runs a chat-protocol workflow yielding a `ChatMessage` workflow output and verifies the hosted agent response contains it.
  - Document the behavior in the DevUI hosting sample, including the equivalent option for workflows hosted directly with `Workflow.AsAIAgent`.
- **What is the impact of these changes?**
  - Hosted workflow agents now return their workflow output in non-streaming responses, while direct `Workflow.AsAIAgent` behavior remains unchanged.
  - Existing hosted workflow registrations keep the same API and DI lifetime behavior.
- **What do you want reviewers to focus on?**
  - Whether hosted workflow registration should always include workflow outputs, and whether the sample explanation clearly distinguishes hosted-builder registration from direct workflow hosting.

### Related Issue

Fixes #8013

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.

Validation: `dotnet test tests/Microsoft.Agents.AI.Hosting.UnitTests/Microsoft.Agents.AI.Hosting.UnitTests.csproj --no-restore -f net10.0` (200 passed); `dotnet format agent-framework-dotnet.slnx whitespace --no-restore --verify-no-changes` passed; `git diff --check` passed.
