### PR TITLE
Python: fix(openai): make function result call_id optional and omit when absent

### DIFF
--- a/python/packages/ag-ui/tests/ag_ui/test_run_common.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run_common.py
@@ -216,7 +216,7 @@ class TestEmitToolResult:
 
     def test_tool_result_without_call_id_returns_empty(self):
         """Tool result Content without call_id returns empty event list."""
-        content = Content.from_function_result(call_id=None, result="some result")  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+        content = Content.from_function_result(call_id=None, result="some result")
         flow = FlowState()
         events = _emit_tool_result(content, flow)
         assert events == []

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -886,7 +886,7 @@ class Content:
     @classmethod
     def from_function_result(
         cls: type[ContentT],
-        call_id: str,
+        call_id: str | None = None,
         *,
         result: Any = None,
         exception: str | None = None,
@@ -902,6 +902,8 @@ class Content:
 
         Args:
             call_id: The ID of the function call this result corresponds to.
+                May be None for results translated from external OpenAI-spec
+                sources, where the Responses API no longer requires a call id.
 
         Keyword Args:
             result: The tool output.  Accepts a ``list[Content]`` (the canonical

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -3460,6 +3460,19 @@ def test_from_function_result_with_string():
     assert result.items[0].text == "just text"
 
 
+def test_from_function_result_without_call_id():
+    """Test Content.from_function_result accepts a missing call_id.
+
+    The OpenAI Responses API no longer requires a call id on function call
+    results, so content translated from external OpenAI-spec sources may not
+    have one.
+    """
+    result = Content.from_function_result(call_id=None, result="some result")
+    assert result.type == "function_result"
+    assert result.call_id is None
+    assert result.result == "some result"
+
+
 def test_content_from_function_result_items_in_to_dict():
     """Test that items are included in to_dict serialization."""
     content_list = [

--- a/python/packages/openai/agent_framework_openai/_chat_client.py
+++ b/python/packages/openai/agent_framework_openai/_chat_client.py
@@ -2059,11 +2059,15 @@ class RawOpenAIChatClient(
                                 output_parts.append(part)
                     if output_parts:
                         output = output_parts
-                return {
-                    "call_id": content.call_id,
+                function_output_item: dict[str, Any] = {
                     "type": "function_call_output",
                     "output": output,
                 }
+                # The Responses API no longer requires a call id on function call
+                # results, so omit the key rather than sending ``"call_id": null``.
+                if content.call_id:
+                    function_output_item["call_id"] = content.call_id
+                return function_output_item
             case "function_approval_request":
                 return {
                     "type": "mcp_approval_request",

--- a/python/packages/openai/tests/openai/test_openai_chat_client.py
+++ b/python/packages/openai/tests/openai/test_openai_chat_client.py
@@ -2907,6 +2907,32 @@ def test_prepare_content_for_openai_hosted_vector_store_content() -> None:
     assert result == {}
 
 
+def test_prepare_content_for_openai_function_result_omits_call_id_when_absent() -> None:
+    """Function result without a call id omits the call_id key (Responses API no longer requires it)."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    function_result = Content.from_function_result(call_id=None, result="done")
+
+    result = client._prepare_content_for_openai("assistant", function_result)
+
+    assert "call_id" not in result
+    assert result["type"] == "function_call_output"
+    assert result["output"] == "done"
+
+
+def test_prepare_content_for_openai_function_result_keeps_call_id_when_present() -> None:
+    """Function result with a call id keeps the call_id key unchanged."""
+    client = OpenAIChatClient(model="test-model", api_key="test-key")
+
+    function_result = Content.from_function_result(call_id="call_1", result="done")
+
+    result = client._prepare_content_for_openai("assistant", function_result)
+
+    assert result["call_id"] == "call_1"
+    assert result["type"] == "function_call_output"
+    assert result["output"] == "done"
+
+
 def test_prepare_content_for_openai_text_uses_role_specific_type() -> None:
     """Text content should use input_text for user and output_text for assistant."""
     client = OpenAIChatClient(model="test-model", api_key="test-key")


### PR DESCRIPTION
**Problem**

`Content.from_function_result` still requires `call_id: str`, although the OpenAI Responses API no longer requires a call id on function call results. Consumers translating between OpenAI-spec SDKs and MAF must fight the type system — the AG-UI tests already pass `call_id=None` with `# type: ignore` comments — and `_prepare_content_for_openai` emits `"call_id": null` in `function_call_output` items when the id is absent.

**Solution**

Relax `Content.from_function_result` to accept `call_id: str | None = None`, a backward-compatible widening since every existing caller passes a `str`. In the Responses client, omit the `call_id` key when absent instead of sending `null`, keeping the payload unchanged when a call id is present. As regression evidence, the now-redundant triple-checker `type: ignore` comment in the AG-UI tests is removed.

**Changes**

- `python/packages/core/agent_framework/_types.py`: widen signature + docstring update
- `python/packages/openai/agent_framework_openai/_chat_client.py`: conditional `call_id` emission in the `function_call_output` branch
- Tests: new cases in `test_types.py` (core) and `test_openai_chat_client.py` (openai); type-ignore cleanup in `test_run_common.py` (ag-ui)

**Testing**

- New unit tests: result without call id → key omitted; result with call id → key preserved (regression)
- Affected suites pass: core `test_types.py`, openai `test_openai_chat_client.py`, ag-ui `test_run_common.py`
- Regression sweep on packages calling `from_function_result` (anthropic / a2a / bedrock / chatkit): all green
- `pyright` strict: 0 errors; `ruff`: clean

**Notes for Reviewer**

- The `function_call` (assistant-side) branch that drops content without a call id is intentionally unchanged — the API still requires it there.
- Shell call output branches (`shell_call_output` / `local_shell_call`) keep their own id schemes and were not touched.
- The signature change is backward compatible: all existing call sites pass a `str`.

Fixes #7922