### PR TITLE
Python: make optional Lightning observability test skip nested import errors

### DIFF
--- a/python/packages/lab/lightning/tests/test_lightning.py
+++ b/python/packages/lab/lightning/tests/test_lightning.py
@@ -126,7 +126,9 @@ async def test_observability(workflow_two_agents: Workflow):
             |                    |
         [chat gpt-4o]        [chat gpt-4o]
     """
-    pytest.importorskip("agentlightning")
+    # agentlightning imports optional proxy dependencies that may fail independently.
+    # Keep this optional observability test skippable when any such import is broken.
+    pytest.importorskip("agentlightning", exc_type=ImportError)
     from agent_framework_lab_lightning import AgentFrameworkTracer
     from agentlightning.adapter import TracerTraceToTriplet
 


### PR DESCRIPTION
### Motivation & Context

The optional Lightning observability test currently uses `pytest.importorskip("agentlightning")`. With pytest 9.1, that only skips `ModuleNotFoundError`; a nested `ImportError` from an installed transitive dependency propagates and hard-fails the resource-intensive lab test. This reproduces with `agentlightning` 0.3.0 importing LiteLLM proxy code against FastAPI 0.141, where `get_flat_dependant` is no longer available.

### Description & Review Guide

- **What are the major changes?**

  Configure the existing optional dependency guard with `exc_type=ImportError`, so both a missing `agentlightning` package and an installed package whose optional dependency import fails are treated as skips.

- **What is the impact of these changes?**

  The resource-intensive observability test no longer hard-fails CI when an optional transitive import is incompatible. The existing tracer setup and assertions remain unchanged, so the test still runs whenever `agentlightning` imports successfully.

- **What do you want reviewers to focus on?**

  Whether treating all `ImportError` failures from the optional integration as a skip matches the intended optional-test boundary.

### Related Issue

Fixes #8057

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
