### PR TITLE
Python: add MLflow to the observability backend examples

### DIFF
--- a/python/samples/02-agents/observability/README.md
+++ b/python/samples/02-agents/observability/README.md
@@ -155,6 +155,23 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "<opik_otlp_headers>"
 enable_sensitive_telemetry()
 ```
 
+Or with [MLflow](https://mlflow.org/docs/latest/genai/tracing/integrations/listing/microsoft-agent-framework/), which ingests traces over OTLP/HTTP at `<tracking-uri>/v1/traces` and routes them to an experiment via a header. MLflow accepts traces only, so pass a span exporter rather than a base `OTEL_EXPORTER_OTLP_ENDPOINT` (which would also aim log and metric exporters at endpoints MLflow does not serve):
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from agent_framework.observability import configure_otel_providers, enable_sensitive_telemetry
+
+# Start a tracking server first, e.g. `mlflow server --backend-store-uri sqlite:///mlflow.db --port 5000`
+exporter = OTLPSpanExporter(
+    endpoint="http://localhost:5000/v1/traces",
+    headers={"x-mlflow-experiment-id": "<mlflow_experiment_id>"},
+)
+configure_otel_providers(exporters=[exporter])
+
+# Optional: opt in to capturing sensitive data
+enable_sensitive_telemetry()
+```
+
 **4. Manual setup**
 
 For full control, set up providers and exporters yourself. See [advanced_manual_setup_console_output.py](./advanced_manual_setup_console_output.py) for a complete example that sends traces, logs, and metrics to the console. The `create_resource()` helper in `agent_framework.observability` can build a resource with the appropriate service name and version from environment variables (or sensible defaults), although the sample does not use it.


### PR DESCRIPTION
Part of #7769

### Motivation & Context

The observability README shows how to point Agent Framework at Langfuse and Comet Opik, but not MLflow, which is a common OTel-based backend. MLflow accepts only traces at `<tracking-uri>/v1/traces`, so users who copy the base `OTEL_EXPORTER_OTLP_ENDPOINT` pattern also get log and metric exporters retrying against endpoints MLflow does not serve. A section with the right shape saves that detour.

### Description & Review Guide

Adds an MLflow entry next to the Langfuse and Opik ones in `python/samples/02-agents/observability/README.md`. It passes a single `OTLPSpanExporter` (HTTP) with the `x-mlflow-experiment-id` header via `configure_otel_providers(exporters=[...])`, which is the same shape as pattern 2 in that README and as MLflow's own integration page, only using the current `configure_otel_providers` / `enable_sensitive_telemetry` names instead of the older `setup_observability` the MLflow docs still show.

Only the GitHub README half of the issue is covered here; the learn-site update is left to the maintainers since that repository is mid-migration.

Verified against a local MLflow 3.16.0 server with the snippet verbatim, driving a real `Agent` with an echo chat client:

```
$ mlflow server --backend-store-uri sqlite:///mlflow.db --port 5002
$ python mlflow_smoke.py
agent said: echo: hello mlflow

$ python -c "import mlflow; ...; mlflow.search_traces(locations=['1'], return_type='list')"
traces: 1
trace_id: tr-52d0e0ab987f500668837c5a86c2d4a6 | state: OK | spans: ['invoke_agent smoke-agent']
```

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
