### PR TITLE
Python: give the Anthropic and OpenAI packages their own dependency-probe Pyright configs

### DIFF
--- a/python/packages/anthropic/pyproject.toml
+++ b/python/packages/anthropic/pyproject.toml
@@ -85,6 +85,10 @@ exclude_dirs = ["tests"]
 executor.type = "uv"
 include = "../../shared_tasks.toml"
 
+[tool.poe.tasks.dependency-pyright]
+help = "Run Pyright over Anthropic implementation files for isolated dependency validation."
+cmd = "pyright --project pyrightconfig.dependency.json"
+
 [tool.poe.tasks.mypy]
 help = "Run MyPy for this package."
 cmd = "mypy --config-file $POE_ROOT/pyproject.toml agent_framework_anthropic"

--- a/python/packages/anthropic/pyrightconfig.dependency.json
+++ b/python/packages/anthropic/pyrightconfig.dependency.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../pyproject.toml",
+    "include": [
+        "agent_framework_anthropic"
+    ],
+    "exclude": [
+        "agent_framework_anthropic/_vertex_client.py"
+    ]
+}

--- a/python/packages/openai/pyproject.toml
+++ b/python/packages/openai/pyproject.toml
@@ -84,6 +84,10 @@ exclude_dirs = ["tests"]
 executor.type = "uv"
 include = "../../shared_tasks.toml"
 
+[tool.poe.tasks.dependency-pyright]
+help = "Run Pyright over OpenAI implementation files for isolated dependency validation."
+cmd = "pyright --project pyrightconfig.dependency.json"
+
 [tool.poe.tasks.mypy]
 help = "Run MyPy for this package."
 cmd = "mypy --config-file $POE_ROOT/pyproject.toml agent_framework_openai"

--- a/python/packages/openai/pyrightconfig.dependency.json
+++ b/python/packages/openai/pyrightconfig.dependency.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../pyproject.toml",
+    "include": [
+        "agent_framework_openai"
+    ]
+}

--- a/python/scripts/dependencies/tests/test_dependency_bounds_runtime.py
+++ b/python/scripts/dependencies/tests/test_dependency_bounds_runtime.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import json
 from collections.abc import Callable
 from pathlib import Path
 
@@ -196,3 +197,28 @@ test = ["azure-monitor-opentelemetry", "mcp[ws]"]
         "mcp[ws]",
     ]
     assert command[-3:-1] == ["python", "-c"]
+
+
+def test_anthropic_probe_uses_its_own_dependency_pyright_task() -> None:
+    """Anthropic's Vertex client type-checks against an undeclared namespace package.
+
+    ``_vertex_client.py`` imports ``google.auth.credentials`` under ``TYPE_CHECKING`` while the
+    package only declares ``anthropic`` without the ``vertex`` extra, so isolated dependency
+    probes have no ``google-auth`` to resolve. Without the package-defined escape hatch the
+    ``lowest-direct`` probe fails on ``reportMissingImports`` and blocks the whole bounds gate.
+    """
+    workspace_root = Path(__file__).resolve().parents[3]
+
+    plans = _build_test_plans(workspace_root, "anthropic")
+
+    assert [plan.typing_task for plan in plans] == ["dependency-pyright"]
+
+
+def test_anthropic_dependency_pyright_config_excludes_the_vertex_client() -> None:
+    workspace_root = Path(__file__).resolve().parents[3]
+    config_path = workspace_root / "packages/anthropic/pyrightconfig.dependency.json"
+
+    config = json.loads(config_path.read_text())
+
+    assert config["include"] == ["agent_framework_anthropic"]
+    assert config["exclude"] == ["agent_framework_anthropic/_vertex_client.py"]

--- a/python/scripts/dependencies/tests/test_dependency_bounds_runtime.py
+++ b/python/scripts/dependencies/tests/test_dependency_bounds_runtime.py
@@ -199,19 +199,26 @@ test = ["azure-monitor-opentelemetry", "mcp[ws]"]
     assert command[-3:-1] == ["python", "-c"]
 
 
-def test_anthropic_probe_uses_its_own_dependency_pyright_task() -> None:
-    """Anthropic's Vertex client type-checks against an undeclared namespace package.
+@pytest.mark.parametrize(
+    ("package", "module"),
+    [("anthropic", "agent_framework_anthropic"), ("openai", "agent_framework_openai")],
+)
+def test_optional_namespace_packages_define_their_own_dependency_pyright_task(package: str, module: str) -> None:
+    """Packages that type-check against deliberately optional namespaces need the probe escape hatch.
 
-    ``_vertex_client.py`` imports ``google.auth.credentials`` under ``TYPE_CHECKING`` while the
-    package only declares ``anthropic`` without the ``vertex`` extra, so isolated dependency
-    probes have no ``google-auth`` to resolve. Without the package-defined escape hatch the
-    ``lowest-direct`` probe fails on ``reportMissingImports`` and blocks the whole bounds gate.
+    ``agent_framework_anthropic`` references ``google.auth`` and ``agent_framework_openai`` references
+    ``azure.core``/``azure.identity``, in both cases without declaring them, because those surfaces are
+    optional. A full workspace sync resolves them transitively, so repo-wide Pyright passes; an isolated
+    dependency probe does not, and the resulting ``reportMissingImports`` aborts the whole bounds gate.
     """
     workspace_root = Path(__file__).resolve().parents[3]
 
-    plans = _build_test_plans(workspace_root, "anthropic")
+    plans = _build_test_plans(workspace_root, package)
 
     assert [plan.typing_task for plan in plans] == ["dependency-pyright"]
+
+    config = json.loads((workspace_root / f"packages/{package}/pyrightconfig.dependency.json").read_text())
+    assert config["include"] == [module]
 
 
 def test_anthropic_dependency_pyright_config_excludes_the_vertex_client() -> None:
@@ -220,5 +227,4 @@ def test_anthropic_dependency_pyright_config_excludes_the_vertex_client() -> Non
 
     config = json.loads(config_path.read_text())
 
-    assert config["include"] == ["agent_framework_anthropic"]
     assert config["exclude"] == ["agent_framework_anthropic/_vertex_client.py"]


### PR DESCRIPTION
### Motivation & Context

The weekly `python-dependency-maintenance` workflow has reported **success** on every scheduled run since 2026-08-03 while validating no dependency bounds at all. Its `Run dependency upper-bound validation` step was **skipped** on all five runs; the last time it executed was 2026-07-27.

The step is gated on `if: steps.validate_bounds_test.outcome == 'success'`, and the step it gates on carries `continue-on-error: true`. That maps the failing step's *conclusion* to success — which is what the job status and the run badge report — while leaving *outcome* at failure. The result is a green run that silently maintains nothing, repo-wide, for five weeks.

The bounds test aborts on the first failing package, and since 2026-08-03 that is always `packages/anthropic`:

```
Task 'pyright' failed for packages/anthropic at resolution 'lowest-direct'.
  _vertex_client.py:23:10 - error: Import "google.auth.credentials" could not be resolved (reportMissingImports)
  (+3 downstream reportUnknown* errors)
```

`_vertex_client.py:23` imports `google.auth.credentials` under `TYPE_CHECKING`, but the package declares plain `anthropic` (no `[vertex]` extra) and nothing in the repo declares `google-auth`. A full workspace sync resolves it transitively, so `poe pyright` passes and PR CI is clean; only the isolated probe sees it missing.

This became a failure with #7342 (merged 2026-07-28, one day after the last passing run), which narrowed probe surfaces so packages stop inheriting transitive extras such as `core[all]`. That was the correct change — `packages/core` received a `dependency-pyright` escape hatch for precisely this case. `packages/anthropic` and `packages/openai` needed one and did not get it.

### Description & Review Guide

- **What are the major changes?**

  Five files, mirroring the existing `packages/core` precedent.

  1. **New** `packages/anthropic/pyrightconfig.dependency.json` — includes `agent_framework_anthropic`, excludes the single file needing the undeclared namespace.
  2. **New** `packages/openai/pyrightconfig.dependency.json` — includes `agent_framework_openai`, **no exclusions needed**.
  3. **`packages/anthropic/pyproject.toml`**, **`packages/openai/pyproject.toml`** — add `[tool.poe.tasks.dependency-pyright]`. This is the documented extension point, not a workaround; `scripts/dependencies/README.md:49` describes it as *"a package-defined `dependency-pyright` task … allowing dependency probes to type-check the package implementation without requiring optional lazy namespace packages."* The probe machinery already prefers it when present (`validate_dependency_bounds.py:107`, `CHECK_TASK_PRIORITY` in both optimizers), so no tooling changes were needed.
  4. **`scripts/dependencies/tests/test_dependency_bounds_runtime.py`** — regression coverage, parametrized over both packages, in the suite #7342 added for this machinery.

  Both packages type-check against surfaces they deliberately do not declare because those surfaces are optional — `openai`'s own docstrings say *"Credential objects require the optional `azure-identity` package"*. `openai` needs no exclusion because `dependency-pyright` reuses the root `test` dependency group, whose `azure-monitor-opentelemetry` pulls `azure-monitor-opentelemetry-exporter` and in turn `azure-identity`. Excluding files would not have worked there anyway: the azure references span four of seven modules, 97% of the package by line count.

- **What is the impact of these changes?**

  **Repo-wide Pyright is unchanged and still checks every file in both packages.** Verified by planting a deliberate error in `_vertex_client.py` and running both configs from `packages/anthropic/`:

  ```
  $ uv run pyright                                           # default config
  _vertex_client.py:165:12 - error: Type "int" is not assignable to return type "str"
  2 errors, 0 warnings, 0 informations

  $ uv run pyright --project pyrightconfig.dependency.json   # probe-only config
  0 errors, 0 warnings, 0 informations
  ```

  The narrowed surface applies only inside isolated dependency probes.

  **On what this does and does not achieve.** The gate aborts on the first failure, so I probed all 35 packages individually to get the real picture rather than a lower bound: **29 pass, 6 fail.** These two fixes take it to **31/35**. The remaining four are genuine defects, not probe artifacts — `declarative` and `lab` under-declare runtime dependencies (`mcp`, `agent-framework-openai`); `azure-contentunderstanding` declares a floor whose API lacks a parameter the code passes; `foundry_hosting` fails an MCP test at its floor. Those are separate packages and separate bounds, two of them changing a published dependency surface, so they are written up in the issue rather than fixed here. **The gate will not go green until they are addressed too** — this PR is a prerequisite for reaching them at all.

  As an illustration of what a restored gate does, the `fastapi` ceiling from #8042 — which this PR deliberately does **not** touch:

  ```
  $ uv run python -m scripts.dependencies._dependency_bounds_upper_impl \
        --packages ag-ui --dependencies fastapi --dry-run
  packages\ag-ui :: fastapi :: baseline current_lower (lowest-direct) [0.121.0]
  packages\ag-ui :: fastapi :: baseline current_upper (highest)       [0.139.2]
  packages\ag-ui :: fastapi -> <0.142.0 (probe 0.141.1)
  ```

  Bound *values* are a maintainer policy call and `--mode upper` is the component designed to choose and validate them, so hand-raising them here would pre-empt it.

- **What do you want reviewers to focus on?**

  Whether the escape hatch is the right long-term answer for these two, or a stopgap. Both packages ship a feature (`AnthropicVertexClient`, Entra ID auth) while leaving its dependency undeclared. If those are meant to work out of the box, `anthropic[vertex]` / an explicit `azure-identity` is the real fix and these configs could be deleted. That changes the shipped dependency surface, so I left it as a maintainer call and raised it in the issue.

  Also worth a look: `core`'s config excludes a leaf file, whereas `_vertex_client.py` is imported and re-exported by `agent_framework_anthropic/__init__.py`. Pyright suppresses diagnostics for excluded files without breaking inference in the importer, which the probe run confirms empirically, but it is the one way this differs from the precedent.

### Related Issue

Refs #8049

Deliberately `Refs` rather than a closing keyword: #8049 tracks the repo-wide bounds-maintenance outage, and this PR clears two of its six blockers. The freeze stays active after this merges, so #8049 must stay open to track the remaining four.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
