### PR TITLE
ci: adds python dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,14 @@ updates:
       interval: "weekly"
       day: "thursday"
     groups:
+      basics:
+        patterns:
+          - "uv"
+          - "ruff"
+          - "prek"
+          - "poethepoet"
+          - "tomli"
+          - "rich"
       pytest:
         patterns:
           - "pytest*"
@@ -60,6 +68,14 @@ updates:
       interval: "weekly"
       day: "thursday"
     groups:
+      basics:
+        patterns:
+          - "uv"
+          - "ruff"
+          - "prek"
+          - "poethepoet"
+          - "tomli"
+          - "rich"
       pytest:
         patterns:
           - "pytest*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    groups:
+      pytest:
+        patterns:
+          - "pytest*"
+      flit:
+        patterns:
+          - "flit*"
+      python-type-checkers:
+        patterns:
+          - "mypy"
+          - "pyrefly"
+          - "ty"
+          - "zuban"
     labels:
       - "python"
       - "dependencies"
@@ -45,6 +58,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    groups:
+      pytest:
+        patterns:
+          - "pytest*"
+      flit:
+        patterns:
+          - "flit*"
+      python-type-checkers:
+        patterns:
+          - "mypy"
+          - "pyrefly"
+          - "ty"
+          - "zuban"
     labels:
       - "python"
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
       python-type-checkers:
         patterns:
           - "mypy"
+          - "pyright"
           - "pyrefly"
           - "ty"
           - "zuban"
@@ -68,6 +69,7 @@ updates:
       python-type-checkers:
         patterns:
           - "mypy"
+          - "pyright"
           - "pyrefly"
           - "ty"
           - "zuban"


### PR DESCRIPTION
### Motivation & Context

Dependabot has recently opened and merged several separate Python dependency PRs for packages that belong to the same tooling families or update cadence. This follows the same noise-reduction approach as #8059 for .NET, but scopes the grouping to the existing Python `pip` and `uv` entries.

### Description & Review Guide

- **What are the major changes?**
  Adds Python Dependabot groups to both the `pip` and `uv` update configurations for `python/`:
  - `pytest`: groups `pytest*` packages. Recent Dependabot activity included a `pytest` workspace bump, and the root dev dependencies include multiple pytest companion packages such as `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, `pytest-timeout`, and `pytest-retry`.
  - `flit`: groups `flit*` packages. Recent Dependabot activity included separate `flit` and `flit-core` updates, so grouping keeps related Python packaging/build tooling updates together.
  - `python-type-checkers`: groups `mypy`, `pyrefly`, `ty`, and `zuban`. These type-checking tools had repeated close-together Dependabot bumps and are part of the same Python dev-tooling maintenance cadence.
- **What is the impact of these changes?**
  Dependabot should create fewer, more coherent Python dependency update PRs for related tooling families. The change only affects Dependabot grouping and does not alter dependency versions or runtime code.
- **What do you want reviewers to focus on?**
  Please review whether these Python groups are scoped narrowly enough to avoid combining unrelated updates while still reducing repeated PR noise for packages that tend to be maintained together.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

No tracked issue. There is no other open PR for this branch. Related context: #8059 applies the same grouping exercise to .NET Dependabot updates.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
