### PR TITLE
Python: fix(core): include tool trajectory details in summarizer input

### DIFF
--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1205,10 +1205,24 @@ def _tool_result_text(value: Any) -> str:
 def _format_summary_content(content: Content) -> str:
     """Render one content item for the summarizer input transcript.
 
-    Returns an empty string when the item has no structured rendering of its
-    own (text contents are aggregated via ``Message.text`` instead), so callers
-    can fall back to the legacy rendering.
+    Tool calls and results are rendered with their name, arguments, result
+    text, and call id so the summarizer sees the tool trajectory instead of a
+    bare content type. Text contents are aggregated via ``Message.text``
+    instead. Returns an empty string when the item has no structured rendering
+    of its own, so callers can fall back to the legacy rendering.
     """
+    if content.type == "function_call":
+        arguments = _tool_result_text(content.arguments) if content.arguments is not None else ""
+        call = f"function_call {content.name or ''}({arguments})"
+        if content.call_id:
+            call += f" [call_id={content.call_id}]"
+        return call
+    if content.type == "function_result":
+        result_text = _tool_result_text(content.result) if content.result is not None else "no result"
+        if content.exception:
+            result_text = f"error({content.exception}): {result_text}"
+        call_id_suffix = f" [call_id={content.call_id}]" if content.call_id else ""
+        return f"function_result: {result_text}{call_id_suffix}"
     return ""
 
 

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1198,7 +1198,10 @@ def _tool_result_text(value: Any) -> str:
         if text_parts:
             return "\n".join(text_parts)
     if isinstance(value, Mapping):
-        return json.dumps(cast(Mapping[str, object], value), ensure_ascii=False)
+        try:
+            return json.dumps(cast(Mapping[str, object], value), ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            return str(cast(object, value))
     return str(cast(object, value))
 
 
@@ -1237,7 +1240,7 @@ def _format_summary_content(content: Content) -> str:
         return f"mcp_tool_result: {result_text}{call_id_suffix}"
     if content.type in ("function_approval_request", "function_approval_response"):
         nested_call = content.function_call
-        name = nested_call.name if nested_call is not None else ""
+        name = "" if nested_call is None else nested_call.name or nested_call.tool_name or ""
         label = "approval_request" if content.type == "function_approval_request" else "approval_response"
         rendered = f"{label}: {name} [id={content.id}]"
         if content.type == "function_approval_response":
@@ -1247,10 +1250,20 @@ def _format_summary_content(content: Content) -> str:
 
 
 def _format_summary_message(index: int, message: Message) -> str:
-    parts = [_format_summary_content(content) for content in message.contents]
-    if message.text:
-        parts.append(message.text)
-    content_text = "; ".join(part for part in parts if part)
+    parts: list[str] = []
+    pending_text: list[str] = []
+    for content in message.contents:
+        rendered = _format_summary_content(content)
+        if rendered:
+            if pending_text:
+                parts.append(" ".join(pending_text))
+                pending_text = []
+            parts.append(rendered)
+        elif content.type == "text" and content.text:
+            pending_text.append(content.text)
+    if pending_text:
+        parts.append(" ".join(pending_text))
+    content_text = "; ".join(parts)
     if not content_text:
         content_text = ", ".join(content.type for content in message.contents)
     return f"{index}. [{message.role}] {content_text}"

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1202,8 +1202,21 @@ def _tool_result_text(value: Any) -> str:
     return str(cast(object, value))
 
 
+def _format_summary_content(content: Content) -> str:
+    """Render one content item for the summarizer input transcript.
+
+    Returns an empty string when the item has no structured rendering of its
+    own (text contents are aggregated via ``Message.text`` instead), so callers
+    can fall back to the legacy rendering.
+    """
+    return ""
+
+
 def _format_summary_message(index: int, message: Message) -> str:
-    content_text = message.text
+    parts = [_format_summary_content(content) for content in message.contents]
+    if message.text:
+        parts.append(message.text)
+    content_text = "; ".join(part for part in parts if part)
     if not content_text:
         content_text = ", ".join(content.type for content in message.contents)
     return f"{index}. [{message.role}] {content_text}"

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1223,6 +1223,26 @@ def _format_summary_content(content: Content) -> str:
             result_text = f"error({content.exception}): {result_text}"
         call_id_suffix = f" [call_id={content.call_id}]" if content.call_id else ""
         return f"function_result: {result_text}{call_id_suffix}"
+    if content.type == "mcp_server_tool_call":
+        arguments = _tool_result_text(content.arguments) if content.arguments is not None else ""
+        call = f"mcp_tool_call {content.tool_name or ''}({arguments})"
+        if content.call_id:
+            call += f" [call_id={content.call_id}]"
+        return call
+    if content.type == "mcp_server_tool_result":
+        result_text = _tool_result_text(content.output)
+        if content.exception:
+            result_text = f"error({content.exception}): {result_text}"
+        call_id_suffix = f" [call_id={content.call_id}]" if content.call_id else ""
+        return f"mcp_tool_result: {result_text}{call_id_suffix}"
+    if content.type in ("function_approval_request", "function_approval_response"):
+        nested_call = content.function_call
+        name = nested_call.name if nested_call is not None else ""
+        label = "approval_request" if content.type == "function_approval_request" else "approval_response"
+        rendered = f"{label}: {name} [id={content.id}]"
+        if content.type == "function_approval_response":
+            rendered += f" approved={content.approved}"
+        return rendered
     return ""
 
 

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1205,6 +1205,28 @@ def _tool_result_text(value: Any) -> str:
     return str(cast(object, value))
 
 
+def _format_summary_item_metadata(item: Content) -> str:
+    """Render safe metadata for non-text rich result items.
+
+    Never embeds binary payloads: data contents carry their bytes as a
+    base64 data URI and are represented by media type and path only.
+    """
+    details: list[str] = []
+    if item.media_type:
+        details.append(f"media_type={item.media_type}")
+    if item.type == "uri" and item.uri:
+        details.append(f"uri={item.uri}")
+    if item.type == "data":
+        path = item.additional_properties.get("path")
+        if isinstance(path, str) and path:
+            details.append(f"path={path}")
+    if item.file_id:
+        details.append(f"file_id={item.file_id}")
+    if item.name:
+        details.append(f"name={item.name}")
+    return f"{item.type} content" + (f" ({', '.join(details)})" if details else "")
+
+
 def _format_summary_result_items(items: Sequence[Content]) -> str:
     """Render function_result items (text and error contents) for the summarizer transcript.
 
@@ -1223,6 +1245,10 @@ def _format_summary_result_items(items: Sequence[Content]) -> str:
                 label = f"{label}: {item.error_details}" if label else item.error_details
             if item.error_code:
                 label = f"error({item.error_code}): {label}"
+            if label:
+                parts.append(label)
+        else:
+            label = _format_summary_item_metadata(item)
             if label:
                 parts.append(label)
     return "\n".join(parts)

--- a/python/packages/core/agent_framework/_compaction.py
+++ b/python/packages/core/agent_framework/_compaction.py
@@ -1205,6 +1205,29 @@ def _tool_result_text(value: Any) -> str:
     return str(cast(object, value))
 
 
+def _format_summary_result_items(items: Sequence[Content]) -> str:
+    """Render function_result items (text and error contents) for the summarizer transcript.
+
+    Rich results store their payload in ``items`` (for example the error
+    contents emitted by Monty and Hyperlight) while ``result`` only carries
+    the concatenated text. Returns an empty string when nothing is renderable
+    so callers can fall back to ``result``.
+    """
+    parts: list[str] = []
+    for item in items:
+        if item.type == "text" and item.text:
+            parts.append(item.text)
+        elif item.type == "error":
+            label = item.message or ""
+            if item.error_details:
+                label = f"{label}: {item.error_details}" if label else item.error_details
+            if item.error_code:
+                label = f"error({item.error_code}): {label}"
+            if label:
+                parts.append(label)
+    return "\n".join(parts)
+
+
 def _format_summary_content(content: Content) -> str:
     """Render one content item for the summarizer input transcript.
 
@@ -1221,7 +1244,9 @@ def _format_summary_content(content: Content) -> str:
             call += f" [call_id={content.call_id}]"
         return call
     if content.type == "function_result":
-        result_text = _tool_result_text(content.result) if content.result is not None else "no result"
+        result_text = _format_summary_result_items(content.items) if content.items else ""
+        if not result_text:
+            result_text = _tool_result_text(content.result) if content.result is not None else "no result"
         if content.exception:
             result_text = f"error({content.exception}): {result_text}"
         call_id_suffix = f" [call_id={content.call_id}]" if content.call_id else ""

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -36,6 +36,7 @@ from agent_framework import (
     included_token_count,
 )
 from agent_framework._compaction import (
+    _format_summary_message,
     _select_summary_input_groups,
     _serialize_message,
     append_compaction_message,
@@ -970,6 +971,68 @@ def test_summary_input_selection_does_not_retokenize_selected_transcript() -> No
         ])
         not in tokenizer.seen_texts
     )
+
+
+def test_format_summary_message_includes_function_call_details() -> None:
+    message = Message(
+        role="assistant",
+        contents=[Content.from_function_call(call_id="call_1", name="get_weather", arguments='{"city":"Seattle"}')],
+    )
+
+    rendered = _format_summary_message(1, message)
+
+    assert "get_weather" in rendered
+    assert '{"city":"Seattle"}' in rendered
+    assert "[call_id=call_1]" in rendered
+
+
+def test_format_summary_message_includes_function_result_and_exception() -> None:
+    message = Message(
+        role="tool",
+        contents=[Content.from_function_result(call_id="call_1", result="42", exception="ValueError")],
+    )
+
+    rendered = _format_summary_message(2, message)
+
+    assert "function_result" in rendered
+    assert "42" in rendered
+    assert "error(ValueError)" in rendered
+    assert "[call_id=call_1]" in rendered
+
+
+def test_format_summary_message_renders_function_result_without_call_id() -> None:
+    message = Message(
+        role="tool",
+        contents=[Content("function_result", call_id=None, result="done")],
+    )
+
+    rendered = _format_summary_message(3, message)
+
+    assert "done" in rendered
+    assert "call_id" not in rendered
+
+
+def test_format_summary_message_combines_tool_calls_with_text() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            "I'll check the weather.",
+            Content.from_function_call(call_id="call_1", name="get_weather", arguments='{"city":"Seattle"}'),
+        ],
+    )
+
+    rendered = _format_summary_message(4, message)
+
+    assert "I'll check the weather." in rendered
+    assert "get_weather" in rendered
+
+
+def test_format_summary_message_preserves_text_only_messages() -> None:
+    message = Message(role="user", contents=["hello world"])
+
+    rendered = _format_summary_message(5, message)
+
+    assert rendered == "5. [user] hello world"
 
 
 async def test_summarization_strategy_returns_false_when_summary_generation_fails(

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import Any
 
 import pytest
@@ -1098,6 +1099,57 @@ def test_format_summary_message_includes_approval_response() -> None:
 
     assert "approval_response" in rendered
     assert "approved=True" in rendered
+
+
+def test_format_summary_message_stringifies_non_json_mcp_result_without_crash() -> None:
+    message = Message(
+        role="tool",
+        contents=[Content("mcp_server_tool_result", call_id="mcp_1", output={"when": date(2026, 1, 1)})],
+    )
+
+    rendered = _format_summary_message(9, message)
+
+    assert "2026" in rendered
+    assert "[call_id=mcp_1]" in rendered
+
+
+def test_format_summary_message_preserves_time_order_for_mixed_contents() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            "I'll check the weather.",
+            Content.from_function_call(call_id="call_1", name="get_weather", arguments='{"city":"Seattle"}'),
+            "Please wait.",
+        ],
+    )
+
+    rendered = _format_summary_message(10, message)
+
+    assert rendered.index("I'll check the weather.") < rendered.index("function_call")
+    assert rendered.index("function_call") < rendered.index("Please wait.")
+
+
+def test_format_summary_message_uses_tool_name_for_mcp_approval() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_function_approval_request(
+                id="approval_mcp_1",
+                function_call=Content.from_mcp_server_tool_call(
+                    call_id="mcp_1",
+                    tool_name="search",
+                    server_name="test_server",
+                    arguments='{"query":"x"}',
+                ),
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(11, message)
+
+    assert "approval_request" in rendered
+    assert "search" in rendered
+    assert "[id=approval_mcp_1]" in rendered
 
 
 async def test_summarization_strategy_returns_false_when_summary_generation_fails(

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -1035,6 +1035,71 @@ def test_format_summary_message_preserves_text_only_messages() -> None:
     assert rendered == "5. [user] hello world"
 
 
+def test_format_summary_message_includes_mcp_tool_details() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_mcp_server_tool_call(
+                call_id="mcp_1",
+                tool_name="search",
+                server_name="test_server",
+                arguments='{"query":"x"}',
+            ),
+            Content.from_mcp_server_tool_result(
+                call_id="mcp_1",
+                output=[Content.from_text("found")],
+            ),
+        ],
+    )
+
+    rendered = _format_summary_message(6, message)
+
+    assert "search" in rendered
+    assert '{"query":"x"}' in rendered
+    assert "[call_id=mcp_1]" in rendered
+    assert "found" in rendered
+
+
+def test_format_summary_message_includes_approval_request() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_function_approval_request(
+                id="approval_1",
+                function_call=Content.from_function_call(
+                    call_id="call_1", name="send_email", arguments='{"to":"a@b.c"}'
+                ),
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(7, message)
+
+    assert "approval_request" in rendered
+    assert "send_email" in rendered
+    assert "[id=approval_1]" in rendered
+
+
+def test_format_summary_message_includes_approval_response() -> None:
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_function_approval_response(
+                approved=True,
+                id="approval_1",
+                function_call=Content.from_function_call(
+                    call_id="call_1", name="send_email", arguments='{"to":"a@b.c"}'
+                ),
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(8, message)
+
+    assert "approval_response" in rendered
+    assert "approved=True" in rendered
+
+
 async def test_summarization_strategy_returns_false_when_summary_generation_fails(
     caplog: Any,
 ) -> None:

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -1243,6 +1243,73 @@ def test_format_summary_message_renders_mixed_text_and_error_items() -> None:
     assert "sandbox timed out" in rendered
 
 
+def test_format_summary_message_renders_metadata_for_data_items() -> None:
+    data_item = Content.from_data(
+        b"some bytes",
+        media_type="application/octet-stream",
+        additional_properties={"path": "/output/result.png"},
+    )
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_data_1",
+                result="",
+                items=[data_item],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(15, message)
+
+    assert "data content" in rendered
+    assert "media_type=application/octet-stream" in rendered
+    assert "path=/output/result.png" in rendered
+    assert data_item.uri is not None
+    assert data_item.uri not in rendered
+
+
+def test_format_summary_message_renders_metadata_for_uri_items() -> None:
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_uri_1",
+                result="",
+                items=[Content.from_uri("https://example.com/result.png", media_type="image/png")],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(16, message)
+
+    assert "uri content" in rendered
+    assert "uri=https://example.com/result.png" in rendered
+    assert "media_type=image/png" in rendered
+
+
+def test_format_summary_message_renders_metadata_for_hosted_file_items() -> None:
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_file_1",
+                result="",
+                items=[Content.from_hosted_file(file_id="file_1", media_type="text/plain", name="out.txt")],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(17, message)
+
+    assert "hosted_file content" in rendered
+    assert "file_id=file_1" in rendered
+    assert "name=out.txt" in rendered
+
+
 async def test_summarization_strategy_returns_false_when_summary_generation_fails(
     caplog: Any,
 ) -> None:

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -916,6 +916,35 @@ async def test_summarization_strategy_bounds_summary_input_to_complete_groups() 
     assert oversized_message.message_id not in summarized_message_ids
 
 
+async def test_summarization_strategy_preserves_tool_trajectory_in_summary_input() -> None:
+    summarizer = _RecordingSummarizer()
+    messages = [
+        Message(role="user", contents=["use the tool"]),
+        _assistant_function_call("call_1"),
+        _tool_result("call_1", "ok"),
+        Message(role="assistant", contents=["tool completed"]),
+        Message(role="user", contents=["what next"]),
+        Message(role="assistant", contents=["here is the follow-up"]),
+    ]
+    strategy = SummarizationStrategy(
+        client=summarizer,  # type: ignore[arg-type]  # pyrefly: ignore[bad-argument-type]  # ty: ignore[invalid-argument-type]
+        target_count=2,
+        threshold=0,
+    )
+    annotate_message_groups(messages)
+
+    changed = await strategy(messages)
+
+    assert changed is True
+    assert len(summarizer.requests) == 1
+    summary_request_text = summarizer.requests[0][1].text
+    assert summary_request_text is not None
+    assert "tool" in summary_request_text
+    assert '{"value":"x"}' in summary_request_text
+    assert "[call_id=call_1]" in summary_request_text
+    assert "ok" in summary_request_text
+
+
 async def test_summarization_strategy_skips_oversized_first_group() -> None:
     summarizer = _RecordingSummarizer()
     messages = [

--- a/python/packages/core/tests/core/test_compaction.py
+++ b/python/packages/core/tests/core/test_compaction.py
@@ -1152,6 +1152,68 @@ def test_format_summary_message_uses_tool_name_for_mcp_approval() -> None:
     assert "[id=approval_mcp_1]" in rendered
 
 
+def test_format_summary_message_renders_error_items_for_rich_results() -> None:
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_err_1",
+                result="",
+                items=[Content.from_error(message="Execution error", error_details="ValueError: boom")],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(12, message)
+
+    assert "Execution error" in rendered
+    assert "ValueError: boom" in rendered
+    assert "[call_id=call_err_1]" in rendered
+
+
+def test_format_summary_message_falls_back_to_result_when_items_render_empty() -> None:
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_fb_1",
+                result="fallback result",
+                items=[Content.from_error()],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(13, message)
+
+    assert "fallback result" in rendered
+    assert "[call_id=call_fb_1]" in rendered
+
+
+def test_format_summary_message_renders_mixed_text_and_error_items() -> None:
+    message = Message(
+        role="tool",
+        contents=[
+            Content(
+                "function_result",
+                call_id="call_mix_1",
+                result="",
+                items=[
+                    Content.from_text("partial output"),
+                    Content.from_error(message="Execution error", error_details="sandbox timed out"),
+                ],
+            )
+        ],
+    )
+
+    rendered = _format_summary_message(14, message)
+
+    assert "partial output" in rendered
+    assert "Execution error" in rendered
+    assert "sandbox timed out" in rendered
+
+
 async def test_summarization_strategy_returns_false_when_summary_generation_fails(
     caplog: Any,
 ) -> None:


### PR DESCRIPTION
### Problem

`SummarizationStrategy` feeds the summarizer LLM a transcript rendered by `_format_summary_message` (`python/packages/core/agent_framework/_compaction.py`), which only uses `Message.text`. Since `Message.text` (`python/packages/core/agent_framework/_types.py`) concatenates `TextContent` only, tool rounds collapse to placeholders like `2. [assistant] function_call` and `3. [tool] function_result`. The summarizer therefore never sees the tool name, arguments, results, exceptions, or `call_id`, and produces summaries that silently discard the tool trajectory.

Fixes #8086

### Solution

Add a per-content renderer `_format_summary_content` that serializes tool trajectory contents into the summary input transcript, and route `_format_summary_message` through it:

- `function_call` → `function_call <name>(<arguments>) [call_id=<id>]`
- `function_result` → `function_result: <result> [call_id=<id>]` (with `error(<exception>)` prefix when the call failed)
- `mcp_server_tool_call` / `mcp_server_tool_result` → same shape with the MCP tool name and output
- `function_approval_request` / `function_approval_response` → nested call name, approval id, and decision

Design decisions:

- **Zero public API change.** Only private formatting helpers in `_compaction.py` change; `SummarizationStrategy`'s trigger conditions, summary message shape, and trace links are untouched.
- **Group-atomic input selection unchanged.** `_select_summary_input_groups` still selects whole groups by token budget; enriched groups simply carry their true payload, so the budget now reflects what the summarizer actually receives.
- **Legacy rendering preserved for text-only messages** (byte-identical, locked in by a regression test).

Before → after (real output from the end-to-end reproduction):

```text
# before
2. [assistant] function_call
3. [tool] function_result

# after
2. [assistant] function_call get_weather({"city":"Seattle"}) [call_id=call_1]
3. [tool] function_result: sunny, 22C [call_id=call_1]
```

### Changes

- `python/packages/core/agent_framework/_compaction.py`
  - New `_format_summary_content` dispatch over tool-call / result / MCP / approval content types (reuses existing `_tool_result_text`).
  - `_format_summary_message` now combines structured renderings with `Message.text`, falling back to the legacy content-type list only when nothing else is available.
- `python/packages/core/tests/core/test_compaction.py`
  - 8 new tests: function call details, results with exceptions, results without `call_id`, mixed text/tool messages, text-only golden rendering, MCP tool details, approval request, approval response.

### Testing

```bash
cd python/packages/core
uv run pytest tests/core/test_compaction.py -q   # 87 passed
uv run pytest tests/core -q                       # full core suite: passed
uv run ruff check agent_framework/_compaction.py tests/core/test_compaction.py
uv run poe pyright                               # no new errors in touched files
```

- End-to-end: a `SummarizationStrategy` run over a 6-message conversation with two tool rounds shows the summarizer input containing names, arguments, results, and `call_id`s, and the summary message replacing the excluded originals with trace links intact.
- Regression anchors: existing budget/selection tests (`test_summarization_strategy_bounds_summary_input_to_complete_groups`, `test_summary_input_selection_does_not_retokenize_selected_transcript`) pass unchanged; group-atomic selection semantics are preserved.

### Notes for Reviewer

- **Token budget**: enriched groups are larger, so a budgeted summarization round may select fewer groups than before. This is intentional — the payload was always part of the context; it was just invisible to the summarizer. Flagged for review in case maintainers prefer an `include_tool_details` opt-in/opt-out.
- **Trust boundary**: tool arguments/results now reach the summarizer LLM. The class docstring already warns that the summarizer must be trusted as much as the primary model; this PR widens the data surface sent to it. A redaction hook could be a follow-up.
- **Out of scope (deliberately)**: `text_reasoning` rendering, structured JSON summary output, and no-`call_id` adjacency pairing in `group_messages` are left unchanged; the last touches pairing semantics covered by spec `docs/specs/004-python-function-calling-loop.md` and is proposed separately.
- Orthogonal to open PR #7944 (synthetic summary reconciliation in `before_run`).
