### PR TITLE
Fix missing native issue types for bug and feature reports

### DIFF
--- a/.github/scripts/set_missing_issue_type.js
+++ b/.github/scripts/set_missing_issue_type.js
@@ -4,7 +4,9 @@
 async function setMissingIssueType({ github, context, core }) {
   const params = { ...context.repo, issue_number: context.issue.number };
   // Read current metadata: a maintainer may have classified or renamed the
-  // issue since the opened/reopened event was queued.
+  // issue since the opened/reopened event was queued. This preserves types
+  // observed at read time; GitHub does not document conditional issue updates,
+  // so a manual edit between this GET and the PATCH can still race.
   const { data: issue } = await github.rest.issues.get(params);
   if (issue.type != null) {
     return;

--- a/.github/scripts/set_missing_issue_type.js
+++ b/.github/scripts/set_missing_issue_type.js
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+/** Set a missing native issue type from the standard bug/feature title prefix. */
+async function setMissingIssueType({ github, context, core }) {
+  const params = { ...context.repo, issue_number: context.issue.number };
+  // Read current metadata: a maintainer may have classified or renamed the
+  // issue since the opened/reopened event was queued.
+  const { data: issue } = await github.rest.issues.get(params);
+  if (issue.type != null) {
+    return;
+  }
+
+  const match = issue.title?.match(/^\s*(?:(?:Python|\.NET):\s*)?\[(Bug|Feature)\]:/i);
+  if (!match) {
+    return;
+  }
+
+  const type = match[1].toLowerCase() === 'bug' ? 'Bug' : 'Feature';
+  await github.rest.issues.update({ ...params, type });
+  core.info(`Set missing issue type to ${type} for #${context.issue.number}.`);
+}
+
+module.exports = setMissingIssueType;

--- a/.github/tests/test_set_missing_issue_type.js
+++ b/.github/tests/test_set_missing_issue_type.js
@@ -2,6 +2,8 @@
 
 const { it } = require('node:test');
 const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
 const setMissingIssueType = require('../scripts/set_missing_issue_type.js');
 
 function createMocks(issue) {
@@ -59,3 +61,37 @@ it('propagates API failures so the workflow reports the failure', async () => {
   mocks.github.rest.issues.update = async () => { throw new Error('API unavailable'); };
   await assert.rejects(setMissingIssueType(mocks), /API unavailable/);
 });
+
+for (const failingMethod of ['get', 'update']) {
+  it(`finishes workflow label assignment before a fallback ${failingMethod} failure`, async () => {
+    const workflow = readFileSync(path.join(__dirname, '../workflows/label-issues.yml'), 'utf8');
+    // Execute the actual github-script steps in workflow order, with API mocks.
+    const scripts = [...workflow.matchAll(/^          script: \|\n((?:^            .*\n|^\n)+)/gm)]
+      .map((match) => match[1].replace(/^            /gm, ''));
+    assert.equal(scripts.length, 2);
+    const mocks = createMocks({ title: 'Python: [Bug]: broken', type: null });
+    const calls = [];
+    mocks.github.rest.issues.addLabels = async ({ labels }) => {
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.deepEqual(labels, ['triage', 'python']);
+      calls.push('labels completed');
+    };
+    mocks.github.rest.issues[failingMethod] = async () => {
+      calls.push('fallback failed');
+      throw new Error('API unavailable');
+    };
+    const requireScript = (name) => name.endsWith('check_team_membership.js')
+      ? async () => ({ isTeamMember: false })
+      : setMissingIssueType;
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const runSteps = async () => {
+      for (const script of scripts) {
+        await new AsyncFunction('github', 'context', 'core', 'require', script)(
+          mocks.github, mocks.context, mocks.core, requireScript,
+        );
+      }
+    };
+    await assert.rejects(runSteps(), /API unavailable/);
+    assert.deepEqual(calls, ['labels completed', 'fallback failed']);
+  });
+}

--- a/.github/tests/test_set_missing_issue_type.js
+++ b/.github/tests/test_set_missing_issue_type.js
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const setMissingIssueType = require('../scripts/set_missing_issue_type.js');
+
+function createMocks(issue) {
+  const updates = [];
+  const context = {
+    repo: { owner: 'microsoft', repo: 'agent-framework' },
+    issue: { number: 123 },
+    // An opened event can be stale by the time the workflow runs.
+    payload: { issue: { title: 'Python: [Bug]: original title', type: null } },
+  };
+  const github = { rest: { issues: {
+    get: async (params) => {
+      assert.deepEqual(params, { ...context.repo, issue_number: 123 });
+      return { data: issue };
+    },
+    update: async (params) => { updates.push(params); },
+  } } };
+  return { github, context, core: { info() {} }, updates };
+}
+
+for (const [title, type] of [
+  ['Python: [Bug]: broken', 'Bug'],
+  ['.NET: [Bug]: broken', 'Bug'],
+  ['[Bug]: broken', 'Bug'],
+  ['[Feature]: new capability', 'Feature'],
+  ['Python: [Feature]: new capability', 'Feature'],
+  ['.NET: [Feature]: new capability', 'Feature'],
+  [' python: [bug]: broken', 'Bug'],
+]) {
+  it(`sets ${type} for ${title}`, async () => {
+    const mocks = createMocks({ title, type: null });
+    await setMissingIssueType(mocks);
+    assert.deepEqual(mocks.updates, [{ ...mocks.context.repo, issue_number: 123, type }]);
+  });
+}
+
+for (const type of [{ name: 'Bug' }, { name: 'Feature' }, { name: 'Task' }]) {
+  it(`preserves an existing ${type.name} despite a stale blank event`, async () => {
+    const mocks = createMocks({ title: 'Python: [Bug]: broken', type });
+    await setMissingIssueType(mocks);
+    assert.deepEqual(mocks.updates, []);
+  });
+}
+
+for (const title of ['Python: [Question]: help', 'Discuss [Bug]: title format', 'Bug report', '', null]) {
+  it(`leaves an unrecognized current title unchanged: ${title}`, async () => {
+    const mocks = createMocks({ title, type: null });
+    await setMissingIssueType(mocks);
+    assert.deepEqual(mocks.updates, []);
+  });
+}
+
+it('propagates API failures so the workflow reports the failure', async () => {
+  const mocks = createMocks({ title: '[Bug]: broken', type: null });
+  mocks.github.rest.issues.update = async () => { throw new Error('API unavailable'); };
+  await assert.rejects(setMissingIssueType(mocks), /API unavailable/);
+});

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -41,15 +41,6 @@ jobs:
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
-      # Use the app token so assigning a type can trigger the triage workflow.
-      - name: Set missing issue type
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.github-auth.outputs.token }}
-          script: |
-            const setMissingIssueType = require('./.github/scripts/set_missing_issue_type.js');
-            await setMissingIssueType({ github, context, core });
-
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.github-auth.outputs.token }}
@@ -129,7 +120,7 @@ jobs:
 
             // Add the labels to the issue (only if there are labels to add)
             if (labels.length > 0) {
-              github.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -138,3 +129,13 @@ jobs:
             }
         env:
           TEAM_NAME: ${{ secrets.DEVELOPER_TEAM }}
+
+      # Run after labeling so fallback API failures do not prevent labels.
+      # Use the app token so assigning a type can trigger the triage workflow.
+      - name: Set missing issue type
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.github-auth.outputs.token }}
+          script: |
+            const setMissingIssueType = require('./.github/scripts/set_missing_issue_type.js');
+            await setMissingIssueType({ github, context, core });

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -22,6 +22,7 @@ jobs:
           sparse-checkout: |
             .github/actions/github-app-token
             .github/scripts/check_team_membership.js
+            .github/scripts/set_missing_issue_type.js
           fetch-depth: 1
           persist-credentials: false
 
@@ -39,6 +40,15 @@ jobs:
           github-app-installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
           repository: ${{ github.repository }}
           fallback-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
+      # Use the app token so assigning a type can trigger the triage workflow.
+      - name: Set missing issue type
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.github-auth.outputs.token }}
+          script: |
+            const setMissingIssueType = require('./.github/scripts/set_missing_issue_type.js');
+            await setMissingIssueType({ github, context, core });
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
### Motivation & Context

Bug and feature reports can arrive with the standard title prefix but no native issue type. The labeling workflow does not fill that gap, so automatic triage skips those reports until someone assigns a type manually.

### Description & Review Guide

- **What are the major changes?** Add a fallback on issue opening and reopening that assigns `Bug` or `Feature` from the standard `[Bug]:` and `[Feature]:` title prefixes, optionally preceded by `Python:` or `.NET:`. Read current issue metadata and assign a type only when it is blank.
- **What is the impact of these changes?** Reports with missing types can enter automatic triage through the resulting `typed` event. Classifications and unrecognized titles observed when the issue is read are preserved. GitHub does not document conditional issue updates, so a manual edit between the read and update can still race. The fallback runs after awaited label assignment and uses the existing GitHub App token. Its API failures remain visible without preventing the preceding labels from being applied.
- **What do you want reviewers to focus on?** Preservation of current classifications when event metadata is stale, title matching, and the App-token workflow integration. Regression tests cover these decisions and API error propagation.

### Related Issue

None.

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
