### PR TITLE
.NET: Improve inline skill argument error guidance

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/Programmatic/AgentInlineSkillScript.cs
@@ -99,7 +99,8 @@ internal sealed class AgentInlineSkillScript : AgentSkillScript
         if (arguments.Value.ValueKind != JsonValueKind.Object)
         {
             throw new InvalidOperationException(
-                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{arguments.Value.ValueKind}'.");
+                $"Inline skill scripts expect arguments as a JSON object but received a JSON element of kind '{arguments.Value.ValueKind}'. " +
+                "Configure a custom argument marshaler on the skill to handle other argument formats.");
         }
 
         var dict = new Dictionary<string, object?>();

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/SkillScriptArgumentMarshalerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/SkillScriptArgumentMarshalerTests.cs
@@ -99,6 +99,7 @@ public sealed class SkillScriptArgumentMarshalerTests
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => script.RunAsync(skill, element, null, CancellationToken.None));
         Assert.Contains("String", ex.Message);
+        Assert.Contains("custom argument marshaler", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation & Context

Local and smaller models may serialize inline skill arguments into a JSON string instead of emitting a JSON object. The resulting exception explains the type mismatch but does not point users to the supported custom argument marshaler, making the recovery path difficult to discover.

### Description & Review Guide

- **What are the major changes?** Extend the invalid inline skill argument exception with a hint to configure a custom argument marshaler, and assert that guidance in the existing unit test for string-wrapped arguments.
- **What is the impact of these changes?** Users receiving unsupported argument formats get an actionable diagnostic without changing marshaling behavior or public APIs.
- **What do you want reviewers to focus on?** Whether the exception guidance clearly identifies the existing customization point without implying unsupported automatic conversion.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Closes #7989

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.