### PR TITLE
Python: Fix Param sentinel compatibility with typing-extensions 4.15

### DIFF
--- a/python/packages/core/agent_framework/_vector_filters.py
+++ b/python/packages/core/agent_framework/_vector_filters.py
@@ -255,7 +255,7 @@ class Param:
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "value_type", value_type)
         object.__setattr__(self, "required", required)
-        object.__setattr__(self, "_default", deepcopy(default))
+        object.__setattr__(self, "_default", default if default is _PARAM_UNSET else deepcopy(default))
         object.__setattr__(self, "omit_if_none", omit_if_none)
         object.__setattr__(self, "description", description)
         object.__setattr__(self, "minimum", minimum)
@@ -271,8 +271,8 @@ class Param:
 
     @property
     def default(self) -> Any:
-        """Return an independent copy of the default value."""
-        return deepcopy(self._default)
+        """Return an independent copy of the default value, or the unset sentinel."""
+        return deepcopy(self._default) if self.has_default else _PARAM_UNSET
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Param:
         return self

--- a/python/packages/core/tests/core/test_vectors.py
+++ b/python/packages/core/tests/core/test_vectors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import AsyncIterable, Callable, Iterator, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import FrozenInstanceError, dataclass, field
 from decimal import Decimal
 from typing import Annotated, Any, ClassVar, Literal, cast
@@ -45,7 +46,7 @@ from agent_framework import (
 )
 from agent_framework._feature_stage import ExperimentalWarning
 from agent_framework._telemetry import FeatureIndex
-from agent_framework._vector_filters import filter_values_equal
+from agent_framework._vector_filters import _PARAM_UNSET, filter_values_equal
 from agent_framework._vectors import _VectorStoreRecordHandler as VectorStoreRecordHandler
 from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
 
@@ -1833,6 +1834,37 @@ def test_filter_model_rejects_invalid_shapes() -> None:
         Filter("text", "in", ("fixed", Param("dynamic", str)))
 
 
+@pytest.mark.parametrize("required", [False, True])
+async def test_param_without_default_preserves_unset_sentinel(required: bool) -> None:
+    def copy_value(value: Any) -> Any:
+        if value is _PARAM_UNSET:
+            raise TypeError("Cannot pickle 'Sentinel' object")
+        return deepcopy(value)
+
+    with patch("agent_framework._vector_filters.deepcopy", side_effect=copy_value):
+        param = Param("tenant", str, required=required)
+        assert not param.has_default
+        assert param.default is _PARAM_UNSET
+        assert deepcopy(param) is param
+        expression = Filter("text", "eq", param)
+        assert deepcopy(expression).value is param
+
+        collection = MockCollection()
+        tool = create_vector_search_tool(collection, filter=expression)
+        schema = tool.parameters()
+        assert schema["properties"]["tenant"] == {"type": "string"}
+        assert schema["required"] == (["query", "tenant"] if required else ["query"])
+
+        await tool(query="query", tenant="acme")
+        assert collection.last_search_filter == Filter("text", "eq", "acme")
+        if required:
+            with pytest.raises(TypeError, match="Missing required.*tenant"):
+                await tool(query="query")
+        else:
+            await tool(query="query")
+            assert collection.last_search_filter is None
+
+
 def test_param_generates_native_schema_and_validates_constraints() -> None:
     param = Param(
         "category",
@@ -2332,6 +2364,8 @@ async def test_search_tool_null_omission_is_opt_in_per_parameter() -> None:
     )
 
     assert not retained.omit_if_none
+    assert retained.has_default
+    assert retained.default is None
     await tool(query="query", text=None, native=None)
     assert collection.last_search_filter == FilterGroup("and", (Filter("text", "provider.nullable", None),))
     await tool(query="query")
@@ -2429,24 +2463,39 @@ async def test_search_tool_copies_mutable_param_values_per_invocation(supply_arg
     assert supplied == ["acme"]
 
 
-async def test_search_tool_deep_copies_supplied_mapping_values() -> None:
+@pytest.mark.parametrize("supply_argument", [False, True])
+async def test_search_tool_deep_copies_mapping_values(supply_argument: bool) -> None:
     class MutatingSearch:
         async def search(
             self, values: Any, *, filter: Filter | FilterGroup | None = None, **kwargs: Any
         ) -> SearchResults[SearchResponse[Record]]:
             assert isinstance(filter, Filter)
+            assert filter.value == {"tags": ["supplied" if supply_argument else "original"]}
             filter.value["tags"].append("mutated")
             return SearchResults([])
 
+    source_default = {"tags": ["original"]}
+    param = Param("metadata", dict[str, list[str]], default=source_default)
+    source_default["tags"].append("source mutation")
+    returned_default = param.default
+    returned_default["tags"].append("access mutation")
+    assert param.has_default
+    assert param.default == {"tags": ["original"]}
+    assert deepcopy(param) is param
+
     tool = create_vector_search_tool(
         cast(SupportsVectorSearch[Record], MutatingSearch()),
-        filter=Filter("metadata", "provider.native", Param("metadata", dict[str, list[str]])),
+        filter=Filter("metadata", "provider.native", param),
     )
-    supplied = {"tags": ["original"]}
+    tool.parameters()["properties"]["metadata"]["default"]["tags"].append("schema mutation")
+    supplied = {"tags": ["supplied"]}
+    arguments = {"metadata": supplied} if supply_argument else {}
 
-    await tool(query="query", metadata=supplied)
+    await tool(query="first", **arguments)
+    await tool(query="second", **arguments)
 
-    assert supplied == {"tags": ["original"]}
+    assert supplied == {"tags": ["supplied"]}
+    assert param.default == {"tags": ["original"]}
 
 
 async def test_runtime_operations_mark_vector_store_feature_usage() -> None:


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Constructing `Param("tenant", str, required=True)` raises `TypeError: Cannot pickle 'Sentinel' object` with `typing-extensions==4.15.0`, which is inside core's supported dependency range. The unset default is an identity sentinel, but `Param` currently deep-copies it during construction and default access. This prevents parameterized vector search tools from working with that supported dependency version.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** Preserve `_PARAM_UNSET` without copying it in the `Param` constructor and `default` getter. Add a deterministic regression that rejects copying the sentinel even on newer `typing-extensions`, and extend nested mutable-default coverage across construction, access, schema generation, and repeated tool invocations.
- **What is the impact of these changes?** Required and optional parameters without defaults work with `typing-extensions` 4.15.0. Real defaults remain defensively copied; explicit `None`, required-argument errors, optional-filter omission, and `omit_if_none` behavior are unchanged. No dependency floors, package versions, lock files, or connector implementations change.
- **What do you want reviewers to focus on?** The distinction between an unset default and an explicit `None`, and preservation of mutable-default isolation while bypassing copying only for the unset sentinel.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

N/A - small compatibility correction to the vector filter APIs introduced in #8115; no standalone issue. No duplicate upstream PR is open. This supports the ongoing Phase 5 vector-connector work associated with #4167 and #1188 without closing either umbrella issue.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.