### PR TITLE
Python: fix(a2a): initialize _close_http_client on the user-supplied-client path

### DIFF
--- a/python/packages/a2a/agent_framework_a2a/_agent.py
+++ b/python/packages/a2a/agent_framework_a2a/_agent.py
@@ -263,6 +263,8 @@ class A2AAgent(AgentTelemetryLayer, BaseAgent):
 
         super().__init__(id=id, name=name, description=description, **kwargs)
         self._http_client: httpx.AsyncClient | None = http_client
+        # every construction path must set this before __aexit__ can run
+        self._close_http_client = False
         self._timeout_config = self._create_timeout_config(timeout)
         bindings = supported_protocol_bindings if supported_protocol_bindings is not None else ["JSONRPC"]
         if client is not None:

--- a/python/packages/a2a/tests/test_a2a_agent.py
+++ b/python/packages/a2a/tests/test_a2a_agent.py
@@ -2536,3 +2536,37 @@ async def test_input_required_sets_task_id_instead_of_reference(mock_a2a_client:
 
 
 # endregion
+
+
+async def test_context_manager_with_user_supplied_http_client() -> None:
+    """A2AAgent(url=..., http_client=mine) must exit cleanly and must not close it.
+
+    The third construction path (no client, caller-provided http_client) used to
+    leave _close_http_client unset, so __aexit__ raised AttributeError.
+    """
+    mock_http_client = MagicMock()
+    mock_http_client.aclose = AsyncMock()
+
+    agent = A2AAgent(url="http://agent.example", http_client=mock_http_client)
+
+    async with agent:
+        pass
+
+    # the client belongs to the caller; we must not close it
+    mock_http_client.aclose.assert_not_called()
+
+
+async def test_context_manager_closes_self_created_http_client() -> None:
+    """A2AAgent(url=...) builds its own client and closes it on exit."""
+
+    with patch("agent_framework_a2a._agent.httpx.AsyncClient") as cls:
+        mock_http_client = MagicMock()
+        mock_http_client.aclose = AsyncMock()
+        cls.return_value = mock_http_client
+
+        agent = A2AAgent(url="http://agent.example")
+
+        async with agent:
+            pass
+
+        mock_http_client.aclose.assert_called_once()


### PR DESCRIPTION
### Motivation & Context

`A2AAgent(url=..., http_client=my_client)` is the documented way to share an httpx client across agents, but that construction path never sets `_close_http_client`: the attribute is only assigned in the `client is not None` early return and in the branch that builds a client itself. Exiting `async with A2AAgent(...)` on the third path therefore raises `AttributeError: 'A2AAgent' object has no attribute '_close_http_client'` (`_agent.py:371`), and the caller's client is never treated according to any ownership rule at all.

Maintainer direction confirmed in the issue ("Please proceed").

### Description & Review Guide

- One-line default: `_close_http_client = False` is now set before the branch split, so every construction path has the attribute by the time `__aexit__` can run. The two self-created paths still flip it to `True`, so ownership semantics are unchanged.
- Impact: the user-supplied-client path exits cleanly and does not close the caller's client, matching the documented ownership intent.
- Review focus: the early-return path (`client is not None`) keeps its existing `_close_http_client = True`; I did not touch that, though it is worth a separate look if the intent there differs.

### Related Issue

Fixes #7950

### Contribution Checklist

- [x] The code follows the code style of this project.
- [x] Tests added for the fix: one covers that a caller-supplied client exits cleanly and is not closed, one covers that a self-created client is still closed on exit.
- [x] **All new and existing tests passed**: `pytest tests/test_a2a_agent.py tests/test_a2a_executor.py tests/test_utils.py` — 161 passed. (`test_a2a_group_chat.py` needs the `agent-framework-orchestrations` extra, not installed locally; CI covers it.)
- [x] The contribution is licensed under the MIT License.
- [x] The code is my own original work, or I have properly attributed it.
- [ ] **Documentation updated** — not needed; no public API or documented behavior changes.
- [x] **Breaking changes**: none.

Verified before the fix, the new test fails with the exact `AttributeError` from the issue; after the fix both tests pass and ruff is clean.
