### PR TITLE
[BREAKING] .NET: Fix strict skill script argument schemas

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI/Skills/AgentSkillsProvider.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
@@ -29,6 +30,12 @@ namespace Microsoft.Agents.AI;
 /// <item><description><strong>Read resources</strong> — supplementary content is read on demand via the <c>read_skill_resource</c> tool.</description></item>
 /// <item><description><strong>Run scripts</strong> — scripts are executed via the <c>run_skill_script</c> tool (when scripts exist).</description></item>
 /// </list>
+/// <para>
+/// The <c>run_skill_script</c> tool accepts its <c>arguments</c> parameter as a JSON-encoded string,
+/// or <see langword="null"/> when no arguments are needed. The provider decodes the string once
+/// before passing the resulting JSON value to the script and its argument marshaler. Direct tool
+/// invocations can also pass structured JSON objects or arrays.
+/// </para>
 /// <para>
 /// The provider can optionally own the lifetime of its underlying <see cref="AgentSkillsSource"/>. When
 /// constructed via one of the convenience constructors (skill paths or in-memory skills) or via
@@ -333,8 +340,22 @@ public sealed partial class AgentSkillsProvider : AIContextProvider, IDisposable
             this.WrapWithApprovalIfRequired(AIFunctionFactory.Create(
                 (string skillName, string scriptName, JsonElement? arguments = null, IServiceProvider? serviceProvider = null, CancellationToken cancellationToken = default) =>
                     this.RunSkillScriptAsync(skills, skillName, scriptName, arguments, serviceProvider, cancellationToken),
-                name: RunSkillScriptToolName,
-                description: "Runs a script associated with a skill."),
+                new AIFunctionFactoryOptions
+                {
+                    Name = RunSkillScriptToolName,
+                    Description = "Runs a script associated with a skill.",
+                    JsonSchemaCreateOptions = new AIJsonSchemaCreateOptions
+                    {
+                        TransformSchemaNode = static (context, schema) =>
+                            context.TypeInfo.Type == typeof(JsonElement?) ?
+                                new JsonObject
+                                {
+                                    ["type"] = new JsonArray("string", "null"),
+                                    ["description"] = "Script arguments encoded as a JSON string matching the script's parameter schema. Use null when no arguments are needed.",
+                                    ["default"] = null,
+                                } : schema,
+                    },
+                }),
                 this._options?.DisableRunSkillScriptApproval is not true),
         ];
     }
@@ -439,6 +460,14 @@ public sealed partial class AgentSkillsProvider : AIContextProvider, IDisposable
             if (script is null)
             {
                 return $"Error: Script '{scriptName}' not found in skill '{skillName}'.";
+            }
+
+            // Models supply a JSON-encoded string so the tool has a strict-compatible schema.
+            // Continue accepting structured JSON from callers invoking the tool directly.
+            if (arguments is { ValueKind: JsonValueKind.String })
+            {
+                using JsonDocument document = JsonDocument.Parse(arguments.Value.GetString()!);
+                arguments = document.RootElement.Clone();
             }
 
             return await script.RunAsync(skill, arguments, serviceProvider, cancellationToken).ConfigureAwait(false);

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/AgentSkills/AgentSkillsProviderTests.cs
@@ -832,8 +832,10 @@ public sealed class AgentSkillsProviderTests : IDisposable
         Assert.True(executorCalled);
     }
 
-    [Fact]
-    public async Task RunSkillScript_ForwardsJsonArgumentsAndServiceProviderToRunnerAsync()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunSkillScript_ForwardsJsonArgumentsAndServiceProviderToRunnerAsync(bool encoded)
     {
         // Arrange — create a skill with a script file
         string skillDir = Path.Combine(this._testRoot, "fwd-skill");
@@ -870,7 +872,7 @@ public sealed class AgentSkillsProviderTests : IDisposable
         {
             ["skillName"] = "fwd-skill",
             ["scriptName"] = "scripts/run.py",
-            ["arguments"] = argsJson,
+            ["arguments"] = encoded ? JsonSerializer.SerializeToElement(argsJson.GetRawText(), AIJsonUtilities.DefaultOptions) : argsJson,
         })
         {
             Services = mockServiceProvider,
@@ -881,6 +883,123 @@ public sealed class AgentSkillsProviderTests : IDisposable
         Assert.Equal(JsonValueKind.Array, capturedArgs!.Value.ValueKind);
         Assert.Equal("""["arg1","arg2"]""", capturedArgs.Value.GetRawText());
         Assert.Same(mockServiceProvider, capturedServiceProvider);
+    }
+
+    [Fact]
+    public async Task RunSkillScript_ArgumentsSchemaIsNullableStringAsync()
+    {
+        // Arrange
+        var provider = new AgentSkillsProvider(new AgentInlineSkill("schema-skill", "Schema test", "Body."));
+
+        // Act
+        var result = await provider.InvokingAsync(new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext()), CancellationToken.None);
+        var tool = Assert.IsAssignableFrom<AIFunction>(result.Tools!.Single(t => t.Name == "run_skill_script"));
+        var schema = tool.JsonSchema.GetProperty("properties").GetProperty("arguments");
+
+        // Assert
+        Assert.Collection(schema.GetProperty("type").EnumerateArray(),
+            type => Assert.Equal("string", type.GetString()),
+            type => Assert.Equal("null", type.GetString()));
+        Assert.Contains("JSON", schema.GetProperty("description").GetString());
+        Assert.IsType<ApprovalRequiredAIFunction>(tool);
+    }
+
+    [Theory]
+    [InlineData("{\"value\":42}", true)]
+    [InlineData("{\"value\":42}", false)]
+    public async Task RunSkillScript_InlineArgumentsAsync(string json, bool encoded)
+    {
+        // Arrange
+        var skill = new AgentInlineSkill("inline-skill", "Inline test", "Body.");
+        skill.AddScript("echo", (int value) => value);
+        var provider = new AgentSkillsProvider(skill);
+        var result = await provider.InvokingAsync(new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext()), CancellationToken.None);
+        var tool = Assert.IsAssignableFrom<AIFunction>(result.Tools!.Single(t => t.Name == "run_skill_script"));
+        using var document = JsonDocument.Parse(json);
+
+        // Act
+        var response = await tool.InvokeAsync(new AIFunctionArguments
+        {
+            ["skillName"] = "inline-skill",
+            ["scriptName"] = "echo",
+            ["arguments"] = encoded ? JsonSerializer.SerializeToElement(json, AIJsonUtilities.DefaultOptions) : document.RootElement,
+        });
+
+        // Assert
+        Assert.Equal("42", response!.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("null")]
+    [InlineData("\"{\\\"value\\\":42}\"")]
+    public async Task RunSkillScript_DecodesArgumentsOnlyOnceAsync(string? json)
+    {
+        // Arrange
+        JsonElement? captured = null;
+        bool called = false;
+        var skill = new AgentInlineSkill("custom-skill", "Custom marshaler", "Body.", argumentMarshaler: arguments =>
+        {
+            captured = arguments;
+            return new AIFunctionArguments();
+        });
+        skill.AddScript("run", () => called = true);
+        var provider = new AgentSkillsProvider(skill);
+        var result = await provider.InvokingAsync(new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext()), CancellationToken.None);
+        var tool = Assert.IsAssignableFrom<AIFunction>(result.Tools!.Single(t => t.Name == "run_skill_script"));
+
+        // Act
+        await tool.InvokeAsync(new AIFunctionArguments
+        {
+            ["skillName"] = "custom-skill",
+            ["scriptName"] = "run",
+            ["arguments"] = JsonSerializer.SerializeToElement(json, AIJsonUtilities.DefaultOptions),
+        });
+
+        // Assert
+        Assert.True(called);
+        if (json is null or "null")
+        {
+            Assert.True(captured is null || captured.Value.ValueKind == JsonValueKind.Null);
+        }
+        else
+        {
+            Assert.Equal(JsonValueKind.String, captured!.Value.ValueKind);
+            Assert.Equal("{\"value\":42}", captured.Value.GetString());
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RunSkillScript_InvalidEncodedArgumentsUsesErrorPolicyAsync(bool includeDetails)
+    {
+        // Arrange
+        bool called = false;
+        var skill = new AgentInlineSkill("invalid-skill", "Invalid test", "Body.");
+        skill.AddScript("run", () => called = true);
+        var provider = new AgentSkillsProvider(new[] { skill }, new AgentSkillsProviderOptions { IncludeDetailedErrors = includeDetails });
+        var result = await provider.InvokingAsync(new AIContextProvider.InvokingContext(this._agent, session: null, new AIContext()), CancellationToken.None);
+        var tool = Assert.IsAssignableFrom<AIFunction>(result.Tools!.Single(t => t.Name == "run_skill_script"));
+        var arguments = new AIFunctionArguments
+        {
+            ["skillName"] = "invalid-skill",
+            ["scriptName"] = "run",
+            ["arguments"] = JsonSerializer.SerializeToElement("invalid JSON", AIJsonUtilities.DefaultOptions),
+        };
+
+        // Act & Assert
+        if (includeDetails)
+        {
+            var response = await tool.InvokeAsync(arguments);
+            Assert.StartsWith("Error: Failed to execute script 'run'", response!.ToString());
+        }
+        else
+        {
+            await Assert.ThrowsAnyAsync<JsonException>(async () => await tool.InvokeAsync(arguments));
+        }
+
+        Assert.False(called);
     }
 
     private sealed class TestServiceProvider : IServiceProvider


### PR DESCRIPTION
### Motivation & Context

`run_skill_script` advertises `JsonElement? arguments` as an unconstrained schema (`{"default":null}`). Azure OpenAI rejects this tool with HTTP 400 `invalid_function_parameters` when strict mode is enabled, including when a skill has no scripts and the request disables tool calls.

### Description & Review Guide

- **What are the major changes?** Advertise `arguments` as a nullable JSON-encoded string using the function schema transformation hook. Decode strings exactly once at the provider boundary, then pass the resulting JSON value to the existing script runner or marshaler. Keep direct object/array invocation, tool names, approval wrapping, service-provider forwarding, and C# script interfaces. Add regression coverage for the schema, file arrays, inline objects, legacy structured calls, null, malformed JSON, and single decoding with a custom marshaler.
- **What is the impact of these changes?** Strict providers receive an explicit parameter type while scripts retain flexible payloads. This changes the model-facing contract: a script expecting `{ "value": 42 }` receives that object after the model supplies `arguments: "{\"value\":42}"`. Custom callers or marshalers that previously used raw string arguments must now JSON-encode those strings. The outer tool schema is strictly validated; payload validation remains with the script or marshaler. Malformed JSON follows the existing `IncludeDetailedErrors` policy.
- **What do you want reviewers to focus on?** Acceptance of the JSON-string contract proposed in the issue, including its interaction with custom marshalers and #7989. This remains a draft for design review; maintainer assignment is not treated as approval of this contract change.

Reproduced before the fix against a live Azure OpenAI `gpt-5.5` deployment using the v1 Chat Completions API, .NET SDK 10.0.303, `Microsoft.Extensions.AI.OpenAI` 10.9.0, and `OpenAI` 2.12.0. The original strict request returned HTTP 400. With the patch, strict and non-strict requests both returned HTTP 200. A further strict request generated an actual `run_skill_script` call with JSON-encoded arguments, and invoking it returned the expected result, `42`.

Full solution build completed with zero warnings or errors. The affected core test project passed all 2,127 tests on .NET 10. The full .NET 10 unit run completed with **7,208 passed, 65 skipped, one failure** in the unrelated `DevUIIntegrationTests.TestServerWithDevUI_ResolvesRequestToWorkflow_ByKeyAsync` test (null discovery collection). The entire DevUI project passed on an immediate isolated rerun. An earlier hosting telemetry assertion also passed on rerun. The all-tests checklist remains unchecked to reflect the full-run result. Local execution used the U.S. locale, `DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE=false`, and permission for the Foundry test host to create its local state directory. Formatting and style checks passed.

### Related Issue

Fixes #8094

No competing open PR was found in the issue discussion or linked timeline when preparing this draft.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
