### PR TITLE
[BREAKING] Python: Bump package versions for 1.17.0 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-09-03
+
+### Added
+- **samples**: Add an end-to-end Foundry-hosted Telegram agent sample ([#7883](https://github.com/microsoft/agent-framework/pull/7883))
+- **agent-framework-foundry-hosting**: Add explicit Agent Server or agent-owned model history selection while preventing duplicated conversation replay ([#7997](https://github.com/microsoft/agent-framework/pull/7997))
+
+### Changed
+- **agent-framework-core**, **agent-framework-foundry**: [BREAKING] Restore sequence-only agent middleware inputs and remove the experimental `agent-hooks` core extra ([#7918](https://github.com/microsoft/agent-framework/pull/7918))
+- **agent-framework-core**, **agent-framework-foundry**, **agent-framework-openai**: Document the same-event-loop concurrency contract for shared chat clients ([#7680](https://github.com/microsoft/agent-framework/pull/7680))
+- **agent-framework-devui**, **agent-framework-hosting-responses**, **agent-framework-openai**: Support OpenAI SDK 3.x while retaining the existing supported floors ([#7967](https://github.com/microsoft/agent-framework/pull/7967))
+- **agent-framework-mistral**: Migrate chat and embedding clients to the official Mistral SDK ([#7960](https://github.com/microsoft/agent-framework/pull/7960))
+
+### Fixed
+- **agent-framework-core**, **agent-framework-devui**, **agent-framework-foundry-hosting**, **agent-framework-hosting-responses**, **agent-framework-openai**: Preserve provider refusals as marked text across history, replay, hosting, and UI conversion ([#7992](https://github.com/microsoft/agent-framework/pull/7992))
+- **agent-framework-ag-ui**, **agent-framework-core**, **agent-framework-devui**, **agent-framework-openai**: Bind approvals to stable function-call occurrences while preserving legacy approval compatibility ([#7988](https://github.com/microsoft/agent-framework/pull/7988))
+- **agent-framework-foundry-hosting**: Persist valid OAuth consent responses and restore consent state during recovery ([#8006](https://github.com/microsoft/agent-framework/pull/8006))
+- **agent-framework-core**: Surface the underlying MCP initialization error when cancellation masks a connection failure ([#7704](https://github.com/microsoft/agent-framework/pull/7704))
+- **agent-framework-ag-ui**, **agent-framework-core**: Preserve client tools and request correlation when resuming workflow-as-agent approvals ([#7776](https://github.com/microsoft/agent-framework/pull/7776))
+- **agent-framework-core**: Project each model call's effective tool set to agent-hooks `pre_model_call` events ([#7747](https://github.com/microsoft/agent-framework/pull/7747))
+- **agent-framework-ag-ui**: Preserve every parallel function result during AG-UI message conversion ([#7980](https://github.com/microsoft/agent-framework/pull/7980))
+- **agent-framework-devui**, **agent-framework-openai**: Preserve Responses message boundaries, multimodal content, measured usage, and streamed response IDs in DevUI ([#7968](https://github.com/microsoft/agent-framework/pull/7968))
+- **agent-framework-hosting-responses**: Align continuation, input, output, and media parsing with the OpenAI Responses schemas ([#7966](https://github.com/microsoft/agent-framework/pull/7966))
+- **agent-framework-foundry**: Declare the HTTPX runtime dependency required by Azure AI Projects 2.3
+- **agent-framework-openai**: Preserve falsey provider values, valid request content, usage details, and embedding order ([#7964](https://github.com/microsoft/agent-framework/pull/7964))
+- **agent-framework-foundry-hosting**: Preserve JSON-safe arguments, falsey results, MCP output consistency, and shell limits in response conversion ([#7965](https://github.com/microsoft/agent-framework/pull/7965))
+- **agent-framework-ag-ui**, **agent-framework-foundry**, **agent-framework-openai**: Preserve Responses replay metadata across stateless and provider-managed AG-UI continuations ([#7906](https://github.com/microsoft/agent-framework/pull/7906))
+- **agent-framework-core**: Preserve compaction mutations across tool-loop calls and align thresholds and observability ([#7912](https://github.com/microsoft/agent-framework/pull/7912))
+- **agent-framework-gemini**: Send Pydantic response formats to Gemini as response schemas ([#7879](https://github.com/microsoft/agent-framework/pull/7879))
+- **agent-framework-redis**: Keep history-provider typing compatible across the supported Redis range ([#7604](https://github.com/microsoft/agent-framework/pull/7604))
+
 ## [1.16.0] - 2026-08-27
 
 ### Added
@@ -1576,7 +1606,8 @@ Release candidate for **agent-framework-core** and **agent-framework-azure-ai** 
 
 For more information, see the [announcement blog post](https://devblogs.microsoft.com/foundry/introducing-microsoft-agent-framework-the-open-source-engine-for-agentic-ai-apps/).
 
-[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.16.0...HEAD
+[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.17.0...HEAD
+[1.17.0]: https://github.com/microsoft/agent-framework/compare/python-1.16.0...python-1.17.0
 [1.16.0]: https://github.com/microsoft/agent-framework/compare/python-1.15.0...python-1.16.0
 [1.15.0]: https://github.com/microsoft/agent-framework/compare/python-1.14.0...python-1.15.0
 [1.14.0]: https://github.com/microsoft/agent-framework/compare/python-1.13.0...python-1.14.0

--- a/python/packages/ag-ui/pyproject.toml
+++ b/python/packages/ag-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-framework-ag-ui"
-version = "1.2.1"
+version = "1.2.2"
 description = "AG-UI protocol integration for Agent Framework"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.16.0"
+version = "1.17.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/devui/pyproject.toml
+++ b/python/packages/devui/pyproject.toml
@@ -4,7 +4,7 @@ description = "Debug UI for Microsoft Agent Framework with OpenAI-compatible API
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://github.com/microsoft/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/foundry/pyproject.toml
+++ b/python/packages/foundry/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Foundry integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.11.1"
+version = "1.12.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/foundry/pyproject.toml
+++ b/python/packages/foundry/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Foundry integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.11.0"
+version = "1.11.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,11 +23,12 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.13.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "agent-framework-openai>=1.10.0,<2",
     "aiohttp>=3.9,<4",
     "azure-ai-inference>=1.0.0b9,<1.0.0b10",
     "azure-ai-projects>=2.2.0,<2.4.0",
+    "httpx>=0.28,<1",
 ]
 
 [tool.uv]

--- a/python/packages/foundry_hosting/pyproject.toml
+++ b/python/packages/foundry_hosting/pyproject.toml
@@ -4,7 +4,7 @@ description = "Foundry Hosting integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.15.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "azure-ai-agentserver-core>=2.1.0,<3",
     "azure-ai-agentserver-responses>=2.2.0b1,<3",
     "azure-ai-agentserver-invocations>=1.1.0,<2",

--- a/python/packages/gemini/pyproject.toml
+++ b/python/packages/gemini/pyproject.toml
@@ -4,7 +4,7 @@ description = "Google Gemini integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -24,7 +24,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.13.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "google-genai>=1.69.0,<3.0.0",
 ]
 

--- a/python/packages/hosting-responses/pyproject.toml
+++ b/python/packages/hosting-responses/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI Responses-shaped helpers for agent-framework-hosting."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260730"
+version = "1.0.0a260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.13.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "agent-framework-hosting==1.0.0a260730",
     "openai>=1.99.0,<4",
 ]

--- a/python/packages/mistral/pyproject.toml
+++ b/python/packages/mistral/pyproject.toml
@@ -4,7 +4,7 @@ description = "Mistral AI integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://learn.microsoft.com/en-us/agent-framework/"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.13.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "mistralai>=2.9.2,<3",
 ]
 

--- a/python/packages/openai/pyproject.toml
+++ b/python/packages/openai/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.14.1"
+version = "1.14.2"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/redis/pyproject.toml
+++ b/python/packages/redis/pyproject.toml
@@ -4,7 +4,7 @@ description = "Redis integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260903"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.15.0,<2",
+    "agent-framework-core>=1.17.0,<2",
     "redis>=6.4.0,<7.2.1",
     "redisvl>=0.11.0,<0.16",
     "numpy>=2.2.6,<3"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.16.0"
+version = "1.17.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core[all]==1.16.0",
+    "agent-framework-core[all]==1.17.0",
 ]
 
 [dependency-groups]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.16.0"
+version = "1.17.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -206,7 +206,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-ag-ui"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "packages/ag-ui" }
 dependencies = [
     { name = "ag-ui-protocol", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -428,7 +428,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -551,7 +551,7 @@ dev = [{ name = "types-pyyaml", specifier = "==6.0.12.20260518" }]
 
 [[package]]
 name = "agent-framework-devui"
-version = "1.0.0b260821"
+version = "1.0.0b260903"
 source = { editable = "packages/devui" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-foundry"
-version = "1.11.0"
+version = "1.11.1"
 source = { editable = "packages/foundry" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -612,6 +612,7 @@ dependencies = [
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-ai-inference", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-ai-projects", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -621,11 +622,12 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9,<4" },
     { name = "azure-ai-inference", specifier = ">=1.0.0b9,<1.0.0b10" },
     { name = "azure-ai-projects", specifier = ">=2.2.0,<2.4.0" },
+    { name = "httpx", specifier = ">=0.28,<1" },
 ]
 
 [[package]]
 name = "agent-framework-foundry-hosting"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 source = { editable = "packages/foundry_hosting" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -665,7 +667,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-gemini"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 source = { editable = "packages/gemini" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -742,7 +744,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-hosting-responses"
-version = "1.0.0a260730"
+version = "1.0.0a260903"
 source = { editable = "packages/hosting-responses" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -903,7 +905,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-mistral"
-version = "1.0.0b260827"
+version = "1.0.0b260903"
 source = { editable = "packages/mistral" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -948,7 +950,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-openai"
-version = "1.14.1"
+version = "1.14.2"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -991,7 +993,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-redis"
-version = "1.0.0b260821"
+version = "1.0.0b260903"
 source = { editable = "packages/redis" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-foundry"
-version = "1.11.1"
+version = "1.12.0"
 source = { editable = "packages/foundry" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
### Motivation & Context

The Python packages need a coordinated 1.17.0 release so the features, fixes, and explicitly breaking core middleware correction merged since 1.16.0 can be published with consistent package metadata, dependency floors, release notes, and lockfile state.

### Description & Review Guide

- **What are the major changes?** Bumps the root package and core to 1.17.0; applies a minor bump to Foundry 1.12.0 and patch bumps to AG-UI 1.2.2 and OpenAI 1.14.2; date-stamps the changed DevUI, Foundry Hosting, Gemini, Mistral, Redis, and Hosting Responses prerelease packages; raises core floors on co-released packages; declares the HTTPX runtime dependency required by Azure AI Projects 2.3; updates the CHANGELOG and comparison links; and minimally updates `uv.lock`.
- **What is the impact of these changes?** Publishes only packages with shipping changes, without a cohort-wide beta bump. The release restores sequence-only middleware inputs as an explicitly breaking correction, ships the accumulated provider, hosting, approval, compaction, and protocol fixes, and keeps co-released packages aligned with core 1.17.0.
- **What do you want reviewers to focus on?** Confirm the CHANGELOG-to-package bump mapping, the conservative core-floor updates, the Foundry HTTPX dependency correction, and the intentionally minimal lockfile delta.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No linked issue; this is scheduled Python release preparation. No competing Python 1.17.0 release PR was open when this PR was created.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and the title prefix in sync automatically.
