### PR TITLE
ci: adds a codeql actions group to the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,10 @@ updates:
     directories:
       - "/"
       - "/.github/actions/*"
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
follow up to #8065, #8059. Unblock #8066 #8067