### PR TITLE
Python: Add PostgreSQL pgvector connector

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -475,6 +475,56 @@ jobs:
           path: ./python/pytest.xml
           if-no-files-found: ignore
 
+  # PostgreSQL tests use a disposable local service and need no cloud credentials.
+  python-tests-postgres:
+    name: Python Integration Tests - PostgreSQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.2-pg17@sha256:feb68f4f15446397d8cac7f4fe48fe4586de83160d1fc48b46283312d1a33966
+        env:
+          POSTGRES_PASSWORD: local_test
+          POSTGRES_DB: af_vectors_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d af_vectors_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      POSTGRES_TEST_CONNECTION_STRING: postgresql://postgres:local_test@localhost:5432/af_vectors_test
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          persist-credentials: false
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Enable pgvector in the disposable test database
+        run: >
+          docker exec "${{ job.services.postgres.id }}" psql -U postgres -d af_vectors_test
+          -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS vector'
+      - name: Test PostgreSQL integration
+        run: >
+          uv run pytest --import-mode=importlib packages/postgres/tests
+          -m integration --timeout=120 --session-timeout=900 --timeout_method thread
+          --junitxml=pytest-postgres.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-postgres
+          path: ./python/pytest-postgres.xml
+          if-no-files-found: ignore
+
   # Integration test trend report (aggregates per-job JUnit XML results)
   python-integration-test-report:
     name: Integration Test Report
@@ -491,6 +541,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-postgres,
       ]
     runs-on: ubuntu-latest
     defaults:
@@ -554,7 +605,8 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
-        python-tests-github-copilot
+        python-tests-github-copilot,
+        python-tests-postgres
       ]
     steps:
       - name: Fail workflow if tests failed

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -40,6 +40,7 @@ jobs:
       foundryHostingChanged: ${{ steps.filter.outputs.foundry_hosting }}
       cosmosChanged: ${{ steps.filter.outputs.cosmos }}
       githubCopilotChanged: ${{ steps.filter.outputs.github_copilot }}
+      postgresChanged: ${{ steps.filter.outputs.postgres }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -86,6 +87,12 @@ jobs:
               - 'python/packages/azure-cosmos/**'
             github_copilot:
               - 'python/packages/github_copilot/**'
+            postgres:
+              - 'python/packages/postgres/**'
+              - 'python/pyproject.toml'
+              - 'python/uv.lock'
+              - '.github/workflows/python-merge-tests.yml'
+              - '.github/workflows/python-integration-tests.yml'
       # run only if 'python' files were changed
       - name: python tests
         if: steps.filter.outputs.python == 'true'
@@ -638,6 +645,71 @@ jobs:
           path: ./python/pytest.xml
           if-no-files-found: ignore
 
+  # PostgreSQL tests use a disposable local service and need no cloud credentials.
+  python-tests-postgres:
+    name: Python Tests - PostgreSQL Integration
+    needs: paths-filter
+    if: >
+      needs.paths-filter.outputs.pythonChanges == 'true' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
+       needs.paths-filter.outputs.postgresChanged == 'true' ||
+       needs.paths-filter.outputs.coreChanged == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.2-pg17@sha256:feb68f4f15446397d8cac7f4fe48fe4586de83160d1fc48b46283312d1a33966
+        env:
+          POSTGRES_PASSWORD: local_test
+          POSTGRES_DB: af_vectors_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d af_vectors_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      POSTGRES_TEST_CONNECTION_STRING: postgresql://postgres:local_test@localhost:5432/af_vectors_test
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Enable pgvector in the disposable test database
+        run: >
+          docker exec "${{ job.services.postgres.id }}" psql -U postgres -d af_vectors_test
+          -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS vector'
+      - name: Test PostgreSQL integration
+        run: >
+          uv run pytest --import-mode=importlib packages/postgres/tests
+          -m integration --timeout=120 --session-timeout=900 --timeout_method thread
+          --junitxml=pytest-postgres.xml
+      - name: Surface failing tests
+        if: always()
+        uses: pmeier/pytest-results-action@fdc7f18d9934e38aca411ca9557e6577bd25ca9c # v0.9.0
+        with:
+          path: ./python/pytest-postgres.xml
+          summary: true
+          display-options: fEX
+          fail-on-empty: false
+          title: PostgreSQL integration test results
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-postgres
+          path: ./python/pytest-postgres.xml
+          if-no-files-found: ignore
+
   # Integration test trend report (aggregates per-job JUnit XML results)
   python-integration-test-report:
     name: Integration Test Report
@@ -654,6 +726,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-postgres,
       ]
     runs-on: ubuntu-latest
     defaults:
@@ -715,6 +788,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-postgres,
       ]
     steps:
       - name: Fail workflow if tests failed

--- a/python/PACKAGE_STATUS.md
+++ b/python/PACKAGE_STATUS.md
@@ -47,6 +47,7 @@ Status is grouped into these buckets:
 | `agent-framework-ollama` | `python/packages/ollama` | `beta` |
 | `agent-framework-openai` | `python/packages/openai` | `released` |
 | `agent-framework-orchestrations` | `python/packages/orchestrations` | `released` |
+| `agent-framework-postgres` | `python/packages/postgres` | `alpha` |
 | `agent-framework-purview` | `python/packages/purview` | `beta` |
 | `agent-framework-redis` | `python/packages/redis` | `beta` |
 | `agent-framework-tools` | `python/packages/tools` | `beta` |

--- a/python/packages/postgres/LICENSE
+++ b/python/packages/postgres/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/python/packages/postgres/README.md
+++ b/python/packages/postgres/README.md
@@ -1,0 +1,123 @@
+# Agent Framework PostgreSQL / pgvector
+
+Store and search vector records in PostgreSQL with this alpha integration for
+[Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/).
+The package uses Psycopg 3 and the official pgvector Python adapter.
+
+- **`PostgresCollection`** provides batch upsert, retrieval, deletion, and vector similarity search.
+- **`PostgresStore`** creates collection clients that share a connection pool.
+- **`PostgresSettings`** describes connection settings resolved by Agent Framework.
+
+## Installation
+
+```bash
+pip install agent-framework-postgres --pre
+```
+
+Requires Python 3.10+, PostgreSQL 13+, and pgvector 0.8.0+.
+Import the connector directly from `agent_framework_postgres`.
+
+## Connection setup
+
+Have your database administrator install and enable the `vector` extension and
+provide an existing schema. The extension must be visible through the connection's
+`search_path`. The connector never creates schemas, enables extensions, or changes
+server-wide configuration. `ensure_collection_exists()` explicitly creates the
+table and requested indexes; it requires the corresponding permissions and does
+not migrate existing tables.
+
+Set `POSTGRES_CONNECTION_STRING` to a PostgreSQL URI or Psycopg conninfo string,
+or pass `connection_string` to either constructor. Both accept a string or AF
+`SecretString`. Settings precedence is **explicit argument > selected `.env`
+file > environment**. Select a file with `env_file_path` and optional
+`env_file_encoding`; missing or empty connection strings are rejected.
+The `schema` argument defaults to `public`.
+
+A connector-created pool is closed by `close()` or an async context manager.
+Alternatively, inject an open Psycopg `AsyncConnection` or `AsyncConnectionPool`
+using `client`; it remains caller-owned and bypasses settings loading.
+Injected clients cannot be combined with connection-string or `.env` options.
+Collections created by a store borrow its pool, so keep the store open while
+using them.
+
+## Example
+
+With `POSTGRES_CONNECTION_STRING` configured, create a typed collection and
+search using precomputed embeddings:
+
+```python
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+from agent_framework_postgres import PostgresStore
+
+
+@vectorstoremodel(collection_name="articles")
+@dataclass
+class Article:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data")]
+    embedding: Annotated[list[float] | None, VectorStoreField("vector", dimensions=3)] = None
+
+
+async def main() -> None:
+    async with PostgresStore() as store:
+        collection = store.get_collection(Article)
+        await collection.ensure_collection_exists()
+        await collection.upsert(
+            [
+                Article("1", "PostgreSQL supports vectors", [1, 0, 0]),
+                Article("2", "A travel journal", [0, 1, 0]),
+            ],
+            generate_vectors=False,
+        )
+        results = await collection.search(
+            vector=[1, 0, 0],
+            filter=Filter("text", "contains_text", "PostgreSQL"),
+            score_threshold=0.25,
+            top=3,
+        )
+        async for result in results:
+            print(result["record"].text, result["score"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Pass `generate_vectors=False` to preserve supplied embeddings. To generate them
+locally, configure an `embedding_generator`. Retrieval excludes embeddings by
+default; use `include_vectors=True` to return them.
+
+## Capabilities and limits
+
+The connector supports typed models, string/integer/UUID keys (including generated
+keys), multiple nullable vector columns, storage aliases, and database-side
+filters and paging. Batch writes are transactional; an existing transaction on
+an injected connection remains under the caller's commit control.
+
+Exact search is the default. HNSW and IVFFlat are optional approximate indexes;
+selective filters can reduce their recall. Use
+`operation_options={"exact": True}` when complete recall is required.
+IVFFlat needs data before index creation: first call
+`ensure_collection_exists(operation_options={"create_indexes": False})`, load
+records, then call `ensure_collection_exists()` again.
+Storage supports up to 16,000 dimensions; ANN indexes support up to 2,000 for
+`vector` and 4,000 for `halfvec`.
+
+Scores use the selected metric's units, not probabilities. The default is cosine
+distance, where lower is better and `score_threshold` is a maximum. Cosine
+similarity and dot product use minimum thresholds; negative dot product, L2, and
+L1 distances use maximum thresholds. IVFFlat does not support L1.
+
+Keyword/hybrid/full-text search, sparse/binary vectors, nested filter paths,
+schema migration, and server-side embedding generation are not supported.
+
+## Documentation
+
+- [Microsoft Agent Framework documentation](https://learn.microsoft.com/agent-framework/)
+- [PostgreSQL documentation](https://www.postgresql.org/docs/current/)
+- [pgvector setup, indexes, and distance functions](https://github.com/pgvector/pgvector)
+- [Psycopg connection pools](https://www.psycopg.org/psycopg3/docs/advanced/pool.html)

--- a/python/packages/postgres/README.md
+++ b/python/packages/postgres/README.md
@@ -98,9 +98,18 @@ keys), multiple nullable vector columns, storage aliases, and database-side
 filters and paging. Batch writes are transactional; an existing transaction on
 an injected connection remains under the caller's commit control.
 
+Vector fields support `float`, `float32`, and `float16` declarations. PostgreSQL
+`vector` storage uses 32-bit floats; `float16` defaults to 16-bit `halfvec`.
+The `postgres.vector_type` provider annotation explicitly selects either storage
+type. Ordinary Python floats and integer-valued elements are accepted and rounded
+to the selected precision; declared `int` and `float64` vector fields are rejected.
+
 Exact search is the default. HNSW and IVFFlat are optional approximate indexes;
 selective filters can reduce their recall. Use
 `operation_options={"exact": True}` when complete recall is required.
+`exact=False` requires an HNSW or IVFFlat field. Result metadata's `approximate`
+flag identifies ANN-permitted query mode, not proof that PostgreSQL used an ANN
+index.
 IVFFlat needs data before index creation: first call
 `ensure_collection_exists(operation_options={"create_indexes": False})`, load
 records, then call `ensure_collection_exists()` again.

--- a/python/packages/postgres/README.md
+++ b/python/packages/postgres/README.md
@@ -104,6 +104,14 @@ The `postgres.vector_type` provider annotation explicitly selects either storage
 type. Ordinary Python floats and integer-valued elements are accepted and rounded
 to the selected precision; declared `int` and `float64` vector fields are rejected.
 
+Storage precision does not determine the model's Python scalar type. The default
+decoder returns ordinary Python floats: use `list[float]` annotations even with
+explicit `float16` or `float32` field metadata. Models annotated with
+`list[numpy.float16]` or `list[numpy.float32]` require a custom `decoder` passed to
+`vectorstoremodel` or `register_vectorstoremodel`. That decoder must reconstruct
+each component with the declared NumPy scalar type and handle omitted vector
+fields when `include_vectors=False`. NumPy is not a connector runtime dependency.
+
 Exact search is the default. HNSW and IVFFlat are optional approximate indexes;
 selective filters can reduce their recall. Use
 `operation_options={"exact": True}` when complete recall is required.

--- a/python/packages/postgres/agent_framework_postgres/__init__.py
+++ b/python/packages/postgres/agent_framework_postgres/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Async PostgreSQL/pgvector vector collections and stores."""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+from ._vector_store import PostgresCollection, PostgresSettings, PostgresStore
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["PostgresCollection", "PostgresSettings", "PostgresStore", "__version__"]

--- a/python/packages/postgres/agent_framework_postgres/_vector_store.py
+++ b/python/packages/postgres/agent_framework_postgres/_vector_store.py
@@ -199,7 +199,9 @@ def _prepare_value(field: VectorStoreField, value: Any) -> Any:
     if field.field_type == "vector":
         if isinstance(value, (str, bytes, bytearray)):
             raise TypeError(f"Vector field '{field.name}' requires a dense numeric vector, not text or bytes.")
-        if isinstance(value, Sequence) and not isinstance(value, list):
+        if isinstance(value, list):
+            value = cast(list[float | int], value)
+        elif isinstance(value, Sequence):
             value = list(cast(Sequence[float | int], value))
         return HalfVector(value) if _prepare_vector_type(field) == "halfvec" else PgVector(value)
     kind = field.type_

--- a/python/packages/postgres/agent_framework_postgres/_vector_store.py
+++ b/python/packages/postgres/agent_framework_postgres/_vector_store.py
@@ -278,10 +278,16 @@ class _FilterCompiler:
 
     def __init__(self, definition: VectorStoreCollectionDefinition) -> None:
         self.definition = definition
-        self.parameters: list[Any] = []
+        self._parameters: list[Any] = []
+
+    def compile(self, expression: FilterExpression) -> tuple[sql.Composable, list[Any]]:
+        """Return SQL and its parameters in placeholder order for one expression."""
+        self._parameters = []
+        condition = self._prepare_filter_condition(expression)
+        return condition, self._parameters
 
     def _prepare_parameter(self, value: Any) -> sql.Placeholder:
-        self.parameters.append(value)
+        self._parameters.append(value)
         return sql.Placeholder()
 
     def _prepare_equality(self, field: VectorStoreField, column: sql.Composable, value: Any) -> sql.Composable:
@@ -580,9 +586,7 @@ class PostgresCollection(
     def _prepare_filter(self, filter: FilterExpression | None) -> tuple[sql.Composable, list[Any]]:
         if filter is None:
             return sql.SQL("TRUE"), []
-        compiler = _FilterCompiler(self.definition)
-        condition = compiler._prepare_filter_condition(filter)  # pyright: ignore[reportPrivateUsage]
-        return condition, compiler.parameters
+        return _FilterCompiler(self.definition).compile(filter)
 
     def _prepare_order_by(self, order_by: Mapping[str, bool] | None) -> sql.Composable:
         parts: list[sql.Composable] = []

--- a/python/packages/postgres/agent_framework_postgres/_vector_store.py
+++ b/python/packages/postgres/agent_framework_postgres/_vector_store.py
@@ -199,6 +199,8 @@ def _prepare_value(field: VectorStoreField, value: Any) -> Any:
     if field.field_type == "vector":
         if isinstance(value, (str, bytes, bytearray)):
             raise TypeError(f"Vector field '{field.name}' requires a dense numeric vector, not text or bytes.")
+        if isinstance(value, Sequence) and not isinstance(value, list):
+            value = list(cast(Sequence[float | int], value))
         return HalfVector(value) if _prepare_vector_type(field) == "halfvec" else PgVector(value)
     kind = field.type_
     if kind == "UUID":
@@ -398,7 +400,7 @@ class PostgresCollection(
     """
 
     supported_key_types: ClassVar[set[str] | None] = {"str", "int", "UUID"}
-    supported_vector_types: ClassVar[set[str] | None] = {"float", "float16", "float32", "float64", "int"}
+    supported_vector_types: ClassVar[set[str] | None] = {"float", "float16", "float32"}
     supported_search_types: ClassVar[set[SearchType]] = {"vector"}
 
     def __init__(
@@ -663,7 +665,7 @@ class PostgresCollection(
             connection.cursor(row_factory=tuple_row) as cursor,
         ):
             # Group adjacent row shapes only, preserving both input order and repeated-key semantics.
-            for names, group in groupby(prepared, key=lambda row: tuple(row)):
+            for names, group in groupby(prepared, key=tuple):
                 rows = list(group)
                 if names:
                     statement = sql.SQL("INSERT INTO {} ({}) VALUES ({})").format(
@@ -781,6 +783,8 @@ class PostgresCollection(
         exact = options.get("exact", field.index_kind in ("flat", "default"))
         if not isinstance(exact, bool):
             raise TypeError("exact must be a boolean.")
+        if not exact and field.index_kind not in ("hnsw", "ivf_flat"):
+            raise ValueError("Approximate search requires an HNSW or IVFFlat vector field.")
         settings: list[tuple[str, str]] = []
         if "hnsw_ef_search" in options:
             if exact or field.index_kind != "hnsw":

--- a/python/packages/postgres/agent_framework_postgres/_vector_store.py
+++ b/python/packages/postgres/agent_framework_postgres/_vector_store.py
@@ -1,0 +1,933 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Async PostgreSQL collection lifecycle, batch operations, and pgvector search."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from datetime import date, datetime
+from itertools import groupby
+from typing import Any, ClassVar, Generic, TypeAlias, cast
+from uuid import UUID
+
+from agent_framework import (
+    BaseVectorCollection,
+    BaseVectorSearch,
+    BaseVectorStore,
+    FilterGroup,
+    SearchResults,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    load_settings,
+)
+from agent_framework._vector_filters import FilterExpression
+from agent_framework._vectors import EmbeddingClient, SearchType, Vector
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from pgvector import HalfVector
+from pgvector import Vector as PgVector
+from pgvector.psycopg import register_vector_async
+from psycopg import AsyncConnection, Error, sql
+from psycopg.rows import dict_row, tuple_row
+from psycopg.types.json import Jsonb
+from psycopg_pool import AsyncConnectionPool
+from typing_extensions import Self, TypedDict, TypeVar
+
+KeyT = TypeVar("KeyT", default=Any)
+ModelT = TypeVar("ModelT", default=Any)
+PostgresClient: TypeAlias = AsyncConnection[Any] | AsyncConnectionPool[AsyncConnection[Any]]
+
+
+class PostgresSettings(TypedDict, total=False):
+    """Connection settings loaded by AF from explicit values, a selected .env file, or ``POSTGRES_`` variables."""
+
+    connection_string: SecretString | None
+    """Psycopg conninfo or URI, resolved from ``POSTGRES_CONNECTION_STRING`` and masked until passed to Psycopg."""
+
+
+def _validate_operation_options(options: Mapping[str, Any] | None, allowed: set[str] | None = None) -> dict[str, Any]:
+    result = dict(options or {})
+    if unknown := result.keys() - (allowed or set()):
+        raise NotImplementedError(f"Unsupported Postgres operation option(s): {', '.join(sorted(unknown))}.")
+    return result
+
+
+def _validate_integer(value: Any, name: str, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}.")
+    return value
+
+
+class _Client:
+    """Own a lazy pool or borrow a caller's pool/connection without closing it."""
+
+    def __init__(self, connection_string: SecretString | None, client: PostgresClient | None) -> None:
+        if (connection_string is None) == (client is None):
+            raise ValueError("Supply exactly one of connection_string or client.")
+        if client is not None and not isinstance(client, (AsyncConnection, AsyncConnectionPool)):
+            raise TypeError("client must be a Psycopg AsyncConnection or AsyncConnectionPool.")
+        self.owned = client is None
+        self.client: PostgresClient
+        if connection_string is not None:
+            conninfo = connection_string.get_secret_value()
+            if not conninfo.strip():
+                raise ValueError("connection_string must not be empty.")
+            self.client = AsyncConnectionPool(
+                conninfo, open=False, min_size=1, max_size=10, kwargs={"autocommit": True}
+            )
+        elif client is not None:
+            self.client = client
+        self.closed = False
+
+    def ensure_open(self) -> None:
+        if self.closed:
+            raise RuntimeError("The Postgres client is closed.")
+
+    @asynccontextmanager
+    async def connection(self, *, vectors: bool = False) -> AsyncGenerator[AsyncConnection[Any]]:
+        self.ensure_open()
+        try:
+            if isinstance(self.client, AsyncConnectionPool):
+                if self.owned:
+                    await self.client.open()
+                async with self.client.connection() as connection, connection.transaction():
+                    if vectors and connection.adapters.types.get("vector") is None:
+                        await register_vector_async(connection)
+                    yield connection
+            else:
+                # A transaction on a borrowed connection becomes a savepoint when already in a transaction.
+                async with self.client.transaction():
+                    if vectors and self.client.adapters.types.get("vector") is None:
+                        await register_vector_async(self.client)
+                    yield self.client
+        except Error as exc:
+            raise IntegrationException("PostgreSQL operation failed; inspect the chained driver exception.") from exc
+
+    async def close(self) -> None:
+        if not self.closed:
+            if self.owned:
+                await self.client.close()
+            self.closed = True
+
+
+def _create_client(
+    connection_string: str | SecretString | None,
+    *,
+    client: PostgresClient | None,
+    env_file_path: str | None,
+    env_file_encoding: str | None,
+) -> _Client:
+    if client is not None:
+        if connection_string is not None or env_file_path is not None or env_file_encoding is not None:
+            raise ValueError("client cannot be combined with connection_string, env_file_path, or env_file_encoding.")
+        return _Client(None, client)
+    settings = load_settings(
+        PostgresSettings,
+        env_prefix="POSTGRES_",
+        connection_string=connection_string,
+        env_file_path=env_file_path,
+        env_file_encoding=env_file_encoding,
+    )
+    resolved_connection_string = settings.get("connection_string")
+    if resolved_connection_string is not None and not isinstance(resolved_connection_string, SecretString):
+        raise TypeError("connection_string must be a string or SecretString.")
+    return _Client(resolved_connection_string, None)
+
+
+_TYPES = {
+    "str": sql.SQL('text COLLATE "C"'),
+    "int": sql.SQL("bigint"),
+    "float": sql.SQL("double precision"),
+    "bool": sql.SQL("boolean"),
+    "UUID": sql.SQL("uuid"),
+    "bytes": sql.SQL("bytea"),
+    "date": sql.SQL("date"),
+    "datetime": sql.SQL("timestamp with time zone"),
+    "list": sql.SQL("jsonb"),
+    "dict": sql.SQL("jsonb"),
+}
+_METRICS = {
+    "DEFAULT": (sql.SQL("<=>"), "cosine"),
+    "cosine_distance": (sql.SQL("<=>"), "cosine"),
+    "cosine_similarity": (sql.SQL("<=>"), "cosine"),
+    "dot_prod": (sql.SQL("<#>"), "ip"),
+    "negative_dot_prod": (sql.SQL("<#>"), "ip"),
+    "euclidean_distance": (sql.SQL("<->"), "l2"),
+    "manhattan": (sql.SQL("<+>"), "l1"),
+}
+_ORDER_OPERATORS = {"gt": sql.SQL(">"), "gte": sql.SQL(">="), "lt": sql.SQL("<"), "lte": sql.SQL("<=")}
+
+
+def _prepare_identifier(name: str) -> sql.Identifier:
+    """Quote a single identifier, rejecting truncation and NUL."""
+    if not isinstance(name, str) or not name or "\0" in name or len(name.encode("utf-8")) > 63:
+        raise ValueError("Postgres identifiers must contain 1-63 UTF-8 bytes and no NUL.")
+    return sql.Identifier(name)
+
+
+def _prepare_vector_type(field: VectorStoreField) -> str:
+    value = field.provider_annotations.get("postgres.vector_type", "halfvec" if field.type_ == "float16" else "vector")
+    if value not in ("vector", "halfvec"):
+        raise NotImplementedError("postgres.vector_type supports only 'vector' and 'halfvec'.")
+    return cast(str, value)
+
+
+def _prepare_metric(field: VectorStoreField) -> tuple[sql.SQL, str]:
+    try:
+        return _METRICS[field.distance_function or "DEFAULT"]
+    except KeyError:
+        raise NotImplementedError(f"Unsupported Postgres distance function '{field.distance_function}'.") from None
+
+
+def _prepare_column_type(field: VectorStoreField) -> sql.Composable:
+    if field.field_type == "vector":
+        storage = _prepare_vector_type(field)
+        return sql.SQL("{}({})").format(_prepare_identifier(storage), sql.Literal(field.dimensions))
+    if field.type_ not in _TYPES:
+        raise NotImplementedError(f"Field '{field.name}' needs a supported explicit type; got '{field.type_}'.")
+    return _TYPES[field.type_]
+
+
+def _prepare_value(field: VectorStoreField, value: Any) -> Any:
+    """Adapt normalized records without silently coercing bools, strings or binary vectors."""
+    if value is None:
+        return None
+    if field.field_type == "vector":
+        if isinstance(value, (str, bytes, bytearray)):
+            raise TypeError(f"Vector field '{field.name}' requires a dense numeric vector, not text or bytes.")
+        return HalfVector(value) if _prepare_vector_type(field) == "halfvec" else PgVector(value)
+    kind = field.type_
+    if kind == "UUID":
+        if isinstance(value, UUID):
+            return value
+        if isinstance(value, str):
+            return UUID(value)
+    elif kind == "date":
+        if type(value) is date:
+            return value
+        if isinstance(value, str):
+            return date.fromisoformat(value)
+    elif kind == "datetime":
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00")) if isinstance(value, str) else value
+        if isinstance(parsed, datetime):
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                raise ValueError(f"Datetime field '{field.name}' requires a timezone.")
+            return parsed
+    elif kind == "float" and type(value) in (int, float):
+        if not math.isfinite(value):
+            raise ValueError(f"Field '{field.name}' requires a finite number.")
+        return float(value)
+    elif kind == "int" and type(value) is int:
+        if not -(2**63) <= value < 2**63:
+            raise ValueError(f"Field '{field.name}' exceeds the PostgreSQL bigint range.")
+        return value
+    elif (
+        (kind == "str" and isinstance(value, str))
+        or (kind == "bool" and type(value) is bool)
+        or (kind == "bytes" and isinstance(value, bytes))
+    ):
+        return value
+    elif (kind == "list" and isinstance(value, list)) or (kind == "dict" and isinstance(value, dict)):
+        return Jsonb(value)
+    raise TypeError(f"Field '{field.name}' requires a value of type '{kind}'.")
+
+
+def _validate_json_filter(value: Any) -> None:
+    # JSON encoding must not turn tuples into lists or non-string keys into strings.
+    if value is None or type(value) in (str, bool, int):
+        return
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("JSON filter numbers must be finite.")
+        return
+    if isinstance(value, list):
+        for item in cast(list[Any], value):
+            _validate_json_filter(item)
+        return
+    if isinstance(value, dict):
+        for key, item in cast(dict[Any, Any], value).items():
+            if not isinstance(key, str):
+                raise TypeError("JSON filter object keys must be strings.")
+            _validate_json_filter(item)
+        return
+    raise TypeError("JSON filters support only JSON scalars, lists, and string-keyed dictionaries.")
+
+
+def _prepare_filter_field(definition: VectorStoreCollectionDefinition, name: str) -> VectorStoreField:
+    # Core supports paths structurally, but this connector exposes only declared columns.
+    if "." in name:
+        raise NotImplementedError("Postgres filters and ordering do not support nested field paths.")
+    field = definition.try_get_field(name)
+    if field is None:
+        raise ValueError(f"Unknown Postgres field '{name}'.")
+    if field.field_type == "vector":
+        raise NotImplementedError("Filtering and ordering vector columns is not supported.")
+    return field
+
+
+class _FilterCompiler:
+    """Translate a core-validated snapshot into total-boolean, parameterized SQL."""
+
+    def __init__(self, definition: VectorStoreCollectionDefinition) -> None:
+        self.definition = definition
+        self.parameters: list[Any] = []
+
+    def _prepare_parameter(self, value: Any) -> sql.Placeholder:
+        self.parameters.append(value)
+        return sql.Placeholder()
+
+    def _prepare_equality(self, field: VectorStoreField, column: sql.Composable, value: Any) -> sql.Composable:
+        if value is None:
+            return sql.SQL("{} IS NULL").format(column)
+        kind = field.type_
+        if (kind == "bool" and type(value) is not bool) or (kind != "bool" and isinstance(value, bool)):
+            return sql.SQL("FALSE")
+        if kind in ("int", "float") and type(value) in (int, float):
+            if not math.isfinite(value):
+                raise ValueError("Numeric filter values must be finite.")
+            adapted = value
+        else:
+            # Do not let Postgres coerce, e.g., string '1' into an integer or boolean.
+            expected_types = {"str": str, "int": int, "float": float, "bytes": bytes, "list": list, "dict": dict}
+            expected = expected_types.get(kind or "")
+            if expected is not None and not isinstance(value, expected):
+                return sql.SQL("FALSE")
+            if kind in ("list", "dict"):
+                _validate_json_filter(value)
+            adapted = _prepare_value(field, value)
+        return sql.SQL("{} IS NOT DISTINCT FROM {}").format(column, self._prepare_parameter(adapted))
+
+    def _prepare_filter_group(self, expression: FilterGroup) -> sql.Composable:
+        parts = [self._prepare_filter_condition(child) for child in expression.filters]
+        if expression.operator == "not":
+            return sql.SQL("(NOT ({}))").format(parts[0])
+        joiner = sql.SQL(" AND ") if expression.operator == "and" else sql.SQL(" OR ")
+        return sql.SQL("({})").format(joiner.join(parts))
+
+    def _prepare_filter_condition(self, expression: FilterExpression) -> sql.Composable:
+        if isinstance(expression, FilterGroup):
+            return self._prepare_filter_group(expression)
+        field = _prepare_filter_field(self.definition, expression.field_name)
+        column: sql.Composable = _prepare_identifier(field.storage_name or field.name)
+        if field.type_ == "str":
+            column = sql.SQL('{} COLLATE "C"').format(column)
+        op, value = expression.operator, expression.value
+        if op == "exists":
+            # Declared SQL columns are present in every row, even when their value is NULL.
+            return sql.SQL("TRUE")
+        if op == "is_null":
+            return sql.SQL("{} IS NULL").format(column)
+        if op == "is_not_null":
+            return sql.SQL("{} IS NOT NULL").format(column)
+        if op in ("eq", "ne"):
+            equality = self._prepare_equality(field, column, value)
+            return equality if op == "eq" else sql.SQL("(NOT ({}))").format(equality)
+        if op in ("in", "not_in"):
+            parts = [self._prepare_equality(field, column, item) for item in value]
+            choices = sql.SQL(" OR ").join(parts) if parts else sql.SQL("FALSE")
+            membership = sql.SQL("({})").format(choices)
+            if op == "not_in":
+                membership = sql.SQL("(NOT {})").format(membership)
+            # Portable membership, unlike eq/ne, never matches a null field.
+            return sql.SQL("({} IS NOT NULL AND {})").format(column, membership)
+        if op in _ORDER_OPERATORS or op == "between":
+            if field.type_ in ("list", "dict", "bool", "bytes"):
+                raise NotImplementedError(f"Ordered filtering is not supported for '{field.type_}'.")
+            operands: Sequence[Any] = value if op == "between" else [value]
+            if any(item is None or isinstance(item, bool) for item in operands):
+                raise TypeError("Ordered filter operands must be non-null scalars of the column's type.")
+            if any(isinstance(item, float) and not math.isfinite(item) for item in operands):
+                raise ValueError("Ordered filter numbers must be finite.")
+            params = [
+                self._prepare_parameter(
+                    item
+                    if field.type_ in ("int", "float") and type(item) in (int, float)
+                    else _prepare_value(field, item)
+                )
+                for item in operands
+            ]
+            comparison = (
+                sql.SQL("{} BETWEEN {} AND {}").format(column, *params)
+                if op == "between"
+                else sql.SQL("{} {} {}").format(column, _ORDER_OPERATORS[op], params[0])
+            )
+            return sql.SQL("({}) IS TRUE").format(comparison)
+        if op in ("contains_text", "starts_with", "ends_with"):
+            if field.type_ != "str":
+                raise TypeError(f"Text filtering requires a string column, not '{field.type_}'.")
+            if not isinstance(value, str):
+                raise TypeError("Text filtering requires a string operand.")
+            # Use ! as the explicit escape character; % and _ remain literal input.
+            escaped = value.replace("!", "!!").replace("%", "!%").replace("_", "!_")
+            pattern = ("%" if op != "starts_with" else "") + escaped + ("%" if op != "ends_with" else "")
+            return sql.SQL("({} LIKE {} ESCAPE '!') IS TRUE").format(column, self._prepare_parameter(pattern))
+        if op in ("contains", "contains_any", "contains_all"):
+            if field.type_ != "list":
+                raise TypeError("Collection membership requires a list column.")
+            operands = [value] if op == "contains" else value
+            for operand in operands:
+                _validate_json_filter(operand)
+            parts = [
+                sql.SQL("EXISTS (SELECT 1 FROM jsonb_array_elements({}) AS item(value) WHERE item.value = {})").format(
+                    column, self._prepare_parameter(Jsonb(item))
+                )
+                for item in operands
+            ]
+            joiner = sql.SQL(" AND ") if op == "contains_all" else sql.SQL(" OR ")
+            combined = joiner.join(parts) if parts else sql.SQL("TRUE" if op == "contains_all" else "FALSE")
+            return sql.SQL("({} IS NOT NULL AND ({}))").format(column, combined)
+        raise NotImplementedError(f"Unsupported Postgres filter operator '{op}'.")
+
+
+class PostgresCollection(
+    BaseVectorCollection[KeyT, ModelT],
+    BaseVectorSearch[KeyT, ModelT],
+    Generic[KeyT, ModelT],
+):
+    """Store typed rows and search dense vectors using PostgreSQL and pgvector.
+
+    The schema and pgvector extension must already exist. The connector never
+    enables extensions, creates schemas, or migrates existing tables. See the
+    package README for metric units, index limits, and ANN recall limitations.
+    Batch writes are transactional; an enclosing caller transaction retains
+    control over commit. Injected connections and pools remain caller-owned.
+    """
+
+    supported_key_types: ClassVar[set[str] | None] = {"str", "int", "UUID"}
+    supported_vector_types: ClassVar[set[str] | None] = {"float", "float16", "float32", "float64", "int"}
+    supported_search_types: ClassVar[set[SearchType]] = {"vector"}
+
+    def __init__(
+        self,
+        record_type: type[ModelT],
+        *,
+        connection_string: str | SecretString | None = None,
+        client: PostgresClient | None = None,
+        schema: str = "public",
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a collection without connecting to PostgreSQL.
+
+        Args:
+            record_type: Decorated/registered model type, or ``dict``.
+            connection_string: Psycopg conninfo or URI for an owned lazy pool. Falls back to
+                ``POSTGRES_CONNECTION_STRING`` in the selected .env file or process environment.
+            client: An open caller-owned async connection or pool, instead of conninfo.
+            schema: Existing PostgreSQL schema containing the table.
+            definition: Explicit field definition for dictionary records.
+            collection_name: Table name, overriding the model's collection name.
+            embedding_generator: Default local embedding client.
+            env_file_path: Optional .env file to read; cannot be combined with an injected client.
+            env_file_encoding: Encoding of the .env file; cannot be combined with an injected client.
+        """
+        super().__init__(
+            record_type,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator,
+            managed_client=client is None,
+        )
+        self.schema = schema
+        self._table = sql.SQL("{}.{}").format(_prepare_identifier(schema), _prepare_identifier(self.collection_name))
+        # Snapshot connector annotations: mutating a model must not change SQL halfway through an operation.
+        self._fields = tuple(
+            replace(field, provider_annotations=field.provider_annotations) for field in self.definition.fields
+        )
+        for field in self._fields:
+            _prepare_identifier(field.storage_name or field.name)
+            _prepare_column_type(field)
+            if field.is_full_text_indexed:
+                raise NotImplementedError("Postgres full-text indexes and keyword-hybrid search are not supported.")
+            if field.field_type == "vector":
+                self._validate_vector_field(field)
+            elif any(name.startswith("postgres.") for name in field.provider_annotations):
+                raise NotImplementedError("Postgres provider annotations are supported only on vector fields.")
+        self._client = _create_client(
+            connection_string, client=client, env_file_path=env_file_path, env_file_encoding=env_file_encoding
+        )
+        self._shared_client = False
+
+    @staticmethod
+    def _validate_vector_field(field: VectorStoreField) -> None:
+        _validate_integer(field.dimensions, "dimensions", 1, 16000)
+        _, ops = _prepare_metric(field)
+        if field.index_kind not in ("default", "flat", "hnsw", "ivf_flat"):
+            raise NotImplementedError(f"Unsupported Postgres index kind '{field.index_kind}'.")
+        annotations = field.provider_annotations
+        allowed = {"postgres.vector_type"}
+        if field.index_kind == "hnsw":
+            allowed.update(("postgres.m", "postgres.ef_construction"))
+            m = _validate_integer(annotations.get("postgres.m", 16), "postgres.m", 2, 100)
+            _validate_integer(annotations.get("postgres.ef_construction", 64), "postgres.ef_construction", 2 * m, 1000)
+        if field.index_kind == "ivf_flat":
+            allowed.add("postgres.lists")
+            _validate_integer(annotations.get("postgres.lists", 100), "postgres.lists", 1, 32768)
+            if ops == "l1":
+                raise NotImplementedError("IVFFlat does not support Manhattan distance.")
+        if unknown := {name for name in annotations if name.startswith("postgres.")} - allowed:
+            raise NotImplementedError(f"Unsupported Postgres provider annotation(s): {', '.join(sorted(unknown))}.")
+        if field.index_kind in ("hnsw", "ivf_flat"):
+            limit = 4000 if _prepare_vector_type(field) == "halfvec" else 2000
+            _validate_integer(field.dimensions, "indexed vector dimensions", 1, limit)
+
+    async def __aenter__(self) -> Self:
+        """Enter the client context; connections open on the first operation."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close resources owned by this collection."""
+        await self.close()
+
+    async def close(self) -> None:
+        """Close an owned pool, never a borrowed client or a store's shared pool."""
+        if not self._shared_client:
+            await self._client.close()
+
+    async def ensure_collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Create a table and requested indexes, without altering an existing schema.
+
+        ``operation_options={"create_indexes": False}`` explicitly creates only
+        the table. Use this before loading IVFFlat training data, then call this
+        method again with the default options to create the requested indexes.
+        IVFFlat creation on an empty table is rejected.
+        """
+        options = _validate_operation_options(operation_options, {"create_indexes"})
+        self._client.ensure_open()
+        create_indexes = options.get("create_indexes", True)
+        if not isinstance(create_indexes, bool):
+            raise TypeError("create_indexes must be a boolean.")
+        columns: list[sql.Composable] = []
+        for field in self._fields:
+            suffix = sql.SQL("")
+            if field.field_type == "key":
+                suffix = sql.SQL(" PRIMARY KEY")
+                if field.is_auto_generated:
+                    suffix = {
+                        "int": sql.SQL(" GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY"),
+                        "UUID": sql.SQL(" DEFAULT pg_catalog.gen_random_uuid() PRIMARY KEY"),
+                        "str": sql.SQL(" DEFAULT pg_catalog.gen_random_uuid()::text PRIMARY KEY"),
+                    }[field.type_ or ""]
+            columns.append(
+                sql.SQL("{} {}{}").format(
+                    _prepare_identifier(field.storage_name or field.name), _prepare_column_type(field), suffix
+                )
+            )
+        async with self._client.connection(vectors=bool(self.definition.vector_fields)) as connection:
+            await connection.execute(
+                sql.SQL("CREATE TABLE IF NOT EXISTS {} ({})").format(self._table, sql.SQL(", ").join(columns))
+            )
+            if create_indexes:
+                for field in self._fields:
+                    if field.field_type == "vector" and field.index_kind in ("hnsw", "ivf_flat"):
+                        if field.index_kind == "ivf_flat":
+                            cursor = await connection.execute(
+                                sql.SQL("SELECT 1 FROM {} WHERE {} IS NOT NULL LIMIT 1").format(
+                                    self._table, _prepare_identifier(field.storage_name or field.name)
+                                )
+                            )
+                            if await cursor.fetchone() is None:
+                                raise ValueError(
+                                    "IVFFlat requires training data. Create with create_indexes=False, "
+                                    "upsert vectors, then call ensure_collection_exists() again."
+                                )
+                        await connection.execute(self._prepare_index(field))
+                    elif field.field_type == "data" and field.is_indexed:
+                        await connection.execute(self._prepare_index(field))
+
+    async def collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> bool:
+        """Return whether the table exists in the configured schema."""
+        _validate_operation_options(operation_options)
+        async with self._client.connection() as connection:
+            cursor = await connection.execute(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = %s AND table_name = %s AND table_type = 'BASE TABLE'",
+                (self.schema, self.collection_name),
+            )
+            return await cursor.fetchone() is not None
+
+    async def ensure_collection_deleted(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Drop only this table, without CASCADE or schema/extension cleanup."""
+        _validate_operation_options(operation_options)
+        async with self._client.connection() as connection:
+            await connection.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(self._table))
+
+    def _deserialize_store_models_to_dicts(
+        self,
+        records: Sequence[Any],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        result = super()._deserialize_store_models_to_dicts(records, context=context)
+        for record in result:
+            for field in self._fields:
+                name = field.storage_name or field.name
+                if field.field_type == "vector" and record.get(name) is not None:
+                    record[name] = record[name].to_list()
+        return result
+
+    def _prepare_filter(self, filter: FilterExpression | None) -> tuple[sql.Composable, list[Any]]:
+        if filter is None:
+            return sql.SQL("TRUE"), []
+        compiler = _FilterCompiler(self.definition)
+        condition = compiler._prepare_filter_condition(filter)  # pyright: ignore[reportPrivateUsage]
+        return condition, compiler.parameters
+
+    def _prepare_order_by(self, order_by: Mapping[str, bool] | None) -> sql.Composable:
+        parts: list[sql.Composable] = []
+        for name, ascending in (order_by or {}).items():
+            if not isinstance(ascending, bool):
+                raise TypeError("Order directions must be booleans.")
+            field = _prepare_filter_field(self.definition, name)
+            if field.type_ in ("list", "dict"):
+                raise NotImplementedError("Ordering JSON columns is not supported.")
+            parts.append(
+                sql.SQL("{} {} NULLS LAST").format(
+                    _prepare_identifier(field.storage_name or field.name),
+                    sql.SQL("ASC") if ascending else sql.SQL("DESC"),
+                )
+            )
+        if self.definition.key_field.name not in (order_by or {}):
+            parts.append(sql.SQL("{} ASC").format(_prepare_identifier(self.definition.key_field_storage_name)))
+        return sql.SQL(", ").join(parts)
+
+    def _prepare_index(self, field: VectorStoreField) -> sql.Composed:
+        storage_name = field.storage_name or field.name
+        digest = hashlib.sha256(f"{self.schema}\0{self.collection_name}\0{storage_name}".encode()).hexdigest()[:32]
+        name = _prepare_identifier(f"af_vector_{digest}")
+        column = _prepare_identifier(storage_name)
+        if field.field_type != "vector":
+            return sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {} ({})").format(name, self._table, column)
+        kind = sql.SQL("hnsw") if field.index_kind == "hnsw" else sql.SQL("ivfflat")
+        _, ops = _prepare_metric(field)
+        opclass = _prepare_identifier(f"{_prepare_vector_type(field)}_{ops}_ops")
+        annotations = field.provider_annotations
+        options = (
+            sql.SQL("m = {}, ef_construction = {}").format(
+                sql.Literal(annotations.get("postgres.m", 16)),
+                sql.Literal(annotations.get("postgres.ef_construction", 64)),
+            )
+            if field.index_kind == "hnsw"
+            else sql.SQL("lists = {}").format(sql.Literal(annotations.get("postgres.lists", 100)))
+        )
+        return sql.SQL("CREATE INDEX IF NOT EXISTS {} ON {} USING {} ({} {}) WITH ({})").format(
+            name, self._table, kind, column, opclass, options
+        )
+
+    def _prepare_columns(self, include_vectors: bool) -> list[str]:
+        return [
+            field.storage_name or field.name
+            for field in self._fields
+            if include_vectors or field.field_type != "vector"
+        ]
+
+    def _prepare_key(self, value: Any) -> Any:
+        if value is None:
+            raise ValueError("Postgres keys cannot be null.")
+        return _prepare_value(self.definition.key_field, value)
+
+    async def _inner_upsert(
+        self,
+        records: Sequence[Any],
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[KeyT]:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        key_name = self.definition.key_field_storage_name
+        prepared: list[dict[str, Any]] = []
+        for record in records:
+            row: dict[str, Any] = {}
+            for field in self._fields:
+                name = field.storage_name or field.name
+                if name not in record and field.field_type == "key" and field.is_auto_generated:
+                    continue
+                row[name] = (
+                    self._prepare_key(record[name])
+                    if field.field_type == "key"
+                    else _prepare_value(field, record[name])
+                )
+            prepared.append(row)
+        if not prepared:
+            return []
+        keys: list[KeyT] = []
+        async with (
+            self._client.connection(vectors=bool(self.definition.vector_fields)) as connection,
+            connection.cursor(row_factory=tuple_row) as cursor,
+        ):
+            # Group adjacent row shapes only, preserving both input order and repeated-key semantics.
+            for names, group in groupby(prepared, key=lambda row: tuple(row)):
+                rows = list(group)
+                if names:
+                    statement = sql.SQL("INSERT INTO {} ({}) VALUES ({})").format(
+                        self._table,
+                        sql.SQL(", ").join(map(_prepare_identifier, names)),
+                        sql.SQL(", ").join(sql.Placeholder() for _ in names),
+                    )
+                else:
+                    statement = sql.SQL("INSERT INTO {} DEFAULT VALUES").format(self._table)
+                if key_name in names:
+                    updates = [name for name in names if name != key_name] or [key_name]
+                    statement += sql.SQL(" ON CONFLICT ({}) DO UPDATE SET {}").format(
+                        _prepare_identifier(key_name),
+                        sql.SQL(", ").join(
+                            sql.SQL("{} = EXCLUDED.{}").format(_prepare_identifier(name), _prepare_identifier(name))
+                            for name in updates
+                        ),
+                    )
+                statement += sql.SQL(" RETURNING {}").format(_prepare_identifier(key_name))
+                await cursor.executemany(
+                    statement, [tuple(row[name] for name in names) for row in rows], returning=True
+                )
+                for index in range(len(rows)):
+                    result = await cursor.fetchone()
+                    if result is None:
+                        raise IntegrationInvalidResponseException("PostgreSQL did not return an upserted key.")
+                    keys.append(cast(KeyT, result[0]))
+                    if index < len(rows) - 1 and not cursor.nextset():
+                        raise IntegrationInvalidResponseException("PostgreSQL returned too few upsert result sets.")
+        return keys
+
+    async def _inner_get(
+        self,
+        *,
+        keys: Sequence[KeyT] | None = None,
+        filter: FilterExpression | None = None,
+        top: int = 10,
+        skip: int = 0,
+        order_by: Mapping[str, bool] | None = None,
+        include_vectors: bool = False,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[Any]:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        columns = self._prepare_columns(include_vectors)
+        adapted: list[Any] = []
+        statement = sql.SQL("SELECT {} FROM {} WHERE ").format(
+            sql.SQL(", ").join(map(_prepare_identifier, columns)), self._table
+        )
+        if keys is not None:
+            if order_by:
+                raise ValueError("order_by applies only to filtered retrieval, not key lookup.")
+            if not keys:
+                return []
+            adapted = [self._prepare_key(key) for key in keys]
+            statement += sql.SQL("{} = ANY(%s)").format(_prepare_identifier(self.definition.key_field_storage_name))
+            params: list[Any] = [adapted]
+        else:
+            where, filter_params = self._prepare_filter(filter)
+            statement += where
+            statement += sql.SQL(" ORDER BY {} LIMIT %s OFFSET %s").format(self._prepare_order_by(order_by))
+            params = [*filter_params, top, skip]
+        async with (
+            self._client.connection(vectors=include_vectors and bool(self.definition.vector_fields)) as connection,
+            connection.cursor(row_factory=dict_row) as cursor,
+        ):
+            await cursor.execute(statement, params)
+            rows = await cursor.fetchall()
+        if keys is not None:
+            by_key = {row[self.definition.key_field_storage_name]: row for row in rows}
+            return [by_key[key] for key in adapted if key in by_key]
+        return rows
+
+    async def _inner_delete(self, keys: Sequence[KeyT], *, operation_options: Mapping[str, Any] | None = None) -> None:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        adapted = [self._prepare_key(key) for key in keys]
+        if not adapted:
+            return
+        async with self._client.connection() as connection:
+            await connection.execute(
+                sql.SQL("DELETE FROM {} WHERE {} = ANY(%s)").format(
+                    self._table, _prepare_identifier(self.definition.key_field_storage_name)
+                ),
+                [adapted],
+            )
+
+    async def _inner_search(
+        self,
+        *,
+        search_type: SearchType,
+        filter: FilterExpression | None = None,
+        values: Any | None = None,
+        vector: Vector | None = None,
+        top: int = 3,
+        skip: int = 0,
+        include_vectors: bool = False,
+        vector_property_name: str | None = None,
+        additional_property_name: str | None = None,
+        score_threshold: float | None = None,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> SearchResults[Any]:
+        options = _validate_operation_options(operation_options, {"exact", "hnsw_ef_search", "ivfflat_probes"})
+        if search_type != "vector" or additional_property_name is not None:
+            raise NotImplementedError("Postgres supports dense vector search only, not keyword-hybrid search.")
+        if vector is None:
+            raise NotImplementedError(
+                "Postgres has no server-side vectorization; supply a vector or embedding generator."
+            )
+        self._client.ensure_open()
+        resolved = self.definition.try_get_vector_field(vector_property_name)
+        if resolved is None:
+            raise ValueError("Select a vector_property_name from the collection definition.")
+        field = next(field for field in self._fields if field.name == resolved.name)
+        exact = options.get("exact", field.index_kind in ("flat", "default"))
+        if not isinstance(exact, bool):
+            raise TypeError("exact must be a boolean.")
+        settings: list[tuple[str, str]] = []
+        if "hnsw_ef_search" in options:
+            if exact or field.index_kind != "hnsw":
+                raise ValueError("hnsw_ef_search requires an HNSW approximate search.")
+            settings.append((
+                "hnsw.ef_search",
+                str(_validate_integer(options["hnsw_ef_search"], "hnsw_ef_search", 1, 1000)),
+            ))
+        if "ivfflat_probes" in options:
+            if exact or field.index_kind != "ivf_flat":
+                raise ValueError("ivfflat_probes requires an IVFFlat approximate search.")
+            settings.append((
+                "ivfflat.probes",
+                str(_validate_integer(options["ivfflat_probes"], "ivfflat_probes", 1, 32768)),
+            ))
+        if not exact:
+            settings.append(("hnsw.iterative_scan", "strict_order"))
+            settings.append(("ivfflat.iterative_scan", "off"))
+        query_vector = _prepare_value(field, vector)
+        operator, _ = _prepare_metric(field)
+        distance = sql.SQL("{} {} %s").format(_prepare_identifier(field.storage_name or field.name), operator)
+        score = distance
+        if field.distance_function == "cosine_similarity":
+            score = sql.SQL("1 - ({})").format(distance)
+        elif field.distance_function == "dot_prod":
+            score = sql.SQL("-({})").format(distance)
+        where, filter_params = self._prepare_filter(filter)
+        columns = self._prepare_columns(include_vectors)
+        statement = sql.SQL("SELECT {}, {} FROM {} WHERE ({}) AND ({}) < 'Infinity'::double precision").format(
+            sql.SQL(", ").join(map(_prepare_identifier, columns)), score, self._table, where, distance
+        )
+        params = [query_vector, *filter_params, query_vector]
+        if score_threshold is not None:
+            if type(score_threshold) not in (int, float) or not math.isfinite(score_threshold):
+                raise ValueError("score_threshold must be a finite number.")
+            cutoff = score_threshold
+            if field.distance_function == "cosine_similarity":
+                cutoff = 1 - cutoff
+            elif field.distance_function == "dot_prod":
+                cutoff = -cutoff
+            statement += sql.SQL(" AND ({}) <= %s").format(distance)
+            params.extend((query_vector, cutoff))
+        # Adding zero explicitly prevents ANN ordering for exact queries without disabling data indexes.
+        ranking = sql.SQL("({}) + 0").format(distance) if exact else distance
+        statement += sql.SQL(" ORDER BY {} ASC LIMIT %s OFFSET %s").format(ranking)
+        params.extend((query_vector, top, skip))
+        async with (
+            self._client.connection(vectors=True) as connection,
+            # Rolling back this read-only savepoint also restores settings inside a caller's outer transaction.
+            connection.transaction(force_rollback=True),
+        ):
+            for setting, value in settings:
+                await connection.execute("SELECT set_config(%s, %s, true)", (setting, value))
+            async with connection.cursor(row_factory=tuple_row) as cursor:
+                await cursor.execute(statement, params)
+                rows = await cursor.fetchall()
+        return SearchResults(
+            [{"record": dict(zip(columns, row[:-1], strict=True)), "score": row[-1]} for row in rows],
+            metadata={"distance_function": field.distance_function or "DEFAULT", "approximate": not exact},
+        )
+
+    def _get_record_from_result(self, result: Any) -> Any:
+        return result["record"]
+
+    def _get_score_from_result(self, result: Any) -> float | None:
+        return float(result["score"])
+
+
+class PostgresStore(BaseVectorStore):
+    """Create collection clients sharing a PostgreSQL pool or connection."""
+
+    def __init__(
+        self,
+        *,
+        connection_string: str | SecretString | None = None,
+        client: PostgresClient | None = None,
+        schema: str = "public",
+        embedding_generator: EmbeddingClient | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a store without connecting to PostgreSQL.
+
+        Args:
+            connection_string: Psycopg conninfo or URI for an owned lazy pool. Falls back to
+                ``POSTGRES_CONNECTION_STRING`` in the selected .env file or process environment.
+            client: An open caller-owned async connection or pool.
+            schema: Existing schema used by all collection clients.
+            embedding_generator: Default embedding generator for collections.
+            env_file_path: Optional .env file to read; cannot be combined with an injected client.
+            env_file_encoding: Encoding of the .env file; cannot be combined with an injected client.
+        """
+        super().__init__(embedding_generator=embedding_generator, managed_client=client is None)
+        _prepare_identifier(schema)
+        self.schema = schema
+        self._client = _create_client(
+            connection_string, client=client, env_file_path=env_file_path, env_file_encoding=env_file_encoding
+        )
+
+    def get_collection(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+    ) -> PostgresCollection[Any, ModelT]:
+        """Create a collection borrowing this store's client and lifecycle."""
+        collection = PostgresCollection(
+            record_type,
+            client=self._client.client,
+            schema=self.schema,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator if embedding_generator is not None else self.embedding_generator,
+        )
+        collection._client = self._client  # pyright: ignore[reportPrivateUsage]
+        collection._shared_client = True  # pyright: ignore[reportPrivateUsage]
+        return collection
+
+    async def list_collection_names(self, *, operation_options: Mapping[str, Any] | None = None) -> Sequence[str]:
+        """List base tables in this store's schema, including externally created tables."""
+        _validate_operation_options(operation_options)
+        async with self._client.connection() as connection, connection.cursor(row_factory=tuple_row) as cursor:
+            await cursor.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = %s AND table_type = 'BASE TABLE' ORDER BY table_name",
+                [self.schema],
+            )
+            return [row[0] for row in await cursor.fetchall()]
+
+    async def _inner_ensure_collection_deleted(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        table = sql.SQL("{}.{}").format(_prepare_identifier(self.schema), _prepare_identifier(collection_name))
+        async with self._client.connection() as connection:
+            await connection.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(table))
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Release the store's owned pool."""
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the store and its owned resources; injected clients remain open."""
+        await self._client.close()

--- a/python/packages/postgres/pyproject.toml
+++ b/python/packages/postgres/pyproject.toml
@@ -1,0 +1,60 @@
+[project]
+name = "agent-framework-postgres"
+description = "PostgreSQL and pgvector integration for Microsoft Agent Framework."
+authors = [{ name = "Microsoft", email = "af-support@microsoft.com" }]
+readme = "README.md"
+requires-python = ">=3.10"
+version = "1.0.0a260908"
+license-files = ["LICENSE"]
+urls.homepage = "https://aka.ms/agent-framework"
+urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
+urls.issues = "https://github.com/microsoft/agent-framework/issues"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+dependencies = [
+    "agent-framework-core>=1.17.0,<2",
+    "psycopg[binary,pool]>=3.3.5,<4",
+    "pgvector>=0.5.0,<0.6",
+]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.extend-per-file-ignores]
+"samples/**" = ["D", "INP", "commented-out-code", "RUF", "S", "print", "CPY"]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["agent_framework_postgres"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra -q -r fEX"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 120
+markers = ["integration: requires an explicitly designated PostgreSQL test database with pgvector"]
+
+[tool.coverage.run]
+omit = ["**/__init__.py"]
+
+[tool.poe]
+executor.type = "uv"
+include = "../../shared_tasks.toml"
+
+[tool.poe.tasks.test]
+cmd = 'pytest -m "not integration" --cov=agent_framework_postgres --cov-report=term-missing:skip-covered tests'
+
+[build-system]
+requires = ["flit-core>=3.11,<4.0"]
+build-backend = "flit_core.buildapi"

--- a/python/packages/postgres/samples/postgres_vectors.py
+++ b/python/packages/postgres/samples/postgres_vectors.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+from uuid import uuid4
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+
+from agent_framework_postgres import PostgresStore
+
+"""
+Use PostgreSQL/pgvector with two vector columns and literal metadata filtering.
+
+Run against an explicitly designated development database with pgvector 0.8+:
+    POSTGRES_CONNECTION_STRING=... uv run --package agent-framework-postgres \
+        python packages/postgres/samples/postgres_vectors.py
+
+The public schema and vector extension must already exist. This example creates
+a uniquely named table and drops only that table. It uses deterministic vectors,
+not a paid embedding service.
+PostgresStore uses AF PostgresSettings to resolve POSTGRES_CONNECTION_STRING.
+Alternatively pass env_file_path="postgres.env" or an explicit connection_string.
+"""
+
+
+@vectorstoremodel
+@dataclass
+class Note:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data", storage_name="body")]
+    category: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    title_vector: Annotated[list[float] | None, VectorStoreField("vector", dimensions=3, index_kind="hnsw")] = None
+    body_vector: Annotated[list[float] | None, VectorStoreField("vector", dimensions=3)] = None
+
+
+async def main() -> None:
+    # 1. Resolve AF settings from the environment. The store owns its pool; collections borrow it.
+    async with PostgresStore() as store:
+        collection = store.get_collection(Note, collection_name=f"af_demo_{uuid4().hex}")
+        await collection.ensure_collection_exists()
+        try:
+            # 2. Preserve supplied vectors. With a generator, select just the fields to regenerate.
+            await collection.upsert(
+                [
+                    Note("postgres", "PostgreSQL supports pgvector", "database", [1, 0, 0], [0, 1, 0]),
+                    Note("travel", "A travel journal", "travel", [0, 1, 0], [1, 0, 0]),
+                ],
+                generate_vectors=False,
+            )
+
+            # 3. Choose a vector column and apply the filter/threshold in PostgreSQL.
+            results = await collection.search(
+                vector=[1, 0, 0],
+                vector_property_name="title_vector",
+                filter=Filter("category", "eq", "database"),
+                score_threshold=0.1,
+            )
+            async for result in results:
+                print(result["record"].text, result["score"])
+
+            # 4. Ordinary retrieval omits vector columns; opt in to return them.
+            notes = await collection.get(["postgres"], include_vectors=True)
+            print(notes[0].body_vector)
+        finally:
+            await collection.ensure_collection_deleted()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# Expected output:
+# PostgreSQL supports pgvector 0.0
+# [0.0, 1.0, 0.0]

--- a/python/packages/postgres/tests/conftest.py
+++ b/python/packages/postgres/tests/conftest.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from agent_framework import VectorStoreCollectionDefinition, VectorStoreField
+from psycopg import AsyncConnection, sql
+
+
+@pytest.fixture
+def definition_factory():
+    def make(
+        *,
+        key_type="str",
+        generated=False,
+        dimensions=3,
+        index_kind="flat",
+        distance_function="DEFAULT",
+        annotations=None,
+        second_vector=False,
+    ):
+        fields = [
+            VectorStoreField("key", name="id", type_=key_type, storage_name="record_id", is_auto_generated=generated),
+            VectorStoreField("data", name="text", type_="str", storage_name='body "text"', is_indexed=True),
+            VectorStoreField("data", name="number", type_="int"),
+            VectorStoreField("data", name="flag", type_="bool"),
+            VectorStoreField("data", name="tags", type_="list"),
+            VectorStoreField(
+                "vector",
+                name="embedding",
+                type_="float",
+                storage_name="dense vector",
+                dimensions=dimensions,
+                index_kind=index_kind,
+                distance_function=distance_function,
+                provider_annotations=annotations,
+            ),
+        ]
+        if second_vector:
+            fields.append(
+                VectorStoreField(
+                    "vector",
+                    name="secondary",
+                    type_="float",
+                    storage_name="other_vector",
+                    dimensions=dimensions,
+                )
+            )
+        return VectorStoreCollectionDefinition(fields, collection_name="documents")
+
+    return make
+
+
+@pytest.fixture
+def record_factory():
+    def make(id="one", *, text="literal 100%_!\\", number=1, flag=True, tags=None, embedding=None, **extra):
+        return {
+            "id": id,
+            "text": text,
+            "number": number,
+            "flag": flag,
+            "tags": tags if tags is not None else [True, 2, None, "tag"],
+            "embedding": embedding if embedding is not None else [1.0, 0.0, 0.0],
+            **extra,
+        }
+
+    return make
+
+
+@pytest.fixture
+async def database():
+    connection_string = os.getenv("POSTGRES_TEST_CONNECTION_STRING")
+    if not connection_string:
+        pytest.skip("Set POSTGRES_TEST_CONNECTION_STRING to an explicitly designated test database.")
+    async with await AsyncConnection.connect(connection_string, autocommit=True) as connection:
+        cursor = await connection.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+        version = await cursor.fetchone()
+        if version is None:
+            pytest.fail("The designated test database must already have the pgvector extension enabled.")
+        schema = f"af_pg_test_{uuid4().hex}"
+        await connection.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
+        try:
+            yield connection, schema
+        finally:
+            cursor = await connection.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = %s", [schema]
+            )
+            for (name,) in await cursor.fetchall():
+                await connection.execute(
+                    sql.SQL("DROP TABLE {}.{}").format(sql.Identifier(schema), sql.Identifier(name))
+                )
+            await connection.execute(sql.SQL("DROP SCHEMA {}").format(sql.Identifier(schema)))

--- a/python/packages/postgres/tests/conftest.py
+++ b/python/packages/postgres/tests/conftest.py
@@ -17,6 +17,7 @@ def definition_factory():
         key_type="str",
         generated=False,
         dimensions=3,
+        vector_type="float",
         index_kind="flat",
         distance_function="DEFAULT",
         annotations=None,
@@ -31,7 +32,7 @@ def definition_factory():
             VectorStoreField(
                 "vector",
                 name="embedding",
-                type_="float",
+                type_=vector_type,
                 storage_name="dense vector",
                 dimensions=dimensions,
                 index_kind=index_kind,

--- a/python/packages/postgres/tests/test_postgres.py
+++ b/python/packages/postgres/tests/test_postgres.py
@@ -1,0 +1,428 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from agent_framework import (
+    Embedding,
+    Filter,
+    FilterGroup,
+    GeneratedEmbeddings,
+    Param,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    create_vector_search_tool,
+    vectorstoremodel,
+)
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from psycopg import AsyncConnection, OperationalError
+from psycopg_pool import AsyncConnectionPool
+
+from agent_framework_postgres import PostgresCollection, PostgresStore
+from agent_framework_postgres._vector_store import _Client, _prepare_identifier, _prepare_value
+
+
+@pytest.fixture
+def collection(definition_factory):
+    return PostgresCollection(dict, definition=definition_factory(), connection_string="host=unused")
+
+
+@pytest.fixture
+def mock_database(collection):
+    connection = MagicMock(spec=AsyncConnection)
+    connection.execute = AsyncMock()
+    cursor = MagicMock()
+    cursor.execute = AsyncMock()
+    cursor.executemany = AsyncMock()
+    cursor.fetchone = AsyncMock(return_value=("one",))
+    cursor.fetchall = AsyncMock(return_value=[])
+    cursor.nextset = MagicMock(return_value=True)
+    connection.cursor.return_value.__aenter__.return_value = cursor
+    with patch.object(collection._client, "connection") as acquire:
+        acquire.return_value.__aenter__.return_value = connection
+        yield connection, cursor, acquire
+
+
+@pytest.mark.parametrize("name", ["", "x\0y", "a" * 64, "\u00e9" * 32])
+def test_identifier_rejects_truncation_and_nul(name):
+    with pytest.raises(ValueError):
+        _prepare_identifier(name)
+
+
+def test_identifiers_are_quoted_not_executed():
+    assert _prepare_identifier('a"; DROP TABLE users; --').as_string() == '"a""; DROP TABLE users; --"'
+    assert _prepare_identifier("public.documents").as_string() == '"public.documents"'
+
+
+def test_filter_values_are_bound(collection):
+    payload = "'; DROP TABLE documents; --%_!"
+    condition, params = collection._prepare_filter(Filter("text", "contains_text", payload))
+    statement = condition.as_string()
+    assert payload not in statement
+    assert '"body ""text"""' in statement
+    assert "%s" in statement and "ESCAPE '!'" in statement
+    assert params == ["%'; DROP TABLE documents; --!%!_!!%"]
+
+
+@pytest.mark.parametrize("op", ["eq", "ne", "gt", "gte", "lt", "lte", "between", "in", "not_in"])
+def test_scalar_operators_parameterized(collection, op):
+    value = [1, 2] if op in ("between", "in", "not_in") else 7
+    condition, params = collection._prepare_filter(Filter("number", op, value))
+    assert "%s" in condition.as_string()
+    assert params == (value if isinstance(value, list) else [value])
+
+
+@pytest.mark.parametrize("field,value", [("number", True), ("flag", 1), ("flag", "true"), ("number", "1")])
+def test_type_mismatched_equality_is_not_coerced(collection, field, value):
+    equality, params = collection._prepare_filter(Filter(field, "eq", value))
+    assert equality.as_string() == "FALSE"
+    assert params == []
+    inequality, params = collection._prepare_filter(Filter(field, "ne", value))
+    assert inequality.as_string() == "(NOT (FALSE))"
+    assert params == []
+
+
+def test_null_and_negative_predicates_are_two_valued(collection):
+    assert collection._prepare_filter(Filter("text", "is_null"))[0].as_string().endswith("IS NULL")
+    assert collection._prepare_filter(Filter("text", "exists"))[0].as_string() == "TRUE"
+    assert collection._prepare_filter(Filter("text", "is_not_null"))[0].as_string().endswith("IS NOT NULL")
+    text = collection._prepare_filter(FilterGroup("not", [Filter("number", "gt", 3)]))[0].as_string()
+    assert "NOT" in text and "IS TRUE" in text
+    text = collection._prepare_filter(Filter("number", "not_in", [1, None]))[0].as_string()
+    assert "IS NOT NULL AND" in text and "IS NULL" in text
+
+
+@pytest.mark.parametrize("op", ["in", "not_in", "contains_any", "contains_all"])
+def test_empty_membership(collection, op):
+    field = "tags" if op.startswith("contains") else "number"
+    condition, params = collection._prepare_filter(Filter(field, op, []))
+    assert "%s" not in condition.as_string()
+    assert params == []
+
+
+def test_nested_groups_and_array_membership(collection):
+    condition, params = collection._prepare_filter(
+        FilterGroup(
+            "and",
+            [
+                Filter("tags", "contains", True),
+                FilterGroup("or", [Filter("tags", "contains_all", [None, 2]), Filter("text", "is_null")]),
+            ],
+        )
+    )
+    text = condition.as_string()
+    assert "jsonb_array_elements" in text and " AND " in text and " OR " in text
+    assert [p.obj for p in params] == [True, None, 2]
+
+
+@pytest.mark.parametrize("value", [("tuple",), [("nested",)], {1: "non-string key"}, b"bytes", float("nan")])
+def test_json_membership_does_not_silently_coerce_types(collection, value):
+    with pytest.raises((TypeError, ValueError)):
+        collection._prepare_filter(Filter("tags", "contains", value))
+
+
+def test_json_equality_rejects_nested_tuple(collection):
+    with pytest.raises(TypeError, match="JSON"):
+        collection._prepare_filter(Filter("tags", "eq", [("nested",)]))
+
+
+@pytest.mark.parametrize(
+    "expression,error",
+    [
+        (Filter("text.nested", "eq", 1), NotImplementedError),
+        (Filter("unknown", "eq", 1), ValueError),
+        (Filter("embedding", "is_null"), NotImplementedError),
+        (Filter("text", "postgres.raw", "anything"), NotImplementedError),
+        (Filter("number", "starts_with", "1"), TypeError),
+        (Filter("text", "contains", "x"), TypeError),
+        (Filter("flag", "gt", 1), NotImplementedError),
+        (Filter("number", "gt", True), TypeError),
+    ],
+)
+def test_unsupported_filters_fail(collection, expression, error):
+    with pytest.raises(error):
+        collection._prepare_filter(expression)
+
+
+def test_order_names_and_directions_validated(collection):
+    text = collection._prepare_order_by({"text": False}).as_string()
+    assert '"body ""text""" DESC NULLS LAST' in text and '"record_id" ASC' in text
+    with pytest.raises(TypeError):
+        collection._prepare_order_by({"text": cast(Any, "DESC; DROP TABLE x")})
+    with pytest.raises(NotImplementedError):
+        collection._prepare_order_by({"tags": True})
+
+
+@pytest.mark.parametrize("key_type,value", [("int", True), ("int", "1"), ("UUID", 1), ("str", 1)])
+async def test_keys_are_strict(definition_factory, record_factory, key_type, value):
+    collection = PostgresCollection(
+        dict, definition=definition_factory(key_type=key_type), connection_string="host=unused"
+    )
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record_factory(value)], generate_vectors=False)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.get([value])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"connection_string": ""},
+        {"connection_string": "x", "client": MagicMock(spec=AsyncConnection)},
+        {"client": object()},
+    ],
+)
+def test_client_configuration_rejected(kwargs, monkeypatch):
+    monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+    with pytest.raises((ValueError, TypeError)):
+        PostgresStore(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"dimensions": 2001, "index_kind": "hnsw"},
+        {"dimensions": 4001, "index_kind": "hnsw", "annotations": {"postgres.vector_type": "halfvec"}},
+        {"dimensions": 16001},
+        {"index_kind": "ivf_flat", "distance_function": "manhattan"},
+        {"index_kind": "untrusted); DROP TABLE x"},
+        {"distance_function": "hamming"},
+        {"distance_function": "euclidean_squared_distance"},
+        {"annotations": {"postgres.vector_type": "sparsevec"}},
+        {"annotations": {"postgres.typo": True}},
+        {"index_kind": "hnsw", "annotations": {"postgres.m": "16); DROP TABLE x"}},
+        {"index_kind": "hnsw", "annotations": {"postgres.m": 40, "postgres.ef_construction": 64}},
+        {"index_kind": "ivf_flat", "annotations": {"postgres.lists": False}},
+    ],
+)
+def test_model_capabilities_rejected_before_io(definition_factory, options):
+    with pytest.raises((ValueError, NotImplementedError)):
+        PostgresCollection(dict, definition=definition_factory(**options), connection_string="host=unused")
+
+
+def test_annotations_are_snapshotted_without_copying_generator(definition_factory):
+    definition = definition_factory(index_kind="hnsw", annotations={"postgres.m": 12})
+    collection = PostgresCollection(dict, definition=definition, connection_string="host=unused")
+    definition.vector_fields[0].provider_annotations["postgres.m"] = "untrusted"
+    assert "m = 12" in collection._prepare_index(collection._fields[-1]).as_string()
+
+
+async def test_lifecycle_sql_is_scoped(collection, mock_database):
+    connection, _, _ = mock_database
+    await collection.ensure_collection_exists()
+    statements = [call.args[0].as_string() for call in connection.execute.call_args_list]
+    assert 'CREATE TABLE IF NOT EXISTS "public"."documents"' in statements[0]
+    assert '"body ""text""" text' in statements[0]
+    assert not any("EXTENSION" in statement or "SCHEMA" in statement for statement in statements)
+    await collection.ensure_collection_deleted()
+    assert connection.execute.call_args.args[0].as_string() == 'DROP TABLE IF EXISTS "public"."documents"'
+
+
+async def test_sql_upsert_returning_and_duplicate_key_order(collection, mock_database, record_factory):
+    _, cursor, _ = mock_database
+    cursor.fetchone.side_effect = [("same",), ("same",)]
+    assert (
+        await collection.upsert([record_factory("same"), record_factory("same")], generate_vectors=False)
+        == ["same"] * 2
+    )
+    statement, params = cursor.executemany.call_args.args
+    assert "ON CONFLICT" in statement.as_string() and "RETURNING" in statement.as_string()
+    assert len(params) == 2 and params[0][0] == "same"
+
+
+async def test_generated_insert_does_not_overwrite_on_identity_collision(definition_factory, record_factory):
+    collection = PostgresCollection(
+        dict, definition=definition_factory(key_type="int", generated=True), connection_string="host=unused"
+    )
+    connection = MagicMock()
+    cursor = MagicMock()
+    cursor.executemany = AsyncMock()
+    cursor.fetchone = AsyncMock(return_value=(1,))
+    connection.cursor.return_value.__aenter__.return_value = cursor
+    with patch.object(collection._client, "connection") as acquire:
+        acquire.return_value.__aenter__.return_value = connection
+        assert await collection.upsert([record_factory(None)], generate_vectors=False) == [1]
+    statement = cursor.executemany.call_args.args[0].as_string()
+    assert "ON CONFLICT" not in statement
+
+
+async def test_upsert_missing_returning_key_fails(collection, mock_database, record_factory):
+    _, cursor, _ = mock_database
+    cursor.fetchone.return_value = None
+    with pytest.raises(IntegrationInvalidResponseException):
+        await collection.upsert([record_factory()], generate_vectors=False)
+
+
+async def test_vectors_excluded_from_projection(collection, mock_database):
+    _, cursor, _ = mock_database
+    await collection.get(["one"])
+    assert '"dense vector"' not in cursor.execute.call_args.args[0].as_string()
+    await collection.get(["one"], include_vectors=True)
+    assert '"dense vector"' in cursor.execute.call_args.args[0].as_string()
+
+
+async def test_search_threshold_before_paging_and_alias_collision(collection, mock_database):
+    _, cursor, _ = mock_database
+    await collection.search(vector=[1, 0, 0], filter=Filter("number", "gt", 3), score_threshold=0.2, top=2, skip=1)
+    query, params = cursor.execute.call_args.args
+    text = query.as_string()
+    assert text.index("<= %s") < text.index("ORDER BY") < text.index("LIMIT %s OFFSET %s")
+    assert " + 0 ASC" in text  # Exact mode deliberately avoids ANN scans.
+    assert params[1] == 3 and params[-2:] == [2, 1]
+    assert '"dense vector"' not in text.split(" FROM ")[0].split(",")[0]
+
+
+async def test_get_and_search_share_filter_preparation(collection, mock_database):
+    expression = Filter("number", "gt", 3)
+    with patch.object(collection, "_prepare_filter", wraps=collection._prepare_filter) as prepare:
+        await collection.get(filter=expression)
+        await collection.search(vector=[1, 0, 0], filter=expression)
+    assert prepare.call_count == 2
+    for call in prepare.call_args_list:
+        assert call.args[0] == expression
+        assert call.args[0] is not expression
+
+
+async def test_closed_collection_rejects_empty_batches(collection, mock_database):
+    await collection.close()
+    with pytest.raises(IntegrationException, match="closed"):
+        await collection.upsert([], generate_vectors=False)
+    with pytest.raises(IntegrationException, match="closed"):
+        await collection.get([])
+    with pytest.raises(IntegrationException, match="closed"):
+        await collection.delete([])
+    mock_database[2].assert_not_called()
+
+
+@pytest.mark.parametrize("required", [False, True])
+async def test_search_tool_param_without_default(collection, mock_database, required):
+    parameter = Param("text", str, required=required)
+    assert not parameter.has_default
+    assert parameter.default is parameter.default
+    collection.embedding_generator = MagicMock(
+        get_embeddings=AsyncMock(return_value=GeneratedEmbeddings([Embedding(vector=[1, 0, 0])]))
+    )
+    search_tool = create_vector_search_tool(
+        collection,
+        filter=FilterGroup("and", [Filter("id", "eq", "one"), Filter("text", "eq", parameter)]),
+    )
+    assert ("text" in search_tool.parameters()["required"]) is required
+
+    assert await search_tool.invoke(arguments={"query": "find", "text": "provided"}, skip_parsing=True) == []
+    _, cursor, _ = mock_database
+    statement, params = cursor.execute.call_args.args
+    assert statement.as_string().count("IS NOT DISTINCT FROM") == 2
+    assert params[1:3] == ["one", "provided"]
+
+    if not required:
+        assert await search_tool.invoke(arguments={"query": "find"}, skip_parsing=True) == []
+        statement, params = cursor.execute.call_args.args
+        assert statement.as_string().count("IS NOT DISTINCT FROM") == 1
+        assert params[1] == "one"
+
+
+@pytest.mark.parametrize(
+    "options,error",
+    [
+        ({"typo": 1}, NotImplementedError),
+        ({"exact": "yes"}, TypeError),
+        ({"hnsw_ef_search": 10}, ValueError),
+        ({"ivfflat_probes": 2}, ValueError),
+    ],
+)
+async def test_unknown_or_inapplicable_search_options(collection, mock_database, options, error):
+    with pytest.raises(error):
+        await collection.search(vector=[1, 0, 0], operation_options=options)
+    mock_database[2].assert_not_called()
+
+
+async def test_unsupported_query_modes(collection, mock_database):
+    with pytest.raises(NotImplementedError):
+        await collection.search("text", search_type="keyword_hybrid", vector=[1, 0, 0])
+    with pytest.raises(NotImplementedError):
+        await collection.search("text")
+    with pytest.raises(NotImplementedError):
+        await collection.search(vector=[1, 0, 0], additional_property_name="text")
+    mock_database[2].assert_not_called()
+
+
+async def test_core_dimension_rejection_precedes_io(collection, mock_database, record_factory):
+    with pytest.raises(ValueError, match="index 1"):
+        await collection.upsert([record_factory(), record_factory(embedding=[1])], generate_vectors=False)
+    with pytest.raises(ValueError, match="dimensions"):
+        await collection.search(vector=[1])
+    mock_database[2].assert_not_called()
+
+
+async def test_empty_batches_do_not_acquire_connection(collection, mock_database):
+    assert await collection.upsert([], generate_vectors=False) == []
+    assert await collection.get([]) == []
+    await collection.delete([])
+    mock_database[2].assert_not_called()
+
+
+async def test_borrowed_client_not_closed_and_driver_errors_chained():
+    connection = MagicMock(spec=AsyncConnection)
+    connection.close = AsyncMock()
+    connection.transaction.return_value.__aenter__.side_effect = OperationalError("broken")
+    owner = _Client(None, connection)
+    with pytest.raises(IntegrationException) as exc:
+        async with owner.connection():
+            pytest.fail("Connection acquisition should fail")
+    assert isinstance(exc.value.__cause__, OperationalError)
+    await owner.close()
+    await owner.close()
+    connection.close.assert_not_called()
+    with pytest.raises(RuntimeError, match="closed"):
+        async with owner.connection():
+            pytest.fail("Closed wrapper must reject operations")
+
+
+async def test_store_collection_close_does_not_close_owned_pool(definition_factory):
+    store = PostgresStore(connection_string="host=unused")
+    collection = store.get_collection(dict, definition=definition_factory())
+    assert not collection.managed_client
+    with patch.object(store._client.client, "close", new_callable=AsyncMock) as close:
+        await collection.close()
+        close.assert_not_called()
+        await store.close()
+        await store.close()
+        close.assert_awaited_once()
+
+
+def test_value_adaptation_and_fulltext_rejection():
+    assert _prepare_value(VectorStoreField("key", name="id", type_="UUID"), str(UUID(int=1))) == UUID(int=1)
+    with pytest.raises(TypeError):
+        _prepare_value(VectorStoreField("vector", name="v", dimensions=3), b"not a dense vector")
+    with pytest.raises(ValueError):
+        _prepare_value(VectorStoreField("data", name="d", type_="datetime"), "2026-01-01T00:00:00")
+    with pytest.raises(NotImplementedError):
+        PostgresCollection(
+            dict,
+            connection_string="host=unused",
+            collection_name="data",
+            definition=VectorStoreCollectionDefinition([
+                VectorStoreField("key", name="id", type_="str"),
+                VectorStoreField("data", name="text", type_="str", is_full_text_indexed=True),
+            ]),
+        )
+
+
+@vectorstoremodel
+@dataclass
+class TypedRecord:
+    id: Annotated[UUID, VectorStoreField("key", is_auto_generated=True)]
+    value: Annotated[str, VectorStoreField("data")]
+    embedding: Annotated[list[float] | None, VectorStoreField("vector", dimensions=3)] = None
+
+
+def test_decorated_model_infers_key_type():
+    collection = PostgresCollection(TypedRecord, collection_name="typed", connection_string="host=unused")
+    assert collection.definition.key_field.type_ == "UUID"
+    assert isinstance(collection._client.client, AsyncConnectionPool)

--- a/python/packages/postgres/tests/test_postgres.py
+++ b/python/packages/postgres/tests/test_postgres.py
@@ -20,6 +20,8 @@ from agent_framework import (
     vectorstoremodel,
 )
 from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from pgvector import HalfVector
+from pgvector import Vector as PgVector
 from psycopg import AsyncConnection, OperationalError
 from psycopg_pool import AsyncConnectionPool
 
@@ -28,8 +30,10 @@ from agent_framework_postgres._vector_store import _Client, _prepare_identifier,
 
 
 @pytest.fixture
-def collection(definition_factory):
-    return PostgresCollection(dict, definition=definition_factory(), connection_string="host=unused")
+def collection(definition_factory, request):
+    return PostgresCollection(
+        dict, definition=definition_factory(**getattr(request, "param", {})), connection_string="host=unused"
+    )
 
 
 @pytest.fixture
@@ -206,6 +210,33 @@ def test_model_capabilities_rejected_before_io(definition_factory, options):
         PostgresCollection(dict, definition=definition_factory(**options), connection_string="host=unused")
 
 
+@pytest.mark.parametrize("vector_type", ["int", "float64"])
+@pytest.mark.parametrize("annotations", [None, {"postgres.vector_type": "vector"}, {"postgres.vector_type": "halfvec"}])
+def test_vector_type_capabilities_rejected_before_client_creation(definition_factory, vector_type, annotations):
+    definition = definition_factory(vector_type=vector_type, annotations=annotations)
+    with (
+        patch("agent_framework_postgres._vector_store.AsyncConnectionPool") as create_pool,
+        pytest.raises(ValueError, match=vector_type),
+    ):
+        PostgresCollection(dict, definition=definition, connection_string="host=unused")
+    create_pool.assert_not_called()
+
+
+def test_inferred_integer_vectors_rejected_before_client_creation():
+    @vectorstoremodel(collection_name="integers")
+    @dataclass
+    class IntegerRecord:
+        id: Annotated[str, VectorStoreField("key")]
+        embedding: Annotated[list[int] | None, VectorStoreField("vector", dimensions=3)] = None
+
+    with (
+        patch("agent_framework_postgres._vector_store.AsyncConnectionPool") as create_pool,
+        pytest.raises(ValueError, match="got 'int'"),
+    ):
+        PostgresCollection(IntegerRecord, connection_string="host=unused")
+    create_pool.assert_not_called()
+
+
 def test_annotations_are_snapshotted_without_copying_generator(definition_factory):
     definition = definition_factory(index_kind="hnsw", annotations={"postgres.m": 12})
     collection = PostgresCollection(dict, definition=definition, connection_string="host=unused")
@@ -267,15 +298,52 @@ async def test_vectors_excluded_from_projection(collection, mock_database):
     assert '"dense vector"' in cursor.execute.call_args.args[0].as_string()
 
 
-async def test_search_threshold_before_paging_and_alias_collision(collection, mock_database):
+@pytest.mark.parametrize("collection", [{"index_kind": "flat"}, {"index_kind": "default"}], indirect=True)
+@pytest.mark.parametrize("options", [None, {"exact": True}])
+async def test_search_threshold_before_paging_and_alias_collision(collection, mock_database, options):
     _, cursor, _ = mock_database
-    await collection.search(vector=[1, 0, 0], filter=Filter("number", "gt", 3), score_threshold=0.2, top=2, skip=1)
+    results = await collection.search(
+        vector=[1, 0, 0],
+        filter=Filter("number", "gt", 3),
+        score_threshold=0.2,
+        top=2,
+        skip=1,
+        operation_options=options,
+    )
+    assert results.metadata is not None
+    assert results.metadata["approximate"] is False
     query, params = cursor.execute.call_args.args
     text = query.as_string()
     assert text.index("<= %s") < text.index("ORDER BY") < text.index("LIMIT %s OFFSET %s")
     assert " + 0 ASC" in text  # Exact mode deliberately avoids ANN scans.
     assert params[1] == 3 and params[-2:] == [2, 1]
     assert '"dense vector"' not in text.split(" FROM ")[0].split(",")[0]
+
+
+@pytest.mark.parametrize(
+    "collection,adapter",
+    [
+        ({"annotations": {"postgres.vector_type": "vector"}}, PgVector),
+        ({"annotations": {"postgres.vector_type": "halfvec"}}, HalfVector),
+    ],
+    indirect=["collection"],
+)
+@pytest.mark.parametrize("vector", [[0, 1, 2], (0, 1, 2), range(3)], ids=["list", "tuple", "range"])
+async def test_numeric_sequences_adapted_for_storage_and_search(
+    collection, mock_database, record_factory, adapter, vector
+):
+    adapted = _prepare_value(collection.definition.vector_fields[0], vector)
+    assert isinstance(adapted, adapter)
+    assert adapted.to_list() == [0.0, 1.0, 2.0]
+    await collection.search(vector=vector)
+    _, cursor, _ = mock_database
+    query_vector = cursor.execute.call_args.args[1][0]
+    assert isinstance(query_vector, adapter)
+    assert query_vector.to_list() == [0.0, 1.0, 2.0]
+    await collection.upsert([record_factory(embedding=tuple(vector))], generate_vectors=False)
+    stored_vector = cursor.executemany.call_args.args[1][0][-1]
+    assert isinstance(stored_vector, adapter)
+    assert stored_vector.to_list() == [0.0, 1.0, 2.0]
 
 
 async def test_get_and_search_share_filter_preparation(collection, mock_database):
@@ -304,7 +372,7 @@ async def test_closed_collection_rejects_empty_batches(collection, mock_database
 async def test_search_tool_param_without_default(collection, mock_database, required):
     parameter = Param("text", str, required=required)
     assert not parameter.has_default
-    assert parameter.default is parameter.default
+    assert parameter.default is Param("other", str).default
     collection.embedding_generator = MagicMock(
         get_embeddings=AsyncMock(return_value=GeneratedEmbeddings([Embedding(vector=[1, 0, 0])]))
     )
@@ -332,10 +400,12 @@ async def test_search_tool_param_without_default(collection, mock_database, requ
     [
         ({"typo": 1}, NotImplementedError),
         ({"exact": "yes"}, TypeError),
+        ({"exact": False}, ValueError),
         ({"hnsw_ef_search": 10}, ValueError),
         ({"ivfflat_probes": 2}, ValueError),
     ],
 )
+@pytest.mark.parametrize("collection", [{"index_kind": "flat"}, {"index_kind": "default"}], indirect=True)
 async def test_unknown_or_inapplicable_search_options(collection, mock_database, options, error):
     with pytest.raises(error):
         await collection.search(vector=[1, 0, 0], operation_options=options)
@@ -426,3 +496,17 @@ def test_decorated_model_infers_key_type():
     collection = PostgresCollection(TypedRecord, collection_name="typed", connection_string="host=unused")
     assert collection.definition.key_field.type_ == "UUID"
     assert isinstance(collection._client.client, AsyncConnectionPool)
+
+
+def test_normal_float_vectors_restore_typed_models():
+    collection = PostgresCollection(TypedRecord, collection_name="typed", connection_string="host=unused")
+    field = collection.definition.vector_fields[0]
+    assert field.type_ == "float"
+    record = collection.deserialize({
+        "id": UUID(int=1),
+        "value": "text",
+        "embedding": _prepare_value(field, [0.1, 1, 0]),
+    })
+    assert isinstance(record, TypedRecord)
+    assert record.id == UUID(int=1)
+    assert record.embedding == pytest.approx([0.1, 1, 0])

--- a/python/packages/postgres/tests/test_postgres.py
+++ b/python/packages/postgres/tests/test_postgres.py
@@ -26,7 +26,7 @@ from psycopg import AsyncConnection, OperationalError
 from psycopg_pool import AsyncConnectionPool
 
 from agent_framework_postgres import PostgresCollection, PostgresStore
-from agent_framework_postgres._vector_store import _Client, _prepare_identifier, _prepare_value
+from agent_framework_postgres._vector_store import _Client, _FilterCompiler, _prepare_identifier, _prepare_value
 
 
 @pytest.fixture
@@ -122,6 +122,33 @@ def test_nested_groups_and_array_membership(collection):
     text = condition.as_string()
     assert "jsonb_array_elements" in text and " AND " in text and " OR " in text
     assert [p.obj for p in params] == [True, None, 2]
+
+
+def test_filter_compiler_preserves_parameter_order_and_isolates_calls(definition_factory):
+    compiler = _FilterCompiler(definition_factory())
+    condition, params = compiler.compile(
+        FilterGroup(
+            "and",
+            [
+                Filter("id", "eq", "one"),
+                FilterGroup("or", [Filter("number", "between", [2, 3]), Filter("text", "eq", "last")]),
+            ],
+        )
+    )
+    text = condition.as_string()
+    assert text.count("%s") == len(params) == 4
+    assert text.index('"record_id"') < text.index('"number"') < text.index('"body ""text"""')
+    assert params == ["one", 2, 3, "last"]
+
+    next_condition, next_params = compiler.compile(Filter("number", "eq", 4))
+    assert next_condition.as_string().count("%s") == 1
+    assert next_params == [4]
+    assert params == ["one", 2, 3, "last"]
+
+    with pytest.raises(ValueError, match="unknown"):
+        compiler.compile(FilterGroup("and", [Filter("id", "eq", "partial"), Filter("unknown", "eq", 5)]))
+    _, recovered_params = compiler.compile(Filter("id", "eq", "after-error"))
+    assert recovered_params == ["after-error"]
 
 
 @pytest.mark.parametrize("value", [("tuple",), [("nested",)], {1: "non-string key"}, b"bytes", float("nan")])

--- a/python/packages/postgres/tests/test_postgres_integration.py
+++ b/python/packages/postgres/tests/test_postgres_integration.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, make_dataclass
 from datetime import date, datetime, timezone
+from types import GenericAlias
 from typing import Annotated, Any
 from uuid import UUID, uuid4
 
@@ -413,6 +414,53 @@ async def test_floating_vector_types_preserve_typed_roundtrips(database, vector_
     assert results[0]["record"] == records[0]
     results = [item async for item in await collection.search(vector=range(3))]
     assert [item["record"].id for item in results] == ["one"]
+
+
+@pytest.mark.parametrize("scalar_name", ["float16", "float32"])
+async def test_numpy_scalar_annotations_roundtrip_with_custom_decoder(database, scalar_name):
+    np = pytest.importorskip("numpy")
+    scalar_type = getattr(np, scalar_name)
+    record_type = make_dataclass(
+        "NumpyRecord",
+        [
+            ("id", str),
+            ("embedding", GenericAlias(list, scalar_type) | None, None),
+        ],
+    )
+
+    def decode_record(row):
+        vector = row.get("embedding")
+        return record_type(
+            id=row["id"],
+            embedding=[scalar_type(value) for value in vector] if vector is not None else None,
+        )
+
+    register_vectorstoremodel(
+        record_type,
+        definition=VectorStoreCollectionDefinition(
+            [
+                VectorStoreField("key", name="id", type_="str"),
+                VectorStoreField("vector", name="embedding", dimensions=3, type_=scalar_name),
+            ],
+            collection_name="numpy_vectors",
+        ),
+        decoder=decode_record,
+    )
+    connection, schema = database
+    collection = PostgresCollection(record_type, client=connection, schema=schema)
+    assert collection.definition.vector_fields[0].type_ == scalar_name
+    await collection.ensure_collection_exists()
+    original = record_type("one", [scalar_type(0.1), scalar_type(1), scalar_type(0)])
+    await collection.upsert([original], generate_vectors=False)
+
+    records = await collection.get(["one"], include_vectors=True)
+    results = [item async for item in await collection.search(vector=(0.1, 1, 0), include_vectors=True)]
+    assert len(records) == len(results) == 1
+    for restored in (records[0], results[0]["record"]):
+        assert isinstance(restored, record_type)
+        assert restored == original
+        assert all(isinstance(value, scalar_type) for value in vars(restored)["embedding"])
+    assert vars((await collection.get(["one"]))[0])["embedding"] is None
 
 
 async def test_missing_schema_is_not_created(database, definition_factory):

--- a/python/packages/postgres/tests/test_postgres_integration.py
+++ b/python/packages/postgres/tests/test_postgres_integration.py
@@ -20,6 +20,7 @@ from agent_framework import (
     VectorStoreCollectionDefinition,
     VectorStoreField,
     create_vector_search_tool,
+    register_vectorstoremodel,
     vectorstoremodel,
 )
 from agent_framework.exceptions import IntegrationException
@@ -316,12 +317,14 @@ async def test_settings_resolved_owned_connections(
         ("hnsw", {"postgres.vector_type": "halfvec"}),
     ],
 )
+@pytest.mark.parametrize("approximate_options", [{}, {"exact": False}])
 async def test_ann_indexes_creation_filtered_query_and_exact_override(
     database,
     definition_factory,
     record_factory,
     index_kind,
     annotations,
+    approximate_options,
 ):
     connection, schema = database
     collection = PostgresCollection(
@@ -346,26 +349,70 @@ async def test_ann_indexes_creation_filtered_query_and_exact_override(
     if annotations.get("postgres.vector_type") == "halfvec":
         assert (await collection.get(["0"], include_vectors=True))[0]["embedding"] == [1, 0, 0]
     options = {"hnsw_ef_search": 100} if index_kind == "hnsw" else {"ivfflat_probes": 1}
-    results = [
-        item
-        async for item in await collection.search(
-            vector=[1, 0, 0],
-            filter=Filter("number", "gte", 90),
-            top=3,
-            operation_options=options,
-        )
-    ]
+    search_results = await collection.search(
+        vector=(1, 0, 0),
+        filter=Filter("number", "gte", 90),
+        top=3,
+        operation_options={**options, **approximate_options},
+    )
+    assert search_results.metadata is not None
+    assert search_results.metadata["approximate"] is True
+    results = [item async for item in search_results]
     assert [item["record"]["id"] for item in results] == ["90", "91", "92"]
-    results = [
-        item
-        async for item in await collection.search(
-            vector=[1, 0, 0],
-            filter=Filter("number", "gte", 90),
-            top=3,
-            operation_options={"exact": True},
-        )
-    ]
+    search_results = await collection.search(
+        vector=(1, 0, 0),
+        filter=Filter("number", "gte", 90),
+        top=3,
+        operation_options={"exact": True},
+    )
+    assert search_results.metadata is not None
+    assert search_results.metadata["approximate"] is False
+    results = [item async for item in search_results]
     assert [item["record"]["id"] for item in results] == ["90", "91", "92"]
+
+
+@pytest.mark.parametrize(
+    "vector_type,annotations",
+    [
+        ("float", None),
+        ("float32", None),
+        ("float16", None),
+        ("float", {"postgres.vector_type": "halfvec"}),
+        ("float32", {"postgres.vector_type": "halfvec"}),
+        ("float16", {"postgres.vector_type": "vector"}),
+    ],
+)
+async def test_floating_vector_types_preserve_typed_roundtrips(database, vector_type, annotations):
+    @dataclass
+    class FloatingRecord:
+        id: str
+        embedding: list[float] | None = None
+
+    register_vectorstoremodel(
+        FloatingRecord,
+        definition=VectorStoreCollectionDefinition(
+            [
+                VectorStoreField("key", name="id", type_="str"),
+                VectorStoreField(
+                    "vector", name="embedding", dimensions=3, type_=vector_type, provider_annotations=annotations
+                ),
+            ],
+            collection_name="floating_vectors",
+        ),
+    )
+    connection, schema = database
+    collection = PostgresCollection(FloatingRecord, client=connection, schema=schema)
+    await collection.ensure_collection_exists()
+    await collection.upsert([FloatingRecord("one", [0.1, 1, 0])], generate_vectors=False)
+    records = await collection.get(["one"], include_vectors=True)
+    assert len(records) == 1
+    assert isinstance(records[0], FloatingRecord)
+    assert records[0].embedding == pytest.approx([0.1, 1, 0], rel=1e-3)
+    results = [item async for item in await collection.search(vector=(0.1, 1, 0), include_vectors=True)]
+    assert len(results) == 1
+    assert results[0]["record"] == records[0]
+    results = [item async for item in await collection.search(vector=range(3))]
+    assert [item["record"].id for item in results] == ["one"]
 
 
 async def test_missing_schema_is_not_created(database, definition_factory):

--- a/python/packages/postgres/tests/test_postgres_integration.py
+++ b/python/packages/postgres/tests/test_postgres_integration.py
@@ -1,0 +1,583 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Annotated, Any
+from uuid import UUID, uuid4
+
+import pytest
+from agent_framework import (
+    Embedding,
+    Filter,
+    FilterGroup,
+    GeneratedEmbeddings,
+    InMemoryCollection,
+    Param,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    create_vector_search_tool,
+    vectorstoremodel,
+)
+from agent_framework.exceptions import IntegrationException
+from psycopg import AsyncConnection, AsyncCursor, sql
+from psycopg_pool import AsyncConnectionPool
+from typing_extensions import Self
+
+from agent_framework_postgres import PostgresCollection, PostgresStore
+
+pytestmark = pytest.mark.integration
+
+
+async def test_lifecycle_crud_multiple_vectors_and_aliases(database, definition_factory, record_factory):
+    connection, schema = database
+    async with PostgresStore(client=connection, schema=schema) as store:
+        collection = store.get_collection(
+            dict, definition=definition_factory(second_vector=True), collection_name='quoted"; -- table'
+        )
+        assert not await collection.collection_exists()
+        assert await store.list_collection_names() == []
+        await collection.ensure_collection_exists()
+        await collection.ensure_collection_exists()
+        assert await store.collection_exists('quoted"; -- table')
+        assert await collection.get() == []
+        assert [
+            item async for item in await collection.search(vector=[1, 0, 0], vector_property_name="embedding")
+        ] == []
+        records = [record_factory("a", secondary=[0, 1, 0]), record_factory("b", secondary=None)]
+        assert await collection.upsert(records, generate_vectors=False) == ["a", "b"]
+        assert await collection.get(["a", "missing", "a"], include_vectors=True) == [records[0], records[0]]
+        assert all("embedding" not in row and "secondary" not in row for row in await collection.get())
+        results = [
+            item
+            async for item in await collection.search(
+                vector=[0, 1, 0],
+                vector_property_name="secondary",
+                include_vectors=True,
+            )
+        ]
+        assert [item["record"]["id"] for item in results] == ["a"]
+        assert results[0]["record"]["secondary"] == [0, 1, 0]
+        await collection.close()
+        assert not connection.closed
+        await collection.delete(["missing", "a"])
+        assert [row["id"] for row in await collection.get()] == ["b"]
+        await store.ensure_collection_deleted('quoted"; -- table')
+        await store.ensure_collection_deleted('quoted"; -- table')
+        assert not await collection.collection_exists()
+    assert not connection.closed
+
+
+async def test_filters_match_portable_semantics_in_database(database, definition_factory, record_factory):
+    connection, schema = database
+    definition = definition_factory()
+    postgres = PostgresCollection(dict, client=connection, schema=schema, definition=definition)
+    memory = InMemoryCollection(dict, definition=definition)
+    rows = [
+        record_factory("a", text="100%_!\\ exact", number=1, flag=True, tags=[True, None, "tag", ["x", True]]),
+        record_factory("b", text="100xx!\\ exact", number=2, flag=False, tags=[1, "other", ["x", 1]]),
+        record_factory("c", text="", number=3, flag=True, tags=[]),
+        {**record_factory("d"), "text": None, "number": None, "flag": None, "tags": None, "embedding": None},
+    ]
+    await postgres.ensure_collection_exists()
+    await memory.ensure_collection_exists()
+    await postgres.upsert(rows, generate_vectors=False)
+    await memory.upsert(rows, generate_vectors=False)
+    expressions: list[Filter | FilterGroup] = [
+        Filter("number", "eq", 1),
+        Filter("number", "eq", True),
+        Filter("flag", "eq", 1),
+        Filter("flag", "eq", True),
+        Filter("number", "ne", True),
+        Filter("flag", "ne", 1),
+        Filter("number", "ne", 1),
+        Filter("number", "gt", 1),
+        Filter("number", "gte", 2),
+        Filter("number", "lt", 2),
+        Filter("number", "lte", 2),
+        Filter("number", "between", [1, 2]),
+        Filter("number", "between", [2, 1]),
+        Filter("number", "in", [True, 2, None]),
+        Filter("number", "not_in", [True, 2, None]),
+        Filter("number", "in", []),
+        Filter("number", "not_in", []),
+        Filter("number", "exists"),
+        Filter("number", "is_null"),
+        Filter("number", "is_not_null"),
+        Filter("tags", "contains", True),
+        Filter("tags", "contains", 1),
+        Filter("tags", "contains_any", [None]),
+        Filter("tags", "contains", ["x", True]),
+        Filter("tags", "contains_any", [True, "other"]),
+        Filter("tags", "contains_all", [True, "tag"]),
+        Filter("tags", "contains_any", []),
+        Filter("tags", "contains_all", []),
+        Filter("tags", "eq", []),
+        Filter("text", "contains_text", "%_"),
+        Filter("text", "starts_with", "100%"),
+        Filter("text", "ends_with", "!\\ exact"),
+        Filter("text", "contains_text", ""),
+        Filter("text", "contains_text", "'; DROP TABLE documents; --"),
+        FilterGroup("not", [Filter("number", "gt", 2)]),
+        FilterGroup("not", [Filter("text", "contains_text", "%_")]),
+        FilterGroup("not", [Filter("number", "not_in", [1])]),
+        FilterGroup(
+            "and",
+            [
+                Filter("number", "lte", 2),
+                FilterGroup(
+                    "or",
+                    [
+                        Filter("flag", "eq", True),
+                        Filter("tags", "contains", "other"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    for expression in expressions:
+        expected = await memory.get(filter=expression, top=10)
+        actual = await postgres.get(filter=expression, top=10)
+        assert {row["id"] for row in actual} == {row["id"] for row in expected}, repr(expression)
+        # Exercise the same filters in native vector queries. Row d has no vector.
+        results = [
+            item
+            async for item in await postgres.search(
+                vector=[1, 0, 0],
+                filter=expression,
+                top=10,
+                score_threshold=0.1,
+            )
+        ]
+        assert {item["record"]["id"] for item in results} == {row["id"] for row in expected} - {"d"}, repr(expression)
+    assert [row["id"] for row in await postgres.get(order_by={"number": False}, top=2, skip=1)] == ["b", "a"]
+
+
+@pytest.mark.parametrize(
+    "metric,query,expected,threshold,accepted",
+    [
+        ("DEFAULT", [1, 0, 0], [0, 1, 2], 1, ["same", "orthogonal"]),
+        ("cosine_distance", [1, 0, 0], [0, 1, 2], 1, ["same", "orthogonal"]),
+        ("cosine_similarity", [1, 0, 0], [1, 0, -1], 0, ["same", "orthogonal"]),
+        ("dot_prod", [2, 0, 0], [2, 0, -2], 0, ["same", "orthogonal"]),
+        ("negative_dot_prod", [2, 0, 0], [-2, 0, 2], 0, ["same", "orthogonal"]),
+        ("euclidean_distance", [1, 0, 0], [0, 2**0.5, 2], 1.5, ["same", "orthogonal"]),
+        ("manhattan", [2, 0, 0], [1, 3, 3], 1, ["same"]),
+    ],
+)
+async def test_metric_units_threshold_ranking_and_offset(
+    database,
+    definition_factory,
+    record_factory,
+    metric,
+    query,
+    expected,
+    threshold,
+    accepted,
+):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict, client=connection, schema=schema, definition=definition_factory(distance_function=metric)
+    )
+    await collection.ensure_collection_exists()
+    rows = [
+        record_factory("opposite", embedding=[-1, 0, 0]),
+        record_factory("orthogonal", embedding=[0, 1, 0]),
+        record_factory("same", embedding=[1, 0, 0]),
+    ]
+    await collection.upsert(rows, generate_vectors=False)
+    results = [item async for item in await collection.search(vector=query, top=10)]
+    assert [item["score"] for item in results] == pytest.approx(expected)
+    assert results[0]["record"]["id"] == "same"
+    filtered = [item async for item in await collection.search(vector=query, score_threshold=threshold, top=10)]
+    assert [item["record"]["id"] for item in filtered] == accepted
+    page = [item async for item in await collection.search(vector=query, score_threshold=threshold, skip=1, top=1)]
+    assert [item["record"]["id"] for item in page] == accepted[1:2]
+    assert all("embedding" not in item["record"] for item in results)
+
+
+@pytest.mark.parametrize("key_type,explicit", [("int", 1000), ("UUID", UUID(int=5)), ("str", "chosen")])
+async def test_generated_and_preserved_typed_keys(database, definition_factory, record_factory, key_type, explicit):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict, client=connection, schema=schema, definition=definition_factory(key_type=key_type, generated=True)
+    )
+    await collection.ensure_collection_exists()
+    omitted = record_factory()
+    del omitted["id"]
+    keys = await collection.upsert([record_factory(None), record_factory(explicit), omitted], generate_vectors=False)
+    assert keys[1] == explicit
+    assert len(set(keys)) == 3
+    assert all(type(key).__name__ == key_type for key in keys)
+    assert [row["id"] for row in await collection.get(list(reversed(keys)))] == list(reversed(keys))
+    await collection.upsert(
+        [record_factory(explicit, text="updated"), record_factory(explicit, text="last")], generate_vectors=False
+    )
+    assert (await collection.get([explicit]))[0]["text"] == "last"
+    await collection.delete(keys)
+    assert await collection.get() == []
+
+
+async def test_atomic_batch_failure_does_not_rollback_callers_prior_work(database, definition_factory, record_factory):
+    connection, schema = database
+    collection = PostgresCollection(dict, client=connection, schema=schema, definition=definition_factory())
+    await collection.ensure_collection_exists()
+    async with connection.transaction():
+        await collection.upsert([record_factory("prior")], generate_vectors=False)
+        with pytest.raises(IntegrationException):
+            # The driver sends both records; pgvector rejects infinity in the second row.
+            await collection.upsert(
+                [
+                    record_factory("new"),
+                    record_factory("bad", embedding=[float("inf"), 0, 0]),
+                ],
+                generate_vectors=False,
+            )
+        assert [row["id"] for row in await collection.get()] == ["prior"]
+    assert [row["id"] for row in await collection.get()] == ["prior"]
+    with pytest.raises(ValueError, match="index 1"):
+        await collection.upsert([record_factory("new"), record_factory("bad", embedding=[1])], generate_vectors=False)
+    assert [row["id"] for row in await collection.get()] == ["prior"]
+
+
+async def test_owned_pool_and_borrowed_pool_lifetimes(database, definition_factory, record_factory):
+    _, schema = database
+    conninfo = os.environ["POSTGRES_TEST_CONNECTION_STRING"]
+    store = PostgresStore(connection_string=conninfo, schema=schema)
+    collection = store.get_collection(dict, definition=definition_factory())
+    assert store._client.client.closed
+    await collection.ensure_collection_exists()
+    assert not store._client.client.closed
+    await collection.upsert([record_factory()], generate_vectors=False)
+    await collection.close()
+    assert await collection.get(["one"])
+    await store.close()
+    assert store._client.client.closed
+    with pytest.raises(RuntimeError, match="closed"):
+        await collection.collection_exists()
+    async with AsyncConnectionPool[AsyncConnection[Any]](conninfo, open=False) as pool:
+        async with PostgresStore(client=pool, schema=schema) as borrowed:
+            child = borrowed.get_collection(dict, definition=definition_factory())
+            assert await child.get(["one"])
+        assert not pool.closed
+        async with pool.connection() as connection:
+            assert await (await connection.execute("SELECT 1")).fetchone() == (1,)
+
+
+@pytest.mark.parametrize("source", ["environment", "file", "secret"])
+@pytest.mark.parametrize("kind", ["collection", "store"])
+async def test_settings_resolved_owned_connections(
+    database,
+    definition_factory,
+    record_factory,
+    monkeypatch,
+    tmp_path,
+    source,
+    kind,
+):
+    _, schema = database
+    conninfo = os.environ["POSTGRES_TEST_CONNECTION_STRING"]
+    options: dict[str, Any] = {}
+    if source == "environment":
+        monkeypatch.setenv("POSTGRES_CONNECTION_STRING", conninfo)
+    elif source == "file":
+        monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=must_not_connect")
+        env_file = tmp_path / "postgres.env"
+        env_file.write_text(f"POSTGRES_CONNECTION_STRING='{conninfo}'\n", encoding="utf-8")
+        options["env_file_path"] = str(env_file)
+    else:
+        monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=must_not_connect")
+        options["connection_string"] = SecretString(conninfo)
+    owner = (
+        PostgresStore(schema=schema, **options)
+        if kind == "store"
+        else PostgresCollection(dict, schema=schema, definition=definition_factory(), **options)
+    )
+    async with owner:
+        collection = (
+            owner.get_collection(dict, definition=definition_factory()) if isinstance(owner, PostgresStore) else owner
+        )
+        await collection.ensure_collection_exists()
+        await collection.upsert([record_factory()], generate_vectors=False)
+        assert (await collection.get(["one"]))[0]["id"] == "one"
+        results = [item async for item in await collection.search(vector=[1, 0, 0], score_threshold=0)]
+        assert [item["record"]["id"] for item in results] == ["one"]
+    assert owner._client.client.closed
+
+
+@pytest.mark.parametrize(
+    "index_kind,annotations",
+    [
+        ("hnsw", {"postgres.m": 8, "postgres.ef_construction": 32}),
+        ("ivf_flat", {"postgres.lists": 1}),
+        ("hnsw", {"postgres.vector_type": "halfvec"}),
+    ],
+)
+async def test_ann_indexes_creation_filtered_query_and_exact_override(
+    database,
+    definition_factory,
+    record_factory,
+    index_kind,
+    annotations,
+):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict,
+        client=connection,
+        schema=schema,
+        definition=definition_factory(index_kind=index_kind, annotations=annotations),
+    )
+    if index_kind == "ivf_flat":
+        with pytest.raises(ValueError, match="training"):
+            await collection.ensure_collection_exists()
+        assert not await collection.collection_exists()
+        await collection.ensure_collection_exists(operation_options={"create_indexes": False})
+    else:
+        await collection.ensure_collection_exists()
+    records = [record_factory(str(i), number=i, embedding=[1, i / 100, 0]) for i in range(100)]
+    await collection.upsert(records, generate_vectors=False)
+    await collection.ensure_collection_exists()
+    cursor = await connection.execute("SELECT indexdef FROM pg_indexes WHERE schemaname = %s", [schema])
+    indexes = [row[0] for row in await cursor.fetchall()]
+    assert any(("USING hnsw" if index_kind == "hnsw" else "USING ivfflat") in item for item in indexes)
+    if annotations.get("postgres.vector_type") == "halfvec":
+        assert (await collection.get(["0"], include_vectors=True))[0]["embedding"] == [1, 0, 0]
+    options = {"hnsw_ef_search": 100} if index_kind == "hnsw" else {"ivfflat_probes": 1}
+    results = [
+        item
+        async for item in await collection.search(
+            vector=[1, 0, 0],
+            filter=Filter("number", "gte", 90),
+            top=3,
+            operation_options=options,
+        )
+    ]
+    assert [item["record"]["id"] for item in results] == ["90", "91", "92"]
+    results = [
+        item
+        async for item in await collection.search(
+            vector=[1, 0, 0],
+            filter=Filter("number", "gte", 90),
+            top=3,
+            operation_options={"exact": True},
+        )
+    ]
+    assert [item["record"]["id"] for item in results] == ["90", "91", "92"]
+
+
+async def test_missing_schema_is_not_created(database, definition_factory):
+    connection, schema = database
+    collection = PostgresCollection(dict, client=connection, schema=f"{schema}_absent", definition=definition_factory())
+    with pytest.raises(IntegrationException):
+        await collection.ensure_collection_exists()
+    cursor = await connection.execute("SELECT 1 FROM pg_namespace WHERE nspname = %s", [f"{schema}_absent"])
+    assert await cursor.fetchone() is None
+
+
+class DeterministicEmbeddingClient:
+    def __init__(self):
+        self.additional_properties: dict[str, Any] = {}
+        self.inputs: list[list[Any]] = []
+
+    async def get_embeddings(self, values, *, options=None):
+        self.inputs.append(list(values))
+        return GeneratedEmbeddings([Embedding(vector=[0, 1, 0]) for _ in values])
+
+
+async def test_generation_selection_and_search_tool_params(database, definition_factory, record_factory):
+    connection, schema = database
+    generator = DeterministicEmbeddingClient()
+    collection = PostgresCollection(
+        dict,
+        client=connection,
+        schema=schema,
+        definition=definition_factory(second_vector=True),
+        embedding_generator=generator,
+    )
+    await collection.ensure_collection_exists()
+    await collection.upsert(
+        [record_factory("one", embedding="generate", secondary=[1, 0, 0])], generate_vectors=["embedding"]
+    )
+    row = (await collection.get(["one"], include_vectors=True))[0]
+    assert row["embedding"] == [0, 1, 0] and row["secondary"] == [1, 0, 0]
+    assert generator.inputs == [["generate"]]
+    await collection.upsert([record_factory("two", embedding="first", secondary="second")])
+    assert generator.inputs[1:] == [["first"], ["second"]]
+    tool_collection = PostgresCollection(
+        dict, client=connection, schema=schema, definition=definition_factory(), embedding_generator=generator
+    )
+    tool = create_vector_search_tool(
+        tool_collection,
+        filter=FilterGroup(
+            "and",
+            [
+                Filter("id", "eq", "one"),
+                Filter("text", "contains_text", Param("text", str | None, default=None, omit_if_none=True)),
+            ],
+        ),
+    )
+    result = await tool.invoke(arguments={"query": "search", "text": None})
+    text = "".join(content.text or "" for content in result)
+    assert "one" in text and "two" not in text
+
+
+@vectorstoremodel
+@dataclass
+class NativeRecord:
+    id: Annotated[UUID, VectorStoreField("key")]
+    day: Annotated[date, VectorStoreField("data")]
+    timestamp: Annotated[datetime, VectorStoreField("data")]
+    data: Annotated[bytes, VectorStoreField("data")]
+    details: Annotated[dict, VectorStoreField("data")]
+    embedding: Annotated[list[float] | None, VectorStoreField("vector", dimensions=3)] = None
+
+
+async def test_msgspec_typed_roundtrip(database):
+    connection, schema = database
+    collection = PostgresCollection(NativeRecord, client=connection, schema=schema, collection_name="native")
+    await collection.ensure_collection_exists()
+    row = NativeRecord(
+        uuid4(),
+        date(2026, 9, 8),
+        datetime(2026, 9, 8, tzinfo=timezone.utc),
+        b"\x00binary",
+        {"nested": [True, 1, None]},
+        [1, 0, 0],
+    )
+    assert await collection.upsert([row], generate_vectors=False) == [row.id]
+    assert await collection.get([row.id], include_vectors=True) == [row]
+    assert (await collection.get([row.id]))[0].embedding is None
+
+
+@pytest.mark.timeout(120)
+async def test_thousand_records_two_1536_dimensional_vectors(database, definition_factory, record_factory):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict, client=connection, schema=schema, definition=definition_factory(dimensions=1536, second_vector=True)
+    )
+    await collection.ensure_collection_exists()
+    records = [
+        record_factory(
+            str(i), number=i, embedding=[1.0, i / 1000, *([0.0] * 1534)], secondary=[i / 1000, 1.0, *([0.0] * 1534)]
+        )
+        for i in range(1000)
+    ]
+    assert await collection.upsert(records, generate_vectors=False) == [str(i) for i in range(1000)]
+    assert len(await collection.get(top=1001)) == 1000
+    stored = await collection.get(["0", "500", "999"], include_vectors=True)
+    assert all(len(row["embedding"]) == len(row["secondary"]) == 1536 for row in stored)
+    assert stored[1]["embedding"] == pytest.approx(records[500]["embedding"])
+    assert stored[2]["secondary"] == pytest.approx(records[999]["secondary"])
+    results = [
+        item
+        async for item in await collection.search(
+            vector=[1.0, 0.0, *([0.0] * 1534)],
+            vector_property_name="embedding",
+            filter=Filter("number", "gte", 900),
+            top=5,
+            score_threshold=0.4,
+        )
+    ]
+    assert [item["record"]["id"] for item in results] == [str(i) for i in range(900, 905)]
+    await collection.delete([str(i) for i in range(1000)])
+    assert await collection.get() == []
+
+
+@pytest.mark.parametrize(
+    "metric,operator",
+    [
+        ("cosine_similarity", "<=>"),
+        ("dot_prod", "<#>"),
+        ("euclidean_distance", "<->"),
+    ],
+)
+async def test_ann_sql_uses_index_and_restores_callers_settings(
+    database,
+    definition_factory,
+    record_factory,
+    metric,
+    operator,
+):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict,
+        client=connection,
+        schema=schema,
+        definition=definition_factory(index_kind="hnsw", distance_function=metric),
+    )
+    await collection.ensure_collection_exists()
+    await collection.upsert(
+        [record_factory(str(i), embedding=[1, i / 100, 0]) for i in range(100)], generate_vectors=False
+    )
+    captured: list[tuple[sql.Composed, Any]] = []
+
+    class RecordingCursor(AsyncCursor):
+        async def execute(
+            self,
+            query: Any,
+            params: Any = None,
+            *,
+            prepare: bool | None = None,
+            binary: bool | None = None,
+        ) -> Self:
+            if isinstance(query, sql.Composed) and "ORDER BY" in query.as_string():
+                captured.append((query, params))
+            return await super().execute(query, params, prepare=prepare, binary=binary)
+
+    original_factory = connection.cursor_factory
+    connection.cursor_factory = RecordingCursor
+    try:
+        async with connection.transaction():
+            await connection.execute("SET LOCAL enable_seqscan = off")
+            await connection.execute("SET LOCAL hnsw.ef_search = 55")
+            await connection.execute("SET LOCAL hnsw.iterative_scan = off")
+            await collection.search(vector=[1, 0, 0], score_threshold=0.5, operation_options={"hnsw_ef_search": 100})
+            assert (await (await connection.execute("SHOW hnsw.ef_search")).fetchone())[0] == "55"
+            assert (await (await connection.execute("SHOW hnsw.iterative_scan")).fetchone())[0] == "off"
+            query, params = captured[0]
+            assert f'ORDER BY "dense vector" {operator} %s ASC LIMIT %s OFFSET %s' in query.as_string()
+            cursor = await connection.execute(sql.SQL("EXPLAIN ") + query, params)
+            assert any("Index Scan using af_vector_" in row[0] for row in await cursor.fetchall())
+    finally:
+        connection.cursor_factory = original_factory
+
+
+async def test_identity_collision_fails_instead_of_overwriting(database, definition_factory, record_factory):
+    connection, schema = database
+    collection = PostgresCollection(
+        dict, client=connection, schema=schema, definition=definition_factory(key_type="int", generated=True)
+    )
+    await collection.ensure_collection_exists()
+    await collection.upsert([record_factory(1, text="preserve")], generate_vectors=False)
+    with pytest.raises(IntegrationException):
+        await collection.upsert([record_factory(None, text="must not overwrite")], generate_vectors=False)
+    assert (await collection.get([1]))[0]["text"] == "preserve"
+
+
+async def test_generated_key_only_table_and_zero_vectors(database, definition_factory, record_factory):
+    connection, schema = database
+    key_only = PostgresCollection(
+        dict,
+        client=connection,
+        schema=schema,
+        collection_name="keys",
+        definition=VectorStoreCollectionDefinition([
+            VectorStoreField("key", name="id", type_="UUID", is_auto_generated=True),
+        ]),
+    )
+    await key_only.ensure_collection_exists()
+    keys = await key_only.upsert([{}, {}], generate_vectors=False)
+    assert len(keys) == 2 and all(isinstance(key, UUID) for key in keys)
+    assert await key_only.upsert([{"id": keys[0]}], generate_vectors=False) == [keys[0]]
+    assert await key_only.get([keys[0]]) == [{"id": keys[0]}]
+    collection = PostgresCollection(dict, client=connection, schema=schema, definition=definition_factory())
+    await collection.ensure_collection_exists()
+    await collection.upsert(
+        [record_factory("zero", embedding=[0, 0, 0]), record_factory("nonzero")], generate_vectors=False
+    )
+    assert [item async for item in await collection.search(vector=[0, 0, 0])] == []
+    results = [item async for item in await collection.search(vector=[1, 0, 0])]
+    assert [item["record"]["id"] for item in results] == ["nonzero"]

--- a/python/packages/postgres/tests/test_postgres_settings.py
+++ b/python/packages/postgres/tests/test_postgres_settings.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import get_type_hints
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agent_framework import SecretString, load_settings
+from psycopg import AsyncConnection
+from psycopg_pool import AsyncConnectionPool
+
+from agent_framework_postgres import PostgresCollection, PostgresSettings, PostgresStore
+from agent_framework_postgres import _vector_store as module
+
+
+@pytest.fixture(params=["collection", "store"])
+def constructor(request, definition_factory, monkeypatch):
+    monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+    if request.param == "collection":
+        return partial(PostgresCollection, dict, definition=definition_factory())
+    return PostgresStore
+
+
+def test_public_settings_use_af_secret_string(monkeypatch):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=environment password=private-test-value")
+    assert get_type_hints(PostgresSettings) == {"connection_string": SecretString | None}
+    settings = load_settings(PostgresSettings, env_prefix="POSTGRES_")
+    value = settings["connection_string"]
+    assert isinstance(value, SecretString)
+    assert value.get_secret_value() == "host=environment password=private-test-value"
+    assert str(value) == "**********"
+    assert "private-test-value" not in repr(settings)
+    assert "private-test-value" not in f"{value}"
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_explicit_connection_precedes_file_and_environment(constructor, monkeypatch, tmp_path, wrapped):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=environment password=environment-secret")
+    env_file = tmp_path / "selected.env"
+    env_file.write_text("POSTGRES_CONNECTION_STRING='host=file password=file-secret'\n", encoding="utf-8")
+    conninfo = "host=explicit password=explicit-secret"
+    value = SecretString(conninfo) if wrapped else conninfo
+    with patch.object(module, "_Client", wraps=module._Client) as create:
+        instance = constructor(connection_string=value, env_file_path=str(env_file))
+    resolved = create.call_args.args[0]
+    assert isinstance(resolved, SecretString)
+    assert resolved.get_secret_value() == conninfo
+    if wrapped:
+        assert resolved is value
+    assert "explicit-secret" not in repr(resolved)
+    assert instance._client.client.conninfo == conninfo
+    assert instance._client.client.closed
+    assert instance.managed_client
+
+
+def test_selected_file_precedes_environment_and_uses_encoding(constructor, monkeypatch, tmp_path):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=environment")
+    env_file = tmp_path / "selected.env"
+    env_file.write_text("POSTGRES_CONNECTION_STRING='host=file password=file-secret'\n", encoding="utf-16")
+    instance = constructor(env_file_path=str(env_file), env_file_encoding="utf-16")
+    assert instance._client.client.conninfo == "host=file password=file-secret"
+    assert instance.schema == "public"
+
+
+def test_environment_fallback_without_schema_override(constructor, monkeypatch, tmp_path):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=environment")
+    monkeypatch.setenv("POSTGRES_SCHEMA", "must_not_be_used")
+    env_file = tmp_path / "selected.env"
+    env_file.write_text("POSTGRES_SCHEMA=also_ignored\n", encoding="utf-8")
+    instance = constructor(env_file_path=str(env_file))
+    assert instance._client.client.conninfo == "host=environment"
+    assert instance.schema == "public"
+    assert constructor(schema="explicit_schema").schema == "explicit_schema"
+
+
+def test_no_implicit_dotenv_discovery_or_default_database(constructor, monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("POSTGRES_CONNECTION_STRING=host=implicit\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("agent_framework._settings.dotenv_values", side_effect=AssertionError("Unexpected .env read")),
+        patch.object(module, "AsyncConnectionPool") as pool,
+        pytest.raises(ValueError, match="exactly one"),
+    ):
+        constructor()
+    pool.assert_not_called()
+
+
+@pytest.mark.parametrize("value", ["", " \t\n", SecretString(""), SecretString("   ")])
+def test_empty_explicit_connection_does_not_fall_back(constructor, monkeypatch, value):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=environment")
+    with patch.object(module, "AsyncConnectionPool") as pool, pytest.raises(ValueError, match="must not be empty"):
+        constructor(connection_string=value)
+    pool.assert_not_called()
+
+
+@pytest.mark.parametrize("source", ["environment", "file"])
+def test_empty_resolved_connection_does_not_fall_back(constructor, monkeypatch, tmp_path, source):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "" if source == "environment" else "host=environment")
+    kwargs = {}
+    if source == "file":
+        env_file = tmp_path / "selected.env"
+        env_file.write_text("POSTGRES_CONNECTION_STRING=''\n", encoding="utf-8")
+        kwargs["env_file_path"] = str(env_file)
+    with patch.object(module, "AsyncConnectionPool") as pool, pytest.raises(ValueError, match="must not be empty"):
+        constructor(**kwargs)
+    pool.assert_not_called()
+
+
+def test_selected_missing_file_is_not_ignored_with_explicit_connection(constructor, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        constructor(connection_string="host=explicit", env_file_path=str(tmp_path / "missing.env"))
+
+
+@pytest.mark.parametrize("value", [123, b"host=bytes", {"password": "must-not-leak"}, lambda: "host=callable"])
+def test_invalid_setting_type_does_not_reach_driver(constructor, value):
+    with patch.object(module, "AsyncConnectionPool") as pool, pytest.raises((ValueError, TypeError)) as error:
+        constructor(connection_string=value)
+    pool.assert_not_called()
+    assert "must-not-leak" not in str(error.value)
+
+
+@pytest.mark.parametrize("client_type", [AsyncConnection, AsyncConnectionPool])
+async def test_injected_client_bypasses_loader_and_remains_borrowed(constructor, monkeypatch, client_type):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "not valid conninfo; must not be read")
+    client = MagicMock(spec=client_type)
+    client.close = AsyncMock()
+    with patch.object(module, "load_settings", side_effect=AssertionError("Injected clients must not load settings")):
+        instance = constructor(client=client)
+        assert instance._client.client is client
+        assert not instance.managed_client
+        await instance.close()
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"connection_string": "host=explicit"},
+        {"connection_string": ""},
+        {"connection_string": SecretString("host=explicit")},
+        {"env_file_path": "missing.env"},
+        {"env_file_path": ""},
+        {"env_file_encoding": "utf-16"},
+        {"env_file_encoding": ""},
+    ],
+)
+def test_injected_client_rejects_conflicting_settings_without_reading(constructor, kwargs):
+    client = MagicMock(spec=AsyncConnection)
+    with (
+        patch.object(module, "load_settings", side_effect=AssertionError("Must not read settings")),
+        pytest.raises(ValueError, match="cannot be combined"),
+    ):
+        constructor(client=client, **kwargs)
+
+
+async def test_store_children_reuse_resolved_client_without_loading_again(monkeypatch, definition_factory):
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "host=initial")
+    store = PostgresStore()
+    monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "")
+    with patch.object(module, "load_settings", side_effect=AssertionError("Must reuse resolved client")):
+        collection = store.get_collection(dict, definition=definition_factory())
+    assert collection._client is store._client
+    assert isinstance(store._client.client, AsyncConnectionPool)
+    assert store._client.client.conninfo == "host=initial"
+    with patch.object(store._client.client, "close", new_callable=AsyncMock) as close:
+        await collection.close()
+        close.assert_not_called()
+        await store.close()
+        close.assert_awaited_once()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -105,6 +105,7 @@ agent-framework-monty = { workspace = true }
 agent-framework-ollama = { workspace = true }
 agent-framework-openai = { workspace = true }
 agent-framework-orchestrations = { workspace = true }
+agent-framework-postgres = { workspace = true }
 agent-framework-purview = { workspace = true }
 agent-framework-redis = { workspace = true }
 agent-framework-azure-contentunderstanding = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -59,6 +59,7 @@ members = [
     "agent-framework-ollama",
     "agent-framework-openai",
     "agent-framework-orchestrations",
+    "agent-framework-postgres",
     "agent-framework-purview",
     "agent-framework-redis",
     "agent-framework-tools",
@@ -973,6 +974,23 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "agent-framework-core", editable = "packages/core" }]
+
+[[package]]
+name = "agent-framework-postgres"
+version = "1.0.0a260908"
+source = { editable = "packages/postgres" }
+dependencies = [
+    { name = "agent-framework-core" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary", "pool"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-framework-core", editable = "packages/core" },
+    { name = "pgvector", specifier = ">=0.5.0,<0.6" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.5,<4" },
+]
 
 [[package]]
 name = "agent-framework-purview"
@@ -5476,6 +5494,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ec/6eb80aebc728200f95229219882994c1b0585b956ca47da5edb9d062627a/pgvector-0.5.0.tar.gz", hash = "sha256:07a9dcf735696879406983afc6eba9a787cef7c0cf6c367ca1a5779f036dee74", size = 35170, upload-time = "2026-07-06T18:27:27.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e4/a5573f2c579ca9ad133293bfb624148ba0893674ca4a6eeec85ced9a6a09/pgvector-0.5.0-py3-none-any.whl", hash = "sha256:fedc9800894e6da2be51358d7b7c574bf34f247ca741a5a09513622135f5964f", size = 30958, upload-time = "2026-07-06T18:27:26.797Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5893,6 +5920,90 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
     { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
     { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/67/ac6b3dfd2d495f8599f7179f8082af4b3be72caa44942ddb45e9613338eb/psycopg_binary-3.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c6bd84e4cf67930f26f015dec33f615472b9c5871d46408efe112dbc1bc021de", size = 4720383, upload-time = "2026-08-31T22:40:22.262Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/c3870c7e5ba6b4444e3e5401c79d5e83afe2c7045844eabb25d5b39adecb/psycopg_binary-3.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fdbeb38c9b7ca8fa57a7bda3802bedb62f4494ad3dd46c7dd36dc3f77fd5093f", size = 4768854, upload-time = "2026-08-31T22:40:26.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a2/04834fb8a2af14d42e48abeb61ace0a4fee2d6f516723d897cff16fce677/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:06de14ac978a2d53e864069fb5487075c6e3cfb0740f1bfd7017bc8b9942067f", size = 5588618, upload-time = "2026-08-31T22:40:36.524Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0d/2eed6e7f8c5ada9e08cbdca4b78083df12f5c2a8d13fa0c62cd6b2b1d762/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8b66353b20e79bf7ac0a80f03ae97f522ccbbf909d687eec62f112e56c0276d", size = 5259471, upload-time = "2026-08-31T22:40:46.43Z" },
+    { url = "https://files.pythonhosted.org/packages/96/66/2347889e693502e8473a60b3defac0300829007275a21980a2197c200418/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af5084124fb2fd16557073822519dfe8c389636a16adef661a4c0c3918733171", size = 6851181, upload-time = "2026-08-31T22:40:52.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/11/039d7bbdc8ac28292a2fb9f54a7385116c7d31a3bf9c87e71eda154b32b9/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1344fd57a19737554670e67aecabd4fb37cd7937f2925840009645d641117e5a", size = 5098916, upload-time = "2026-08-31T22:40:57.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/01/5f77284d0c682106279da7d9e26527ae99f3241a91f0549b033c84441404/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2719fe19a4da752c4110cc767716d0a5bdb760d1153d89018bb7c9c61717bde5", size = 4617043, upload-time = "2026-08-31T22:41:04.555Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4a/c07000298ffa3eaf25a720a5fd4bc9326676e99712722ca1accb40071e66/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:893ce86a4b997f6ca1261a7826db2506727332a6ff66646fa7f024b39b5e630e", size = 4310458, upload-time = "2026-08-31T22:41:11.72Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0a/cc7da5bb2bed198354f8dcc7c5dab3f1473edf2b6a177c1e8ec3fa9841ea/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a5e45e4bb68656253ce5c7a344c0a425c293581eba954d7fd7c2e4b2dc9f3038", size = 4039320, upload-time = "2026-08-31T22:41:20.783Z" },
+    { url = "https://files.pythonhosted.org/packages/17/60/f65755f1ab74223b437f1d366f63915b6f5e1292234de47643f898c29faf/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ca8af7c0454cdce235d4aedcb5528857468f1490202d25e24fc7af40e176d563", size = 4342427, upload-time = "2026-08-31T22:41:27.068Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3c/6b1ea5b5544fa51ee6da8e99e96ca6a639ed1e0da2e335467893f14d3182/psycopg_binary-3.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:7b443f943abfe35aa5a776630cea27c9348aa66659286cee0b99084332252080", size = 3665235, upload-time = "2026-08-31T22:41:30.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/83/ba396428a4fb6b70f0dd41315ad86a2c14441b7214afd47b2d49cb450b78/psycopg_binary-3.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25105f9b46bdf2a30fcb67f56976ed66f6855941ae16bc024192609b917d493c", size = 4700169, upload-time = "2026-08-31T22:41:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/b23c5978e55cf4effdc5a3e13a17d69a580a487993e01b7c3768dd24281c/psycopg_binary-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0249c3e960cdee686000eb77169fb6590105c05bacc37e057ccdffdcd8e6ebde", size = 4763037, upload-time = "2026-08-31T22:41:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d8/b41108bfe194b4098076c8b873b05ec2ca9582445eccfd9075970d7b948e/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5698ab5941a4d138c30fef858588e651fe7d583280cd6e41832825ad9e747750", size = 5546232, upload-time = "2026-08-31T22:41:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d1/0f244dfef389e52e9dc3056f2a9033d1f6901e97d24d9a9c8b836e32ab6b/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:682a17a57415c3ca1731eec018ed031f012ffcb81ba74806eb219cb396065672", size = 5227752, upload-time = "2026-08-31T22:42:03.776Z" },
+    { url = "https://files.pythonhosted.org/packages/31/88/a4781365f09807fb91435e2d00096f3f6ae5d06bce15ef3c3c385dc22772/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2a61e8147902771df7efe14062a3c8736347850d0d8befcf048235752504f2e", size = 6824658, upload-time = "2026-08-31T22:42:13.263Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f1/072c4a46287644694731b3e40fab120ebacf6d153cce7ebf7a5b208f5561/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f7e1e45aad410e20de45df2b159df68ff6c8dbf47a3501f806c4489b27f4ad2b", size = 5061439, upload-time = "2026-08-31T22:42:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/1776a95c16941b8bbce89407cc7cf9ea3fd557efb503a40873c9e2b6394f/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c09775c549b40b274206e1b043c5e5b5af39666e85c98382a30bd05d23ab677b", size = 4588586, upload-time = "2026-08-31T22:42:25.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/64/44ec87b9a74faebe966856307b65c0d35ee6321ce509cdd0e8d6a3f5338b/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cf0e5e63ee86098299c673992053d556c489ba9ae6aca6cb6e24d16a8e0b09e6", size = 4265161, upload-time = "2026-08-31T22:42:31.864Z" },
+    { url = "https://files.pythonhosted.org/packages/24/88/cf181df5651395a80afc520f5fefac72beb035c0c9d58ab7fcc880c9b221/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c065531e8c1815276f50dbfa283e3a7f022671414cdda6fa9a16794dd53b28f9", size = 3998727, upload-time = "2026-08-31T22:42:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1e/c72a1107647db4bb3f534c7fe1b57b1957d9c099e795f5aa81f4a2e0c312/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:df9853b832b7b916e02ef68e0d5403a7dab2d5c1ddfe94f22b1b155eb862622f", size = 4310119, upload-time = "2026-08-31T22:42:46.403Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/452620608cafff164737e20b42ebffee8151b865ee171ba0d6692a560a44/psycopg_binary-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:35885e333020fc152d27bea1a494bef13b2e68f6fd92b6229015e93539152008", size = 3648197, upload-time = "2026-08-31T22:42:51.575Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/e718752cc63cf4e99e4a10fd36e3a3364dabdd0819484a24c0d79fbb9685/psycopg_binary-3.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e85d50b87257fb117675a19ee59daa7bf9a57f6431500adf7059df799232ef4", size = 4704421, upload-time = "2026-08-31T22:42:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/a0e748e27c09b92738e4460582d121ba1908be3e36791e150f435e54b332/psycopg_binary-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5becd311f9af8d180bad372f51fb2252fd02cb2073056e2b170c9274f95fe7f", size = 4765054, upload-time = "2026-08-31T22:43:05.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/62/0cbac0266d56c94dd1f702d9af2b5d54bf80b6e658048f4f2c5bd63dd7e3/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:19e5bf9872dbd164c220567fd385ba2309c7d9df1541f78343510c6b0f36a1b7", size = 5547137, upload-time = "2026-08-31T22:43:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3a/73c6f8871f38fc07a9c0b4cbc9467beb116a2783cecf87dfa53900a396dc/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb3b3bffebfe07110730626e76238161124f35ac87b748d663316a28d22f58b0", size = 5227577, upload-time = "2026-08-31T22:43:20.767Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/9f17b9f4d297b774dc574199c4dcd02dadc32a00c4056265918de5c70635/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2111f880add40fb03c60556069ad68e884a0908a74d2debafc603caf93b73552", size = 6824606, upload-time = "2026-08-31T22:43:33.698Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/d84dadd94a004dbbb43ce0579f1f766fdc6b8cbef745090e24bea77b5283/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:40505676b1526b9ea387dace034040a8c8b0bcf984cd6bd4720a2ab15e813586", size = 5060854, upload-time = "2026-08-31T22:43:42.258Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d0/e5078be2c7d2490c0d6cd4cb7b3601aec44be2fa8b3fe927e9419b06004f/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5816472e3bb05615f33a741e0835043d1f4bf9709ff30d2f4aed71815cfc6b5e", size = 4589511, upload-time = "2026-08-31T22:43:50.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/08dfb5b18fa482e025864fd91a022310d0782c42e4cf5dda5d0e010b6790/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:358748fc4c8ccdc0e2bdf55420494930e19c3ade586ea9c3a6de3dad1f897311", size = 4268144, upload-time = "2026-08-31T22:43:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b9/cb01dc1d63f3241b49b2ca7fb9f98d0f5c76127f0dbb9440635a6ad0233e/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1ef2e498be47800f6202b9a2304c22646325ca6d54001b7c785bcfdb24a1e8ab", size = 4001036, upload-time = "2026-08-31T22:44:04.429Z" },
+    { url = "https://files.pythonhosted.org/packages/95/49/7c17dd832c05b380562ff2ff5f6ab2bcaeca8b7fff2c2b355854368a5bdb/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88e01aa2e938a45655a8a5213fc3a44ba78cb4cab8a569b3e0bcb3d1d0eaba16", size = 4313112, upload-time = "2026-08-31T22:44:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2c/b0b2f887185d6a2ec0b3bef948cc07656d2d1a5d96fa7f2bb03f6ef06ca4/psycopg_binary-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:ba466011569297114449df9d523438e1adeedf3e4f31ffb78e897ec3fef3076b", size = 3647313, upload-time = "2026-08-31T22:44:19.139Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7f/4e2395da194558533bd9c31f35e4dc58ecbbae6a7176b0d2f72d629e8a51/psycopg_binary-3.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f8b132c7243ef5f503f0b6f986bf16d38a51b0df1c6ba2577743f128be03e3", size = 4712612, upload-time = "2026-08-31T22:44:25.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/fdb2093c8ccd7048449156db526ad746740cf34fe9c01e5dc1b7a7a8b257/psycopg_binary-3.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0cac998b9b1e82dec853d2e53b3d34d56a525cf231f9441a636cfd5992929a9", size = 4775139, upload-time = "2026-08-31T22:44:36.719Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/5195e87960715f7be2005761b72d56fce4e7757d5333fd40384f071c2de1/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:479b96fd78149cfa10369dc53fbfb89ee729be13146b584a23dbc7e164c0cf1e", size = 5556807, upload-time = "2026-08-31T22:44:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/2d616210a91e1327516ed5ae71961aaa31bb740e4a61d7190f2221685a40/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f45d77e398542ce0937d9fa3cd9d84e9c5fc6b34c50a66404ae840bada312750", size = 5236206, upload-time = "2026-08-31T22:44:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2e/e54b0d4cc263b3526e3728bb50a69660d5e79e52255ccd2a1a71e40e6f9a/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98a388509306e5e08a4203253ac52846bc1b034e5cbd0ae6da1211593cc28594", size = 6838066, upload-time = "2026-08-31T22:44:55.701Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ec22a110f81a44c411965982097efeee86006bdd5a1f51f628318106c84c/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ab39e2794b95af61a2ff69e33e5ab6ac5df36e9ffea9a3b18e38b2aaca8c5ad5", size = 5072036, upload-time = "2026-08-31T22:45:02.838Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/7bc3c3ac769ab4fe0c619f2179b4aab3ae043f4d478283dd8279d24c0be4/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9c071bf78e5c2e6efa40bc9089a954d7b41221347a72f35c6bf2d8c96e632f75", size = 4604058, upload-time = "2026-08-31T22:45:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/8e7414f7dc10b2959e664330cdcf393e412f67355975dafa876cef265264/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:14fdfd65a96ecbd8b586d14546105641f4a6ac7cbe335c786830ea4de94bbe60", size = 4284766, upload-time = "2026-08-31T22:45:17.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/33f293c1d3ee9114f47e9ef4880f31c9de864e84a9b09454c26e106c25ed/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8dbd694f3741dd4ac5bc60b70e17f7841aefb3f0f38cef4d2756de270e03af43", size = 4011958, upload-time = "2026-08-31T22:45:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/8e38840e5a7d006987bbc9acb29951912253fa50549a4db92b3aa535f089/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:14f432430fd9e1a9e7d9ab2fe14956c77f5d074ebdc556a1ad04e9a1bd3fca04", size = 4323273, upload-time = "2026-08-31T22:45:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/b7ebf601c307f93e7c4c4ebac0edc9db3b2729ca038efe700a18f86b5517/psycopg_binary-3.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:df209e64674a34b41662c67fdc8b4e0ffd77d2136393790691d086a09f9a6cab", size = 3745885, upload-time = "2026-08-31T22:45:40.537Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Applications using PostgreSQL need a native Agent Framework vector-store connector to persist typed records and retrieve relevant context without a separate vector database. This adds an alpha PostgreSQL/pgvector integration for RAG and agent-memory scenarios using the existing vector-store abstractions.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** Adds the standalone `agent-framework-postgres` package with `PostgresCollection`, `PostgresStore`, and `PostgresSettings` in a single implementation module. Connection settings use AF `load_settings` and `SecretString`. Psycopg async connections support lazily opened, connector-owned pools or caller-owned borrowed clients. The connector provides transactional batch CRUD, typed and generated string/integer/UUID keys, multiple vector columns, native SQL filtering, and exact, HNSW, or IVFFlat vector search. IVFFlat index creation is an explicit post-load operation. Includes consumer documentation, a runnable sample, unit/settings/integration coverage, workspace registration, alpha package status, and paired integration/merge CI jobs using disposable PostgreSQL/pgvector services.
- **What is the impact of these changes?** PostgreSQL-backed applications can use the existing typed collection and store interfaces with database-side filtering, score thresholds, and paging. Database administrators retain control of schema and extension prerequisites: the connector does not create schemas or enable extensions. Injected clients and transactions remain caller-owned. Hybrid/keyword/full-text search, sparse/binary vectors, schema migration, and server-side embedding generation are explicitly unsupported. There is no generic ORM, core behavior change, or core namespace/export change.
- **What do you want reviewers to focus on?** Connection/pool and transaction ownership; settings precedence and secret handling; SQL identifier composition and value parametrization; typed-key and multi-vector round trips; ANN index eligibility and explicit post-load IVFFlat creation; metric-specific score thresholds applied before paging; and parity between the connector contract, consumer example, and paired CI jobs.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Related to #4167 and #1188. This PR implements only the PostgreSQL/pgvector portion of those umbrella issues and intentionally does not close either one. It is one of four coordinated connector PRs: Azure AI Search is covered by #8153, while Qdrant and Redis are handled separately. The issue-exclusivity checklist item is therefore intentionally unchecked.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.