### PR TITLE
ci: adds additional dependabot groups in dotnet to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,23 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 8 * * 4,0" # Every Thursday(4) and Sunday(0) at 8:00 UTC
+    groups:
+      aspire:
+        patterns:
+          - "Aspire.*"
+          - "CommunityToolkit.Aspire.*"
+      azure-ai-agentserver:
+        patterns:
+          - "Azure.AI.AgentServer.*"
+      agui:
+        patterns:
+          - "AGUI.*"
+      communitytoolkit-vectordata:
+        patterns:
+          - "CommunityToolkit.VectorData.*"
+      anthropic:
+        patterns:
+          - "Anthropic*"
     ignore:
       # For all System.* and Microsoft.Extensions/Bcl.* packages, ignore all major version updates
       - dependency-name: "System.*"


### PR DESCRIPTION
### Motivation & Context

Dependabot has recently opened and merged several separate .NET NuGet update PRs for package families that share package namespacing and release cadence. Grouping those related packages should reduce Dependabot PR noise while keeping updates scoped to coherent SDK families.

### Description & Review Guide

- **What are the major changes?**
  Adds NuGet Dependabot groups for the `dotnet/` update configuration:
  - `aspire`: groups `Aspire.*` and `CommunityToolkit.Aspire.*` packages. This is based on recent `Aspire.Hosting` Dependabot updates and the related Aspire package family already tracked together in central package management.
  - `azure-ai-agentserver`: groups `Azure.AI.AgentServer.*` packages. This keeps AgentServer core, invocations, and responses packages on the same update path.
  - `agui`: groups `AGUI.*` packages. These packages currently share the same version and are maintained as one SDK family.
  - `communitytoolkit-vectordata`: groups `CommunityToolkit.VectorData.*` packages. These vector data packages share the same namespace and compatible release cadence.
  - `anthropic`: groups `Anthropic*` packages. Recent Dependabot activity covered both `Anthropic` and `Anthropic.Foundry`, so grouping keeps related Anthropic SDK updates together.
- **What is the impact of these changes?**
  Dependabot should create fewer, more coherent .NET dependency update PRs for related NuGet package families. The change only affects Dependabot PR grouping and does not alter package versions or runtime code.
- **What do you want reviewers to focus on?**
  Please review whether the selected groups are scoped narrowly enough to avoid combining unrelated package updates while still reducing noise for packages that typically move together.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No tracked issue. There is no other open PR for this branch.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
