### PR TITLE
Python: Add Qdrant vector store connector

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -38,6 +38,52 @@ env:
   UV_PYTHON: "3.13"
 
 jobs:
+  python-tests-qdrant:
+    name: Python Integration Tests - Qdrant
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      qdrant:
+        image: qdrant/qdrant:v1.16.2
+        env:
+          QDRANT__TELEMETRY_DISABLED: "true"
+        ports:
+          - 6333:6333
+    env:
+      QDRANT_TEST_URL: "http://localhost:6333"
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          persist-credentials: false
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Wait for Qdrant
+        run: |
+          for i in {1..60}; do
+            if curl --fail --silent http://localhost:6333/readyz > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Qdrant did not become ready in time." >&2
+          exit 1
+      - name: Test with pytest (Qdrant integration)
+        run: uv run --directory packages/qdrant poe test-integration --junitxml=${{ github.workspace }}/python/pytest.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-qdrant
+          path: ./python/pytest.xml
+          if-no-files-found: ignore
+
   # Unit tests: all non-integration tests across all packages
   python-tests-unit:
     name: Python Integration Tests - Unit
@@ -490,6 +536,7 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
+        python-tests-qdrant,
         python-tests-github-copilot,
       ]
     runs-on: ubuntu-latest
@@ -554,6 +601,7 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
+        python-tests-qdrant,
         python-tests-github-copilot
       ]
     steps:

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -39,6 +39,7 @@ jobs:
       foundryChanged: ${{ steps.filter.outputs.foundry }}
       foundryHostingChanged: ${{ steps.filter.outputs.foundry_hosting }}
       cosmosChanged: ${{ steps.filter.outputs.cosmos }}
+      qdrantChanged: ${{ steps.filter.outputs.qdrant }}
       githubCopilotChanged: ${{ steps.filter.outputs.github_copilot }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -84,6 +85,10 @@ jobs:
               - 'python/packages/foundry_hosting/**'
             cosmos:
               - 'python/packages/azure-cosmos/**'
+            qdrant:
+              - 'python/packages/qdrant/**'
+              - '.github/workflows/python-merge-tests.yml'
+              - '.github/workflows/python-integration-tests.yml'
             github_copilot:
               - 'python/packages/github_copilot/**'
       # run only if 'python' files were changed
@@ -94,6 +99,55 @@ jobs:
       - name: not python tests
         if: steps.filter.outputs.python != 'true'
         run: echo "NOT python file"
+  python-tests-qdrant:
+    name: Python Integration Tests - Qdrant
+    needs: paths-filter
+    if: >
+      needs.paths-filter.outputs.pythonChanges == 'true' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+       needs.paths-filter.outputs.qdrantChanged == 'true' ||
+       needs.paths-filter.outputs.coreChanged == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      qdrant:
+        image: qdrant/qdrant:v1.16.2
+        env:
+          QDRANT__TELEMETRY_DISABLED: "true"
+        ports:
+          - 6333:6333
+    env:
+      QDRANT_TEST_URL: "http://localhost:6333"
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Wait for Qdrant
+        run: |
+          for i in {1..60}; do
+            if curl --fail --silent http://localhost:6333/readyz > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Qdrant did not become ready in time." >&2
+          exit 1
+      - name: Test with pytest (Qdrant integration)
+        run: uv run --directory packages/qdrant poe test-integration --junitxml=${{ github.workspace }}/python/pytest.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-qdrant
+          path: ./python/pytest.xml
+          if-no-files-found: ignore
+
   # Unit tests: always run all non-integration tests across all packages
   python-tests-unit:
     name: Python Tests - Unit
@@ -653,6 +707,7 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
+        python-tests-qdrant,
         python-tests-github-copilot,
       ]
     runs-on: ubuntu-latest
@@ -714,6 +769,7 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
+        python-tests-qdrant,
         python-tests-github-copilot,
       ]
     steps:

--- a/python/PACKAGE_STATUS.md
+++ b/python/PACKAGE_STATUS.md
@@ -48,6 +48,7 @@ Status is grouped into these buckets:
 | `agent-framework-openai` | `python/packages/openai` | `released` |
 | `agent-framework-orchestrations` | `python/packages/orchestrations` | `released` |
 | `agent-framework-purview` | `python/packages/purview` | `beta` |
+| `agent-framework-qdrant` | `python/packages/qdrant` | `alpha` |
 | `agent-framework-redis` | `python/packages/redis` | `beta` |
 | `agent-framework-tools` | `python/packages/tools` | `beta` |
 

--- a/python/packages/qdrant/LICENSE
+++ b/python/packages/qdrant/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/python/packages/qdrant/README.md
+++ b/python/packages/qdrant/README.md
@@ -74,6 +74,11 @@ asyncio.run(main())
 Use `get([key], include_vectors=True)` to retrieve vectors, or `delete([key])`
 to remove records. Without `include_vectors=True`, retrieval omits vectors.
 Batch writes can partially succeed if the server reports an error.
+Tuple payload values, including nested tuples, are stored as JSON arrays without
+modifying the input records. Typed models restore tuples through their registered decoder.
+
+Ordered retrieval (`order_by`) is not supported. Unordered retrieval uses bounded
+scroll pages without retaining the skipped prefix.
 
 ## Capabilities and limits
 

--- a/python/packages/qdrant/README.md
+++ b/python/packages/qdrant/README.md
@@ -86,6 +86,8 @@ scroll pages without retaining the skipped prefix.
   Arbitrary strings and automatically generated keys are not supported.
 - Multiple named dense-vector fields are supported. Binary, sparse,
   multivector-fusion, and keyword-hybrid search are not supported.
+- Vector fields must declare a floating-point element type. Qdrant stores dense
+  vectors as float32; integer-valued inputs remain valid for floating-point fields.
 - Scores and thresholds use native Qdrant units. The default is cosine
   similarity; dot product, Euclidean distance, and Manhattan distance are also supported.
 - Portable filters require a server. SDK local mode supports unfiltered storage

--- a/python/packages/qdrant/README.md
+++ b/python/packages/qdrant/README.md
@@ -1,0 +1,99 @@
+# Qdrant vector stores
+
+An alpha Qdrant integration for Microsoft Agent Framework. `QdrantCollection`
+provides async batch storage and dense-vector search, `QdrantStore` manages
+collection clients, and `QdrantSettings` handles connection configuration.
+
+## Installation
+
+```bash
+pip install agent-framework-qdrant --pre
+```
+
+Requires Python 3.10+ and Qdrant server 1.16.2+. The official async
+`qdrant-client` SDK is installed automatically.
+
+## Connection settings
+
+Set `QDRANT_URL` to your server URL and optionally `QDRANT_API_KEY` for
+authentication. If no URL is supplied, the SDK defaults to localhost.
+
+Both constructors resolve settings from explicit `url`/`api_key` arguments,
+then an optional `env_file_path`, then environment variables. API keys accept
+`str` or AF `SecretString` and are unwrapped only when creating the SDK client.
+
+You can instead pass a configured `AsyncQdrantClient` as `async_client` for
+advanced SDK options. Supplied clients bypass settings loading and remain
+caller-owned unless `managed_client=True`; connector-created clients are closed
+on async context exit.
+
+## Usage
+
+This example stores and searches a record using a supplied vector, without
+an embedding service:
+
+```python
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+from agent_framework_qdrant import QdrantStore
+
+
+@vectorstoremodel
+@dataclass
+class Document:
+    id: Annotated[int, VectorStoreField("key")]
+    title: Annotated[str, VectorStoreField("data")]
+    embedding: Annotated[
+        list[float] | None, VectorStoreField("vector", dimensions=3)
+    ] = None
+
+
+async def main() -> None:
+    async with QdrantStore() as store:
+        collection = store.get_collection(Document, collection_name="documents")
+        await collection.ensure_collection_exists()
+        await collection.upsert(
+            [Document(1, "Hello Qdrant", [1.0, 0.0, 0.0])],
+            generate_vectors=False,
+        )
+        results = await collection.search(
+            vector=[1.0, 0.0, 0.0],
+            filter=Filter("title", "eq", "Hello Qdrant"),
+            top=3,
+        )
+        async for result in results:
+            print(result["record"].title, result["score"])
+
+
+asyncio.run(main())
+```
+
+Use `get([key], include_vectors=True)` to retrieve vectors, or `delete([key])`
+to remove records. Without `include_vectors=True`, retrieval omits vectors.
+Batch writes can partially succeed if the server reports an error.
+
+## Capabilities and limits
+
+- Keys must be unsigned 64-bit integers or UUIDs (`str` or `uuid.UUID`).
+  Arbitrary strings and automatically generated keys are not supported.
+- Multiple named dense-vector fields are supported. Binary, sparse,
+  multivector-fusion, and keyword-hybrid search are not supported.
+- Scores and thresholds use native Qdrant units. The default is cosine
+  similarity; dot product, Euclidean distance, and Manhattan distance are also supported.
+- Portable filters require a server. SDK local mode supports unfiltered storage
+  and dense search, but rejects portable filters and does not build payload indexes.
+- Filters support scalar comparisons, collection membership, and AND/OR/NOT.
+  Literal text, nested-path, and array/object-equality filters are unsupported.
+  Numeric range and mixed numeric membership operands are limited to
+  `+/- (2**53-1)`; integer equality supports the full signed 64-bit range.
+
+## Documentation
+
+- [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/)
+- [Qdrant documentation](https://qdrant.tech/documentation/)
+- [Points and IDs](https://qdrant.tech/documentation/manage-data/points/)
+- [Search and metrics](https://qdrant.tech/documentation/search/search/)
+- [Filtering](https://qdrant.tech/documentation/search/filtering/)

--- a/python/packages/qdrant/agent_framework_qdrant/__init__.py
+++ b/python/packages/qdrant/agent_framework_qdrant/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Qdrant vector stores for Microsoft Agent Framework."""
+
+import importlib.metadata
+
+from ._vector_store import QdrantCollection, QdrantSettings, QdrantStore
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["QdrantCollection", "QdrantSettings", "QdrantStore", "__version__"]

--- a/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
+++ b/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
@@ -1,0 +1,883 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Async Qdrant dense-vector collections and stores."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar, Generic, cast
+from uuid import UUID
+
+from agent_framework import (
+    BaseVectorCollection,
+    BaseVectorSearch,
+    BaseVectorStore,
+    Filter,
+    FilterGroup,
+    SearchResults,
+    SearchType,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    load_settings,
+)
+from agent_framework._telemetry import FeatureIndex, mark_feature_used
+from agent_framework._vector_filters import FilterExpression
+from agent_framework._vectors import EmbeddingClient, Vector
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from qdrant_client import AsyncQdrantClient, models
+from typing_extensions import TypedDict, TypeVar
+
+KeyT = TypeVar("KeyT", default=Any)
+ModelT = TypeVar("ModelT", default=Any)
+
+
+class QdrantSettings(TypedDict, total=False):
+    """Connection settings loaded through Agent Framework's ``load_settings``.
+
+    Explicit constructor arguments take precedence over an explicitly selected
+    ``.env`` file, then environment variables prefixed with ``QDRANT_``.
+
+    Keys:
+        url: Server URL from ``QDRANT_URL``. When unset, the SDK defaults to localhost.
+        api_key: Optional API key from ``QDRANT_API_KEY``, stored as an AF ``SecretString``.
+    """
+
+    url: str | None
+    api_key: SecretString | None
+
+
+def _create_client(
+    *,
+    url: str | None,
+    api_key: str | SecretString | None,
+    env_file_path: str | None,
+    env_file_encoding: str | None,
+) -> AsyncQdrantClient:
+    settings = load_settings(
+        QdrantSettings,
+        env_prefix="QDRANT_",
+        url=url,
+        api_key=api_key,
+        env_file_path=env_file_path,
+        env_file_encoding=env_file_encoding,
+    )
+    resolved_api_key = settings.get("api_key")
+    return AsyncQdrantClient(
+        url=settings.get("url"),
+        api_key=resolved_api_key.get_secret_value() if resolved_api_key is not None else None,
+    )
+
+
+_DISTANCES = {
+    "DEFAULT": models.Distance.COSINE,
+    "cosine_similarity": models.Distance.COSINE,
+    "dot_prod": models.Distance.DOT,
+    "euclidean_distance": models.Distance.EUCLID,
+    "manhattan": models.Distance.MANHATTAN,
+}
+_PAYLOAD_INDEXES = {
+    "str": models.PayloadSchemaType.KEYWORD,
+    "int": models.PayloadSchemaType.INTEGER,
+    "float": models.PayloadSchemaType.FLOAT,
+    "bool": models.PayloadSchemaType.BOOL,
+}
+_READ_OPTIONS = {"consistency", "shard_key_selector", "timeout"}
+_WRITE_OPTIONS = {"ordering", "shard_key_selector", "timeout"}
+_BATCH_SIZE = 256
+_MAX_EXACT_INTEGER = 2**53 - 1
+_CREATE_OPTIONS = {
+    "shard_number",
+    "replication_factor",
+    "write_consistency_factor",
+    "on_disk_payload",
+    "optimizers_config",
+    "wal_config",
+    "timeout",
+}
+
+
+def _validate_operation_options(options: Mapping[str, Any] | None, allowed: set[str]) -> dict[str, Any]:
+    result = dict(options or {})
+    unknown = result.keys() - allowed
+    if unknown:
+        raise ValueError(f"Unsupported Qdrant operation option(s): {', '.join(sorted(unknown))}.")
+    return result
+
+
+def _prepare_point_id(value: Any) -> int | str:
+    """Validate and canonicalize a Qdrant point ID without hashing or coercing numbers."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        if 0 <= value <= 2**64 - 1:
+            return value
+        raise ValueError("Qdrant integer keys must be unsigned 64-bit integers.")
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, str):
+        try:
+            return str(UUID(value))
+        except ValueError as exc:
+            raise ValueError("Qdrant string keys must be UUIDs; arbitrary strings are not supported.") from exc
+    raise TypeError("Qdrant keys must be unsigned 64-bit integers or UUIDs, not booleans.")
+
+
+def _prepare_dense_vector(value: Any, name: str) -> list[float]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError(
+            f"Qdrant vector '{name}' must be a dense numeric sequence; sparse and binary vectors are unsupported."
+        )
+    result: list[float] = []
+    for item in cast(Sequence[Any], value):
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise TypeError(f"Qdrant vector '{name}' must contain numbers, not booleans.")
+        number = float(item)
+        if not math.isfinite(number) or abs(number) > 3.4028234663852886e38:
+            raise ValueError(f"Qdrant vector '{name}' must contain finite float32 values.")
+        result.append(number)
+    return result
+
+
+def _validate_payload(value: Any) -> None:
+    if value is None or isinstance(value, (str, bool)):
+        return
+    if isinstance(value, int):
+        if not -(2**63) <= value < 2**63:
+            raise ValueError("Qdrant integer payloads must be signed 64-bit integers.")
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Qdrant payload numbers must be finite.")
+        return
+    if isinstance(value, list):
+        for item in cast(list[Any], value):
+            _validate_payload(item)
+        return
+    if isinstance(value, dict):
+        for key, item in cast(dict[Any, Any], value).items():
+            if not isinstance(key, str):
+                raise TypeError("Qdrant payload object keys must be strings.")
+            _validate_payload(item)
+        return
+    raise TypeError(f"Qdrant payloads must be JSON-compatible, not {type(value).__name__}.")
+
+
+def _validate_field_payload(field: VectorStoreField, value: Any) -> None:
+    _validate_payload(value)
+    if value is None or field.type_ is None:
+        return
+    types: dict[str, tuple[type[Any], ...]] = {
+        "str": (str,),
+        "int": (int,),
+        "float": (int, float),
+        "bool": (bool,),
+        "list": (list,),
+        "tuple": (list,),
+        "set": (list,),
+        "Sequence": (list,),
+        "dict": (dict,),
+    }
+    expected = types.get(field.type_)
+    if expected is None:
+        raise NotImplementedError(f"Qdrant payload field type '{field.type_}' is not supported.")
+    if not isinstance(value, expected) or (field.type_ in {"int", "float"} and isinstance(value, bool)):
+        raise TypeError(f"Qdrant payload field '{field.name}' must have declared type '{field.type_}'.")
+
+
+def _prepare_payload_index(field: VectorStoreField) -> models.PayloadSchemaType | None:
+    configured = field.provider_annotations.get("qdrant.payload_index")
+    if configured is not None:
+        schema = models.PayloadSchemaType(configured)
+        if schema not in _PAYLOAD_INDEXES.values():
+            raise NotImplementedError("Qdrant supports keyword, integer, float and bool payload indexes here.")
+        if field.is_indexed is False:
+            raise ValueError("qdrant.payload_index cannot be combined with is_indexed=False.")
+        expected = _PAYLOAD_INDEXES.get(field.type_ or "")
+        if expected is not None and schema != expected:
+            raise ValueError(f"Qdrant payload index for '{field.name}' must match its declared type.")
+        return schema
+    if field.is_indexed:
+        if field.type_ not in _PAYLOAD_INDEXES:
+            raise ValueError(
+                f"Indexed field '{field.name}' requires a scalar type or a qdrant.payload_index annotation."
+            )
+        return _PAYLOAD_INDEXES[field.type_]
+    return None
+
+
+def _validate_update_result(result: models.UpdateResult) -> None:
+    if result.status != models.UpdateStatus.COMPLETED:
+        raise IntegrationInvalidResponseException(f"Qdrant write did not complete: {result.status}.")
+
+
+def _prepare_false_condition() -> models.HasIdCondition:
+    return models.HasIdCondition(has_id=[])
+
+
+def _prepare_presence_condition(name: str) -> models.FieldCondition:
+    # Unlike is_empty, the server's values_count distinguishes missing from null and [].
+    return models.FieldCondition(key=name, values_count=models.ValuesCount(gte=0))
+
+
+def _prepare_null_condition(name: str) -> models.IsNullCondition:
+    return models.IsNullCondition(is_null=models.PayloadField(key=name))
+
+
+def _prepare_non_null_condition(name: str) -> models.Filter:
+    return models.Filter(must=[_prepare_presence_condition(name)], must_not=[_prepare_null_condition(name)])
+
+
+def _prepare_range_operand(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("Qdrant ordered filters require numeric operands, not booleans.")
+    if not math.isfinite(value):
+        raise ValueError("Qdrant numeric filter operands must be finite.")
+    if abs(value) > _MAX_EXACT_INTEGER:
+        raise ValueError("Qdrant numeric range operands must be within +/- (2**53-1) to compare integers exactly.")
+    return float(value)
+
+
+def _prepare_equality_condition(
+    name: str,
+    value: Any,
+    field: VectorStoreField,
+    *,
+    element: bool = False,
+) -> models.Condition:
+    if value is None:
+        if element:
+            raise NotImplementedError("Qdrant collection membership with a null operand is not supported.")
+        return _prepare_null_condition(name)
+    if not isinstance(value, (str, bool, int, float)):
+        raise NotImplementedError("Qdrant equality and membership operands must be JSON scalars.")
+    kind = field.type_
+    if not element:
+        if kind not in {"str", "bool", "int", "float"}:
+            raise NotImplementedError(
+                f"Qdrant scalar equality requires a str, bool, int or float field type; '{field.name}' has {kind!r}."
+            )
+        if isinstance(value, bool):
+            if kind != "bool":
+                return _prepare_false_condition()
+        elif isinstance(value, str):
+            if kind != "str":
+                return _prepare_false_condition()
+        elif kind not in {"int", "float"}:
+            return _prepare_false_condition()
+    if isinstance(value, (str, bool)):
+        return models.FieldCondition(key=name, match=models.MatchValue(value=value))
+    if kind == "int" and not element:
+        if isinstance(value, float) and (not math.isfinite(value) or not value.is_integer()):
+            return _prepare_false_condition()
+        integer = int(value)
+        if not -(2**63) <= integer < 2**63:
+            return _prepare_false_condition()
+        return models.FieldCondition(key=name, match=models.MatchValue(value=integer))
+    number = _prepare_range_operand(value)
+    # Range also matches equal integer/float values, but never bools on the server.
+    return models.FieldCondition(key=name, range=models.Range(gte=number, lte=number))
+
+
+def _prepare_key_filter_condition(expression: Filter) -> models.Condition:
+    operator, value = expression.operator, expression.value
+    if operator in {"exists", "is_not_null"}:
+        return models.Filter(must_not=[_prepare_false_condition()])
+    if operator == "is_null" or (operator == "eq" and value is None):
+        return _prepare_false_condition()
+    if operator == "ne" and value is None:
+        return models.Filter(must_not=[_prepare_false_condition()])
+    if operator in {"eq", "ne"}:
+        condition = models.HasIdCondition(has_id=[_prepare_point_id(value)])
+    elif operator in {"in", "not_in"}:
+        condition = models.HasIdCondition(has_id=[_prepare_point_id(item) for item in value if item is not None])
+    else:
+        raise NotImplementedError(f"Qdrant key filters do not support '{operator}'.")
+    return models.Filter(must_not=[condition]) if operator in {"ne", "not_in"} else condition
+
+
+class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT, ModelT], Generic[KeyT, ModelT]):
+    """Store and search records with the official async Qdrant client.
+
+    All dense fields are named vectors. The default metric is cosine similarity
+    (larger is better), not cosine distance. Scores and thresholds retain native
+    Qdrant units. Supplied clients remain caller-owned unless explicitly managed.
+
+    Portable filters require a server: Qdrant's local emulator has different
+    null/missing and numeric matching behavior across supported SDK versions.
+    Local mode supports unfiltered CRUD and dense search.
+    """
+
+    supported_key_types: ClassVar[set[str] | None] = {"int", "str", "UUID"}
+    supported_vector_types: ClassVar[set[str] | None] = {
+        "float",
+        "float16",
+        "float32",
+        "float64",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+    }
+    supported_search_types: ClassVar[set[SearchType]] = {"vector"}
+
+    def __init__(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        async_client: AsyncQdrantClient | None = None,
+        url: str | None = None,
+        api_key: str | SecretString | None = None,
+        managed_client: bool | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a collection.
+
+        Args:
+            record_type: Registered application model, or dict with an explicit definition.
+            definition: Explicit dictionary schema.
+            collection_name: Collection name, overriding the model name.
+            embedding_generator: Default local embedding client.
+            async_client: Existing async client, borrowed by default. Use this for local mode or advanced configuration.
+            url: Server URL override; otherwise loaded from QdrantSettings, then the SDK defaults to localhost.
+            api_key: API key override as a string or SecretString; otherwise loaded from QdrantSettings.
+            managed_client: Whether to close the client. Defaults to True only for connector-created clients.
+            env_file_path: Optional .env file to load before process environment variables.
+            env_file_encoding: Encoding for the .env file; defaults to UTF-8.
+        """
+        if async_client is not None and any(
+            value is not None for value in (url, api_key, env_file_path, env_file_encoding)
+        ):
+            raise ValueError("Pass async_client or connection settings, not both.")
+        super().__init__(
+            record_type,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator,
+            managed_client=async_client is None if managed_client is None else managed_client,
+        )
+        self.async_client = (
+            async_client
+            if async_client is not None
+            else _create_client(
+                url=url,
+                api_key=api_key,
+                env_file_path=env_file_path,
+                env_file_encoding=env_file_encoding,
+            )
+        )
+        self._closed = False
+
+    def _validate_data_model(self) -> None:
+        super()._validate_data_model()
+        if self.definition.key_field.is_auto_generated:
+            raise NotImplementedError("Qdrant requires application-provided point IDs; it does not generate keys.")
+        for field in self.definition.fields:
+            unknown = field.provider_annotations.keys() - {"qdrant.payload_index"}
+            if unknown:
+                raise NotImplementedError(f"Unsupported Qdrant field annotation(s): {', '.join(sorted(unknown))}.")
+            if field.field_type == "vector":
+                if not isinstance(field.dimensions, int) or isinstance(field.dimensions, bool):
+                    raise TypeError("Qdrant vector dimensions must be an integer.")
+                if field.distance_function not in _DISTANCES:
+                    raise NotImplementedError(f"Qdrant distance function '{field.distance_function}' is not supported.")
+                if field.index_kind not in {"default", "hnsw", "flat"}:
+                    raise NotImplementedError(f"Qdrant index kind '{field.index_kind}' is not supported.")
+                if field.provider_annotations:
+                    raise ValueError("qdrant.payload_index applies only to data fields.")
+            elif field.field_type == "data":
+                name = field.storage_name or field.name
+                if any(character in name for character in '.[]"\\') or not name:
+                    raise ValueError("Qdrant payload storage names cannot contain JSON-path punctuation.")
+                if field.is_full_text_indexed:
+                    raise NotImplementedError("Qdrant full-text indexes are not part of this dense-vector connector.")
+                _prepare_payload_index(field)
+            elif field.provider_annotations:
+                raise ValueError("qdrant.payload_index applies only to data fields.")
+
+    async def collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> bool:
+        """Check whether this collection exists."""
+        _validate_operation_options(operation_options, set())
+        mark_feature_used(FeatureIndex.CORE_VECTOR_STORES)
+        return await self.async_client.collection_exists(self.collection_name)
+
+    async def ensure_collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Create the collection and payload indexes, or validate an existing dense schema."""
+        options = _validate_operation_options(operation_options, _CREATE_OPTIONS)
+        if not await self.collection_exists():
+            vectors = {
+                field.storage_name or field.name: models.VectorParams(
+                    size=cast(int, field.dimensions),
+                    distance=_DISTANCES[cast(str, field.distance_function)],
+                    hnsw_config=models.HnswConfigDiff(m=0) if field.index_kind == "flat" else None,
+                )
+                for field in self.definition.vector_fields
+            }
+            if not await self.async_client.create_collection(
+                collection_name=self.collection_name, vectors_config=vectors, **options
+            ):
+                raise IntegrationException(f"Qdrant did not create collection '{self.collection_name}'.")
+        info = await self.async_client.get_collection(self.collection_name)
+        configured = info.config.params.vectors
+        if not isinstance(configured, dict):
+            raise ValueError("QdrantCollection requires named vectors, not an unnamed-vector collection.")
+        for field in self.definition.vector_fields:
+            vector = configured.get(field.storage_name or field.name)
+            if (
+                vector is None
+                or vector.size != field.dimensions
+                or vector.distance != _DISTANCES[cast(str, field.distance_function)]
+                or vector.multivector_config is not None
+                or vector.datatype not in {None, models.Datatype.FLOAT32}
+            ):
+                raise ValueError(f"Existing Qdrant vector '{field.name}' does not match the collection definition.")
+            index_m = info.config.hnsw_config.m
+            if vector.hnsw_config is not None and vector.hnsw_config.m is not None:
+                index_m = vector.hnsw_config.m
+            if field.index_kind == "flat" and index_m != 0:
+                raise ValueError(f"Existing Qdrant vector '{field.name}' does not use a flat index.")
+            if field.index_kind == "hnsw" and index_m == 0:
+                raise ValueError(f"Existing Qdrant vector '{field.name}' does not use an HNSW index.")
+        for field in self.definition.data_fields:
+            schema = _prepare_payload_index(field)
+            if schema is not None:
+                name = field.storage_name or field.name
+                existing = info.payload_schema.get(name)
+                if existing is not None and existing.data_type != schema:
+                    raise ValueError(f"Existing Qdrant payload index '{name}' has a different type.")
+                if existing is None:
+                    _validate_update_result(
+                        await self.async_client.create_payload_index(
+                            self.collection_name,
+                            field_name=name,
+                            field_schema=schema,
+                            wait=True,
+                        )
+                    )
+
+    async def ensure_collection_deleted(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Delete this collection if it exists."""
+        options = _validate_operation_options(operation_options, {"timeout"})
+        if await self.collection_exists() and not await self.async_client.delete_collection(
+            self.collection_name, **options
+        ):
+            raise IntegrationException(f"Qdrant did not delete collection '{self.collection_name}'.")
+
+    async def aclose(self) -> None:
+        """Close an owned client once; borrowed clients are left open."""
+        if self.managed_client and not self._closed:
+            await self.async_client.close()
+            self._closed = True
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the owned client on context exit."""
+        await self.aclose()
+
+    def _serialize_dicts_to_store_models(
+        self,
+        records: Sequence[dict[str, Any]],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[models.PointStruct]:
+        points: list[models.PointStruct] = []
+        for record in records:
+            key = _prepare_point_id(record[self.definition.key_field_storage_name])
+            kind = self.definition.key_field.type_
+            if (kind == "int" and not isinstance(key, int)) or (kind in {"str", "UUID"} and not isinstance(key, str)):
+                raise TypeError(f"Qdrant key must match declared type '{kind}'.")
+            payload: dict[str, Any] = {}
+            for field in self.definition.data_fields:
+                name = field.storage_name or field.name
+                _validate_field_payload(field, record[name])
+                payload[name] = record[name]
+            vectors: dict[str, models.Vector] = {
+                field.storage_name or field.name: _prepare_dense_vector(
+                    record[field.storage_name or field.name], field.name
+                )
+                for field in self.definition.vector_fields
+                if record[field.storage_name or field.name] is not None
+            }
+            points.append(models.PointStruct(id=key, payload=payload, vector=vectors))
+        return points
+
+    def _deserialize_store_models_to_dicts(
+        self,
+        records: Sequence[Any],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for point in records:
+            if not isinstance(point, (models.Record, models.ScoredPoint)):
+                raise TypeError("Qdrant responses must contain Record or ScoredPoint values.")
+            record = dict(point.payload or {})
+            record[self.definition.key_field_storage_name] = self._prepare_result_key(point.id)
+            if point.vector is not None:
+                if not isinstance(point.vector, dict):
+                    raise IntegrationInvalidResponseException("Expected named vectors in the Qdrant response.")
+                for field in self.definition.vector_fields:
+                    name = field.storage_name or field.name
+                    record[name] = point.vector.get(name)
+            result.append(record)
+        return result
+
+    def _prepare_result_key(self, key: Any) -> KeyT:
+        return cast(KeyT, UUID(str(key)) if self.definition.key_field.type_ == "UUID" else key)
+
+    def _prepare_filter(self, filter: FilterExpression | None) -> models.Filter | None:
+        if filter is None:
+            return None
+        options = self.async_client.init_options
+        if options.get("location") == ":memory:" or options.get("path") is not None:
+            raise NotImplementedError(
+                "Portable filters require a Qdrant server; local mode differs for missing/null and numeric values."
+            )
+        return models.Filter(must=[self._prepare_filter_condition(filter)])
+
+    def _prepare_filter_condition(self, expression: FilterExpression) -> models.Condition:
+        if isinstance(expression, FilterGroup):
+            children = [self._prepare_filter_condition(child) for child in expression.filters]
+            if expression.operator == "and":
+                return models.Filter(must=children)
+            if expression.operator == "or":
+                return models.Filter(should=children)
+            # NOT applies to the entire child, not separately to its constituent leaves.
+            return models.Filter(must_not=children)
+
+        field = self.definition.try_get_field(expression.field_name)
+        if field is None or "." in expression.field_name:
+            raise NotImplementedError("Qdrant filters support declared top-level logical fields only.")
+        if field.field_type == "key":
+            return _prepare_key_filter_condition(expression)
+        if field.field_type == "vector":
+            raise NotImplementedError("Portable Qdrant filters do not operate on vector fields.")
+        name = field.storage_name or field.name
+        operator, value = expression.operator, expression.value
+        if operator == "exists":
+            return _prepare_presence_condition(name)
+        if operator == "is_null":
+            return _prepare_null_condition(name)
+        if operator == "is_not_null":
+            return _prepare_non_null_condition(name)
+        if operator in {"eq", "ne"}:
+            condition = _prepare_equality_condition(name, value, field)
+            return (
+                models.Filter(must=[_prepare_presence_condition(name)], must_not=[condition])
+                if operator == "ne"
+                else condition
+            )
+        if operator in {"gt", "gte", "lt", "lte", "between"}:
+            if field.type_ not in {"int", "float"}:
+                raise NotImplementedError("Qdrant ordered comparisons require a declared int or float field.")
+            bounds = (
+                {"gte": _prepare_range_operand(value[0]), "lte": _prepare_range_operand(value[1])}
+                if operator == "between"
+                else {operator: _prepare_range_operand(value)}
+            )
+            return models.FieldCondition(key=name, range=models.Range(**bounds))
+        if operator in {"in", "not_in"}:
+            condition = (
+                models.Filter(should=[_prepare_equality_condition(name, item, field) for item in value])
+                if value
+                else _prepare_false_condition()
+            )
+            if operator == "not_in":
+                return models.Filter(must=[_prepare_non_null_condition(name)], must_not=[condition])
+            return models.Filter(must=[_prepare_non_null_condition(name), condition])
+        if operator in {"contains", "contains_any", "contains_all"}:
+            if field.type_ not in {"list", "tuple", "set", "Sequence"}:
+                raise NotImplementedError("Qdrant collection membership requires a declared collection field type.")
+            operands: Sequence[Any] = [value] if operator == "contains" else value
+            conditions = [_prepare_equality_condition(name, item, field, element=True) for item in operands]
+            if operator == "contains_all":
+                return models.Filter(must=[_prepare_non_null_condition(name), *conditions])
+            return models.Filter(should=conditions) if conditions else _prepare_false_condition()
+        raise NotImplementedError(
+            f"Qdrant does not support portable filter operator '{operator}'. "
+            "Literal text operations are not equivalent to tokenized full-text search."
+        )
+
+    async def _inner_upsert(
+        self,
+        records: Sequence[Any],
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[KeyT]:
+        options = _validate_operation_options(operation_options, _WRITE_OPTIONS)
+        if not records:
+            return []
+        for start in range(0, len(records), _BATCH_SIZE):
+            points = list(records[start : start + _BATCH_SIZE])
+            result = await self.async_client.upsert(
+                self.collection_name,
+                points=points,
+                wait=True,
+                **options,
+            )
+            _validate_update_result(result)
+        return [self._prepare_result_key(point.id) for point in records]
+
+    async def _inner_get(
+        self,
+        *,
+        keys: Sequence[KeyT] | None = None,
+        filter: FilterExpression | None = None,
+        top: int = 10,
+        skip: int = 0,
+        order_by: Mapping[str, bool] | None = None,
+        include_vectors: bool = False,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[models.Record]:
+        options = _validate_operation_options(operation_options, _READ_OPTIONS)
+        if keys is not None:
+            if order_by or skip:
+                raise ValueError("Qdrant key retrieval cannot be combined with order_by or skip.")
+            ids = [_prepare_point_id(key) for key in keys]
+            result: list[models.Record] = []
+            for start in range(0, len(ids), _BATCH_SIZE):
+                page = await self.async_client.retrieve(
+                    self.collection_name,
+                    ids=ids[start : start + _BATCH_SIZE],
+                    with_payload=True,
+                    with_vectors=include_vectors,
+                    **options,
+                )
+                result.extend(page)
+            return result
+        native_filter = self._prepare_filter(filter)
+        if order_by:
+            if len(order_by) != 1:
+                raise NotImplementedError("Qdrant retrieval supports one numeric order_by field.")
+            name, ascending = next(iter(order_by.items()))
+            if not isinstance(ascending, bool):
+                raise TypeError("order_by directions must be booleans.")
+            field = self.definition.try_get_field(name)
+            if field is None or field.field_type != "data" or field.type_ not in {"int", "float"}:
+                raise NotImplementedError("Qdrant order_by requires an indexed numeric data field.")
+            if _prepare_payload_index(field) not in {models.PayloadSchemaType.INTEGER, models.PayloadSchemaType.FLOAT}:
+                raise ValueError("Qdrant order_by requires a numeric payload index.")
+            order = models.OrderBy(
+                key=field.storage_name or field.name,
+                direction=models.Direction.ASC if ascending else models.Direction.DESC,
+            )
+            # Scroll's ordered mode has no point-ID cursor. Fetch only the requested prefix, not the collection.
+            records, _ = await self.async_client.scroll(
+                self.collection_name,
+                scroll_filter=native_filter,
+                limit=skip + top,
+                order_by=order,
+                with_payload=True,
+                with_vectors=include_vectors,
+                **options,
+            )
+            return records[skip:]
+        records: list[models.Record] = []
+        offset = None
+        remaining_skip = skip
+        while len(records) < top:
+            page, offset = await self.async_client.scroll(
+                self.collection_name,
+                scroll_filter=native_filter,
+                offset=offset,
+                limit=min(_BATCH_SIZE, remaining_skip + top - len(records)),
+                with_payload=True,
+                with_vectors=include_vectors,
+                **options,
+            )
+            discarded = min(remaining_skip, len(page))
+            remaining_skip -= discarded
+            records.extend(page[discarded:])
+            if offset is None:
+                break
+        return records
+
+    async def _inner_delete(
+        self,
+        keys: Sequence[KeyT],
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        options = _validate_operation_options(operation_options, _WRITE_OPTIONS)
+        ids: list[models.ExtendedPointId] = [_prepare_point_id(key) for key in keys]
+        for start in range(0, len(ids), _BATCH_SIZE):
+            selector = models.PointIdsList(points=ids[start : start + _BATCH_SIZE])
+            result = await self.async_client.delete(
+                self.collection_name,
+                points_selector=selector,
+                wait=True,
+                **options,
+            )
+            _validate_update_result(result)
+
+    async def _inner_search(
+        self,
+        *,
+        search_type: SearchType,
+        filter: FilterExpression | None = None,
+        values: Any | None = None,
+        vector: Vector | None = None,
+        top: int = 3,
+        skip: int = 0,
+        include_vectors: bool = False,
+        vector_property_name: str | None = None,
+        additional_property_name: str | None = None,
+        score_threshold: float | None = None,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> SearchResults[models.ScoredPoint]:
+        options = _validate_operation_options(operation_options, _READ_OPTIONS | {"search_params"})
+        if additional_property_name is not None:
+            raise NotImplementedError("Qdrant keyword-hybrid search is not supported by this connector.")
+        if vector is None:
+            raise ValueError("Qdrant search requires a dense vector or a configured embedding generator.")
+        field = self.definition.try_get_vector_field(vector_property_name)
+        if field is None:
+            raise ValueError("Qdrant search requires a declared vector field.")
+        if score_threshold is not None and (
+            isinstance(score_threshold, bool)
+            or not isinstance(score_threshold, (int, float))
+            or not math.isfinite(score_threshold)
+        ):
+            raise ValueError("Qdrant score_threshold must be a finite number.")
+        query = _prepare_dense_vector(vector, field.name)
+        native_filter = self._prepare_filter(filter)
+        response = await self.async_client.query_points(
+            self.collection_name,
+            query=query,
+            using=field.storage_name or field.name,
+            query_filter=native_filter,
+            limit=top,
+            offset=skip,
+            with_payload=True,
+            with_vectors=include_vectors,
+            score_threshold=score_threshold,
+            **options,
+        )
+        return SearchResults(response.points)
+
+    def _get_record_from_result(self, result: Any) -> models.ScoredPoint:
+        if not isinstance(result, models.ScoredPoint):
+            raise IntegrationInvalidResponseException("Expected a Qdrant ScoredPoint.")
+        return result
+
+    def _get_score_from_result(self, result: Any) -> float:
+        return self._get_record_from_result(result).score
+
+
+class QdrantStore(BaseVectorStore):
+    """Create Qdrant collection clients sharing one async connection."""
+
+    def __init__(
+        self,
+        *,
+        async_client: AsyncQdrantClient | None = None,
+        url: str | None = None,
+        api_key: str | SecretString | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        managed_client: bool | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a store.
+
+        Args:
+            async_client: Existing async client; borrowed unless managed_client=True.
+            url: Server URL override; otherwise loaded from QdrantSettings, then the SDK defaults to localhost.
+            api_key: API key override as a string or SecretString; otherwise loaded from QdrantSettings.
+            embedding_generator: Default embedding client inherited by collections.
+            managed_client: Whether to close the client. Defaults to True for connector-created clients.
+            env_file_path: Optional .env file to load before process environment variables.
+            env_file_encoding: Encoding for the .env file; defaults to UTF-8.
+        """
+        if async_client is not None and any(
+            value is not None for value in (url, api_key, env_file_path, env_file_encoding)
+        ):
+            raise ValueError("Pass async_client or connection settings, not both.")
+        super().__init__(
+            embedding_generator=embedding_generator,
+            managed_client=async_client is None if managed_client is None else managed_client,
+        )
+        self.async_client = (
+            async_client
+            if async_client is not None
+            else _create_client(
+                url=url,
+                api_key=api_key,
+                env_file_path=env_file_path,
+                env_file_encoding=env_file_encoding,
+            )
+        )
+        self._closed = False
+
+    def get_collection(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+    ) -> QdrantCollection[Any, ModelT]:
+        """Create a collection that borrows this store's client."""
+        return QdrantCollection(
+            record_type,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator if embedding_generator is not None else self.embedding_generator,
+            async_client=self.async_client,
+            managed_client=False,
+        )
+
+    async def list_collection_names(self, *, operation_options: Mapping[str, Any] | None = None) -> Sequence[str]:
+        """List collection names on the server."""
+        _validate_operation_options(operation_options, set())
+        mark_feature_used(FeatureIndex.CORE_VECTOR_STORES)
+        return [collection.name for collection in (await self.async_client.get_collections()).collections]
+
+    async def collection_exists(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> bool:
+        """Check collection existence without downloading the collection list."""
+        _validate_operation_options(operation_options, set())
+        mark_feature_used(FeatureIndex.CORE_VECTOR_STORES)
+        return await self.async_client.collection_exists(collection_name)
+
+    async def ensure_collection_deleted(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Delete a collection if it exists, applying timeout only to deletion."""
+        options = _validate_operation_options(operation_options, {"timeout"})
+        if await self.collection_exists(collection_name):
+            await self._inner_ensure_collection_deleted(collection_name, operation_options=options)
+
+    async def _inner_ensure_collection_deleted(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        options = _validate_operation_options(operation_options, {"timeout"})
+        if not await self.async_client.delete_collection(collection_name, **options):
+            raise IntegrationException(f"Qdrant did not delete collection '{collection_name}'.")
+
+    async def aclose(self) -> None:
+        """Close an owned client once, leaving borrowed clients open."""
+        if self.managed_client and not self._closed:
+            await self.async_client.close()
+            self._closed = True
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the owned client on context exit."""
+        await self.aclose()

--- a/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
+++ b/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
@@ -26,7 +26,10 @@ from agent_framework._telemetry import FeatureIndex, mark_feature_used
 from agent_framework._vector_filters import FilterExpression
 from agent_framework._vectors import EmbeddingClient, Vector
 from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from grpc import StatusCode
+from grpc.aio import AioRpcError
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import UnexpectedResponse
 from typing_extensions import TypedDict, TypeVar
 
 KeyT = TypeVar("KeyT", default=Any)
@@ -131,41 +134,43 @@ def _prepare_dense_vector(value: Any, name: str) -> list[float]:
     for item in cast(Sequence[Any], value):
         if isinstance(item, bool) or not isinstance(item, (int, float)):
             raise TypeError(f"Qdrant vector '{name}' must contain numbers, not booleans.")
-        number = float(item)
+        try:
+            number = float(item)
+        except OverflowError as exc:
+            raise ValueError(f"Qdrant vector '{name}' must contain finite float32 values.") from exc
         if not math.isfinite(number) or abs(number) > 3.4028234663852886e38:
             raise ValueError(f"Qdrant vector '{name}' must contain finite float32 values.")
         result.append(number)
     return result
 
 
-def _validate_payload(value: Any) -> None:
+def _prepare_payload(value: Any) -> Any:
     if value is None or isinstance(value, (str, bool)):
-        return
+        return value
     if isinstance(value, int):
         if not -(2**63) <= value < 2**63:
             raise ValueError("Qdrant integer payloads must be signed 64-bit integers.")
-        return
+        return value
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError("Qdrant payload numbers must be finite.")
-        return
-    if isinstance(value, list):
-        for item in cast(list[Any], value):
-            _validate_payload(item)
-        return
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_prepare_payload(item) for item in cast(Sequence[Any], value)]
     if isinstance(value, dict):
+        result: dict[str, Any] = {}
         for key, item in cast(dict[Any, Any], value).items():
             if not isinstance(key, str):
                 raise TypeError("Qdrant payload object keys must be strings.")
-            _validate_payload(item)
-        return
+            result[key] = _prepare_payload(item)
+        return result
     raise TypeError(f"Qdrant payloads must be JSON-compatible, not {type(value).__name__}.")
 
 
-def _validate_field_payload(field: VectorStoreField, value: Any) -> None:
-    _validate_payload(value)
+def _prepare_field_payload(field: VectorStoreField, value: Any) -> Any:
+    value = _prepare_payload(value)
     if value is None or field.type_ is None:
-        return
+        return value
     types: dict[str, tuple[type[Any], ...]] = {
         "str": (str,),
         "int": (int,),
@@ -182,6 +187,7 @@ def _validate_field_payload(field: VectorStoreField, value: Any) -> None:
         raise NotImplementedError(f"Qdrant payload field type '{field.type_}' is not supported.")
     if not isinstance(value, expected) or (field.type_ in {"int", "float"} and isinstance(value, bool)):
         raise TypeError(f"Qdrant payload field '{field.name}' must have declared type '{field.type_}'.")
+    return value
 
 
 def _prepare_payload_index(field: VectorStoreField) -> models.PayloadSchemaType | None:
@@ -230,7 +236,7 @@ def _prepare_non_null_condition(name: str) -> models.Filter:
 def _prepare_range_operand(value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise TypeError("Qdrant ordered filters require numeric operands, not booleans.")
-    if not math.isfinite(value):
+    if isinstance(value, float) and not math.isfinite(value):
         raise ValueError("Qdrant numeric filter operands must be finite.")
     if abs(value) > _MAX_EXACT_INTEGER:
         raise ValueError("Qdrant numeric range operands must be within +/- (2**53-1) to compare integers exactly.")
@@ -278,7 +284,24 @@ def _prepare_equality_condition(
     return models.FieldCondition(key=name, range=models.Range(gte=number, lte=number))
 
 
-def _prepare_key_filter_condition(expression: Filter) -> models.Condition:
+def _prepare_key_filter_id(value: Any, kind: str | None) -> int | str | None:
+    if isinstance(value, bool):
+        return None
+    if kind in {None, "int"} and isinstance(value, (int, float)):
+        if isinstance(value, float):
+            if not math.isfinite(value) or not value.is_integer():
+                return None
+            value = int(value)
+        return value if 0 <= value <= 2**64 - 1 else None
+    if kind in {None, "str", "UUID"} and isinstance(value, (str, UUID)):
+        try:
+            return _prepare_point_id(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _prepare_key_filter_condition(expression: Filter, field: VectorStoreField) -> models.Condition:
     operator, value = expression.operator, expression.value
     if operator in {"exists", "is_not_null"}:
         return models.Filter(must_not=[_prepare_false_condition()])
@@ -287,9 +310,12 @@ def _prepare_key_filter_condition(expression: Filter) -> models.Condition:
     if operator == "ne" and value is None:
         return models.Filter(must_not=[_prepare_false_condition()])
     if operator in {"eq", "ne"}:
-        condition = models.HasIdCondition(has_id=[_prepare_point_id(value)])
+        key = _prepare_key_filter_id(value, field.type_)
+        condition = models.HasIdCondition(has_id=[] if key is None else [key])
     elif operator in {"in", "not_in"}:
-        condition = models.HasIdCondition(has_id=[_prepare_point_id(item) for item in value if item is not None])
+        condition = models.HasIdCondition(
+            has_id=[key for item in value if (key := _prepare_key_filter_id(item, field.type_)) is not None]
+        )
     else:
         raise NotImplementedError(f"Qdrant key filters do not support '{operator}'.")
     return models.Filter(must_not=[condition]) if operator in {"ne", "not_in"} else condition
@@ -304,7 +330,7 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
 
     Portable filters require a server: Qdrant's local emulator has different
     null/missing and numeric matching behavior across supported SDK versions.
-    Local mode supports unfiltered CRUD and dense search.
+    Local mode supports unfiltered CRUD and dense search. Ordered retrieval is unsupported.
     """
 
     supported_key_types: ClassVar[set[str] | None] = {"int", "str", "UUID"}
@@ -376,6 +402,11 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
         )
         self._closed = False
 
+    @property
+    def _is_local(self) -> bool:
+        options = self.async_client.init_options
+        return options.get("location") == ":memory:" or options.get("path") is not None
+
     def _validate_data_model(self) -> None:
         super()._validate_data_model()
         if self.definition.key_field.is_auto_generated:
@@ -421,10 +452,22 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
                 )
                 for field in self.definition.vector_fields
             }
-            if not await self.async_client.create_collection(
-                collection_name=self.collection_name, vectors_config=vectors, **options
-            ):
-                raise IntegrationException(f"Qdrant did not create collection '{self.collection_name}'.")
+            try:
+                created = await self.async_client.create_collection(
+                    collection_name=self.collection_name, vectors_config=vectors, **options
+                )
+            except UnexpectedResponse as exc:
+                if exc.status_code != 409:
+                    raise
+            except AioRpcError as exc:
+                if exc.code() != StatusCode.ALREADY_EXISTS:
+                    raise
+            except ValueError as exc:
+                if not self._is_local or str(exc) != f"Collection {self.collection_name} already exists":
+                    raise
+            else:
+                if not created and not await self.collection_exists():
+                    raise IntegrationException(f"Qdrant did not create collection '{self.collection_name}'.")
         info = await self.async_client.get_collection(self.collection_name)
         configured = info.config.params.vectors
         if not isinstance(configured, dict):
@@ -496,8 +539,7 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
             payload: dict[str, Any] = {}
             for field in self.definition.data_fields:
                 name = field.storage_name or field.name
-                _validate_field_payload(field, record[name])
-                payload[name] = record[name]
+                payload[name] = _prepare_field_payload(field, record[name])
             vectors: dict[str, models.Vector] = {
                 field.storage_name or field.name: _prepare_dense_vector(
                     record[field.storage_name or field.name], field.name
@@ -535,8 +577,7 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
     def _prepare_filter(self, filter: FilterExpression | None) -> models.Filter | None:
         if filter is None:
             return None
-        options = self.async_client.init_options
-        if options.get("location") == ":memory:" or options.get("path") is not None:
+        if self._is_local:
             raise NotImplementedError(
                 "Portable filters require a Qdrant server; local mode differs for missing/null and numeric values."
             )
@@ -556,7 +597,7 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
         if field is None or "." in expression.field_name:
             raise NotImplementedError("Qdrant filters support declared top-level logical fields only.")
         if field.field_type == "key":
-            return _prepare_key_filter_condition(expression)
+            return _prepare_key_filter_condition(expression, field)
         if field.field_type == "vector":
             raise NotImplementedError("Portable Qdrant filters do not operate on vector fields.")
         name = field.storage_name or field.name
@@ -637,9 +678,13 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
         operation_options: Mapping[str, Any] | None = None,
     ) -> Sequence[models.Record]:
         options = _validate_operation_options(operation_options, _READ_OPTIONS)
+        if order_by:
+            raise NotImplementedError(
+                "Qdrant ordered retrieval is not supported. Omit order_by to use unordered retrieval."
+            )
         if keys is not None:
-            if order_by or skip:
-                raise ValueError("Qdrant key retrieval cannot be combined with order_by or skip.")
+            if skip:
+                raise ValueError("Qdrant key retrieval cannot be combined with skip.")
             ids = [_prepare_point_id(key) for key in keys]
             result: list[models.Record] = []
             for start in range(0, len(ids), _BATCH_SIZE):
@@ -653,32 +698,6 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
                 result.extend(page)
             return result
         native_filter = self._prepare_filter(filter)
-        if order_by:
-            if len(order_by) != 1:
-                raise NotImplementedError("Qdrant retrieval supports one numeric order_by field.")
-            name, ascending = next(iter(order_by.items()))
-            if not isinstance(ascending, bool):
-                raise TypeError("order_by directions must be booleans.")
-            field = self.definition.try_get_field(name)
-            if field is None or field.field_type != "data" or field.type_ not in {"int", "float"}:
-                raise NotImplementedError("Qdrant order_by requires an indexed numeric data field.")
-            if _prepare_payload_index(field) not in {models.PayloadSchemaType.INTEGER, models.PayloadSchemaType.FLOAT}:
-                raise ValueError("Qdrant order_by requires a numeric payload index.")
-            order = models.OrderBy(
-                key=field.storage_name or field.name,
-                direction=models.Direction.ASC if ascending else models.Direction.DESC,
-            )
-            # Scroll's ordered mode has no point-ID cursor. Fetch only the requested prefix, not the collection.
-            records, _ = await self.async_client.scroll(
-                self.collection_name,
-                scroll_filter=native_filter,
-                limit=skip + top,
-                order_by=order,
-                with_payload=True,
-                with_vectors=include_vectors,
-                **options,
-            )
-            return records[skip:]
         records: list[models.Record] = []
         offset = None
         remaining_skip = skip
@@ -740,12 +759,15 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
         field = self.definition.try_get_vector_field(vector_property_name)
         if field is None:
             raise ValueError("Qdrant search requires a declared vector field.")
-        if score_threshold is not None and (
-            isinstance(score_threshold, bool)
-            or not isinstance(score_threshold, (int, float))
-            or not math.isfinite(score_threshold)
-        ):
-            raise ValueError("Qdrant score_threshold must be a finite number.")
+        if score_threshold is not None:
+            if isinstance(score_threshold, bool) or not isinstance(score_threshold, (int, float)):
+                raise ValueError("Qdrant score_threshold must be a finite number.")
+            try:
+                score_threshold = float(score_threshold)
+            except OverflowError as exc:
+                raise ValueError("Qdrant score_threshold must be a finite number.") from exc
+            if not math.isfinite(score_threshold):
+                raise ValueError("Qdrant score_threshold must be a finite number.")
         query = _prepare_dense_vector(vector, field.name)
         native_filter = self._prepare_filter(filter)
         response = await self.async_client.query_points(

--- a/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
+++ b/python/packages/qdrant/agent_framework_qdrant/_vector_store.py
@@ -334,21 +334,7 @@ class QdrantCollection(BaseVectorCollection[KeyT, ModelT], BaseVectorSearch[KeyT
     """
 
     supported_key_types: ClassVar[set[str] | None] = {"int", "str", "UUID"}
-    supported_vector_types: ClassVar[set[str] | None] = {
-        "float",
-        "float16",
-        "float32",
-        "float64",
-        "int",
-        "int8",
-        "int16",
-        "int32",
-        "int64",
-        "uint8",
-        "uint16",
-        "uint32",
-        "uint64",
-    }
+    supported_vector_types: ClassVar[set[str] | None] = {"float", "float16", "float32", "float64"}
     supported_search_types: ClassVar[set[SearchType]] = {"vector"}
 
     def __init__(

--- a/python/packages/qdrant/pyproject.toml
+++ b/python/packages/qdrant/pyproject.toml
@@ -1,0 +1,67 @@
+[project]
+name = "agent-framework-qdrant"
+description = "Qdrant vector stores for Microsoft Agent Framework."
+authors = [{ name = "Microsoft", email = "af-support@microsoft.com" }]
+readme = "README.md"
+requires-python = ">=3.10"
+version = "1.0.0a260908"
+license-files = ["LICENSE"]
+urls.homepage = "https://aka.ms/agent-framework"
+urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
+urls.issues = "https://github.com/microsoft/agent-framework/issues"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+dependencies = [
+    "agent-framework-core>=1.17.0,<2",
+    "qdrant-client>=1.16.2,<2",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra -q -r fEX"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 120
+markers = [
+    "integration: marks tests as integration tests that require external services",
+]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.per-file-ignores]
+"samples/**" = ["D", "INP", "commented-out-code", "RUF", "S", "print", "CPY"]
+"tests/**" = ["D", "INP", "TD", "commented-out-code", "RUF", "S"]
+
+[tool.coverage.run]
+omit = ["**/__init__.py"]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["agent_framework_qdrant"]
+
+[tool.poe]
+executor.type = "uv"
+include = "../../shared_tasks.toml"
+
+[tool.poe.tasks.test]
+help = "Run Qdrant unit and local-mode tests."
+cmd = 'pytest -m "not integration" --cov=agent_framework_qdrant --cov-report=term-missing:skip-covered tests'
+
+[tool.poe.tasks.test-integration]
+help = "Run tests against the disposable server at QDRANT_TEST_URL."
+cmd = 'pytest -m integration tests'
+
+[build-system]
+requires = ["flit-core>=3.11,<4.0"]
+build-backend = "flit_core.buildapi"

--- a/python/packages/qdrant/samples/README.md
+++ b/python/packages/qdrant/samples/README.md
@@ -1,0 +1,11 @@
+# Qdrant samples
+
+`qdrant_vectors.py` demonstrates batch CRUD, named dense-vector selection,
+native portable filtering, and score thresholds using deterministic vectors.
+It creates and deletes its own unique collection.
+
+Run a disposable Qdrant 1.16.2+ server, set `QDRANT_URL`, and follow the
+[package README](../README.md#connection-settings). No embedding
+service is needed. Optional `QDRANT_API_KEY` is supported by the sample and
+the connector's `QdrantSettings`, which also supports explicitly selected `.env` files.
+Portable filters deliberately require a server, not `:memory:` local mode.

--- a/python/packages/qdrant/samples/qdrant_vectors.py
+++ b/python/packages/qdrant/samples/qdrant_vectors.py
@@ -1,5 +1,16 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+"""Use two named dense vectors with a disposable Qdrant server collection.
+
+Run from python/:
+    export QDRANT_URL=http://localhost:6333
+    uv run --package agent-framework-qdrant python packages/qdrant/samples/qdrant_vectors.py
+
+QDRANT_URL is required; QDRANT_API_KEY is optional. Use a development server,
+not production. No embedding model, inference service, or OpenAI credentials
+are used: the vectors are deliberately small and deterministic.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -11,18 +22,6 @@ from uuid import uuid4
 from agent_framework import Filter, VectorStoreField, vectorstoremodel
 
 from agent_framework_qdrant import QdrantStore
-
-"""
-Use two named dense vectors with a disposable Qdrant server collection.
-
-Run from python/:
-    export QDRANT_URL=http://localhost:6333
-    uv run --package agent-framework-qdrant python packages/qdrant/samples/qdrant_vectors.py
-
-QDRANT_URL is required; QDRANT_API_KEY is optional. Use a development server,
-not production. No embedding model, inference service, or OpenAI credentials
-are used: the vectors are deliberately small and deterministic.
-"""
 
 
 @vectorstoremodel

--- a/python/packages/qdrant/samples/qdrant_vectors.py
+++ b/python/packages/qdrant/samples/qdrant_vectors.py
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Annotated
+from uuid import uuid4
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+
+from agent_framework_qdrant import QdrantStore
+
+"""
+Use two named dense vectors with a disposable Qdrant server collection.
+
+Run from python/:
+    export QDRANT_URL=http://localhost:6333
+    uv run --package agent-framework-qdrant python packages/qdrant/samples/qdrant_vectors.py
+
+QDRANT_URL is required; QDRANT_API_KEY is optional. Use a development server,
+not production. No embedding model, inference service, or OpenAI credentials
+are used: the vectors are deliberately small and deterministic.
+"""
+
+
+@vectorstoremodel
+@dataclass
+class Document:
+    id: Annotated[int, VectorStoreField("key")]
+    title: Annotated[str, VectorStoreField("data", storage_name="document_title")]
+    category: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    text_vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=3, storage_name="text", distance_function="dot_prod"),
+    ] = None
+    image_vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=3, storage_name="image", distance_function="dot_prod"),
+    ] = None
+
+
+async def main() -> None:
+    # 1. The store owns its async client. Child collections borrow it.
+    async with QdrantStore(url=os.environ["QDRANT_URL"], api_key=os.getenv("QDRANT_API_KEY")) as store:
+        collection = store.get_collection(Document, collection_name=f"af_qdrant_sample_{uuid4().hex}")
+        await collection.ensure_collection_exists()
+        try:
+            # 2. Preserve supplied vectors instead of generating embeddings.
+            await collection.upsert(
+                [
+                    Document(1, "Qdrant guide", "reference", [1.0, 0.0, 0.0], [0.0, 0.5, 0.0]),
+                    Document(2, "Image guide", "reference", [0.5, 0.0, 0.0], [0.0, 1.0, 0.0]),
+                    Document(3, "Unrelated", "notes", [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]),
+                ],
+                generate_vectors=False,
+            )
+
+            # 3. The server applies the filter and threshold before paging.
+            results = await collection.search(
+                vector=[0.0, 1.0, 0.0],
+                vector_property_name="image_vector",
+                filter=Filter("category", "eq", "reference"),
+                score_threshold=0.75,
+                top=2,
+            )
+            async for result in results:
+                print(f"{result['record'].title}: {result['score']:.2f}")
+
+            # 4. Vectors are excluded from retrieval unless requested.
+            documents = await collection.get([1], include_vectors=True)
+            print(f"Text vector: {documents[0].text_vector}")
+        finally:
+            # Delete only this sample's unique collection, including on errors.
+            await collection.ensure_collection_deleted()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# Expected output:
+# Image guide: 1.00
+# Text vector: [1.0, 0.0, 0.0]

--- a/python/packages/qdrant/tests/qdrant/conftest.py
+++ b/python/packages/qdrant/tests/qdrant/conftest.py
@@ -1,0 +1,111 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from agent_framework import VectorStoreCollectionDefinition, VectorStoreField
+from qdrant_client import AsyncQdrantClient
+
+from agent_framework_qdrant import QdrantCollection
+
+SERVER_MARKS = [
+    pytest.mark.integration,
+    pytest.mark.flaky,
+    pytest.mark.skipif(not os.getenv("QDRANT_TEST_URL"), reason="Set QDRANT_TEST_URL to a disposable Qdrant server."),
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_connection_environment(monkeypatch):
+    monkeypatch.delenv("QDRANT_URL", raising=False)
+    monkeypatch.delenv("QDRANT_API_KEY", raising=False)
+
+
+@pytest.fixture(params=["local", pytest.param("server", marks=SERVER_MARKS)])
+async def client(request):
+    client = AsyncQdrantClient(
+        location=":memory:" if request.param == "local" else None,
+        url=os.getenv("QDRANT_TEST_URL") if request.param == "server" else None,
+        check_compatibility=False,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+def definition():
+    return VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int", storage_name="point_key"),
+        VectorStoreField("data", name="text", type_="str", storage_name="body"),
+        VectorStoreField("data", name="number", type_="float", storage_name="price", is_indexed=True),
+        VectorStoreField("data", name="integer", type_="int"),
+        VectorStoreField("data", name="flag", type_="bool"),
+        VectorStoreField("data", name="tags", type_="list"),
+        VectorStoreField(
+            "vector", name="embedding", storage_name="dense_text", dimensions=3, distance_function="dot_prod"
+        ),
+        VectorStoreField(
+            "vector", name="image", storage_name="dense_image", dimensions=3, distance_function="dot_prod"
+        ),
+    ])
+
+
+@pytest.fixture
+def record():
+    def make(id=1, **values):
+        return {
+            "id": id,
+            "text": "hello",
+            "number": float(id),
+            "integer": id,
+            "flag": True,
+            "tags": ["one", "two"],
+            "embedding": [1.0, 0.0, 0.0],
+            "image": [0.0, 1.0, 0.0],
+        } | values
+
+    return make
+
+
+@pytest.fixture
+async def collection_factory(client, definition):
+    names: list[str] = []
+
+    def make(record_type=dict, *, definition=definition, embedding_generator=None):
+        name = f"af_qdrant_test_{uuid4().hex}"
+        names.append(name)
+        return QdrantCollection(
+            record_type,
+            async_client=client,
+            collection_name=name,
+            definition=definition if record_type is dict else None,
+            embedding_generator=embedding_generator,
+        )
+
+    yield make
+    for name in names:
+        if await client.collection_exists(name):
+            await client.delete_collection(name)
+
+
+@pytest.fixture
+async def server_collection(definition):
+    if not os.getenv("QDRANT_TEST_URL"):
+        pytest.skip("Set QDRANT_TEST_URL to a disposable Qdrant server.")
+    async with QdrantCollection(
+        dict,
+        definition=definition,
+        collection_name=f"af_qdrant_test_{uuid4().hex}",
+        async_client=AsyncQdrantClient(url=os.environ["QDRANT_TEST_URL"], check_compatibility=False),
+        managed_client=True,
+    ) as collection:
+        await collection.ensure_collection_exists()
+        try:
+            yield collection
+        finally:
+            await collection.ensure_collection_deleted()

--- a/python/packages/qdrant/tests/qdrant/test_collection.py
+++ b/python/packages/qdrant/tests/qdrant/test_collection.py
@@ -180,6 +180,33 @@ async def test_missing_vectors_and_selective_embeddings(collection_factory, reco
     assert generator.get_embeddings.await_args.args == (["query"],)
 
 
+@pytest.mark.parametrize(
+    "vector_type",
+    ["int", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"],
+)
+def test_integer_vector_declarations_rejected_before_io(vector_type):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("vector", name="v", type_=vector_type, dimensions=2),
+    ])
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with pytest.raises(ValueError, match="must be one of"):
+        QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    client.create_collection.assert_not_awaited()
+    client.upsert.assert_not_awaited()
+
+
+async def test_integer_values_round_trip_for_float_vector_field(collection_factory):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("vector", name="v", type_="float", dimensions=2, distance_function="dot_prod"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    await collection.upsert([{"id": 1, "v": [16_777_217, 0]}], generate_vectors=False)
+    assert await collection.get([1], include_vectors=True) == [{"id": 1, "v": [16_777_216.0, 0.0]}]
+
+
 async def test_registered_models_and_custom_codecs(collection_factory):
     @vectorstoremodel
     @dataclass

--- a/python/packages/qdrant/tests/qdrant/test_collection.py
+++ b/python/packages/qdrant/tests/qdrant/test_collection.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
@@ -20,7 +21,11 @@ from agent_framework import (
     vectorstoremodel,
 )
 from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from grpc import StatusCode
+from grpc.aio import AioRpcError, Metadata
+from httpx import Headers
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import UnexpectedResponse
 
 from agent_framework_qdrant import QdrantCollection, QdrantStore
 
@@ -87,7 +92,8 @@ async def test_multiple_vectors_search_and_paging(collection_factory, record):
     assert alias[0]["record"]["id"] == 3
     assert [item["id"] for item in await collection.get(top=1, skip=1)] == [2]
     assert await collection.get(top=5, skip=999) == []
-    assert [item["id"] for item in await collection.get(order_by={"number": False}, top=1, skip=1)] == [2]
+    with pytest.raises(NotImplementedError, match="Omit order_by"):
+        await collection.get(order_by={"number": False}, top=1, skip=1)
     with pytest.raises(ValueError, match="vector field|Vector field"):
         await collection.search(vector=[1, 0, 0], vector_property_name="unknown")
 
@@ -206,6 +212,48 @@ async def test_registered_models_and_custom_codecs(collection_factory):
     await external.ensure_collection_exists()
     await external.upsert([External(7, "custom")], generate_vectors=False)
     assert (await external.get([7]))[0].text == "custom"
+
+
+async def test_tuple_payload_round_trip_and_input_ownership(collection_factory):
+    @vectorstoremodel
+    @dataclass
+    class Document:
+        id: Annotated[int, VectorStoreField("key")]
+        tags: Annotated[tuple[str, ...], VectorStoreField("data")]
+        nested: Annotated[dict[str, tuple[int, ...]], VectorStoreField("data")]
+
+    collection = collection_factory(Document)
+    await collection.ensure_collection_exists()
+    document = Document(1, ("one", "two"), {"values": (1, 2)})
+    await collection.upsert([document], generate_vectors=False)
+    assert (await collection.get([1]))[0] == document
+    assert isinstance(document.tags, tuple) and isinstance(document.nested["values"], tuple)
+    raw = (await collection.async_client.retrieve(collection.collection_name, [1]))[0]
+    assert raw.payload == {"tags": ["one", "two"], "nested": {"values": [1, 2]}}
+
+
+@pytest.mark.parametrize("field_type", ["tuple", "Sequence"])
+async def test_dictionary_tuple_payloads(collection_factory, field_type):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("data", name="values", type_=field_type),
+        VectorStoreField("data", name="nested", type_="dict"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    value = {"id": 1, "values": ("one", (2, None)), "nested": {"items": [(True, 3.0)]}}
+    await collection.upsert([value], generate_vectors=False)
+    assert await collection.get([1]) == [{"id": 1, "values": ["one", [2, None]], "nested": {"items": [[True, 3.0]]}}]
+    assert value == {"id": 1, "values": ("one", (2, None)), "nested": {"items": [(True, 3.0)]}}
+
+
+@pytest.mark.parametrize("invalid", [b"binary", math.inf, 2**63])
+async def test_nested_tuple_validation_rejects_batch_before_write(definition, record, invalid):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record(1), record(2, tags=("valid", (invalid,)))], generate_vectors=False)
+    client.upsert.assert_not_awaited()
 
 
 async def test_large_batch_multi_1536_vectors(collection_factory):
@@ -341,6 +389,56 @@ async def test_local_filters_rejected_even_on_empty_collection(definition):
             await collection.search(vector=[1, 0, 0], filter=Filter("integer", "eq", 1))
 
 
+@pytest.mark.parametrize("init_options", [{}, {"location": ":memory:"}, {"path": "local-storage"}])
+@pytest.mark.parametrize("skip", [0, 1_000_000])
+@pytest.mark.parametrize("keys", [None, [1]])
+async def test_ordering_rejected_before_io(definition, init_options, skip, keys):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = init_options
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises(NotImplementedError, match="Omit order_by"):
+        await collection.get(keys, order_by={"number": True}, skip=skip, top=600)
+    client.scroll.assert_not_awaited()
+    client.query_points.assert_not_awaited()
+    client.retrieve.assert_not_awaited()
+
+
+async def test_empty_order_by_preserves_unordered_reads(collection_factory, record):
+    collection = collection_factory()
+    await collection.ensure_collection_exists()
+    await collection.upsert([record(index) for index in range(3)], generate_vectors=False)
+    assert await collection.get(order_by={}, top=1, skip=1) == await collection.get(top=1, skip=1)
+    assert await collection.get([1], order_by={}) == await collection.get([1])
+
+
+@pytest.mark.parametrize("value", [pytest.param(10**400, id="positive"), pytest.param(-(10**400), id="negative")])
+@pytest.mark.parametrize(
+    "operation", ["upsert", "search", "range_get", "range_search", "equality", "contains", "threshold"]
+)
+async def test_oversized_numeric_inputs_raise_validation_errors(definition, record, value, operation):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = {}
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises(ValueError):
+        if operation == "upsert":
+            await collection.upsert([record(1), record(2, embedding=[value, 0, 0])], generate_vectors=False)
+        elif operation == "search":
+            await collection.search(vector=[value, 0, 0])
+        elif operation == "range_get":
+            await collection.get(filter=Filter("integer", "gte", value))
+        elif operation == "range_search":
+            await collection.search(vector=[1, 0, 0], filter=Filter("integer", "between", (0, value)))
+        elif operation == "equality":
+            await collection.get(filter=Filter("number", "eq", value))
+        elif operation == "contains":
+            await collection.get(filter=Filter("tags", "contains", value))
+        else:
+            await collection.search(vector=[1, 0, 0], score_threshold=value)
+    client.upsert.assert_not_awaited()
+    client.query_points.assert_not_awaited()
+    client.scroll.assert_not_awaited()
+
+
 async def test_unsupported_options_and_schema(definition):
     client = AsyncMock(spec=AsyncQdrantClient)
     client.init_options = {}
@@ -351,17 +449,14 @@ async def test_unsupported_options_and_schema(definition):
         await collection.search("query")
     with pytest.raises(ValueError, match="Unsupported"):
         await collection.get(operation_options={"with_payload": False})
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError, match="order_by"):
         await collection.get([1], order_by={"number": True})
     with pytest.raises(NotImplementedError):
         await collection.get(order_by={"number": True, "integer": True})
     with pytest.raises(NotImplementedError):
         await collection.get(order_by={"text": True})
-    with pytest.raises(ValueError, match="numeric payload index"):
+    with pytest.raises(NotImplementedError, match="order_by"):
         await collection.get(order_by={"integer": True})
-    with pytest.raises(TypeError):
-        invalid_order: Any = {"number": "asc"}
-        await collection.get(order_by=invalid_order)
     with pytest.raises(ValueError, match="finite"):
         await collection.search(vector=[1, 0, 0], score_threshold=math.nan)
     with pytest.raises(ValueError, match="connection settings"):
@@ -401,6 +496,101 @@ async def test_existing_collection_mismatch(collection_factory, client):
     )
     with pytest.raises(ValueError, match="does not match"):
         await collection.ensure_collection_exists()
+
+
+@pytest.mark.parametrize("matching_schema", [True, False])
+async def test_concurrent_collection_creation_validates_winning_schema(collection_factory, client, matching_schema):
+    def definition(dimensions):
+        return VectorStoreCollectionDefinition([
+            VectorStoreField("key", name="id", type_="int"),
+            VectorStoreField("vector", name="v", dimensions=dimensions),
+        ])
+
+    first = collection_factory(definition=definition(2))
+    second = QdrantCollection(
+        dict,
+        definition=definition(2 if matching_schema else 3),
+        collection_name=first.collection_name,
+        async_client=client,
+    )
+    exists = client.collection_exists
+    ready = asyncio.Event()
+    count = 0
+
+    async def check_together(name):
+        nonlocal count
+        present = await exists(name)
+        if not present and count < 2:
+            count += 1
+            if count == 2:
+                ready.set()
+            await ready.wait()
+        return present
+
+    with patch.object(client, "collection_exists", side_effect=check_together):
+        results = await asyncio.gather(
+            first.ensure_collection_exists(), second.ensure_collection_exists(), return_exceptions=True
+        )
+    if matching_schema:
+        assert results == [None, None]
+    else:
+        assert sum(result is None for result in results) == 1
+        assert sum(isinstance(result, ValueError) and "does not match" in str(result) for result in results) == 1
+
+
+@pytest.mark.parametrize("outcome", ["rest_conflict", "grpc_conflict", "false"])
+async def test_create_race_revalidates_existing_collection(collection_factory, client, outcome):
+    collection = collection_factory()
+    await collection.ensure_collection_exists()
+    error = (
+        UnexpectedResponse(409, "Conflict", b"collection already exists", Headers())
+        if outcome == "rest_conflict"
+        else AioRpcError(StatusCode.ALREADY_EXISTS, Metadata(), Metadata(), "collection already exists")
+    )
+    with (
+        patch.object(client, "collection_exists", side_effect=[False, True]),
+        patch.object(
+            client, "create_collection", return_value=False, side_effect=None if outcome == "false" else error
+        ),
+        patch.object(client, "get_collection", wraps=client.get_collection) as get_collection,
+    ):
+        await collection.ensure_collection_exists()
+        get_collection.assert_awaited_once_with(collection.collection_name)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        UnexpectedResponse(403, "Forbidden", b"not authorized", Headers()),
+        UnexpectedResponse(500, "Internal Server Error", b"failed", Headers()),
+        AioRpcError(StatusCode.PERMISSION_DENIED, Metadata(), Metadata(), "not authorized"),
+        AioRpcError(StatusCode.DEADLINE_EXCEEDED, Metadata(), Metadata(), "timed out"),
+        ValueError("invalid configuration"),
+        TimeoutError("connection timed out"),
+    ],
+)
+async def test_create_errors_are_not_reconciled(definition, error):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = {}
+    client.collection_exists.return_value = False
+    client.create_collection.side_effect = error
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises(type(error)) as result:
+        await collection.ensure_collection_exists()
+    assert result.value is error
+    client.get_collection.assert_not_awaited()
+
+
+async def test_conflict_does_not_hide_missing_collection(definition):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.collection_exists.return_value = False
+    client.create_collection.side_effect = UnexpectedResponse(409, "Conflict", b"already exists", Headers())
+    missing = UnexpectedResponse(404, "Not Found", b"collection is absent", Headers())
+    client.get_collection.side_effect = missing
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises(UnexpectedResponse) as result:
+        await collection.ensure_collection_exists()
+    assert result.value is missing
 
 
 @pytest.mark.parametrize("configuration", ["uint8", "flat"])

--- a/python/packages/qdrant/tests/qdrant/test_collection.py
+++ b/python/packages/qdrant/tests/qdrant/test_collection.py
@@ -1,0 +1,528 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Annotated, Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from agent_framework import (
+    Embedding,
+    Filter,
+    GeneratedEmbeddings,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    register_vectorstoremodel,
+    vectorstoremodel,
+)
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from qdrant_client import AsyncQdrantClient, models
+
+from agent_framework_qdrant import QdrantCollection, QdrantStore
+
+
+async def test_lifecycle_crud_aliases_vectors(collection_factory, client, record):
+    collection = collection_factory()
+    store = QdrantStore(async_client=client)
+    assert not await collection.collection_exists()
+    assert await collection.get([]) == []
+    assert await collection.upsert([], generate_vectors=False) == []
+    await collection.delete([])
+    await collection.ensure_collection_deleted()
+    await collection.ensure_collection_exists()
+    await collection.ensure_collection_exists()
+    assert await store.collection_exists(collection.collection_name)
+    assert collection.collection_name in await store.list_collection_names()
+    assert await collection.get() == []
+    assert [item async for item in await collection.search(vector=[1, 0, 0])] == []
+    values = [record(1), record(2, text="' OR 1=1; [x] \\\\ \"* % _")]
+    assert await collection.upsert(values, generate_vectors=False) == [1, 2]
+    loaded = sorted(await collection.get([1, 2, 999], include_vectors=True), key=lambda item: item["id"])
+    assert loaded == values
+    assert all("embedding" not in item and "image" not in item for item in await collection.get([1, 2]))
+    raw = (await client.retrieve(collection.collection_name, [1], with_vectors=True))[0]
+    assert "body" in raw.payload and "text" not in raw.payload and "point_key" not in raw.payload
+    assert set(raw.vector) == {"dense_text", "dense_image"}
+    await collection.upsert([record(1, text="replacement")], generate_vectors=False)
+    assert (await collection.get([1]))[0]["text"] == "replacement"
+    await collection.delete([1, 999])
+    assert await collection.get([1]) == []
+    await store.ensure_collection_deleted(collection.collection_name, operation_options={"timeout": 10})
+    await store.ensure_collection_deleted(collection.collection_name)
+    assert not await collection.collection_exists()
+
+
+async def test_multiple_vectors_search_and_paging(collection_factory, record):
+    collection = collection_factory()
+    await collection.ensure_collection_exists()
+    await collection.upsert(
+        [
+            record(1, embedding=[3.0, 0, 0], image=[0.0, 1.0, 0.0]),
+            record(2, embedding=[2.0, 0, 0], image=[0.0, 2.0, 0.0]),
+            record(3, embedding=[1.0, 0, 0], image=[0.0, 3.0, 0.0]),
+        ],
+        generate_vectors=False,
+    )
+    first = [item async for item in await collection.search(vector=[1, 0, 0], top=2, skip=1, include_vectors=True)]
+    assert [item["record"]["id"] for item in first] == [2, 3]
+    assert [item["score"] for item in first] == [2, 1]
+    assert first[0]["record"]["embedding"] == [2, 0, 0]
+    second = [
+        item
+        async for item in await collection.search(
+            vector=[0, 1, 0],
+            vector_property_name="image",
+            score_threshold=2.5,
+        )
+    ]
+    assert [item["record"]["id"] for item in second] == [3]
+    assert "image" not in second[0]["record"]
+    alias = [
+        item async for item in await collection.search(vector=[0, 1, 0], vector_property_name="dense_image", top=1)
+    ]
+    assert alias[0]["record"]["id"] == 3
+    assert [item["id"] for item in await collection.get(top=1, skip=1)] == [2]
+    assert await collection.get(top=5, skip=999) == []
+    assert [item["id"] for item in await collection.get(order_by={"number": False}, top=1, skip=1)] == [2]
+    with pytest.raises(ValueError, match="vector field|Vector field"):
+        await collection.search(vector=[1, 0, 0], vector_property_name="unknown")
+
+
+@pytest.mark.parametrize(
+    ("metric", "query", "threshold", "expected_score"),
+    [
+        ("DEFAULT", [1, 0, 0], 0.9, 1.0),
+        ("cosine_similarity", [1, 0, 0], 0.9, 1.0),
+        ("dot_prod", [1, 0, 0], 1.5, 2.0),
+        ("euclidean_distance", [1, 0, 0], 1.1, 1.0),
+        ("manhattan", [1, 0, 0], 1.1, 1.0),
+    ],
+)
+async def test_native_metrics_and_threshold_direction(collection_factory, metric, query, threshold, expected_score):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("vector", name="v", dimensions=3, distance_function=metric, index_kind="flat"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    await collection.upsert([{"id": 1, "v": [2.0, 0, 0]}, {"id": 2, "v": [-3.0, 0, 0]}], generate_vectors=False)
+    results = [item async for item in await collection.search(vector=query, score_threshold=threshold)]
+    assert len(results) == 1 and results[0]["record"]["id"] == 1
+    assert results[0]["score"] == pytest.approx(expected_score)
+
+
+@pytest.mark.parametrize("key_type", ["int", "str", "UUID"])
+async def test_key_types_and_limits(collection_factory, key_type):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="key", storage_name="physical_key", type_=key_type),
+        VectorStoreField("data", name="text", type_="str"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    ids: list[int | str | UUID] = [0, 2**64 - 1] if key_type == "int" else [uuid4(), uuid4()]
+    if key_type == "str":
+        ids = [str(value) for value in ids]
+    assert await collection.upsert([{"key": key, "text": "test"} for key in ids], generate_vectors=False) == ids
+    assert {value["key"] for value in await collection.get(ids)} == set(ids)
+    await collection.delete(ids)
+    assert await collection.get() == []
+
+
+@pytest.mark.parametrize("invalid", [-1, 2**64, True, False, 1.0, "arbitrary", "123", None])
+async def test_invalid_keys_reject_whole_batch(definition, record, invalid):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record(1), record(invalid)], generate_vectors=False)
+    client.upsert.assert_not_awaited()
+    with pytest.raises((TypeError, ValueError)):
+        await collection.get([invalid])
+    client.retrieve.assert_not_awaited()
+    with pytest.raises(IntegrationException):
+        await collection.delete([invalid])
+    client.delete.assert_not_awaited()
+
+
+@pytest.mark.parametrize("vector", [[1, 2], [math.nan, 0, 0], [math.inf, 0, 0], [True, 0, 0], b"abc", {"indices": [0]}])
+async def test_invalid_dense_vectors_before_dispatch(definition, record, vector):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record(1), record(2, embedding=vector)], generate_vectors=False)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.search(vector=vector)
+    client.upsert.assert_not_awaited()
+    client.query_points.assert_not_awaited()
+
+
+async def test_missing_vectors_and_selective_embeddings(collection_factory, record):
+    generator = AsyncMock()
+    generator.get_embeddings.return_value = GeneratedEmbeddings([Embedding(vector=[2.0, 0, 0])])
+    collection = collection_factory(embedding_generator=generator)
+    await collection.ensure_collection_exists()
+    value = record(1, embedding="source text", image=None)
+    await collection.upsert([value], generate_vectors=["embedding"])
+    generator.get_embeddings.assert_awaited_once_with(["source text"], options={"dimensions": 3})
+    assert value["embedding"] == "source text"
+    loaded = (await collection.get([1], include_vectors=True))[0]
+    assert loaded["embedding"] == [2, 0, 0] and loaded["image"] is None
+    assert len([item async for item in await collection.search("query", top=1)]) == 1
+    assert generator.get_embeddings.await_args.args == (["query"],)
+
+
+async def test_registered_models_and_custom_codecs(collection_factory):
+    @vectorstoremodel
+    @dataclass
+    class Document:
+        key: Annotated[UUID, VectorStoreField("key")]
+        text: Annotated[str, VectorStoreField("data", storage_name="content")]
+        vector: Annotated[list[float] | None, VectorStoreField("vector", dimensions=2)] = None
+
+    collection = collection_factory(Document)
+    await collection.ensure_collection_exists()
+    key = uuid4()
+    assert await collection.upsert([Document(key, "hi", [1.0, 0.0])], generate_vectors=False) == [key]
+    assert (await collection.get([key]))[0] == Document(key, "hi")
+    assert (await collection.get([key], include_vectors=True))[0].vector == [1, 0]
+
+    class External:
+        def __init__(self, key, text):
+            self.key, self.text = key, text
+
+    register_vectorstoremodel(
+        External,
+        definition=VectorStoreCollectionDefinition([
+            VectorStoreField("key", name="key", type_="int"),
+            VectorStoreField("data", name="text", type_="str"),
+        ]),
+        encoder=lambda item: {"key": item.key, "text": item.text},
+        decoder=lambda item: External(item["key"], item["text"]),
+    )
+    external = collection_factory(External)
+    await external.ensure_collection_exists()
+    await external.upsert([External(7, "custom")], generate_vectors=False)
+    assert (await external.get([7]))[0].text == "custom"
+
+
+async def test_large_batch_multi_1536_vectors(collection_factory):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("vector", name="text", dimensions=1536, distance_function="dot_prod"),
+        VectorStoreField("vector", name="image", dimensions=1536, distance_function="dot_prod"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    values = [
+        {"id": index, "text": [float(index + 1), *([0.0] * 1535)], "image": [0.0, 1.0, *([0.0] * 1534)]}
+        for index in range(1000)
+    ]
+    assert await collection.upsert(values, generate_vectors=False) == list(range(1000))
+    assert len(await collection.get(list(range(1000)))) == 1000
+    results = [item async for item in await collection.search(vector=[1, *([0.0] * 1535)], top=1)]
+    assert results[0]["record"]["id"] == 999
+    page = await collection.get(top=4, skip=510)
+    assert [item["id"] for item in page] == [510, 511, 512, 513]
+    await collection.delete(list(range(1000)))
+    assert await collection.get() == []
+
+
+async def test_client_ownership(definition):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    async with (
+        QdrantStore(async_client=client) as store,
+        store.get_collection(dict, definition=definition, collection_name="test"),
+    ):
+        pass
+    client.close.assert_not_awaited()
+    async with QdrantStore(async_client=client, managed_client=True) as owner:
+        pass
+    await owner.aclose()
+    client.close.assert_awaited_once()
+    client.reset_mock()
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client):
+        async with QdrantCollection(
+            dict, definition=definition, collection_name="test", url="http://localhost:6333"
+        ) as c:
+            pass
+        await c.aclose()
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize("route", ["collection", "store"])
+@pytest.mark.parametrize(
+    ("api_key", "expected"),
+    [
+        pytest.param(None, None, id="none"),
+        pytest.param("test-api-key", "test-api-key", id="string"),
+        pytest.param(SecretString("test-api-key"), "test-api-key", id="framework-secret"),
+        pytest.param("", "", id="empty-string"),
+        pytest.param(SecretString(""), "", id="empty-framework-secret"),
+    ],
+)
+async def test_api_key_unwrapped_at_sdk_boundary(
+    definition,
+    route: str,
+    api_key: str | SecretString | None,
+    expected: str | None,
+):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        connector: QdrantCollection | QdrantStore
+        if route == "collection":
+            connector = QdrantCollection(
+                dict,
+                definition=definition,
+                collection_name="test",
+                url="https://qdrant.example",
+                api_key=api_key,
+            )
+        else:
+            connector = QdrantStore(url="https://qdrant.example", api_key=api_key)
+        factory.assert_called_once_with(url="https://qdrant.example", api_key=expected)
+        assert connector.async_client is client
+        await connector.aclose()
+        client.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize("route", ["collection", "store"])
+@pytest.mark.parametrize("api_key", [SecretString("test-api-key"), SecretString("")])
+def test_api_key_rejected_with_supplied_client(definition, route: str, api_key: SecretString):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with (
+        patch("agent_framework_qdrant._vector_store.AsyncQdrantClient") as factory,
+        pytest.raises(ValueError, match="connection settings"),
+    ):
+        if route == "collection":
+            QdrantCollection(
+                dict,
+                definition=definition,
+                collection_name="test",
+                async_client=client,
+                api_key=api_key,
+            )
+        else:
+            QdrantStore(async_client=client, api_key=api_key)
+    factory.assert_not_called()
+
+
+async def test_failed_and_partial_batches(definition, record):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    client.upsert.return_value = models.UpdateResult(status=models.UpdateStatus.ACKNOWLEDGED, operation_id=1)
+    with pytest.raises(IntegrationInvalidResponseException, match="did not complete"):
+        await collection.upsert([record()], generate_vectors=False)
+    client.upsert.side_effect = [
+        models.UpdateResult(status=models.UpdateStatus.COMPLETED, operation_id=1),
+        RuntimeError("server batch failure"),
+    ]
+    client.upsert.reset_mock()
+    with pytest.raises(IntegrationException, match="server batch failure"):
+        await collection.upsert([record(index) for index in range(300)], generate_vectors=False)
+    assert client.upsert.await_count == 2
+    assert all(call.kwargs["wait"] for call in client.upsert.await_args_list)
+
+
+async def test_local_filters_rejected_even_on_empty_collection(definition):
+    async with QdrantCollection(
+        dict,
+        definition=definition,
+        collection_name="test",
+        async_client=AsyncQdrantClient(":memory:"),
+        managed_client=True,
+    ) as collection:
+        await collection.ensure_collection_exists()
+        with pytest.raises(NotImplementedError, match="server"):
+            await collection.get(filter=Filter("text", "eq", "hi"))
+        with pytest.raises(NotImplementedError, match="server"):
+            await collection.search(vector=[1, 0, 0], filter=Filter("integer", "eq", 1))
+
+
+async def test_unsupported_options_and_schema(definition):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = {}
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises(NotImplementedError):
+        await collection.search("query", search_type="keyword_hybrid")
+    with pytest.raises(ValueError, match="dense vector"):
+        await collection.search("query")
+    with pytest.raises(ValueError, match="Unsupported"):
+        await collection.get(operation_options={"with_payload": False})
+    with pytest.raises(ValueError):
+        await collection.get([1], order_by={"number": True})
+    with pytest.raises(NotImplementedError):
+        await collection.get(order_by={"number": True, "integer": True})
+    with pytest.raises(NotImplementedError):
+        await collection.get(order_by={"text": True})
+    with pytest.raises(ValueError, match="numeric payload index"):
+        await collection.get(order_by={"integer": True})
+    with pytest.raises(TypeError):
+        invalid_order: Any = {"number": "asc"}
+        await collection.get(order_by=invalid_order)
+    with pytest.raises(ValueError, match="finite"):
+        await collection.search(vector=[1, 0, 0], score_threshold=math.nan)
+    with pytest.raises(ValueError, match="connection settings"):
+        QdrantStore(async_client=client, url="http://localhost")
+    with pytest.raises(ValueError, match="connection settings"):
+        QdrantCollection(
+            dict, definition=definition, collection_name="test", async_client=client, url="http://localhost"
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"distance_function": "cosine_distance"},
+        {"distance_function": "euclidean_squared_distance"},
+        {"distance_function": "negative_dot_prod"},
+        {"distance_function": "hamming"},
+        {"index_kind": "ivf_flat"},
+        {"type_": "bytes"},
+        {"provider_annotations": {"qdrant.fusion": True}},
+    ],
+)
+def test_unsupported_vector_definitions(kwargs):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id"),
+        VectorStoreField("vector", name="v", dimensions=3, **kwargs),
+    ])
+    with pytest.raises((ValueError, NotImplementedError)):
+        QdrantCollection(dict, definition=definition, collection_name="test")
+
+
+async def test_existing_collection_mismatch(collection_factory, client):
+    collection = collection_factory()
+    await client.create_collection(
+        collection.collection_name,
+        vectors_config={"dense_text": models.VectorParams(size=4, distance=models.Distance.DOT)},
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        await collection.ensure_collection_exists()
+
+
+@pytest.mark.parametrize("configuration", ["uint8", "flat"])
+async def test_existing_vector_datatype_and_index_mismatch(collection_factory, client, configuration):
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("vector", name="v", dimensions=3, distance_function="dot_prod", index_kind="hnsw"),
+    ])
+    collection = collection_factory(definition=definition)
+    await client.create_collection(
+        collection.collection_name,
+        vectors_config={
+            "v": models.VectorParams(
+                size=3,
+                distance=models.Distance.DOT,
+                datatype=models.Datatype.UINT8 if configuration == "uint8" else None,
+                hnsw_config=models.HnswConfigDiff(m=0) if configuration == "flat" else None,
+            )
+        },
+    )
+    with pytest.raises(ValueError, match="does not"):
+        await collection.ensure_collection_exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("integer", 2**63),
+        ("integer", True),
+        ("number", math.nan),
+        ("flag", 1),
+        ("tags", "not an array"),
+        ("text", b"binary"),
+    ],
+)
+async def test_payload_validation_before_any_write(definition, record, field, value):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record(1), record(2, **{field: value})], generate_vectors=False)
+    client.upsert.assert_not_awaited()
+
+
+async def test_json_objects_arrays_and_array_like_vectors(collection_factory):
+    import numpy as np
+
+    definition = VectorStoreCollectionDefinition([
+        VectorStoreField("key", name="id", type_="int"),
+        VectorStoreField("data", name="data", type_="dict"),
+        VectorStoreField("vector", name="v", dimensions=2, distance_function="dot_prod"),
+    ])
+    collection = collection_factory(definition=definition)
+    await collection.ensure_collection_exists()
+    payload = {"nested": [None, True, 2**63 - 1, "literal'_%*"], "empty": {}}
+    await collection.upsert([{"id": 1, "data": payload, "v": np.array([1.0, 0.0])}], generate_vectors=False)
+    assert await collection.get([1], include_vectors=True) == [{"id": 1, "data": payload, "v": [1.0, 0.0]}]
+
+
+async def test_missing_collection_errors(collection_factory):
+    collection = collection_factory()
+    with pytest.raises((ValueError, IntegrationException)):
+        await collection.get([1])
+    with pytest.raises((ValueError, IntegrationException)):
+        await collection.search(vector=[1, 0, 0])
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        VectorStoreField("key", name="id", is_auto_generated=True),
+        VectorStoreField("data", name="text", is_full_text_indexed=True),
+        VectorStoreField("data", name="text", storage_name="nested.path"),
+        VectorStoreField("data", name="text", is_indexed=True),
+        VectorStoreField("data", name="text", type_="str", provider_annotations={"qdrant.payload_index": "integer"}),
+        VectorStoreField(
+            "data", name="text", type_="str", is_indexed=False, provider_annotations={"qdrant.payload_index": "keyword"}
+        ),
+    ],
+)
+def test_invalid_data_and_key_schema(field):
+    fields = [field] if field.field_type == "key" else [VectorStoreField("key", name="id"), field]
+    with pytest.raises((NotImplementedError, ValueError)):
+        QdrantCollection(dict, definition=VectorStoreCollectionDefinition(fields), collection_name="test")
+
+
+async def test_lifecycle_failed_responses_and_options(definition):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    client.collection_exists.return_value = False
+    client.create_collection.return_value = False
+    with pytest.raises(IntegrationException, match="did not create"):
+        await collection.ensure_collection_exists()
+    client.collection_exists.return_value = True
+    client.delete_collection.return_value = False
+    with pytest.raises(IntegrationException, match="did not delete"):
+        await collection.ensure_collection_deleted()
+    store = QdrantStore(async_client=client)
+    with pytest.raises(IntegrationException, match="did not delete"):
+        await store.ensure_collection_deleted("test")
+    with pytest.raises(ValueError, match="Unsupported"):
+        await store.collection_exists("test", operation_options={"timeout": 1})
+    with pytest.raises(ValueError, match="Unsupported"):
+        await collection.ensure_collection_exists(operation_options={"vectors_config": {}})
+
+
+async def test_read_request_native_options(definition, record):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = {}
+    client.query_points.return_value.points = []
+    collection = QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+    params = models.SearchParams(exact=True)
+    await collection.search(
+        vector=[1, 0, 0],
+        top=7,
+        skip=3,
+        score_threshold=-0.5,
+        include_vectors=True,
+        filter=Filter("integer", "eq", 1),
+        operation_options={"search_params": params, "timeout": 10},
+    )
+    call = client.query_points.await_args.kwargs
+    assert call["limit"] == 7 and call["offset"] == 3 and call["score_threshold"] == -0.5
+    assert call["with_payload"] is True and call["with_vectors"] is True
+    assert call["search_params"] is params and call["timeout"] == 10
+    assert call["query_filter"] is not None and call["using"] == "dense_text"

--- a/python/packages/qdrant/tests/qdrant/test_filters.py
+++ b/python/packages/qdrant/tests/qdrant/test_filters.py
@@ -69,7 +69,7 @@ def test_reject_non_equivalent_operations(collection, expression):
         collection._prepare_filter(expression)
 
 
-@pytest.mark.parametrize("value", [2**53, -(2**53), float("inf"), True])
+@pytest.mark.parametrize("value", [2**53, -(2**53), float("inf"), True, pytest.param(10**400, id="oversized-int")])
 def test_reject_unsafe_numeric_range(collection, value):
     with pytest.raises((TypeError, ValueError)):
         collection._prepare_filter(Filter("integer", "gt", value))
@@ -82,3 +82,32 @@ def test_numeric_equality_preserves_bool_distinction(collection):
     native = collection._prepare_filter(Filter("integer", "eq", 1.0))
     assert native is not None
     assert native.model_dump(exclude_none=True) == {"must": [{"key": "integer", "match": {"value": 1}}]}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, [1]),
+        (1.0, [1]),
+        (True, []),
+        (False, []),
+        (1.5, []),
+        (-1, []),
+        ("1", []),
+        (2**53 + 1, [2**53 + 1]),
+        (2**63, [2**63]),
+        (float(2**63), [2**63]),
+        (2**64 - 1, [2**64 - 1]),
+        (float(2**64 - 1), []),
+        (2**64, []),
+        pytest.param(10**400, [], id="oversized-int"),
+    ],
+)
+@pytest.mark.parametrize("operator", ["eq", "ne", "in", "not_in"])
+def test_integer_key_filter_operand_semantics(collection, value, expected, operator):
+    expression = Filter("id", operator, [value, True, None, "invalid"] if operator in {"in", "not_in"} else value)
+    condition = collection._prepare_filter_condition(expression)
+    expected_condition = {"has_id": expected}
+    assert condition.model_dump(exclude_none=True) == (
+        {"must_not": [expected_condition]} if operator in {"ne", "not_in"} else expected_condition
+    )

--- a/python/packages/qdrant/tests/qdrant/test_filters.py
+++ b/python/packages/qdrant/tests/qdrant/test_filters.py
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from agent_framework import Filter, FilterGroup
+from agent_framework._vector_filters import validate_filter
+from qdrant_client import AsyncQdrantClient
+
+from agent_framework_qdrant import QdrantCollection
+
+
+@pytest.fixture
+def collection(definition):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    client.init_options = {}
+    return QdrantCollection(dict, definition=definition, collection_name="test", async_client=client)
+
+
+def test_group_and_negation_translation(collection):
+    expression = FilterGroup(
+        "not",
+        [
+            FilterGroup("or", [Filter("text", "eq", "x' OR true"), Filter("integer", "eq", 2**63 - 1)]),
+        ],
+    )
+    native = collection._prepare_filter(expression)
+    assert native is not None
+    assert native.model_dump(exclude_none=True) == {
+        "must": [
+            {
+                "must_not": [
+                    {
+                        "should": [
+                            {"key": "body", "match": {"value": "x' OR true"}},
+                            {"key": "integer", "match": {"value": 2**63 - 1}},
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("operator", ["starts_with", "ends_with", "contains_text", "qdrant.text", "redis.tag"])
+def test_reject_literal_text_and_unknown_namespaces(collection, operator):
+    expression = Filter("text", operator, "literal*_%'")
+    validate_filter(expression, field_names=collection.definition.names)
+    with pytest.raises(NotImplementedError, match="operator"):
+        collection._prepare_filter(expression)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        Filter("tags", "eq", ["one"]),
+        Filter("tags", "ne", ["one"]),
+        Filter("text", "contains", "one"),
+        Filter("text", "gt", "a"),
+        Filter("tags", "contains_any", [None]),
+        Filter("embedding", "exists"),
+        Filter("id", "gt", 3),
+    ],
+)
+def test_reject_non_equivalent_operations(collection, expression):
+    with pytest.raises(NotImplementedError):
+        collection._prepare_filter(expression)
+
+
+@pytest.mark.parametrize("value", [2**53, -(2**53), float("inf"), True])
+def test_reject_unsafe_numeric_range(collection, value):
+    with pytest.raises((TypeError, ValueError)):
+        collection._prepare_filter(Filter("integer", "gt", value))
+
+
+def test_numeric_equality_preserves_bool_distinction(collection):
+    native = collection._prepare_filter(Filter("integer", "eq", True))
+    assert native is not None
+    assert native.model_dump(exclude_none=True) == {"must": [{"has_id": []}]}
+    native = collection._prepare_filter(Filter("integer", "eq", 1.0))
+    assert native is not None
+    assert native.model_dump(exclude_none=True) == {"must": [{"key": "integer", "match": {"value": 1}}]}

--- a/python/packages/qdrant/tests/qdrant/test_server_filters.py
+++ b/python/packages/qdrant/tests/qdrant/test_server_filters.py
@@ -1,0 +1,187 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from agent_framework import Filter, FilterGroup, Param, create_vector_search_tool
+from agent_framework.exceptions import IntegrationInvalidResponseException
+from qdrant_client import models
+
+from agent_framework_qdrant import QdrantCollection
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.flaky,
+    pytest.mark.skipif(not os.getenv("QDRANT_TEST_URL"), reason="Set QDRANT_TEST_URL to a disposable Qdrant server."),
+]
+
+
+@pytest.fixture
+async def payload_collection(server_collection):
+    payloads = [
+        {},
+        {"body": None, "tags": None},
+        {"body": "", "tags": []},
+        {"body": "x' OR true %_*", "tags": ["one", "two"], "integer": 1, "price": 1.0, "flag": True},
+        {"body": "other", "tags": ["two", True, 1.0], "integer": 2, "price": 2.0, "flag": False},
+        {"body": "one", "tags": [None], "integer": 2**63 - 1},
+        {"body": "two", "integer": -(2**63)},
+    ]
+    await server_collection.async_client.upsert(
+        server_collection.collection_name,
+        points=[models.PointStruct(id=index, vector={}, payload=payload) for index, payload in enumerate(payloads)],
+        wait=True,
+    )
+    return server_collection
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        (Filter("text", "exists"), [1, 2, 3, 4, 5, 6]),
+        (Filter("text", "is_null"), [1]),
+        (Filter("text", "is_not_null"), [2, 3, 4, 5, 6]),
+        (Filter("text", "ne", "other"), [1, 2, 3, 5, 6]),
+        (Filter("text", "eq", "x' OR true %_*"), [3]),
+        (Filter("text", "in", ["other", None]), [4]),
+        (Filter("text", "not_in", ["other"]), [2, 3, 5, 6]),
+        (Filter("text", "not_in", []), [2, 3, 4, 5, 6]),
+        (Filter("text", "in", []), []),
+        (Filter("tags", "exists"), [1, 2, 3, 4, 5]),
+        (Filter("tags", "is_null"), [1]),
+        (Filter("tags", "is_not_null"), [2, 3, 4, 5]),
+        (Filter("tags", "contains", "two"), [3, 4]),
+        (Filter("tags", "contains", True), [4]),
+        (Filter("tags", "contains", 1), [4]),
+        (Filter("tags", "contains_any", ["one", "two"]), [3, 4]),
+        (Filter("tags", "contains_any", []), []),
+        (Filter("tags", "contains_all", ["one", "two"]), [3]),
+        (Filter("tags", "contains_all", []), [2, 3, 4, 5]),
+        (Filter("integer", "eq", 2**63 - 1), [5]),
+        (Filter("integer", "ne", 2**63 - 1), [3, 4, 6]),
+        (Filter("integer", "eq", -(2**63)), [6]),
+        (Filter("integer", "eq", 1.0), [3]),
+        (Filter("integer", "eq", True), []),
+        (Filter("flag", "eq", 1), []),
+        (Filter("flag", "eq", True), [3]),
+        (Filter("number", "eq", 1), [3]),
+        (Filter("number", "gt", 1), [4]),
+        (Filter("number", "gte", 1), [3, 4]),
+        (Filter("number", "lt", 2), [3]),
+        (Filter("number", "lte", 2), [3, 4]),
+        (Filter("number", "between", (1, 2)), [3, 4]),
+        (Filter("integer", "gt", 2**53 - 1), [5]),
+        (Filter("id", "in", [0, 3]), [0, 3]),
+        (Filter("id", "not_in", [0, 3]), [1, 2, 4, 5, 6]),
+        (Filter("id", "is_null"), []),
+        (FilterGroup("not", [Filter("text", "eq", "other")]), [0, 1, 2, 3, 5, 6]),
+        (
+            FilterGroup(
+                "and",
+                [
+                    Filter("text", "exists"),
+                    FilterGroup(
+                        "or",
+                        [
+                            Filter("text", "is_null"),
+                            Filter("text", "eq", "other"),
+                        ],
+                    ),
+                ],
+            ),
+            [1, 4],
+        ),
+        (
+            FilterGroup("not", [FilterGroup("and", [Filter("integer", "gte", 1), Filter("flag", "eq", True)])]),
+            [0, 1, 2, 4, 5, 6],
+        ),
+    ],
+)
+async def test_server_native_portable_semantics(payload_collection: QdrantCollection, expression, expected):
+    collection = payload_collection
+    points, _ = await collection.async_client.scroll(
+        collection.collection_name,
+        scroll_filter=collection._prepare_filter(expression),
+        limit=100,
+    )
+    assert [point.id for point in points] == expected
+
+
+async def test_filtered_get_search_and_tool_params(server_collection, record):
+    collection = server_collection
+    await collection.upsert(
+        [
+            record(1, text="tenant-a", embedding=[3, 0, 0]),
+            record(2, text="tenant-b", embedding=[2, 0, 0]),
+            record(3, text="tenant-a", embedding=[1, 0, 0]),
+        ],
+        generate_vectors=False,
+    )
+    expression = Filter("text", "eq", "tenant-a")
+    values = await collection.get(filter=expression, top=1, skip=1, order_by={"number": True})
+    assert values[0]["id"] == 3
+    results = [item async for item in await collection.search(vector=[1, 0, 0], filter=expression, top=1, skip=1)]
+    assert results[0]["record"]["id"] == 3
+    assert [
+        item
+        async for item in await collection.search(
+            vector=[1, 0, 0],
+            filter=expression,
+            score_threshold=4,
+        )
+    ] == []
+    # A deterministic embedding client allows the actual search tool to run without an OpenAI dependency.
+    from unittest.mock import AsyncMock
+
+    from agent_framework import Embedding, GeneratedEmbeddings
+
+    generator = AsyncMock()
+    generator.get_embeddings.return_value = GeneratedEmbeddings([Embedding(vector=[1.0, 0, 0])])
+    collection.embedding_generator = generator
+    tool = create_vector_search_tool(
+        collection,
+        filter=Filter("text", "eq", Param("tenant", str, required=True)),
+        result_mapper=lambda response: response["record"]["text"],
+    )
+    response = await tool.invoke(arguments={"query": "test", "tenant": "tenant-a"})
+    assert len(response) == 2
+    assert all(content.text == "tenant-a" for content in response)
+
+    optional_tool = create_vector_search_tool(
+        collection,
+        filter=FilterGroup(
+            "and",
+            [
+                Filter("integer", "gte", 2),
+                Filter("text", "eq", Param("tenant", str | None, default=None, omit_if_none=True)),
+            ],
+        ),
+        result_mapper=lambda response: str(response["record"]["id"]),
+    )
+    assert [content.text for content in await optional_tool.invoke(arguments={"query": "test"})] == ["2", "3"]
+    assert [
+        content.text
+        for content in await optional_tool.invoke(
+            arguments={"query": "test", "tenant": "tenant-a"},
+        )
+    ] == ["3"]
+
+
+async def test_missing_payload_is_not_fabricated(payload_collection: QdrantCollection):
+    with pytest.raises(IntegrationInvalidResponseException, match="missing required"):
+        await payload_collection.get([0])
+
+
+async def test_ordering_excludes_nulls_and_pages(server_collection, record):
+    await server_collection.upsert(
+        [
+            record(1, number=None),
+            record(2, number=2.0),
+            record(3, number=1.0),
+        ],
+        generate_vectors=False,
+    )
+    assert [item["id"] for item in await server_collection.get(order_by={"number": True})] == [3, 2]
+    assert await server_collection.get(order_by={"number": True}, skip=2, top=1) == []

--- a/python/packages/qdrant/tests/qdrant/test_server_filters.py
+++ b/python/packages/qdrant/tests/qdrant/test_server_filters.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 import os
+from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
-from agent_framework import Filter, FilterGroup, Param, create_vector_search_tool
+from agent_framework import (
+    Filter,
+    FilterGroup,
+    Param,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    create_vector_search_tool,
+)
+from agent_framework._vector_filters import filter_values_equal
 from agent_framework.exceptions import IntegrationInvalidResponseException
 from qdrant_client import models
 
@@ -120,8 +130,10 @@ async def test_filtered_get_search_and_tool_params(server_collection, record):
         generate_vectors=False,
     )
     expression = Filter("text", "eq", "tenant-a")
-    values = await collection.get(filter=expression, top=1, skip=1, order_by={"number": True})
+    values = await collection.get(filter=expression, top=1, skip=1)
     assert values[0]["id"] == 3
+    with pytest.raises(NotImplementedError, match="order_by"):
+        await collection.get(filter=expression, top=1, skip=1, order_by={"number": True})
     results = [item async for item in await collection.search(vector=[1, 0, 0], filter=expression, top=1, skip=1)]
     assert results[0]["record"]["id"] == 3
     assert [
@@ -174,7 +186,7 @@ async def test_missing_payload_is_not_fabricated(payload_collection: QdrantColle
         await payload_collection.get([0])
 
 
-async def test_ordering_excludes_nulls_and_pages(server_collection, record):
+async def test_ordering_rejected_with_nulls_and_offsets(server_collection, record):
     await server_collection.upsert(
         [
             record(1, number=None),
@@ -183,5 +195,68 @@ async def test_ordering_excludes_nulls_and_pages(server_collection, record):
         ],
         generate_vectors=False,
     )
-    assert [item["id"] for item in await server_collection.get(order_by={"number": True})] == [3, 2]
-    assert await server_collection.get(order_by={"number": True}, skip=2, top=1) == []
+    for skip in (0, 2):
+        with pytest.raises(NotImplementedError, match="order_by"):
+            await server_collection.get(order_by={"number": True}, skip=skip, top=1)
+
+
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize("filtered", [True, False])
+async def test_ordered_reads_rejected_with_large_ties(server_collection, record, ascending, filtered):
+    collection = server_collection
+    ids = list(range(1000))
+    values = [record(index, number=float(index // 700), flag=index % 2 == 0) for index in reversed(ids)]
+    await collection.upsert(values, generate_vectors=False)
+    expression = Filter("flag", "eq", True) if filtered else None
+    with (
+        patch.object(collection.async_client, "scroll") as scroll,
+        patch.object(collection.async_client, "query_points") as query_points,
+    ):
+        for skip in (0, 253, 1000):
+            with pytest.raises(NotImplementedError, match="Omit order_by"):
+                await collection.get(order_by={"number": ascending}, filter=expression, top=300, skip=skip)
+        scroll.assert_not_awaited()
+        query_points.assert_not_awaited()
+    assert {item["id"] for item in await collection.get(top=1005)} == set(ids)
+
+
+@pytest.mark.parametrize("operator", ["eq", "ne", "in", "not_in"])
+async def test_portable_integer_key_filters(server_collection, record, operator):
+    collection = server_collection
+    keys = [0, 1, 2, 2**53 + 1, 2**63, 2**64 - 1]
+    await collection.upsert([record(key, integer=0, number=0.0) for key in keys], generate_vectors=False)
+    for value in [1.0, True, False, 1.5, -1, "1", 2**53 + 1, float(2**63), 2**64 - 1, float(2**64 - 1), 10**400]:
+        operands = [value, True, None, "invalid"] if operator in {"in", "not_in"} else [value]
+        expected = {
+            key
+            for key in keys
+            if any(filter_values_equal(key, operand) for operand in operands) != (operator in {"ne", "not_in"})
+        }
+        records = await collection.get(
+            filter=Filter("id", operator, operands if operator in {"in", "not_in"} else value)
+        )
+        assert {item["id"] for item in records} == expected
+
+
+@pytest.mark.parametrize("key_type", ["str", "UUID"])
+async def test_uuid_key_filters_preserve_identity(server_collection, key_type):
+    definition = VectorStoreCollectionDefinition([VectorStoreField("key", name="id", type_=key_type)])
+    collection = QdrantCollection(
+        dict,
+        definition=definition,
+        collection_name=server_collection.collection_name,
+        async_client=server_collection.async_client,
+    )
+    uuids = [uuid4(), uuid4()]
+    keys = [str(key) for key in uuids] if key_type == "str" else uuids
+    await collection.upsert([{"id": key} for key in keys], generate_vectors=False)
+    assert [item["id"] for item in await collection.get(filter=Filter("id", "eq", str(uuids[0])))] == [keys[0]]
+    assert [item["id"] for item in await collection.get(filter=Filter("id", "ne", str(uuids[0])))] == [keys[1]]
+    assert await collection.get(filter=Filter("id", "eq", 1.0)) == []
+    assert await collection.get(filter=Filter("id", "eq", True)) == []
+    assert [item["id"] for item in await collection.get(filter=Filter("id", "in", [str(uuids[0]), 1, True]))] == [
+        keys[0]
+    ]
+    assert [item["id"] for item in await collection.get(filter=Filter("id", "not_in", [str(uuids[0]), 1, True]))] == [
+        keys[1]
+    ]

--- a/python/packages/qdrant/tests/qdrant/test_settings.py
+++ b/python/packages/qdrant/tests/qdrant/test_settings.py
@@ -1,0 +1,148 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from functools import partial
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from agent_framework import SecretString, load_settings
+from qdrant_client import AsyncQdrantClient
+
+from agent_framework_qdrant import QdrantCollection, QdrantSettings, QdrantStore
+
+
+@pytest.fixture(params=["collection", "store"])
+def connector_factory(request, definition):
+    if request.param == "collection":
+        return partial(QdrantCollection, dict, definition=definition, collection_name="test")
+    return QdrantStore
+
+
+def test_settings_wrap_environment_secrets(monkeypatch):
+    monkeypatch.setenv("QDRANT_URL", "https://environment.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "environment-key")
+    settings = load_settings(QdrantSettings, env_prefix="QDRANT_")
+    assert settings["url"] == "https://environment.example"
+    secret = settings["api_key"]
+    assert isinstance(secret, SecretString)
+    assert secret.get_secret_value() == "environment-key"
+    assert "environment-key" not in repr(settings)
+
+
+async def test_constructor_uses_environment_settings(connector_factory, monkeypatch):
+    monkeypatch.setenv("QDRANT_URL", "https://environment.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "environment-key")
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        async with connector_factory():
+            pass
+    factory.assert_called_once_with(url="https://environment.example", api_key="environment-key")
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-16"])
+async def test_explicit_env_file_overrides_environment(connector_factory, monkeypatch, tmp_path, encoding):
+    monkeypatch.setenv("QDRANT_URL", "https://environment.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "environment-key")
+    env_file = tmp_path / "qdrant.env"
+    env_file.write_text("QDRANT_URL=https://file.example\nQDRANT_API_KEY=file-key\n", encoding=encoding)
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        async with connector_factory(env_file_path=str(env_file), env_file_encoding=encoding):
+            pass
+    factory.assert_called_once_with(url="https://file.example", api_key="file-key")
+
+
+@pytest.mark.parametrize(
+    ("api_key", "expected"),
+    [
+        ("explicit-key", "explicit-key"),
+        (SecretString("explicit-key"), "explicit-key"),
+        ("", ""),
+        (SecretString(""), ""),
+    ],
+)
+async def test_explicit_settings_override_file_and_environment(
+    connector_factory,
+    monkeypatch,
+    tmp_path,
+    api_key,
+    expected,
+):
+    monkeypatch.setenv("QDRANT_URL", "https://environment.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "environment-key")
+    env_file = tmp_path / "qdrant.env"
+    env_file.write_text("QDRANT_URL=https://file.example\nQDRANT_API_KEY=file-key\n", encoding="utf-8")
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        async with connector_factory(
+            url="https://explicit.example",
+            api_key=api_key,
+            env_file_path=str(env_file),
+        ):
+            pass
+    factory.assert_called_once_with(url="https://explicit.example", api_key=expected)
+
+
+async def test_none_overrides_allow_partial_file_and_environment_settings(connector_factory, monkeypatch, tmp_path):
+    monkeypatch.setenv("QDRANT_URL", "https://environment.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "environment-key")
+    env_file = tmp_path / "qdrant.env"
+    env_file.write_text("QDRANT_URL=https://file.example\n", encoding="utf-8")
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        async with connector_factory(url=None, api_key=None, env_file_path=str(env_file)):
+            pass
+    factory.assert_called_once_with(url="https://file.example", api_key="environment-key")
+
+
+async def test_absent_settings_keep_sdk_defaults_without_implicit_dotenv(connector_factory, monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("QDRANT_URL=https://file.example\nQDRANT_API_KEY=file-key\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.AsyncQdrantClient", return_value=client) as factory:
+        async with connector_factory():
+            pass
+    factory.assert_called_once_with(url=None, api_key=None)
+
+
+def test_missing_env_file_fails_before_sdk_creation(connector_factory, tmp_path):
+    with (
+        patch("agent_framework_qdrant._vector_store.AsyncQdrantClient") as factory,
+        pytest.raises(FileNotFoundError),
+    ):
+        connector_factory(env_file_path=str(tmp_path / "missing.env"))
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize("settings", [{"url": {}}, {"api_key": 123}])
+def test_invalid_settings_fail_before_sdk_creation(connector_factory, settings):
+    with (
+        patch("agent_framework_qdrant._vector_store.AsyncQdrantClient") as factory,
+        pytest.raises(ValueError, match="Invalid type for setting"),
+    ):
+        connector_factory(**settings)
+    factory.assert_not_called()
+
+
+async def test_injected_client_bypasses_environment_settings(connector_factory, monkeypatch):
+    monkeypatch.setenv("QDRANT_URL", "https://unrelated.example")
+    monkeypatch.setenv("QDRANT_API_KEY", "unrelated-key")
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with patch("agent_framework_qdrant._vector_store.load_settings") as loader:
+        async with connector_factory(async_client=client) as connector:
+            assert connector.async_client is client
+    loader.assert_not_called()
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.parametrize("settings", [{"env_file_path": "unused.env"}, {"env_file_encoding": "utf-16"}])
+def test_injected_client_rejects_explicit_env_options(connector_factory, settings):
+    client = AsyncMock(spec=AsyncQdrantClient)
+    with (
+        patch("agent_framework_qdrant._vector_store.load_settings") as loader,
+        pytest.raises(ValueError, match="connection settings"),
+    ):
+        connector_factory(async_client=client, **settings)
+    loader.assert_not_called()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -106,6 +106,7 @@ agent-framework-ollama = { workspace = true }
 agent-framework-openai = { workspace = true }
 agent-framework-orchestrations = { workspace = true }
 agent-framework-purview = { workspace = true }
+agent-framework-qdrant = { workspace = true }
 agent-framework-redis = { workspace = true }
 agent-framework-azure-contentunderstanding = { workspace = true }
 agent-framework-tools = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -60,6 +60,7 @@ members = [
     "agent-framework-openai",
     "agent-framework-orchestrations",
     "agent-framework-purview",
+    "agent-framework-qdrant",
     "agent-framework-redis",
     "agent-framework-tools",
 ]
@@ -989,6 +990,21 @@ requires-dist = [
     { name = "agent-framework-core", editable = "packages/core" },
     { name = "azure-core", specifier = ">=1.30.0,<2" },
     { name = "httpx", specifier = ">=0.27.0,<0.29" },
+]
+
+[[package]]
+name = "agent-framework-qdrant"
+version = "1.0.0a260908"
+source = { editable = "packages/qdrant" }
+dependencies = [
+    { name = "agent-framework-core" },
+    { name = "qdrant-client" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-framework-core", editable = "packages/core" },
+    { name = "qdrant-client", specifier = ">=1.16.2,<2" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Add a Qdrant connector so applications can store records and run dense-vector retrieval through Agent Framework's vector-store abstractions without implementing their own Qdrant adapter. This contributes the Qdrant portion of the broader vector-connector work tracked in #4167 and #1188.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** Add the alpha `agent-framework-qdrant` package with `QdrantCollection`, `QdrantStore`, and `QdrantSettings` implemented in one module. The connector uses the official async Qdrant client for batch CRUD, multiple named dense-vector fields, native filters, score thresholds, and paging, with unsigned 64-bit integer and UUID keys. Connection settings use AF `load_settings` and `SecretString`, and client ownership is explicit. Include package documentation, a self-contained sample, unit and real-server integration coverage, workspace registration, and dedicated Qdrant service jobs in both Python integration and merge workflows.
- **What is the impact of these changes?** Applications can opt into Qdrant-backed storage and dense-vector retrieval while retaining the existing Agent Framework collection and model APIs. Scores and thresholds remain in native Qdrant units. Portable filters preserve null-versus-missing, boolean, and integer-comparison semantics; local mode rejects portable filters rather than silently changing their behavior. Caller-supplied clients remain caller-owned unless explicitly managed. This is an additive connector package: core runtime behavior, namespace exports, and the meta-package's `all` extra are unchanged, and core request validation remains in core.
- **What do you want reviewers to focus on?** The translation of portable filters to native Qdrant conditions, particularly null/missing fields, booleans, integer boundaries, and local-mode rejection; named-vector serialization, key handling, native score thresholds, and paging; settings precedence and async client ownership; and the paired real-server CI jobs and their coverage of connector behavior.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Related to #4167 and #1188. This PR covers only the Qdrant connector; the other three connectors are being contributed in separate PRs. These are intentionally non-closing links because this partial contribution does not complete either umbrella issue. No duplicate open Qdrant PR was found before publication. The shared-issue exclusivity checklist item remains unchecked because the umbrella work spans multiple connector PRs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and the title prefix in sync automatically.