### PR TITLE
Python: Document anonymous Parallel Search MCP usage

### DIFF
--- a/python/samples/02-agents/mcp/README.md
+++ b/python/samples/02-agents/mcp/README.md
@@ -43,6 +43,8 @@ async def main() -> None:
         url="https://search.parallel.ai/mcp",
         load_prompts=False,
         request_timeout=30,
+        # Use the text payload once; Parallel also returns it as structured content.
+        parse_tool_results=lambda result: "\n".join(c.text for c in result.content if c.type == "text"),
     ) as mcp:
         print("Tools:", [tool.name for tool in mcp.functions])
         search_result = await mcp.call_tool(
@@ -58,12 +60,11 @@ async def main() -> None:
             session_id=session_id,
         )
         for result in (search_result, fetch_result):
-            for content in result:
-                if content.type == "text":
-                    print(content.text)
+            print(result)
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 The output lists `web_search` and `web_fetch`, followed by their results, including source URLs and excerpts. Queries, requested URLs, objectives, and the session identifier are sent to Parallel when the calls run. The context manager closes the connection afterward.

--- a/python/samples/02-agents/mcp/README.md
+++ b/python/samples/02-agents/mcp/README.md
@@ -17,6 +17,59 @@ The Model Context Protocol (MCP) is an open standard for connecting AI agents to
 | **Progressive Disclosure** | [`mcp_progressive_disclosure.py`](mcp_progressive_disclosure.py) | Demonstrates `use_progressive_disclosure`, `always_load`, `allowed_tools`, and prefixed `list_mcp_tools` / `load_tool` / `unload_tool` names. `load_tool` and `unload_tool` can accept one tool name or multiple names. Self-spawns a stdio MCP child server |
 | **Sampling Approval** | [`mcp_sampling_approval.py`](mcp_sampling_approval.py) | Demonstrates gating server-initiated `sampling/createMessage` requests with a `sampling_approval_callback`, plus the `sampling_max_tokens` and `sampling_max_requests` guardrails. MCP sampling is denied by default |
 
+## Anonymous web search and fetch
+
+Use `MCPStreamableHTTPTool` with [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) to search the public web and extract page content. This example calls the tools directly, so it needs neither a Parallel API key nor a model provider account. Free access is rate limited.
+
+Install the client dependencies in a Python 3.10+ environment:
+
+```bash
+pip install agent-framework-core "mcp>=1.24,<2"
+```
+
+Save this as `parallel_search.py` and run `python parallel_search.py`:
+
+```python
+import asyncio
+from uuid import uuid4
+
+from agent_framework import MCPStreamableHTTPTool
+
+
+async def main() -> None:
+    session_id = str(uuid4())  # Reuse for related search and fetch calls.
+    async with MCPStreamableHTTPTool(
+        name="parallel-search",
+        url="https://search.parallel.ai/mcp",
+        load_prompts=False,
+        request_timeout=30,
+    ) as mcp:
+        print("Tools:", [tool.name for tool in mcp.functions])
+        search_result = await mcp.call_tool(
+            "web_search",
+            objective="Find Microsoft Agent Framework MCP documentation",
+            search_queries=["Microsoft Agent Framework MCP tools"],
+            session_id=session_id,
+        )
+        fetch_result = await mcp.call_tool(
+            "web_fetch",
+            urls=["https://github.com/microsoft/agent-framework"],
+            objective="Describe the framework's MCP support",
+            session_id=session_id,
+        )
+        for result in (search_result, fetch_result):
+            for content in result:
+                if content.type == "text":
+                    print(content.text)
+
+
+asyncio.run(main())
+```
+
+The output lists `web_search` and `web_fetch`, followed by their results, including source URLs and excerpts. Queries, requested URLs, objectives, and the session identifier are sent to Parallel when the calls run. The context manager closes the connection afterward.
+
+To make these tools available to an existing agent, pass the MCP tool as `tools` when constructing `Agent`. The agent can then choose to invoke them during a run; remove that tool to disable access. This example does not change any configured providers or defaults.
+
 ## Prerequisites
 
 Most samples in this folder use OpenAI:


### PR DESCRIPTION
### Motivation & Context

The MCP examples show authenticated servers, but lack a runnable example of anonymous public web search and page extraction. This adds one to the existing MCP README using `MCPStreamableHTTPTool`.

Parallel Fast looks worth trying here. In [Artificial Analysis's August 31 Search API results](https://artificialanalysis.ai/agents/search-api), it scored **80.2/100 on DeepSearchQA F1** and **73.1/100 on the overall Search Index**, with **19.2 seconds per task** including model and search time. [That benchmark tests Search APIs](https://artificialanalysis.ai/methodology/search-api), so it is a reason to try this option rather than a measurement of this MCP example.

The [Python harness](https://github.com/microsoft/agent-framework/blob/2c49f50cf08ebb6c1687146336f039051f159333/python/packages/core/agent_framework/_harness/_agent.py#L626-L630) already enables the selected client's hosted web search by default. Artificial Analysis does not list those hosted implementations. We would need a head-to-head comparison before recommending a new default.

I work at Parallel, which operates this service.

### Description & Review Guide

- **What are the major changes?** A README example with dependency installation, tool discovery, and direct `web_search` and `web_fetch` calls through Parallel Search MCP. It reuses one session identifier and closes the connection through the existing context manager.
- **What is the impact of these changes?** Readers can try both tools without a Parallel key or a model provider account. The guide explains data sent to Parallel, rate limits, and agent activation. Existing providers, defaults, and framework APIs are unchanged.
- **What do you want reviewers to focus on?** The setup instructions and fit within the MCP guide. The exact snippet passed with prebuilt `agent-framework-core` 1.17.0 and `mcp` 1.29.1 in an empty credential environment: both tools were discovered, search returned results, and fetch returned page content without errors. Ruff and the diff whitespace check passed. No repository build or full test suite was run for this documentation-only change.

### Related Issue

No linked issue. This small documentation addition uses existing APIs and follows the trivial-change exception in the contributing guide's suggested workflow.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix). A workflow keeps the label and title prefix in sync automatically.
