### PR TITLE
Python: Fix checkpoint pickling of runtime raw representations

### DIFF
--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -151,6 +151,35 @@ def _is_serialization_protocol(value: Any) -> TypeGuard[SerializationProtocol]:
     return callable(getattr(value, "to_dict", None)) and callable(getattr(value, "from_dict", None))
 
 
+def _iter_instance_fields(instance: Any) -> dict[str, Any]:
+    """Return attributes stored in ``__dict__`` or slots."""
+    fields = dict(getattr(instance, "__dict__", {}))
+    for cls in type(instance).__mro__:
+        slots = cls.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for field_name in slots:
+            if field_name not in {"__dict__", "__weakref__"} and hasattr(instance, field_name):
+                fields[field_name] = getattr(instance, field_name)
+    return fields
+
+
+def _get_pickle_state(instance: Any, omitted_fields: set[str]) -> dict[str, Any]:
+    """Build pickle state while omitting runtime-only fields."""
+    state = _iter_instance_fields(instance)
+    for field_name in omitted_fields:
+        state.pop(field_name, None)
+    return state
+
+
+def _restore_pickle_state(instance: Any, state: dict[str, Any], omitted_fields: set[str]) -> None:
+    """Restore dict- and slot-backed pickle state."""
+    for field_name, value in state.items():
+        object.__setattr__(instance, field_name, value)
+    for field_name in omitted_fields:
+        object.__setattr__(instance, field_name, None)
+
+
 class SerializationMixin:
     """Mixin class providing comprehensive serialization and deserialization capabilities.
 
@@ -284,6 +313,15 @@ class SerializationMixin:
     DEFAULT_EXCLUDE: ClassVar[set[str]] = set()
     INJECTABLE: ClassVar[set[str]] = set()
     _SHALLOW_COPY_FIELDS: ClassVar[set[str]] = {"raw_representation"}
+    _PICKLE_OMIT_FIELDS: ClassVar[set[str]] = {"raw_representation"}
+
+    def __copy__(self) -> SerializationMixin:
+        """Create a shallow copy without invoking pickle state hooks."""
+        cls = type(self)
+        result = cls.__new__(cls)
+        for field_name, value in _iter_instance_fields(self).items():
+            object.__setattr__(result, field_name, value)
+        return result
 
     def __deepcopy__(self, memo: dict[int, Any]) -> SerializationMixin:
         """Create a deep copy, preserving ``_SHALLOW_COPY_FIELDS`` by reference.
@@ -296,7 +334,7 @@ class SerializationMixin:
         cls = type(self)
         result = cls.__new__(cls)
         memo[id(self)] = result
-        for k, v in self.__dict__.items():
+        for k, v in _iter_instance_fields(self).items():
             if k in cls._SHALLOW_COPY_FIELDS:
                 object.__setattr__(result, k, v)
             else:
@@ -305,16 +343,11 @@ class SerializationMixin:
 
     def __getstate__(self) -> dict[str, Any]:
         """Return pickle state without runtime-only shallow-copy fields."""
-        state = dict(self.__dict__)
-        for field_name in self._SHALLOW_COPY_FIELDS:
-            state.pop(field_name, None)
-        return state
+        return _get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
-        self.__dict__.update(state)
-        for field_name in self._SHALLOW_COPY_FIELDS:
-            self.__dict__.setdefault(field_name, None)
+        _restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 
     def to_dict(self, *, exclude: set[str] | None = None, exclude_none: bool = True) -> dict[str, Any]:
         """Convert the instance and any nested objects to a dictionary.

--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -172,12 +172,20 @@ def _get_pickle_state(instance: Any, omitted_fields: set[str]) -> dict[str, Any]
     return state
 
 
-def _restore_pickle_state(instance: Any, state: dict[str, Any], omitted_fields: set[str]) -> None:
+def _restore_pickle_state(
+    instance: Any,
+    state: dict[str, Any] | tuple[dict[str, Any], dict[str, Any]],
+    omitted_fields: set[str],
+) -> None:
     """Restore dict- and slot-backed pickle state."""
+    if isinstance(state, tuple):
+        dict_state, slot_state = state
+        state = {**dict_state, **slot_state}
     for field_name, value in state.items():
         object.__setattr__(instance, field_name, value)
     for field_name in omitted_fields:
-        object.__setattr__(instance, field_name, None)
+        if field_name in _iter_instance_fields(instance) or hasattr(instance, "__dict__"):
+            object.__setattr__(instance, field_name, None)
 
 
 class SerializationMixin:

--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -303,6 +303,19 @@ class SerializationMixin:
                 object.__setattr__(result, k, copy.deepcopy(v, memo))
         return result
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Return pickle state without runtime-only shallow-copy fields."""
+        state = dict(self.__dict__)
+        for field_name in self._SHALLOW_COPY_FIELDS:
+            state.pop(field_name, None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickle state and reset runtime-only shallow-copy fields."""
+        self.__dict__.update(state)
+        for field_name in self._SHALLOW_COPY_FIELDS:
+            self.__dict__.setdefault(field_name, None)
+
     def to_dict(self, *, exclude: set[str] | None = None, exclude_none: bool = True) -> dict[str, Any]:
         """Convert the instance and any nested objects to a dictionary.
 

--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -164,7 +164,7 @@ def _iter_instance_fields(instance: Any) -> dict[str, Any]:
     return fields
 
 
-def _get_pickle_state(instance: Any, omitted_fields: set[str]) -> dict[str, Any]:
+def get_pickle_state(instance: Any, omitted_fields: set[str]) -> dict[str, Any]:
     """Build pickle state while omitting runtime-only fields."""
     state = _iter_instance_fields(instance)
     for field_name in omitted_fields:
@@ -172,7 +172,7 @@ def _get_pickle_state(instance: Any, omitted_fields: set[str]) -> dict[str, Any]
     return state
 
 
-def _restore_pickle_state(
+def restore_pickle_state(
     instance: Any,
     state: dict[str, Any] | tuple[dict[str, Any], dict[str, Any]],
     omitted_fields: set[str],
@@ -351,11 +351,11 @@ class SerializationMixin:
 
     def __getstate__(self) -> dict[str, Any]:
         """Return pickle state without runtime-only shallow-copy fields."""
-        return _get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
+        return get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
-        _restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
+        restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 
     def to_dict(self, *, exclude: set[str] | None = None, exclude_none: bool = True) -> dict[str, Any]:
         """Convert the instance and any nested objects to a dictionary.

--- a/python/packages/core/agent_framework/_serialization.py
+++ b/python/packages/core/agent_framework/_serialization.py
@@ -353,7 +353,7 @@ class SerializationMixin:
         """Return pickle state without runtime-only shallow-copy fields."""
         return get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
 
-    def __setstate__(self, state: dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
         restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -611,6 +611,14 @@ class Content:
                 object.__setattr__(result, k, deepcopy(v, memo))
         return result
 
+    def __copy__(self) -> Content:
+        """Create a shallow copy while preserving provider runtime fields."""
+        cls = type(self)
+        result = cls.__new__(cls)
+        for field_name, value in self.__dict__.items():
+            object.__setattr__(result, field_name, value)
+        return result
+
     def __getstate__(self) -> dict[str, Any]:
         """Return pickle state without runtime-only shallow-copy fields."""
         state = _get_pickle_state(self, self._PICKLE_OMIT_FIELDS)

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -629,7 +629,7 @@ class Content:
             ]
         return state
 
-    def __setstate__(self, state: dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
         restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Final, Generic, Literal, NewTyp
 from typing_extensions import TypedDict
 
 from ._feature_stage import ExperimentalFeature, experimental
-from ._serialization import SerializationMixin
+from ._serialization import SerializationMixin, _get_pickle_state, _restore_pickle_state
 from .exceptions import AdditionItemMismatch, ContentError
 
 if sys.version_info >= (3, 13):
@@ -483,6 +483,7 @@ class Content:
     """
 
     _SHALLOW_COPY_FIELDS: ClassVar[set[str]] = {"raw_representation"}
+    _PICKLE_OMIT_FIELDS: ClassVar[set[str]] = {"raw_representation"}
 
     def __init__(
         self,
@@ -612,16 +613,17 @@ class Content:
 
     def __getstate__(self) -> dict[str, Any]:
         """Return pickle state without runtime-only shallow-copy fields."""
-        state = dict(self.__dict__)
-        for field_name in self._SHALLOW_COPY_FIELDS:
-            state.pop(field_name, None)
+        state = _get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
+        if self.annotations is not None:
+            state["annotations"] = [
+                {key: value for key, value in annotation.items() if key != "raw_representation"}
+                for annotation in self.annotations
+            ]
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
-        self.__dict__.update(state)
-        for field_name in self._SHALLOW_COPY_FIELDS:
-            self.__dict__.setdefault(field_name, None)
+        _restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 
     @classmethod
     def from_text(

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -610,6 +610,19 @@ class Content:
                 object.__setattr__(result, k, deepcopy(v, memo))
         return result
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Return pickle state without runtime-only shallow-copy fields."""
+        state = dict(self.__dict__)
+        for field_name in self._SHALLOW_COPY_FIELDS:
+            state.pop(field_name, None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickle state and reset runtime-only shallow-copy fields."""
+        self.__dict__.update(state)
+        for field_name in self._SHALLOW_COPY_FIELDS:
+            self.__dict__.setdefault(field_name, None)
+
     @classmethod
     def from_text(
         cls: type[ContentT],

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Final, Generic, Literal, NewTyp
 from typing_extensions import TypedDict
 
 from ._feature_stage import ExperimentalFeature, experimental
-from ._serialization import SerializationMixin, _get_pickle_state, _restore_pickle_state
+from ._serialization import SerializationMixin, get_pickle_state, restore_pickle_state
 from .exceptions import AdditionItemMismatch, ContentError
 
 if sys.version_info >= (3, 13):
@@ -621,7 +621,7 @@ class Content:
 
     def __getstate__(self) -> dict[str, Any]:
         """Return pickle state without runtime-only shallow-copy fields."""
-        state = _get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
+        state = get_pickle_state(self, self._PICKLE_OMIT_FIELDS)
         if self.annotations is not None:
             state["annotations"] = [
                 {key: value for key, value in annotation.items() if key != "raw_representation"}
@@ -631,7 +631,7 @@ class Content:
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore pickle state and reset runtime-only shallow-copy fields."""
-        _restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
+        restore_pickle_state(self, state, self._PICKLE_OMIT_FIELDS)
 
     @classmethod
     def from_text(

--- a/python/packages/core/tests/core/test_serializable_mixin.py
+++ b/python/packages/core/tests/core/test_serializable_mixin.py
@@ -598,6 +598,20 @@ class TestSerializationMixin:
 
         assert restored.value == "value"
 
+    def test_pickle_restores_legacy_tuple_state(self):
+        """Pickle restoration should accept the legacy dict-and-slots tuple."""
+
+        class TestClass(SerializationMixin):
+            __slots__ = ("value",)
+
+            def __init__(self):
+                self.value = "new"
+
+        restored = TestClass.__new__(TestClass)
+        restored.__setstate__(({"other": "dict"}, {"value": "legacy"}))
+
+        assert restored.value == "legacy"
+
     def test_pickle_omission_is_separate_from_shallow_copy_policy(self):
         """Fields shallow-copied by default remain persistent unless explicitly omitted."""
         class TestClass(SerializationMixin):

--- a/python/packages/core/tests/core/test_serializable_mixin.py
+++ b/python/packages/core/tests/core/test_serializable_mixin.py
@@ -572,6 +572,45 @@ class TestSerializationMixin:
         assert cloned.items is not obj.items
         assert cloned.items == ["a"]
 
+    def test_shallow_copy_preserves_pickle_omitted_fields(self):
+        """Shallow copies retain runtime fields that pickle omits."""
+
+        class TestClass(SerializationMixin):
+            def __init__(self, raw_representation: Any):
+                self.raw_representation = raw_representation
+
+        raw = object()
+        cloned = copy.copy(TestClass(raw))
+
+        assert cloned.raw_representation is raw
+
+    def test_pickle_restores_slot_fields(self):
+        """Pickle state should include fields declared in slots."""
+        class TestClass(SerializationMixin):
+            __slots__ = ("value",)
+
+            def __init__(self, value: str):
+                self.value = value
+
+        original = TestClass("value")
+        restored = TestClass.__new__(TestClass)
+        restored.__setstate__(original.__getstate__())
+
+        assert restored.value == "value"
+
+    def test_pickle_omission_is_separate_from_shallow_copy_policy(self):
+        """Fields shallow-copied by default remain persistent unless explicitly omitted."""
+        class TestClass(SerializationMixin):
+            _PICKLE_OMIT_FIELDS = set()
+
+            def __init__(self, raw_representation: Any):
+                self.raw_representation = raw_representation
+
+        raw = {"provider": "value"}
+        state = TestClass(raw).__getstate__()
+
+        assert state["raw_representation"] == raw
+
     def test_dependency_dict_merge_does_not_mutate_input(self):
         """Test that dict dependency merging does not mutate the caller's input dictionary."""
 

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -2733,6 +2733,19 @@ def test_content_deepcopy_discards_raw_representation(caplog: pytest.LogCaptureF
     assert caplog.messages == ["Discarding field 'raw_representation' while deep-copying Content."]
 
 
+def test_content_pickle_discards_nested_annotation_raw_representation() -> None:
+    """Pickle should omit provider objects stored on annotations."""
+    import pickle
+
+    raw = object()
+    annotation: Annotation = {"type": "citation", "url": "https://example.com", "raw_representation": raw}
+    content = Content.from_text("hello", annotations=[annotation])
+
+    restored = pickle.loads(pickle.dumps(content))
+
+    assert restored.annotations == [{"type": "citation", "url": "https://example.com"}]
+
+
 def test_message_deepcopy_preserves_raw_representation():
     """Test that deepcopy of Message keeps raw_representation by reference."""
     import copy

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -2746,6 +2746,16 @@ def test_content_pickle_discards_nested_annotation_raw_representation() -> None:
     assert restored.annotations == [{"type": "citation", "url": "https://example.com"}]
 
 
+def test_content_shallow_copy_preserves_raw_representation() -> None:
+    """Shallow copies of Content retain provider runtime fields."""
+    import copy
+
+    raw = _NonCopyableRaw()
+    cloned = copy.copy(Content.from_text("hello", raw_representation=raw))
+
+    assert cloned.raw_representation is raw
+
+
 def test_message_deepcopy_preserves_raw_representation():
     """Test that deepcopy of Message keeps raw_representation by reference."""
     import copy

--- a/python/packages/core/tests/workflow/test_agent_executor.py
+++ b/python/packages/core/tests/workflow/test_agent_executor.py
@@ -1,5 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import pickle
+
 from collections.abc import AsyncIterable, Awaitable
 from typing import Any, Literal, overload
 
@@ -336,6 +338,9 @@ class _NonCopyableRaw:
     def __deepcopy__(self, memo: dict) -> Any:
         raise TypeError("Cannot deepcopy this object")
 
+    def __reduce__(self) -> Any:
+        raise TypeError("Cannot pickle this object")
+
 
 class _AgentWithRawRepr(BaseAgent):
     """Agent that returns responses with a non-copyable raw_representation."""
@@ -385,6 +390,20 @@ async def test_agent_executor_workflow_with_non_copyable_raw_representation() ->
     assert len(agent_responses) > 0
     assert agent_responses[0].text == "reply from AgentA"
     assert agent_responses[0].raw_representation is raw
+
+
+def test_serialization_mixin_omits_non_pickleable_raw_representation() -> None:
+    """Pickling framework objects should not include runtime-only raw representations."""
+    raw = _NonCopyableRaw()
+    response = AgentResponse(
+        messages=[Message("assistant", [Content.from_text(text="reply", raw_representation=raw)])],
+        raw_representation=raw,
+    )
+
+    restored = pickle.loads(pickle.dumps(response))
+
+    assert restored.raw_representation is None
+    assert restored.messages[0].contents[0].raw_representation is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation & Context

Workflow checkpoint creation fails when A2A responses are present in workflow state. A2A protobuf objects such as `a2a_pb2.Part` can be retained in framework `raw_representation` fields, but the generated module is not importable by Python pickle. The workflow continues, but the affected checkpoint is skipped and durable workflow recovery can lose that checkpoint boundary.

This change ensures provider-specific runtime objects do not prevent framework-native workflow state from being persisted.

### Description & Review Guide

- **What are the major changes?**
  - Add pickle state hooks to `SerializationMixin` and `Content`.
  - Exclude runtime-only fields listed in `_SHALLOW_COPY_FIELDS`, including `raw_representation`, from pickle state.
  - Restore omitted shallow-copy fields as `None` after unpickling.
  - Add regression coverage using an intentionally unpickleable raw representation, including nested `Content`.
- **What is the impact of these changes?**
  - A2A protobuf-backed content can be checkpointed without emitting the checkpoint failure warning.
  - Framework-native content, messages, executor state, and workflow state remain persisted.
  - Active-run provider objects remain available; only restored checkpoints omit transient raw representations.
  - This is not a breaking change to the active-run response API.
- **What do you want reviewers to focus on?**
  - Confirm that `_SHALLOW_COPY_FIELDS` is the right source of truth for pickle exclusion.
  - Confirm that restoring runtime-only fields to `None` is appropriate for checkpoint resume semantics.
  - Review whether the behavior should also be covered by additional checkpoint storage integration tests.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers focus on?" item above is intended for human reviewers only. Automated/AI reviewers should ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Fixes #8022

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix) — a workflow keeps the label and title prefix in sync automatically.