### PR TITLE
.NET: [BREAKING] Clarify A2A agent run modes

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -33,7 +33,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// Initializes a new instance of the <see cref="A2AAgentHandler"/> class.
     /// </summary>
     /// <param name="hostAgent">The hosted agent that provides the execution logic.</param>
-    /// <param name="runMode">Controls whether the agent runs in background mode.</param>
+    /// <param name="runMode">Controls which A2A artifact the agent response is returned as.</param>
     public A2AAgentHandler(
         AIHostAgent hostAgent,
         AgentRunMode runMode)
@@ -80,20 +80,20 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// <param name="eventQueue">The queue the response events are written to.</param>
     /// <param name="aggregateTaskUpdates">
     /// <see langword="true"/> to run the agent to completion before emitting a single completed task;
-    /// <see langword="false"/> to emit task updates as they are produced. Ignored when the server disallows
-    /// background responses, because a message response is always aggregated.
+    /// <see langword="false"/> to emit task updates as they are produced. Ignored when the server is configured
+    /// through <see cref="AgentRunMode"/> to return a message, because a message response is always aggregated.
     /// </param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the operation.</param>
     /// <remarks>
     /// The response shape is decided by two independent inputs:
     /// <list type="number">
     /// <item><description>
-    /// Whether the server allows background responses. This is configured per agent registration, for example:
+    /// Which A2A artifact the server returns. This is configured per agent registration, for example:
     /// <code>
     /// builder.AddA2AServer(agent, (A2AServerRegistrationOptions options) =>
-    ///     options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported);
+    ///     options.AgentRunMode = AgentRunMode.ReturnTask);
     /// </code>
-    /// Use <c>AgentRunMode.DisallowBackground</c> to always respond with a message instead of a task.
+    /// Use <c>AgentRunMode.ReturnMessage</c> to always respond with a message instead of a task.
     /// </description></item>
     /// <item><description>
     /// Whether the client asked for an immediate response. In the A2A protocol this is the
@@ -104,17 +104,20 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// The resulting combinations are:
     /// <list type="bullet">
     /// <item><description>
-    /// Server allows background responses and <c>ReturnImmediately = true</c>: returns the initial task, then the
-    /// rest of the updates piece by piece.
+    /// Server is configured through <see cref="AgentRunMode"/> to return a task and <c>ReturnImmediately = true</c>:
+    /// returns the initial task, then the rest of the updates piece by piece.
     /// </description></item>
     /// <item><description>
-    /// Server allows background responses and <c>ReturnImmediately = false</c>: returns a single completed task.
+    /// Server is configured through <see cref="AgentRunMode"/> to return a task and <c>ReturnImmediately = false</c>:
+    /// returns a single completed task.
     /// </description></item>
     /// <item><description>
-    /// Server disallows background responses and <c>ReturnImmediately = true</c>: returns a message.
+    /// Server is configured through <see cref="AgentRunMode"/> to return a message and <c>ReturnImmediately = true</c>:
+    /// returns a message.
     /// </description></item>
     /// <item><description>
-    /// Server disallows background responses and <c>ReturnImmediately = false</c>: returns a message.
+    /// Server is configured through <see cref="AgentRunMode"/> to return a message and <c>ReturnImmediately = false</c>:
+    /// returns a message.
     /// </description></item>
     /// </list>
     /// </remarks>
@@ -133,11 +136,12 @@ internal sealed class A2AAgentHandler : IAgentHandler
 
         List<ChatMessage> chatMessages = context.Message is not null ? [context.Message.ToChatMessage()] : [];
 
-        var options = CreateRunOptions(context);
-
-        // Decide whether to run in background based on user preferences and agent capabilities
+        // Decide which A2A artifact to return based on the configured run mode. Returning a task also allows
+        // background responses so that the streamed updates carry continuation tokens for stream resumption.
         var decisionContext = new A2ARunDecisionContext(context);
-        var returnTask = await this._runMode.ShouldRunInBackgroundAsync(decisionContext, cancellationToken).ConfigureAwait(false);
+        var returnTask = await this._runMode.ShouldReturnTaskAsync(decisionContext, cancellationToken).ConfigureAwait(false);
+
+        var options = CreateRunOptions(context, returnTask);
 
         var updates = this._hostAgent.RunStreamingAsync(chatMessages, session, options, cancellationToken);
 
@@ -148,20 +152,20 @@ internal sealed class A2AAgentHandler : IAgentHandler
                 var taskUpdater = new TaskUpdater(eventQueue, context.TaskId, contextId);
                 if (aggregateTaskUpdates)
                 {
-                    // The server allows background responses, but the non-streaming client request has
+                    // The server is configured through AgentRunMode to return a task, but the non-streaming client request has
                     // ReturnImmediately disabled, so collect all updates and return a completed task.
                     await AggregateTaskUpdatesAsync(updates, taskUpdater, eventQueue, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    // The server allows background responses and this is either a streaming request or a
+                    // The server is configured through AgentRunMode to return a task and this is either a streaming request or a
                     // non-streaming request with ReturnImmediately enabled, so emit task updates as they arrive.
                     await StreamTaskUpdatesAsync(updates, taskUpdater, cancellationToken).ConfigureAwait(false);
                 }
             }
             else
             {
-                // The server disallows background responses, so return one aggregated message regardless
+                // The server is configured through AgentRunMode to return a message, so return one aggregated message regardless
                 // of the client request's ReturnImmediately value.
                 await StreamMessageUpdatesAsync(contextId, updates, eventQueue, cancellationToken).ConfigureAwait(false);
             }
@@ -180,9 +184,9 @@ internal sealed class A2AAgentHandler : IAgentHandler
         List<ChatMessage> chatMessages = ExtractChatMessagesFromTaskHistory(context.Task);
 
         var decisionContext = new A2ARunDecisionContext(context);
-        var allowBackgroundResponses = await this._runMode.ShouldRunInBackgroundAsync(decisionContext, cancellationToken).ConfigureAwait(false);
+        var returnTask = await this._runMode.ShouldReturnTaskAsync(decisionContext, cancellationToken).ConfigureAwait(false);
 
-        var options = CreateRunOptions(context, allowBackgroundResponses);
+        var options = CreateRunOptions(context, returnTask);
 
         AgentResponse response;
         try
@@ -234,12 +238,12 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// </summary>
     /// <param name="context">The A2A request context of the incoming request.</param>
     /// <param name="allowBackgroundResponses">
-    /// The value to assign to <see cref="AgentRunOptions.AllowBackgroundResponses"/>. Defaults to <see langword="null"/>, which leaves it unset.
+    /// Whether to enable <see cref="AgentRunOptions.AllowBackgroundResponses"/> for the hosted agent run.
     /// </param>
     /// <returns>
     /// The run options to invoke the agent with, or <see langword="null"/> when there is nothing to forward.
     /// </returns>
-    private static AgentRunOptions? CreateRunOptions(RequestContext context, bool? allowBackgroundResponses = null)
+    private static AgentRunOptions? CreateRunOptions(RequestContext context, bool allowBackgroundResponses)
     {
         AdditionalPropertiesDictionary? additionalProperties = context.Metadata is { Count: > 0 }
             ? context.Metadata.ToAdditionalProperties()
@@ -252,7 +256,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
             (additionalProperties ??= [])[ConfigurationPropertyKey] = configuration;
         }
 
-        if (allowBackgroundResponses is null && additionalProperties is null)
+        if (!allowBackgroundResponses && additionalProperties is null)
         {
             return null;
         }
@@ -294,7 +298,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// Emits a task and streams the agent updates into it as artifacts as they are produced.
     /// </summary>
     /// <remarks>
-    /// Handles the case where the server allows background responses and the response is delivered incrementally:
+    /// Handles the case where the server is configured through <see cref="AgentRunMode"/> to return a task and the
+    /// response is delivered incrementally:
     /// either a streaming (<c>message/stream</c>) request, or a non-streaming request with
     /// <c>ReturnImmediately = true</c>. In the latter case the caller receives the initial task immediately and
     /// obtains the remaining updates by polling the task.
@@ -342,7 +347,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// Consumes the agent updates without emitting them and then returns a single completed task.
     /// </summary>
     /// <remarks>
-    /// Handles the case where the server allows background responses and a non-streaming client sent
+    /// Handles the case where the server is configured through <see cref="AgentRunMode"/> to return a task and a
+    /// non-streaming client sent
     /// <c>ReturnImmediately = false</c>, meaning it wants the final result in the response rather than a task
     /// it has to poll. No task event is emitted until the agent stream finishes, because the server returns on the
     /// first task event; emitting early would hand the caller an in-progress task instead of a completed one.
@@ -384,7 +390,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// Consumes the agent updates and emits the aggregated result as a single message.
     /// </summary>
     /// <remarks>
-    /// Handles the case where the server disallows background responses, which applies regardless of the client's
+    /// Handles the case where the server is configured through <see cref="AgentRunMode"/> to return a message, which
+    /// applies regardless of the client's
     /// <c>ReturnImmediately</c> value: a message is not a long-running entity, so there is nothing to return early
     /// or poll for and the full agent run is always aggregated into one message. An empty message is emitted when
     /// the agent produces no messages.

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -240,10 +240,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// <param name="allowBackgroundResponses">
     /// Whether to enable <see cref="AgentRunOptions.AllowBackgroundResponses"/> for the hosted agent run.
     /// </param>
-    /// <returns>
-    /// The run options to invoke the agent with, or <see langword="null"/> when there is nothing to forward.
-    /// </returns>
-    private static AgentRunOptions? CreateRunOptions(RequestContext context, bool allowBackgroundResponses)
+    /// <returns>The run options to invoke the agent with.</returns>
+    private static AgentRunOptions CreateRunOptions(RequestContext context, bool allowBackgroundResponses)
     {
         AdditionalPropertiesDictionary? additionalProperties = context.Metadata is { Count: > 0 }
             ? context.Metadata.ToAdditionalProperties()
@@ -254,11 +252,6 @@ internal sealed class A2AAgentHandler : IAgentHandler
         if (context.Configuration is { } configuration)
         {
             (additionalProperties ??= [])[ConfigurationPropertyKey] = configuration;
-        }
-
-        if (!allowBackgroundResponses && additionalProperties is null)
-        {
-            return null;
         }
 
         return new AgentRunOptions

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AAgentHandler.cs
@@ -136,12 +136,11 @@ internal sealed class A2AAgentHandler : IAgentHandler
 
         List<ChatMessage> chatMessages = context.Message is not null ? [context.Message.ToChatMessage()] : [];
 
-        // Decide which A2A artifact to return based on the configured run mode. Returning a task also allows
-        // background responses so that the streamed updates carry continuation tokens for stream resumption.
+        // Decide which A2A artifact to return based on the configured run mode.
         var decisionContext = new A2ARunDecisionContext(context);
         var returnTask = await this._runMode.ShouldReturnTaskAsync(decisionContext, cancellationToken).ConfigureAwait(false);
 
-        var options = CreateRunOptions(context, returnTask);
+        var options = CreateRunOptions(context);
 
         var updates = this._hostAgent.RunStreamingAsync(chatMessages, session, options, cancellationToken);
 
@@ -183,10 +182,7 @@ internal sealed class A2AAgentHandler : IAgentHandler
 
         List<ChatMessage> chatMessages = ExtractChatMessagesFromTaskHistory(context.Task);
 
-        var decisionContext = new A2ARunDecisionContext(context);
-        var returnTask = await this._runMode.ShouldReturnTaskAsync(decisionContext, cancellationToken).ConfigureAwait(false);
-
-        var options = CreateRunOptions(context, returnTask);
+        var options = CreateRunOptions(context);
 
         AgentResponse response;
         try
@@ -237,11 +233,8 @@ internal sealed class A2AAgentHandler : IAgentHandler
     /// <c>MessageSendParams.metadata</c> and <c>MessageSendParams.configuration</c> to the hosted agent.
     /// </summary>
     /// <param name="context">The A2A request context of the incoming request.</param>
-    /// <param name="allowBackgroundResponses">
-    /// Whether to enable <see cref="AgentRunOptions.AllowBackgroundResponses"/> for the hosted agent run.
-    /// </param>
     /// <returns>The run options to invoke the agent with.</returns>
-    private static AgentRunOptions CreateRunOptions(RequestContext context, bool allowBackgroundResponses)
+    private static AgentRunOptions CreateRunOptions(RequestContext context)
     {
         AdditionalPropertiesDictionary? additionalProperties = context.Metadata is { Count: > 0 }
             ? context.Metadata.ToAdditionalProperties()
@@ -256,7 +249,6 @@ internal sealed class A2AAgentHandler : IAgentHandler
 
         return new AgentRunOptions
         {
-            AllowBackgroundResponses = allowBackgroundResponses,
             AdditionalProperties = additionalProperties
         };
     }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerRegistrationOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerRegistrationOptions.cs
@@ -16,7 +16,7 @@ public sealed class A2AServerRegistrationOptions
     /// Gets or sets the agent run mode that controls how the agent responds to A2A requests.
     /// </summary>
     /// <remarks>
-    /// When <see langword="null"/>, defaults to <see cref="AgentRunMode.DisallowBackground"/>.
+    /// When <see langword="null"/>, defaults to <see cref="AgentRunMode.ReturnMessage"/>.
     /// </remarks>
     public AgentRunMode? AgentRunMode { get; set; }
 

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerServiceCollectionExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/A2AServerServiceCollectionExtensions.cs
@@ -186,7 +186,7 @@ public static class A2AServerServiceCollectionExtensions
         if (agentHandler is null)
         {
             var agentSessionStore = serviceProvider.GetKeyedService<AgentSessionStore>(agent.Name);
-            var runMode = options?.AgentRunMode ?? AgentRunMode.DisallowBackground;
+            var runMode = options?.AgentRunMode ?? AgentRunMode.ReturnMessage;
 
             // Ensure that we have an IsolationKeyScopedAgentSessionStore registered.
             if (agentSessionStore?.GetService<IsolationKeyScopedAgentSessionStore>() is null)

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentRunMode.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentRunMode.cs
@@ -43,12 +43,13 @@ public sealed class AgentRunMode : IEquatable<AgentRunMode>
 
     /// <summary>
     /// Defers the choice between an <c>AgentMessage</c> and an <c>AgentTask</c> to the supplied
-    /// <paramref name="returnTask"/> delegate, which is invoked per request. The delegate receives an
-    /// <see cref="A2ARunDecisionContext"/> describing the incoming request and returns <see langword="true"/>
-    /// to return an <c>AgentTask</c>, or <see langword="false"/> to return an <c>AgentMessage</c>.
+    /// <paramref name="returnTask"/> delegate, which is invoked for each new-message request. The delegate receives
+    /// an <see cref="A2ARunDecisionContext"/> describing the incoming request and returns <see langword="true"/> to
+    /// return an <c>AgentTask</c>, or <see langword="false"/> to return an <c>AgentMessage</c>. Continuations of an
+    /// existing task remain task responses and do not invoke the delegate.
     /// </summary>
     /// <param name="returnTask">
-    /// An async delegate that decides whether the response is returned as an <c>AgentTask</c>.
+    /// An async delegate that decides whether a new-message response is returned as an <c>AgentTask</c>.
     /// </param>
     public static AgentRunMode ReturnTaskWhen(Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>> returnTask)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentRunMode.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.A2A/AgentRunMode.cs
@@ -10,7 +10,8 @@ using Microsoft.Shared.DiagnosticIds;
 namespace Microsoft.Agents.AI.Hosting.A2A;
 
 /// <summary>
-/// Specifies how the A2A hosting layer determines whether to run <see cref="AIAgent"/> in background or not.
+/// Specifies which A2A protocol artifact the hosting layer returns for a run of an <see cref="AIAgent"/>:
+/// an <c>AgentMessage</c> or an <c>AgentTask</c>.
 /// </summary>
 [Experimental(DiagnosticIds.Experiments.AIResponseContinuations)]
 public sealed class AgentRunMode : IEquatable<AgentRunMode>
@@ -20,48 +21,45 @@ public sealed class AgentRunMode : IEquatable<AgentRunMode>
     private const string DynamicValue = "dynamic";
 
     private readonly string _value;
-    private readonly Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>>? _runInBackground;
+    private readonly Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>>? _returnTask;
 
-    private AgentRunMode(string value, Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>>? runInBackground = null)
+    private AgentRunMode(string value, Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>>? returnTask = null)
     {
         this._value = value;
-        this._runInBackground = runInBackground;
+        this._returnTask = returnTask;
     }
 
     /// <summary>
-    /// Disallows the background responses from the agent. Is equivalent to configuring <see cref="AgentRunOptions.AllowBackgroundResponses"/> as <c>false</c>.
-    /// In the A2A protocol terminology will make responses be returned as <c>AgentMessage</c>.
+    /// Returns the agent response as an <c>AgentMessage</c>. The updates produced by the agent are aggregated
+    /// into a single message.
     /// </summary>
-    public static AgentRunMode DisallowBackground => new(MessageValue);
+    public static AgentRunMode ReturnMessage => new(MessageValue);
 
     /// <summary>
-    /// Allows the background responses from the agent. Is equivalent to configuring <see cref="AgentRunOptions.AllowBackgroundResponses"/> as <c>true</c>.
-    /// In the A2A protocol terminology will make responses be returned as <c>AgentTask</c> if the agent supports background responses, and as <c>AgentMessage</c> otherwise.
+    /// Returns the agent response as an <c>AgentTask</c>, allowing the caller to track its lifecycle and to
+    /// receive the result incrementally.
     /// </summary>
-    public static AgentRunMode AllowBackgroundIfSupported => new(TaskValue);
+    public static AgentRunMode ReturnTask => new(TaskValue);
 
     /// <summary>
-    /// The agent run mode is decided by the supplied <paramref name="runInBackground"/> delegate.
-    /// The delegate receives an <see cref="A2ARunDecisionContext"/> with the incoming
-    /// message and returns a boolean specifying whether to run the agent in background mode.
-    /// <see langword="true"/> indicates that the agent should run in background mode and return an
-    /// <c>AgentTask</c> if the agent supports background mode; otherwise, it returns an <c>AgentMessage</c>
-    /// if the mode is not supported. <see langword="false"/> indicates that the agent should run in
-    /// non-background mode and return an <c>AgentMessage</c>.
+    /// Defers the choice between an <c>AgentMessage</c> and an <c>AgentTask</c> to the supplied
+    /// <paramref name="returnTask"/> delegate, which is invoked per request. The delegate receives an
+    /// <see cref="A2ARunDecisionContext"/> describing the incoming request and returns <see langword="true"/>
+    /// to return an <c>AgentTask</c>, or <see langword="false"/> to return an <c>AgentMessage</c>.
     /// </summary>
-    /// <param name="runInBackground">
-    /// An async delegate that decides whether the response should be wrapped in an <c>AgentTask</c>.
+    /// <param name="returnTask">
+    /// An async delegate that decides whether the response is returned as an <c>AgentTask</c>.
     /// </param>
-    public static AgentRunMode AllowBackgroundWhen(Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>> runInBackground)
+    public static AgentRunMode ReturnTaskWhen(Func<A2ARunDecisionContext, CancellationToken, ValueTask<bool>> returnTask)
     {
-        ArgumentNullException.ThrowIfNull(runInBackground);
-        return new(DynamicValue, runInBackground);
+        ArgumentNullException.ThrowIfNull(returnTask);
+        return new(DynamicValue, returnTask);
     }
 
     /// <summary>
     /// Determines whether the agent response should be returned as an <c>AgentTask</c>.
     /// </summary>
-    internal ValueTask<bool> ShouldRunInBackgroundAsync(A2ARunDecisionContext context, CancellationToken cancellationToken)
+    internal ValueTask<bool> ShouldReturnTaskAsync(A2ARunDecisionContext context, CancellationToken cancellationToken)
     {
         if (string.Equals(this._value, MessageValue, StringComparison.OrdinalIgnoreCase))
         {
@@ -74,9 +72,9 @@ public sealed class AgentRunMode : IEquatable<AgentRunMode>
         }
 
         // Dynamic: delegate to custom callback.
-        if (this._runInBackground is not null)
+        if (this._returnTask is not null)
         {
-            return this._runInBackground(context, cancellationToken);
+            return this._returnTask(context, cancellationToken);
         }
 
         // No delegate provided — fall back to "message" behavior.
@@ -87,7 +85,7 @@ public sealed class AgentRunMode : IEquatable<AgentRunMode>
     public bool Equals(AgentRunMode? other) =>
         other is not null
         && string.Equals(this._value, other._value, StringComparison.OrdinalIgnoreCase)
-        && ReferenceEquals(this._runInBackground, other._runInBackground);
+        && ReferenceEquals(this._returnTask, other._returnTask);
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => this.Equals(obj as AgentRunMode);
@@ -95,7 +93,7 @@ public sealed class AgentRunMode : IEquatable<AgentRunMode>
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(
         StringComparer.OrdinalIgnoreCase.GetHashCode(this._value),
-        RuntimeHelpers.GetHashCode(this._runInBackground));
+        RuntimeHelpers.GetHashCode(this._returnTask));
 
     /// <inheritdoc/>
     public override string ToString() => this._value;

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -24,10 +24,10 @@ public sealed class A2AAgentHandlerTests
     private const string ConfigurationPropertyKey = "a2a.configuration";
 
     /// <summary>
-    /// Verifies that when there is no request data to forward, null options are passed to RunStreamingAsync.
+    /// Verifies that when there is no request data to forward, empty options are passed to RunStreamingAsync.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenMetadataIsNull_PassesNullOptionsToRunStreamingAsync()
+    public async Task ExecuteAsync_WhenMetadataIsNull_PassesEmptyOptionsToRunStreamingAsync()
     {
         // Arrange
         AgentRunOptions? capturedOptions = null;
@@ -40,7 +40,9 @@ public sealed class A2AAgentHandlerTests
         });
 
         // Assert
-        Assert.Null(capturedOptions);
+        Assert.NotNull(capturedOptions);
+        Assert.Null(capturedOptions.AllowBackgroundResponses);
+        Assert.Null(capturedOptions.AdditionalProperties);
     }
 
     /// <summary>
@@ -1500,10 +1502,10 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that streaming mode passes null options when metadata is null.
+    /// Verifies that streaming mode passes empty options when metadata is null.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_Streaming_WithNullMetadata_PassesNullOptionsAsync()
+    public async Task ExecuteAsync_Streaming_WithNullMetadata_PassesEmptyOptionsAsync()
     {
         // Arrange
         AgentRunOptions? capturedOptions = null;
@@ -1522,7 +1524,9 @@ public sealed class A2AAgentHandlerTests
 
         // Assert
         Assert.True(optionsCaptured);
-        Assert.Null(capturedOptions);
+        Assert.NotNull(capturedOptions);
+        Assert.Null(capturedOptions.AllowBackgroundResponses);
+        Assert.Null(capturedOptions.AdditionalProperties);
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -2132,6 +2132,36 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
+    /// Verifies that the ReturnTaskWhen delegate is not invoked when updating an existing task.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_OnContinuation_DoesNotInvokeDynamicModeCallbackAsync()
+    {
+        // Arrange
+        bool callbackInvoked = false;
+        A2AAgentHandler handler = CreateHandler(
+            CreateAgentMock(_ => { }),
+            runMode: AgentRunMode.ReturnTaskWhen((_, _) =>
+            {
+                callbackInvoked = true;
+                return ValueTask.FromResult(false);
+            }));
+
+        // Act
+        await InvokeExecuteAsync(handler, new RequestContext
+        {
+            StreamingResponse = false,
+            TaskId = "task-1",
+            ContextId = "ctx-1",
+            Message = new Message { MessageId = "empty", Role = Role.User, Parts = [] },
+            Task = new AgentTask { Id = "task-1", ContextId = "ctx-1", History = [new Message { Role = Role.User, Parts = [new Part { Text = "Hello" }] }] }
+        });
+
+        // Assert
+        Assert.False(callbackInvoked);
+    }
+
+    /// <summary>
     /// Verifies that in the non-streaming endpoint path, SaveSessionAsync is called with
     /// CancellationToken.None even when RunStreamingAsync throws an exception.
     /// </summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -2132,35 +2132,6 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that the agent run mode is applied on the continuation/task-update path,
-    /// not just the new message path.
-    /// </summary>
-    [Fact]
-    public async Task ExecuteAsync_OnContinuation_RunModeIsAppliedAsync()
-    {
-        // Arrange
-        AgentRunOptions? capturedOptions = null;
-        A2AAgentHandler handler = CreateHandler(
-            CreateAgentMock(options => capturedOptions = options),
-            runMode: AgentRunMode.ReturnTask);
-
-        // Act
-        await InvokeExecuteAsync(handler, new RequestContext
-        {
-            StreamingResponse = false,
-            TaskId = "task-1",
-            ContextId = "ctx-1",
-            Message = new Message { MessageId = "empty", Role = Role.User, Parts = [] },
-
-            Task = new AgentTask { Id = "task-1", ContextId = "ctx-1", History = [new Message { Role = Role.User, Parts = [new Part { Text = "Hello" }] }] }
-        });
-
-        // Assert
-        Assert.NotNull(capturedOptions);
-        Assert.True(capturedOptions.AllowBackgroundResponses);
-    }
-
-    /// <summary>
     /// Verifies that in the non-streaming endpoint path, SaveSessionAsync is called with
     /// CancellationToken.None even when RunStreamingAsync throws an exception.
     /// </summary>

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AAgentHandlerTests.cs
@@ -146,7 +146,7 @@ public sealed class A2AAgentHandlerTests
         AgentRunOptions? capturedOptions = null;
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(options => capturedOptions = options),
-            runMode: AgentRunMode.DisallowBackground);
+            runMode: AgentRunMode.ReturnMessage);
 
         // Act
         await InvokeExecuteAsync(handler, new RequestContext
@@ -250,7 +250,7 @@ public sealed class A2AAgentHandlerTests
         // Arrange
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(_ => { }),
-            runMode: AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(false)));
+            runMode: AgentRunMode.ReturnTaskWhen((_, _) => ValueTask.FromResult(false)));
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -272,7 +272,7 @@ public sealed class A2AAgentHandlerTests
         // Arrange
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(_ => { }),
-            runMode: AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(true)));
+            runMode: AgentRunMode.ReturnTaskWhen((_, _) => ValueTask.FromResult(true)));
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -288,10 +288,10 @@ public sealed class A2AAgentHandlerTests
 #pragma warning disable MEAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
-    /// Verifies that an immediate request emits the initial task and streams subsequent updates when background responses are allowed.
+    /// Verifies that an immediate request emits the initial task and streams subsequent updates in ReturnTask mode.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenBackgroundResponsesAllowedAndReturnImmediatelyTrue_StreamsTaskUpdatesAsync()
+    public async Task ExecuteAsync_WhenReturnTaskModeAndReturnImmediatelyTrue_StreamsTaskUpdatesAsync()
     {
         // Arrange
         AgentResponseUpdate[] updates =
@@ -306,7 +306,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -592,7 +592,7 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that the dynamic AllowBackgroundWhen delegate receives the correct RequestContext.
+    /// Verifies that the dynamic ReturnTaskWhen delegate receives the correct RequestContext.
     /// </summary>
     [Fact]
     public async Task ExecuteAsync_DynamicMode_DelegateReceivesRequestContextAsync()
@@ -601,7 +601,7 @@ public sealed class A2AAgentHandlerTests
         A2ARunDecisionContext? capturedContext = null;
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(_ => { }),
-            runMode: AgentRunMode.AllowBackgroundWhen((ctx, _) =>
+            runMode: AgentRunMode.ReturnTaskWhen((ctx, _) =>
             {
                 capturedContext = ctx;
                 return ValueTask.FromResult(false);
@@ -698,10 +698,10 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that allowing background responses emits a task lifecycle in streaming mode.
+    /// Verifies that ReturnTask mode emits a task lifecycle in streaming mode.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_Streaming_WhenBackgroundResponsesAllowed_StreamsTaskUpdatesAsync()
+    public async Task ExecuteAsync_Streaming_WhenReturnTaskMode_StreamsTaskUpdatesAsync()
     {
         // Arrange
         AgentResponseUpdate[] updates =
@@ -730,7 +730,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -782,7 +782,7 @@ public sealed class A2AAgentHandlerTests
     /// Verifies that a non-immediate request aggregates all updates into a completed task.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenBackgroundResponsesAllowedAndReturnImmediatelyFalse_ReturnsCompletedTaskAsync()
+    public async Task ExecuteAsync_WhenReturnTaskModeAndReturnImmediatelyFalse_ReturnsCompletedTaskAsync()
     {
         // Arrange
         AgentResponseUpdate[] updates =
@@ -792,7 +792,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -831,7 +831,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -869,7 +869,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
         var events = new EventCollector();
         var eventQueue = new AgentEventQueue();
         var readerTask = ReadEventsAsync(eventQueue, events);
@@ -917,7 +917,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsForThrowingExecuteAsync<InvalidOperationException>(handler, new RequestContext
@@ -940,10 +940,10 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that an immediate request returns one aggregated message when background responses are disabled.
+    /// Verifies that an immediate request returns one aggregated message in ReturnMessage mode.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenBackgroundResponsesDisallowedAndReturnImmediatelyTrue_ReturnsMessageAsync()
+    public async Task ExecuteAsync_WhenReturnMessageModeAndReturnImmediatelyTrue_ReturnsMessageAsync()
     {
         // Arrange
         AgentResponseUpdate[] updates =
@@ -953,7 +953,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.DisallowBackground);
+            runMode: AgentRunMode.ReturnMessage);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -973,10 +973,10 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that a non-immediate request aggregates all updates into one message when background responses are disabled.
+    /// Verifies that a non-immediate request aggregates all updates into one message in ReturnMessage mode.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WhenBackgroundResponsesDisallowedAndReturnImmediatelyFalse_ReturnsMessageAsync()
+    public async Task ExecuteAsync_WhenReturnMessageModeAndReturnImmediatelyFalse_ReturnsMessageAsync()
     {
         // Arrange
         AgentResponseUpdate[] updates =
@@ -986,7 +986,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.DisallowBackground);
+            runMode: AgentRunMode.ReturnMessage);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1021,7 +1021,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1063,7 +1063,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1106,7 +1106,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1156,7 +1156,7 @@ public sealed class A2AAgentHandlerTests
                 ItExpr.IsAny<AgentRunOptions?>(),
                 ItExpr.IsAny<CancellationToken>())
             .Returns(() => ToCancelingAsyncEnumerableAsync(cts));
-        A2AAgentHandler handler = CreateHandler(agentMock, runMode: AgentRunMode.AllowBackgroundIfSupported);
+        A2AAgentHandler handler = CreateHandler(agentMock, runMode: AgentRunMode.ReturnTask);
         var events = new EventCollector();
         var eventQueue = new AgentEventQueue();
         var readerTask = ReadEventsAsync(eventQueue, events);
@@ -1199,7 +1199,7 @@ public sealed class A2AAgentHandlerTests
             CreateThrowingStreamingAgentMock(
                 [new AgentResponseUpdate(ChatRole.Assistant, "chunk 1") { ResponseId = "r1", MessageId = "m1" }],
                 new InvalidOperationException("Stream failed")),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsForThrowingExecuteAsync<InvalidOperationException>(handler, new RequestContext
@@ -1245,7 +1245,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateThrowingStreamingAgentMock(updates, new InvalidOperationException("Stream failed")),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsForThrowingExecuteAsync<InvalidOperationException>(handler, new RequestContext
@@ -1291,7 +1291,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1345,7 +1345,7 @@ public sealed class A2AAgentHandlerTests
         // Arrange
         A2AAgentHandler handler = CreateHandler(
             CreateThrowingStreamingAgentMock([], new OperationCanceledException("Agent gave up")),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsForThrowingExecuteAsync<OperationCanceledException>(handler, new RequestContext
@@ -1369,7 +1369,7 @@ public sealed class A2AAgentHandlerTests
         // Arrange
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock([]),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1404,7 +1404,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -1435,7 +1435,7 @@ public sealed class A2AAgentHandlerTests
         ];
         A2AAgentHandler handler = CreateHandler(
             CreateStreamingAgentMock(updates),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         var events = await CollectEventsAsync(handler, new RequestContext
@@ -2072,7 +2072,7 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that when the AllowBackgroundWhen delegate throws, the exception propagates
+    /// Verifies that when the ReturnTaskWhen delegate throws, the exception propagates
     /// and the agent is not invoked.
     /// </summary>
     [Fact]
@@ -2082,7 +2082,7 @@ public sealed class A2AAgentHandlerTests
         bool agentInvoked = false;
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(_ => agentInvoked = true),
-            runMode: AgentRunMode.AllowBackgroundWhen((_, _) =>
+            runMode: AgentRunMode.ReturnTaskWhen((_, _) =>
                 throw new InvalidOperationException("Callback failed")));
 
         // Act & Assert
@@ -2096,7 +2096,7 @@ public sealed class A2AAgentHandlerTests
     }
 
     /// <summary>
-    /// Verifies that the CancellationToken is propagated to the AllowBackgroundWhen delegate.
+    /// Verifies that the CancellationToken is propagated to the ReturnTaskWhen delegate.
     /// </summary>
     [Fact]
     public async Task ExecuteAsync_DynamicMode_CancellationTokenIsPropagatedToCallbackAsync()
@@ -2106,7 +2106,7 @@ public sealed class A2AAgentHandlerTests
         using var cts = new CancellationTokenSource();
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(_ => { }),
-            runMode: AgentRunMode.AllowBackgroundWhen((_, ct) =>
+            runMode: AgentRunMode.ReturnTaskWhen((_, ct) =>
             {
                 capturedToken = ct;
                 return ValueTask.FromResult(false);
@@ -2138,7 +2138,7 @@ public sealed class A2AAgentHandlerTests
         AgentRunOptions? capturedOptions = null;
         A2AAgentHandler handler = CreateHandler(
             CreateAgentMock(options => capturedOptions = options),
-            runMode: AgentRunMode.AllowBackgroundIfSupported);
+            runMode: AgentRunMode.ReturnTask);
 
         // Act
         await InvokeExecuteAsync(handler, new RequestContext
@@ -2463,7 +2463,7 @@ public sealed class A2AAgentHandlerTests
         AgentRunMode? runMode = null,
         AgentSessionStore? agentSessionStore = null)
     {
-        runMode ??= AgentRunMode.DisallowBackground;
+        runMode ??= AgentRunMode.ReturnMessage;
 
         var hostAgent = new AIHostAgent(
             innerAgent: agentMock.Object,

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AEndpointRouteBuilderExtensionsTests.cs
@@ -248,7 +248,7 @@ public sealed class A2AEndpointRouteBuilderExtensionsTests
         IChatClient mockChatClient = new DummyChatClient();
         builder.Services.AddKeyedSingleton("chat-client", mockChatClient);
         IHostedAgentBuilder agentBuilder = builder.AddAIAgent("agent", "Instructions", chatClientServiceKey: "chat-client");
-        agentBuilder.AddA2AServer(options => options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported);
+        agentBuilder.AddA2AServer(options => options.AgentRunMode = AgentRunMode.ReturnTask);
         builder.Services.AddLogging();
         using WebApplication app = builder.Build();
 

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/A2AServerServiceCollectionExtensionsTests.cs
@@ -249,7 +249,7 @@ public sealed class A2AServerServiceCollectionExtensionsTests
         services.AddA2AServer(AgentName, options =>
         {
             callbackInvoked = true;
-            options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported;
+            options.AgentRunMode = AgentRunMode.ReturnTask;
         });
 
         // Assert - callback is invoked during resolution
@@ -510,7 +510,7 @@ public sealed class A2AServerServiceCollectionExtensionsTests
         services.AddKeyedSingleton(AgentName, (_, _) => agentMock.Object);
         services.AddA2AServer(
             AgentName,
-            options => options.AgentRunMode = AgentRunMode.AllowBackgroundIfSupported);
+            options => options.AgentRunMode = AgentRunMode.ReturnTask);
         await using var provider = services.BuildServiceProvider();
         var server = provider.GetRequiredKeyedService<A2AServer>(AgentName);
         SendMessageRequest request = CreateTestSendMessageRequest();

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/AgentRunModeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/AgentRunModeTests.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Agents.AI.Hosting.A2A.UnitTests;
 public sealed class AgentRunModeTests
 {
     /// <summary>
-    /// Verifies that AllowBackgroundWhen throws ArgumentNullException for null delegate.
+    /// Verifies that ReturnTaskWhen throws ArgumentNullException for null delegate.
     /// </summary>
     [Fact]
-    public void AllowBackgroundWhen_NullDelegate_ThrowsArgumentNullException()
+    public void ReturnTaskWhen_NullDelegate_ThrowsArgumentNullException()
     {
         // Arrange & Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            AgentRunMode.AllowBackgroundWhen(null!));
+            AgentRunMode.ReturnTaskWhen(null!));
     }
 
     /// <summary>
-    /// Verifies that DisallowBackground equals another DisallowBackground instance.
+    /// Verifies that ReturnMessage equals another ReturnMessage instance.
     /// </summary>
     [Fact]
-    public void Equals_DisallowBackground_AreEqual()
+    public void Equals_ReturnMessage_AreEqual()
     {
         // Arrange
-        var mode1 = AgentRunMode.DisallowBackground;
-        var mode2 = AgentRunMode.DisallowBackground;
+        var mode1 = AgentRunMode.ReturnMessage;
+        var mode2 = AgentRunMode.ReturnMessage;
 
         // Act & Assert
         Assert.True(mode1.Equals(mode2));
@@ -40,14 +40,14 @@ public sealed class AgentRunModeTests
     }
 
     /// <summary>
-    /// Verifies that AllowBackgroundIfSupported equals another AllowBackgroundIfSupported instance.
+    /// Verifies that ReturnTask equals another ReturnTask instance.
     /// </summary>
     [Fact]
-    public void Equals_AllowBackgroundIfSupported_AreEqual()
+    public void Equals_ReturnTask_AreEqual()
     {
         // Arrange
-        var mode1 = AgentRunMode.AllowBackgroundIfSupported;
-        var mode2 = AgentRunMode.AllowBackgroundIfSupported;
+        var mode1 = AgentRunMode.ReturnTask;
+        var mode2 = AgentRunMode.ReturnTask;
 
         // Act & Assert
         Assert.True(mode1.Equals(mode2));
@@ -55,19 +55,19 @@ public sealed class AgentRunModeTests
     }
 
     /// <summary>
-    /// Verifies that DisallowBackground and AllowBackgroundIfSupported are not equal.
+    /// Verifies that ReturnMessage and ReturnTask are not equal.
     /// </summary>
     [Fact]
     public void Equals_DifferentModes_AreNotEqual()
     {
         // Arrange
-        var disallow = AgentRunMode.DisallowBackground;
-        var allow = AgentRunMode.AllowBackgroundIfSupported;
+        var message = AgentRunMode.ReturnMessage;
+        var task = AgentRunMode.ReturnTask;
 
         // Act & Assert
-        Assert.False(disallow.Equals(allow));
-        Assert.False(disallow == allow);
-        Assert.True(disallow != allow);
+        Assert.False(message.Equals(task));
+        Assert.False(message == task);
+        Assert.True(message != task);
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public sealed class AgentRunModeTests
     public void Equals_Null_ReturnsFalse()
     {
         // Arrange
-        var mode = AgentRunMode.DisallowBackground;
+        var mode = AgentRunMode.ReturnMessage;
 
         // Act & Assert
         Assert.False(mode.Equals(null));
@@ -108,9 +108,9 @@ public sealed class AgentRunModeTests
     public void ToString_ReturnsExpectedValues()
     {
         // Act & Assert
-        Assert.Equal("message", AgentRunMode.DisallowBackground.ToString());
-        Assert.Equal("task", AgentRunMode.AllowBackgroundIfSupported.ToString());
-        Assert.Equal("dynamic", AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(true)).ToString());
+        Assert.Equal("message", AgentRunMode.ReturnMessage.ToString());
+        Assert.Equal("task", AgentRunMode.ReturnTask.ToString());
+        Assert.Equal("dynamic", AgentRunMode.ReturnTaskWhen((_, _) => ValueTask.FromResult(true)).ToString());
     }
 
     /// <summary>
@@ -120,24 +120,24 @@ public sealed class AgentRunModeTests
     public void Equals_WithObjectParameter_WorksCorrectly()
     {
         // Arrange
-        var mode = AgentRunMode.DisallowBackground;
+        var mode = AgentRunMode.ReturnMessage;
 
         // Act & Assert
-        Assert.True(mode.Equals((object)AgentRunMode.DisallowBackground));
-        Assert.False(mode.Equals((object)AgentRunMode.AllowBackgroundIfSupported));
+        Assert.True(mode.Equals((object)AgentRunMode.ReturnMessage));
+        Assert.False(mode.Equals((object)AgentRunMode.ReturnTask));
         Assert.False(mode.Equals("not a run mode"));
     }
 
     /// <summary>
-    /// Verifies that two AllowBackgroundWhen instances with different delegates are not considered equal,
+    /// Verifies that two ReturnTaskWhen instances with different delegates are not considered equal,
     /// because equality includes delegate identity for dynamic modes.
     /// </summary>
     [Fact]
-    public void Equals_AllowBackgroundWhen_DifferentDelegates_AreNotEqual()
+    public void Equals_ReturnTaskWhen_DifferentDelegates_AreNotEqual()
     {
         // Arrange
-        var mode1 = AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(true));
-        var mode2 = AgentRunMode.AllowBackgroundWhen((_, _) => ValueTask.FromResult(false));
+        var mode1 = AgentRunMode.ReturnTaskWhen((_, _) => ValueTask.FromResult(true));
+        var mode2 = AgentRunMode.ReturnTaskWhen((_, _) => ValueTask.FromResult(false));
 
         // Act & Assert
         Assert.False(mode1.Equals(mode2));
@@ -145,15 +145,15 @@ public sealed class AgentRunModeTests
     }
 
     /// <summary>
-    /// Verifies that two AllowBackgroundWhen instances with the same delegate are considered equal.
+    /// Verifies that two ReturnTaskWhen instances with the same delegate are considered equal.
     /// </summary>
     [Fact]
-    public void Equals_AllowBackgroundWhen_SameDelegate_AreEqual()
+    public void Equals_ReturnTaskWhen_SameDelegate_AreEqual()
     {
         // Arrange
         static ValueTask<bool> CallbackAsync(A2ARunDecisionContext _, CancellationToken __) => ValueTask.FromResult(true);
-        var mode1 = AgentRunMode.AllowBackgroundWhen(CallbackAsync);
-        var mode2 = AgentRunMode.AllowBackgroundWhen(CallbackAsync);
+        var mode1 = AgentRunMode.ReturnTaskWhen(CallbackAsync);
+        var mode2 = AgentRunMode.ReturnTaskWhen(CallbackAsync);
 
         // Act & Assert
         Assert.True(mode1.Equals(mode2));

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/AgentRunModeTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.A2A.UnitTests/AgentRunModeTests.cs
@@ -67,7 +67,6 @@ public sealed class AgentRunModeTests
         // Act & Assert
         Assert.False(message.Equals(task));
         Assert.False(message == task);
-        Assert.True(message != task);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation & Context

A2A hosting exposes `AgentRunMode` to control what an agent returns to the caller: an `AgentMessage` or an `AgentTask`. The modes were named after a mechanism that no longer drives that decision.

The names — `DisallowBackground`, `AllowBackgroundIfSupported`, and `AllowBackgroundWhen` — imply that the mode controls how the underlying agent executes and that returning a task depends on agent capability. The handler no longer works that way: it consumes the agent through `RunStreamingAsync` and builds and manages the `AgentTask` itself. The response shape therefore depends only on the configured mode, never on whether the hosted agent supports background responses.

Since the handler works with any `AIAgent`, the old terminology is misleading: it suggests that some agents cannot be hosted in task mode and describes capability negotiation that does not occur. This change renames the modes to describe the A2A artifact returned by the hosting layer while leaving the underlying agent execution options unchanged.

### Description & Review Guide

- **What are the major changes?**
  - Rename the run modes to `ReturnMessage`, `ReturnTask`, and `ReturnTaskWhen`.
  - Rename the internal decision method to `ShouldReturnTaskAsync`.
  - Update the corresponding tests and documentation to describe A2A response shape rather than background execution.
- **What is the impact of these changes?**
  - This is a breaking API rename for consumers configuring A2A hosting.
  - Message responses remain aggregated into a single A2A message, while task responses continue to use the A2A task lifecycle.
  - The mode no longer implies capability negotiation with the underlying `AIAgent`.
- **What do you want reviewers to focus on?**
  - Whether the renamed modes clearly communicate the A2A response behavior.
  - Whether the updated terminology consistently separates A2A response shape from underlying agent execution.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

### Related Issue

Fixes #

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.