### PR TITLE
.NET: Log a warning when an unsupported declarative action is skipped

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/WorkflowActionVisitor.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/Interpreter/WorkflowActionVisitor.cs
@@ -9,6 +9,7 @@ using Microsoft.Agents.AI.Workflows.Declarative.Kit;
 using Microsoft.Agents.AI.Workflows.Declarative.ObjectModel;
 using Microsoft.Agents.AI.Workflows.Declarative.PowerFx;
 using Microsoft.Agents.ObjectModel;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Agents.AI.Workflows.Declarative.Interpreter;
 
@@ -27,6 +28,7 @@ internal sealed class WorkflowActionVisitor : DialogActionVisitor
         public static string Restart(string actionId) => $"{actionId}_{nameof(Restart)}";
     }
 
+    private readonly ILogger _logger;
     private readonly Executor _rootAction;
     private readonly WorkflowModel<Func<object?, bool>> _workflowModel;
     private readonly DeclarativeWorkflowOptions _workflowOptions;
@@ -37,6 +39,7 @@ internal sealed class WorkflowActionVisitor : DialogActionVisitor
         WorkflowFormulaState state,
         DeclarativeWorkflowOptions options)
     {
+        this._logger = options.LoggerFactory.CreateLogger<WorkflowActionVisitor>();
         this._rootAction = rootAction;
         this._workflowModel = new WorkflowModel<Func<object?, bool>>((IModeledAction)rootAction);
         this._workflowOptions = options;
@@ -645,6 +648,7 @@ internal sealed class WorkflowActionVisitor : DialogActionVisitor
     private void NotSupported(DialogAction item)
     {
         Debug.WriteLine($"> UNKNOWN: {new string('\t', this._workflowModel.GetDepth(item.GetParentId()))}{FormatItem(item)} => {FormatParent(item)}");
+        this._logger.LogWarning("Unsupported action skipped: {ActionType} ({ActionId}).", item.GetType().Name, item.GetId());
         this.HasUnsupportedActions = true;
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DeclarativeWorkflowTest.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DeclarativeWorkflowTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Agents.AI.Workflows.Declarative.Kit;
 using Microsoft.Agents.AI.Workflows.Declarative.PowerFx;
 using Microsoft.Agents.ObjectModel;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit.Sdk;
 
@@ -246,6 +247,36 @@ public sealed class DeclarativeWorkflowTest(ITestOutputHelper output) : Workflow
         Assert.True(visitor.HasUnsupportedActions);
     }
 
+    [Fact]
+    public void UnsupportedActionLogsWarning()
+    {
+        SearchKnowledgeSources.Builder unsupportedAction = new() { Id = "action_bad" };
+        AdaptiveDialog.Builder dialogBuilder =
+            new()
+            {
+                BeginDialog =
+                    new OnActivity.Builder()
+                    {
+                        Id = "anything",
+                        Actions = [unsupportedAction]
+                    }
+            };
+        AdaptiveDialog dialog = dialogBuilder.Build();
+
+        WorkflowFormulaState state = new(RecalcEngineFactory.Create());
+        Mock<ResponseAgentProvider> mockAgentProvider = CreateMockProvider("1");
+        CapturingLoggerFactory loggerFactory = new();
+        DeclarativeWorkflowOptions options = new(mockAgentProvider.Object) { LoggerFactory = loggerFactory };
+        WorkflowActionVisitor visitor = new(new DeclarativeWorkflowExecutor<string>(WorkflowActionVisitor.Steps.Root("anything"), options, state, (message) => DeclarativeWorkflowBuilder.DefaultTransform(message)), state, options);
+        WorkflowElementWalker walker = new(visitor);
+        walker.Visit(dialog);
+
+        Assert.True(visitor.HasUnsupportedActions);
+        (LogLevel Level, string Message) warning = Assert.Single(loggerFactory.Entries, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains(nameof(SearchKnowledgeSources), warning.Message, StringComparison.Ordinal);
+        Assert.Contains("action_bad", warning.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("CaseInsensitive.yaml", "end_when_match")]
     [InlineData("ClearAllVariables.yaml", "clear_all")]
@@ -404,5 +435,30 @@ public sealed class DeclarativeWorkflowTest(ITestOutputHelper output) : Workflow
                 Body = "{\"ok\":true}",
             }));
         return mockHandler;
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(this.Entries);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger(List<(LogLevel Level, string Message)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }


### PR DESCRIPTION
### Motivation & Context

`WorkflowActionVisitor` routes 32 declarative action kinds to `NotSupported`, which records
the skip in two ways and neither reaches the caller. `Debug.WriteLine` is
`System.Diagnostics.Debug`, annotated `[Conditional("DEBUG")]`, so the compiler removes the
call in Release. `HasUnsupportedActions` is declared on `WorkflowActionVisitor`, which is
`internal sealed`, and across the repository it is read in exactly one place, a unit test in
`DeclarativeWorkflowTest`.

The result is that a workflow containing `SearchKnowledgeSources`, `InvokeFlowAction`,
`OAuthInput` or any of the other 29 kinds builds, runs to completion and reports success
while never performing that step. In a Release build nothing is written anywhere.

The Python implementation already reports this. `_declarative_builder.py` in
`_create_executor_for_action` logs "Unknown action kind ... action will be skipped" and
returns `None` at the same point in the build, so the two languages currently disagree.

### Description & Review Guide

- **What are the major changes?** `NotSupported` now logs a warning through the
  `ILoggerFactory` that `DeclarativeWorkflowOptions` already supplies to the visitor, naming
  the action type and id. The visitor creates one logger in its constructor. A regression
  test, `UnsupportedActionLogsWarning`, builds an `AdaptiveDialog` containing a
  `SearchKnowledgeSources` action and asserts a single warning carrying both values. Local
  checks: `dotnet build -c Release` (0 warnings, 0 errors),
  `dotnet test -f net10.0` in Debug and in Release (878 passed, 0 failed), and
  `dotnet format --verify-no-changes` clean on both projects. Reverting only the source
  change and rerunning leaves 877 passing with `UnsupportedActionLogsWarning` failing.
- **What is the impact of these changes?** Control flow is unchanged and every action that
  was skipped before is still skipped. No public API is added, so the public API baselines
  and package validation are untouched. `LoggerFactory` defaults to
  `NullLoggerFactory.Instance`, so callers that configure no logging see no behavior change.
- **What do you want reviewers to focus on?** `Debug.WriteLine` is
  `[Conditional("DEBUG")]`, so `item.GetId()` did not execute in Release before this change
  and now does. It is a plain property read that cannot throw for a `DialogAction`, and it
  renders as `(null)` for an action that carries no id.

If you would rather surface this as a `WorkflowWarningEvent` raised on first run instead of a
log, I am happy to change it.

### Related Issue

Fixes #8040

No other open pull request for #8040 was found during the duplicate check.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
