### PR TITLE
 ci: adds a codeql actions group to the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,10 @@ updates:
       codeql-actions:
         patterns:
           - "github/codeql-action/*"
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
follow up to #8070