### PR TITLE
.NET: Clarify declarative workflow input serialization

### DIFF
--- a/dotnet/samples/03-workflows/Declarative/AotCheckpointing/Program.cs
+++ b/dotnet/samples/03-workflows/Declarative/AotCheckpointing/Program.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.AI.Projects;
 using Azure.AI.Projects.Agents;
 using Azure.Identity;
@@ -15,12 +17,12 @@ namespace Demo.Workflows.Declarative.AotCheckpointing;
 
 /// <summary>
 /// Demonstrates JSON checkpointing of a declarative workflow under reflection-disabled
-/// <see cref="System.Text.Json.JsonSerializer"/> (the AOT / trim-aggressive constraint set
+/// <see cref="JsonSerializer"/> (the AOT / trim-aggressive constraint set
 /// via <c>JsonSerializerIsReflectionEnabledByDefault=false</c> in the csproj).
 /// </summary>
 /// <remarks>
-/// The key call is <see cref="CheckpointManager.CreateJson(ICheckpointStore{System.Text.Json.JsonElement}, System.Text.Json.JsonSerializerOptions?)"/>
-/// with <see cref="DeclarativeWorkflowJsonOptions.Default"/>. Drop the options argument to observe the AOT failure. See README.
+/// The key call is <see cref="CheckpointManager.CreateJson"/> with
+/// <see cref="DeclarativeWorkflowJsonOptions.Default"/>. Drop the options argument to observe the AOT failure. See README.
 /// </remarks>
 internal sealed class Program
 {
@@ -31,14 +33,14 @@ internal sealed class Program
 
         await CreateGreeterAgentAsync(foundryEndpoint, configuration);
 
-        string workflowInput = Application.GetInput(args);
+        WorkflowInput workflowInput = new(Application.GetInput(args));
 
         Workflow CreateWorkflow()
         {
             AzureAgentProvider agentProvider = new(foundryEndpoint, new AzureCliCredential());
             DeclarativeWorkflowOptions options = new(agentProvider) { Configuration = configuration };
             string workflowPath = Path.Combine(AppContext.BaseDirectory, "AotCheckpointing.yaml");
-            return DeclarativeWorkflowBuilder.Build<string>(workflowPath, options);
+            return DeclarativeWorkflowBuilder.Build<WorkflowInput>(workflowPath, options, TransformInput);
         }
 
         DirectoryInfo checkpointFolder = Directory.CreateDirectory(Path.Combine(".", $"chk-{DateTime.Now:yyMMdd-HHmmss-ff}"));
@@ -74,7 +76,10 @@ internal sealed class Program
         }
     }
 
-    private static async Task<List<CheckpointInfo>> RunAndStreamAsync(Workflow workflow, string input, CheckpointManager checkpointManager)
+    private static ChatMessage TransformInput(WorkflowInput input) =>
+        new(ChatRole.User, JsonSerializer.Serialize(input, AotCheckpointingJsonContext.Default.WorkflowInput));
+
+    private static async Task<List<CheckpointInfo>> RunAndStreamAsync(Workflow workflow, WorkflowInput input, CheckpointManager checkpointManager)
     {
         StreamingRun run = await InProcessExecution.RunStreamingAsync(workflow, input, checkpointManager).ConfigureAwait(false);
         return await DrainAsync(run).ConfigureAwait(false);
@@ -172,3 +177,8 @@ internal sealed class Program
         }
     }
 }
+
+internal sealed record WorkflowInput(string Message);
+
+[JsonSerializable(typeof(WorkflowInput))]
+internal sealed partial class AotCheckpointingJsonContext : JsonSerializerContext;

--- a/dotnet/samples/03-workflows/Declarative/AotCheckpointing/README.md
+++ b/dotnet/samples/03-workflows/Declarative/AotCheckpointing/README.md
@@ -25,15 +25,53 @@ reflection-disabled `System.Text.Json` -- the same constraint imposed by
      return is the proof JSON **reads** round-trip too. The resumed run
      is disposed immediately; without a pending external request it
      would park in `WaitForInputAsync` indefinitely.
+- The initial workflow input is a `WorkflowInput` record. `TransformInput` uses the
+  source-generated `AotCheckpointingJsonContext` to serialize it into a
+  `ChatMessage` before the declarative workflow runs.
 
 `DeclarativeWorkflowJsonOptions` is marked
 `[Experimental("MAAI001")]`. Suppress that diagnostic in your csproj to
 use it.
 
-### Registering user-defined types
+### Initial input and checkpoint serialization are separate
 
-For workflows whose inputs or custom `ActionExecutorResult.Result`
-payloads are user-defined, clone `Default` and append your own resolver:
+`DeclarativeWorkflowBuilder.Build` accepts an optional `inputTransform` delegate.
+For a non-`ChatMessage` input, the default behavior is to call `ToString()`; the
+checkpoint serializer is not involved in this conversion. Use a source-generated
+context (or your own `JsonSerializerOptions`) in the delegate when the workflow
+should receive a JSON representation of a typed input:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Agents.AI.Workflows.Declarative;
+using Microsoft.Extensions.AI;
+
+internal sealed record WorkflowInput(string Message);
+
+[JsonSerializable(typeof(WorkflowInput))]
+internal sealed partial class AppJsonContext : JsonSerializerContext;
+
+Workflow workflow = DeclarativeWorkflowBuilder.Build<WorkflowInput>(
+    workflowPath,
+    options,
+    input => new ChatMessage(
+        ChatRole.User,
+        JsonSerializer.Serialize(input, AppJsonContext.Default.WorkflowInput)));
+```
+
+This sample uses `AotCheckpointingJsonContext` for that initial-input transform.
+The separate `DeclarativeWorkflowJsonOptions.Default` passed to
+`CheckpointManager.CreateJson` supplies type information for declarative workflow
+checkpoint state. If checkpoint state also contains application-defined payloads,
+clone those options and append the application's resolver as shown below; adding
+the resolver to checkpoint options does not automatically change the initial input.
+
+### Registering user-defined checkpoint types
+
+For custom `ActionExecutorResult.Result` payloads or other user-defined values
+that are persisted in workflow checkpoint state, clone `Default` and append your
+own resolver:
 
 ```csharp
 JsonSerializerOptions options = new(DeclarativeWorkflowJsonOptions.Default);

--- a/dotnet/samples/03-workflows/Declarative/AotCheckpointing/README.md
+++ b/dotnet/samples/03-workflows/Declarative/AotCheckpointing/README.md
@@ -44,6 +44,7 @@ should receive a JSON representation of a typed input:
 ```csharp
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Agents.AI.Workflows;
 using Microsoft.Agents.AI.Workflows.Declarative;
 using Microsoft.Extensions.AI;
 


### PR DESCRIPTION
### Motivation & Context

Issue #8016 reports that typed inputs to declarative workflows fall back to `ToString()`, while the documentation's serializer example focuses on checkpoint state. This makes it unclear how to reliably serialize an initial input and can lead to confusing expectations that checkpoint serializer registration also transforms that input.

### Description & Review Guide

- **What are the major changes?**
  - Update the AOT checkpointing sample to pass a typed `WorkflowInput` through `DeclarativeWorkflowBuilder.Build` with an explicit `inputTransform`.
  - Add a source-generated `JsonSerializerContext` for the sample's initial input and serialize it into a `ChatMessage`.
  - Document the separate responsibilities of `inputTransform` and checkpoint `JsonSerializerOptions`, including how to register user-defined checkpoint payloads.
- **What is the impact of these changes?**
  - The sample provides a tested, copyable path for deterministic typed-input serialization under reflection-disabled `System.Text.Json`.
  - The documentation now makes clear that checkpoint serializer registration does not automatically transform the initial workflow input.
- **What do you want reviewers to focus on?**
  - Whether the distinction between initial-input transformation and checkpoint-state serialization is clear and accurately reflects the current API behavior.

### Related Issue

Fixes #8016

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
