### PR TITLE
Python: Add Redis HASH and JSON vector stores

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -475,6 +475,49 @@ jobs:
           path: ./python/pytest.xml
           if-no-files-found: ignore
 
+  python-tests-redis:
+    name: Python Integration Tests - Redis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    services:
+      redis:
+        image: redis:8.0.3
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      REDIS_VECTOR_TEST_URL: redis://localhost:6379
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          persist-credentials: false
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Test Redis HASH and JSON vector collections
+        run: >
+          uv run --no-sync pytest packages/redis/tests/test_vector_store.py
+          -m integration --timeout=120 --junitxml=pytest-redis.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-redis
+          path: ./python/pytest-redis.xml
+          if-no-files-found: ignore
+
   # Integration test trend report (aggregates per-job JUnit XML results)
   python-integration-test-report:
     name: Integration Test Report
@@ -491,6 +534,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-redis,
       ]
     runs-on: ubuntu-latest
     defaults:
@@ -554,7 +598,8 @@ jobs:
         python-tests-foundry,
         python-tests-foundry-hosting,
         python-tests-cosmos,
-        python-tests-github-copilot
+        python-tests-github-copilot,
+        python-tests-redis,
       ]
     steps:
       - name: Fail workflow if tests failed

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -39,6 +39,7 @@ jobs:
       foundryChanged: ${{ steps.filter.outputs.foundry }}
       foundryHostingChanged: ${{ steps.filter.outputs.foundry_hosting }}
       cosmosChanged: ${{ steps.filter.outputs.cosmos }}
+      redisChanged: ${{ steps.filter.outputs.redis }}
       githubCopilotChanged: ${{ steps.filter.outputs.github_copilot }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -84,6 +85,9 @@ jobs:
               - 'python/packages/foundry_hosting/**'
             cosmos:
               - 'python/packages/azure-cosmos/**'
+            redis:
+              - 'python/packages/redis/**'
+              - 'python/packages/core/agent_framework/redis/**'
             github_copilot:
               - 'python/packages/github_copilot/**'
       # run only if 'python' files were changed
@@ -638,6 +642,53 @@ jobs:
           path: ./python/pytest.xml
           if-no-files-found: ignore
 
+  python-tests-redis:
+    name: Python Tests - Redis Integration
+    needs: paths-filter
+    if: >
+      github.event_name != 'pull_request' &&
+      needs.paths-filter.outputs.pythonChanges == 'true' &&
+      (github.event_name != 'merge_group' ||
+       needs.paths-filter.outputs.redisChanged == 'true' ||
+       needs.paths-filter.outputs.coreChanged == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    services:
+      redis:
+        image: redis:8.0.3
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      REDIS_VECTOR_TEST_URL: redis://localhost:6379
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up python and install the project
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+          os: ${{ runner.os }}
+      - name: Test Redis HASH and JSON vector collections
+        run: >
+          uv run --no-sync pytest packages/redis/tests/test_vector_store.py
+          -m integration --timeout=120 --junitxml=pytest-redis.xml
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-redis
+          path: ./python/pytest-redis.xml
+          if-no-files-found: ignore
+
   # Integration test trend report (aggregates per-job JUnit XML results)
   python-integration-test-report:
     name: Integration Test Report
@@ -654,6 +705,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-redis,
       ]
     runs-on: ubuntu-latest
     defaults:
@@ -715,6 +767,7 @@ jobs:
         python-tests-foundry-hosting,
         python-tests-cosmos,
         python-tests-github-copilot,
+        python-tests-redis,
       ]
     steps:
       - name: Fail workflow if tests failed

--- a/python/packages/core/agent_framework/redis/__init__.py
+++ b/python/packages/core/agent_framework/redis/__init__.py
@@ -6,8 +6,11 @@ This module lazily re-exports objects from:
 - ``agent-framework-redis``
 
 Supported classes:
+- RedisCollection
 - RedisContextProvider
 - RedisHistoryProvider
+- RedisSettings
+- RedisStore
 """
 
 import importlib
@@ -15,7 +18,7 @@ from typing import Any
 
 IMPORT_PATH = "agent_framework_redis"
 PACKAGE_NAME = "agent-framework-redis"
-_IMPORTS = ["RedisContextProvider", "RedisHistoryProvider"]
+_IMPORTS = ["RedisCollection", "RedisContextProvider", "RedisHistoryProvider", "RedisSettings", "RedisStore"]
 
 
 def __getattr__(name: str) -> Any:

--- a/python/packages/core/agent_framework/redis/__init__.pyi
+++ b/python/packages/core/agent_framework/redis/__init__.pyi
@@ -1,11 +1,17 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 from agent_framework_redis import (
+    RedisCollection,
     RedisContextProvider,
     RedisHistoryProvider,
+    RedisSettings,
+    RedisStore,
 )
 
 __all__ = [
+    "RedisCollection",
     "RedisContextProvider",
     "RedisHistoryProvider",
+    "RedisSettings",
+    "RedisStore",
 ]

--- a/python/packages/redis/AGENTS.md
+++ b/python/packages/redis/AGENTS.md
@@ -13,6 +13,8 @@ Redis-based storage for agent threads and context.
   the store, separate from the preexisting history/context providers. `_create_client` shares AF settings resolution;
   `RedisCollection._prepare_filter` validates support and translates portable filters to native Redis queries.
   Requires Redis Search with INDEXMISSING/INDEXEMPTY support.
+  Nonempty CRUD/search operations recheck index existence and schema. These checks observe completed external
+  lifecycle changes but are not atomic with subsequent operations.
   See README for the per-type native filter restrictions, HASH null rejection, and distance units.
 
 ## Vector connector tests
@@ -25,7 +27,7 @@ uv run --no-sync pytest packages/redis/tests/test_vector_store.py packages/redis
 
 Set `REDIS_VECTOR_TEST_URL` to an explicitly disposable Search/JSON instance
 and select `-m integration` to run integration tests in `tests/test_vector_store.py`.
-Live tests cover Redis 8.0.3 and 8.8. A configured but insufficient server fails;
+Automated live tests use Redis 8.0.3, pinned in both CI workflows. A configured but insufficient server fails;
 only an unset URL skips them. Tests create unique namespaces and clean only
 their own indexes/keys, never `FLUSHALL`. Coverage includes both formats and
 1000-record batches with two 1536-dimensional vectors without embedding API calls.

--- a/python/packages/redis/AGENTS.md
+++ b/python/packages/redis/AGENTS.md
@@ -10,7 +10,9 @@ Redis-based storage for agent threads and context.
   explicit URL overrides, an optional .env file, or `REDIS_URL`. URLs use `SecretString` to mask credentials.
 - **`RedisCollection` / `RedisStore`** - Experimental generic vector storage and search over native HASH and JSON
   documents. `_vector_store.py` contains settings, connection/codec/schema/filter helpers, the collection, and
-  the store, separate from the preexisting history/context providers. `_create_client` shares AF settings resolution;
+  the store, separate from the preexisting history/context providers. `_create_client` shares AF settings resolution
+  and requires database 0, strict UTF-8 encoding, RESP2, and binary responses for URL-created and borrowed clients.
+  `_RedisNamespaceNames` owns the persisted index/document prefix format and canonical index-name parsing;
   `RedisCollection._prepare_filter` validates support and translates portable filters to native Redis queries.
   Requires Redis Search with INDEXMISSING/INDEXEMPTY support.
   Nonempty CRUD/search operations recheck index existence and schema. These checks observe completed external

--- a/python/packages/redis/AGENTS.md
+++ b/python/packages/redis/AGENTS.md
@@ -6,6 +6,29 @@ Redis-based storage for agent threads and context.
 
 - **`RedisHistoryProvider`** - Persistent chat history provider using Redis
 - **`RedisContextProvider`** - Context provider with Redis-backed retrieval
+- **`RedisSettings`** - TypedDict connection settings for vector stores, resolved with core `load_settings` from
+  explicit URL overrides, an optional .env file, or `REDIS_URL`. URLs use `SecretString` to mask credentials.
+- **`RedisCollection` / `RedisStore`** - Experimental generic vector storage and search over native HASH and JSON
+  documents. `_vector_store.py` contains settings, connection/codec/schema/filter helpers, the collection, and
+  the store, separate from the preexisting history/context providers. `_create_client` shares AF settings resolution;
+  `RedisCollection._prepare_filter` validates support and translates portable filters to native Redis queries.
+  Requires Redis Search with INDEXMISSING/INDEXEMPTY support.
+  See README for the per-type native filter restrictions, HASH null rejection, and distance units.
+
+## Vector connector tests
+
+From `python/`, run the connector's deterministic unit tests with:
+
+```bash
+uv run --no-sync pytest packages/redis/tests/test_vector_store.py packages/redis/tests/test_vector_settings.py -m "not integration"
+```
+
+Set `REDIS_VECTOR_TEST_URL` to an explicitly disposable Search/JSON instance
+and select `-m integration` to run integration tests in `tests/test_vector_store.py`.
+Live tests cover Redis 8.0.3 and 8.8. A configured but insufficient server fails;
+only an unset URL skips them. Tests create unique namespaces and clean only
+their own indexes/keys, never `FLUSHALL`. Coverage includes both formats and
+1000-record batches with two 1536-dimensional vectors without embedding API calls.
 
 ## Usage
 

--- a/python/packages/redis/README.md
+++ b/python/packages/redis/README.md
@@ -49,6 +49,8 @@ Conversation history uses Redis Lists and does not require Search or RedisJSON.
 Context retrieval requires Redis Search. Vector collections require Redis
 8.0.3 or later with Search, including `INDEXMISSING` and `INDEXEMPTY` support;
 JSON collections additionally require RedisJSON.
+Redis Search indexes require logical database 0, so vector-store URLs and clients
+must select database 0 (the default).
 
 Choose `storage_type="hash"` for non-null records with binary vector storage,
 or `"json"` for nullable fields/vectors and native JSON data. HASH rejects
@@ -62,9 +64,13 @@ settings loader. Connection precedence is an explicit `redis_url`, then
 with `SecretString`; use `rediss://` when your server requires TLS.
 
 You may supply a standalone `redis.asyncio.Redis` client using
-`decode_responses=False` and RESP2. Supplied clients take precedence over URL
-settings and remain caller-owned. Closing a store closes its owned connection,
-not its stored data. Redis Cluster clients are not supported.
+`decode_responses=False` and RESP2. Both URL-created and supplied clients must use
+strict UTF-8 encoding (`encoding="utf-8"`, `encoding_errors="strict"`, the defaults)
+so Unicode keys and string fields round-trip without lossy conversions.
+Incompatible encoding or database settings are rejected before connecting.
+Supplied clients take precedence over URL settings and remain caller-owned.
+Closing a store closes its owned connection, not its stored data. Redis Cluster
+clients are not supported.
 
 Vector collections support dense search and a subset of portable filters,
 not hybrid/full-text search or literal substring/prefix/suffix filters.

--- a/python/packages/redis/README.md
+++ b/python/packages/redis/README.md
@@ -1,53 +1,130 @@
-# Get Started with Microsoft Agent Framework Redis
+# Microsoft Agent Framework Redis
 
-Please install this package via pip:
+Redis-backed conversation history, memory retrieval, and vector storage for
+[Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/).
+
+## Choose the right component
+
+| Your goal | Component |
+| --- | --- |
+| Persist ordered conversation messages across runs and application restarts | `RedisHistoryProvider` |
+| Retrieve relevant memories and add them to an agent's context | `RedisContextProvider` |
+| Store and search your own documents or embeddings | `RedisCollection` (experimental) |
+| Manage vector collections with a shared connection and namespace | `RedisStore` (experimental) |
+| Resolve vector-store connection configuration from arguments, `.env`, or environment variables | `RedisSettings` |
+
+These components can be used together, but do not automatically share stored
+records. Import them from `agent_framework.redis` or `agent_framework_redis`.
+
+## Install
+
+Requires Python 3.10 or later:
 
 ```bash
 pip install agent-framework-redis --pre
 ```
 
-## Components
+## Run Redis
 
-### Memory Context Provider
+Choose a managed service or run Redis locally:
 
-The `RedisContextProvider` enables persistent context and memory capabilities for your agents, allowing them to remember user preferences and conversation context across sessions and threads.
+- **Azure Managed Redis**: Run Redis as a managed Azure service. Follow the
+  [Azure Managed Redis quickstart](https://learn.microsoft.com/en-us/azure/redis/quickstart-create-managed-redis)
+  to create an instance.
+- **Redis Cloud**: Use [Redis Cloud](https://redis.io/cloud/) for a fully managed
+  Redis database.
+- **Local Docker**: Start Redis on your machine with:
 
-#### Basic Usage Examples
+  ```bash
+  docker run --rm --name agent-framework-redis -p 127.0.0.1:6379:6379 redis:8.0.3
+  ```
 
-Review the set of [getting started examples](../../samples/02-agents/context_providers/redis/README.md) for using the Redis context provider.
+For managed services, choose a configuration with the Search/JSON capabilities
+required by your component below, and use the service's connection endpoint
+and authentication settings.
 
-### Redis History Provider
+## Requirements and configuration
 
-The `RedisHistoryProvider` provides persistent conversation storage using Redis Lists, enabling chat history to survive application restarts and support distributed applications.
+Conversation history uses Redis Lists and does not require Search or RedisJSON.
+Context retrieval requires Redis Search. Vector collections require Redis
+8.0.3 or later with Search, including `INDEXMISSING` and `INDEXEMPTY` support;
+JSON collections additionally require RedisJSON.
 
-#### Key Features
+Choose `storage_type="hash"` for non-null records with binary vector storage,
+or `"json"` for nullable fields/vectors and native JSON data. HASH rejects
+`None`, including `vector=None`; JSON preserves explicit null. Both support
+multiple vector fields and FLAT/HNSW indexes.
 
-- **Persistent Storage**: Messages survive application restarts
-- **Thread Isolation**: Each conversation thread has its own Redis key
-- **Message Limits**: Configurable automatic trimming of old messages
-- **Serialization Support**: Full compatibility with Agent Framework thread serialization
-- **Production Ready**: Connection pooling, error handling, and performance optimized
+`RedisCollection` and `RedisStore` use `RedisSettings` with the Agent Framework
+settings loader. Connection precedence is an explicit `redis_url`, then
+`REDIS_URL` in a supplied `env_file_path`, then the process environment, with
+`redis://localhost:6379` as the default. Settings mask credential-bearing URLs
+with `SecretString`; use `rediss://` when your server requires TLS.
 
-#### Basic Usage Examples
+You may supply a standalone `redis.asyncio.Redis` client using
+`decode_responses=False` and RESP2. Supplied clients take precedence over URL
+settings and remain caller-owned. Closing a store closes its owned connection,
+not its stored data. Redis Cluster clients are not supported.
 
-See the complete [Redis history provider examples](../../samples/02-agents/conversations/redis_history_provider.py) including:
-- User session management
-- Conversation persistence across restarts
-- Session serialization and deserialization
-- Automatic message trimming
-- Error handling patterns
+Vector collections support dense search and a subset of portable filters,
+not hybrid/full-text search or literal substring/prefix/suffix filters.
+JSON null checks are supported on numeric and boolean fields, not strings or
+arrays. Indexed strings cannot contain surrounding whitespace, NUL, or U+001F,
+and must fit Redis's 4096-byte TAG limit; these restrictions do not apply to
+unindexed payloads. Unsupported operations raise an error.
 
-### Installing and running Redis
+## Store and search documents
 
-You have 3 options to set-up Redis:
+This example uses precomputed vectors, so no embedding service is needed.
+It connects using `REDIS_URL` or the localhost default:
 
-#### Option A: Local Redis with Docker
-```bash
-docker run --name redis -p 6379:6379 -d redis:8.0.3
+```python
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+from agent_framework import VectorStoreField, vectorstoremodel
+from agent_framework.redis import RedisStore
+
+
+@vectorstoremodel
+@dataclass
+class Document:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data")]
+    vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=2, index_kind="flat"),
+    ] = None
+
+
+async def main() -> None:
+    async with RedisStore(storage_type="json", namespace="my-app") as store:
+        collection = store.get_collection(Document, collection_name="documents")
+        await collection.ensure_collection_exists()
+        await collection.upsert(
+            [Document("one", "A guide to Redis", [1.0, 0.0])],
+            generate_vectors=False,
+        )
+        results = await collection.search(vector=[1.0, 0.0], top=3)
+        async for result in results:
+            print(result["record"].text, result["score"])
+
+
+asyncio.run(main())
 ```
 
-#### Option B: Redis Cloud
-Get a free db at https://redis.io/cloud/
+CRUD operations accept batches. Provide an embedding generator to generate
+vectors automatically, or use `generate_vectors=False` to keep supplied vectors.
+Retrieval excludes vectors by default; use `include_vectors=True` to return them.
+Search scores are native distances (cosine distance by default), where lower is
+better; a nonnegative `score_threshold` sets a maximum distance before paging.
 
-#### Option C: Azure Managed Redis
-Here's a quickstart guide to create **Azure Managed Redis** for as low as $12 monthly: https://learn.microsoft.com/en-us/azure/redis/quickstart-create-managed-redis
+## Documentation and examples
+
+- [Agent Framework documentation](https://learn.microsoft.com/agent-framework/)
+- [Redis documentation](https://redis.io/docs/latest/)
+- [Redis vector search](https://redis.io/docs/latest/develop/ai/search-and-query/vectors/)
+- [Redis conversation-history example](https://github.com/microsoft/agent-framework/blob/main/python/samples/02-agents/conversations/redis_history_provider.py)
+- [Redis context-provider examples](https://github.com/microsoft/agent-framework/tree/main/python/samples/02-agents/context_providers/redis)
+- [HASH and JSON vector-store example](https://github.com/microsoft/agent-framework/blob/main/python/samples/02-agents/vector_stores/redis_store.py)

--- a/python/packages/redis/agent_framework_redis/__init__.py
+++ b/python/packages/redis/agent_framework_redis/__init__.py
@@ -1,8 +1,12 @@
 # Copyright (c) Microsoft. All rights reserved.
+
+"""Redis history, context providers, and experimental vector collections."""
+
 import importlib.metadata
 
 from ._context_provider import RedisContextProvider
 from ._history_provider import RedisHistoryProvider
+from ._vector_store import RedisCollection, RedisSettings, RedisStore
 
 try:
     __version__ = importlib.metadata.version(__name__)
@@ -10,7 +14,10 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
 
 __all__ = [
+    "RedisCollection",
     "RedisContextProvider",
     "RedisHistoryProvider",
+    "RedisSettings",
+    "RedisStore",
     "__version__",
 ]

--- a/python/packages/redis/agent_framework_redis/_vector_store.py
+++ b/python/packages/redis/agent_framework_redis/_vector_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import math
 import re
+from codecs import lookup
 from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Generic, Literal, cast
 from uuid import uuid4
@@ -102,6 +103,14 @@ def _create_client(
     kwargs = cast(dict[str, Any], redis_client.connection_pool.connection_kwargs)  # pyright: ignore[reportUnknownMemberType]
     if kwargs.get("decode_responses", False) or kwargs.get("protocol", 2) != 2:
         raise ValueError("Redis vector stores require decode_responses=False and RESP protocol=2.")
+    try:
+        encoding = lookup(kwargs.get("encoding", "utf-8")).name
+    except LookupError as exc:
+        raise ValueError("Redis vector stores require strict UTF-8 encoding.") from exc
+    if encoding != "utf-8" or kwargs.get("encoding_errors", "strict") != "strict":
+        raise ValueError("Redis vector stores require strict UTF-8 encoding.")
+    if kwargs.get("db", 0) != 0:
+        raise ValueError("Redis vector stores require database 0; Redis Search cannot index other databases.")
     return redis_client
 
 
@@ -116,10 +125,33 @@ def _prepare_namespace_component(value: str) -> str:
     return value.encode("utf-8").hex()
 
 
-def _prepare_collection_names(namespace: str, collection_name: str) -> tuple[str, str]:
-    base = f"af:vector:{_prepare_namespace_component(namespace)}:"
-    collection = _prepare_namespace_component(collection_name)
-    return f"{base}index:{collection}", f"{base}data:{collection}:"
+class _RedisNamespaceNames:
+    """Encode and parse persisted collection names within one Redis namespace."""
+
+    def __init__(self, namespace: str) -> None:
+        base = f"af:vector:{_prepare_namespace_component(namespace)}:"
+        self._index_prefix = f"{base}index:"
+        self._data_prefix = f"{base}data:"
+
+    def for_collection(self, collection_name: str) -> tuple[str, str]:
+        """Return the index name and document prefix for a collection."""
+        collection = _prepare_namespace_component(collection_name)
+        return f"{self._index_prefix}{collection}", f"{self._data_prefix}{collection}:"
+
+    def try_parse_index_name(self, index_name: bytes) -> str | None:
+        """Return a canonical collection name, or None for foreign/malformed index names."""
+        prefix = self._index_prefix.encode("ascii")
+        if not index_name.startswith(prefix):
+            return None
+        encoded_name = index_name[len(prefix) :]
+        if not 2 <= len(encoded_name) <= 512:
+            return None
+        try:
+            name = bytes.fromhex(encoded_name.decode("ascii")).decode("utf-8")
+            canonical_index, _ = self.for_collection(name)
+        except ValueError:
+            return None
+        return name if index_name == canonical_index.encode("ascii") else None
 
 
 def _prepare_vector(value: Any, field: VectorStoreField) -> np.ndarray[Any, np.dtype[Any]]:
@@ -314,7 +346,8 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
     Tested with Redis 8.0.3+ including Search and, for JSON, RedisJSON.
     Index creation requires INDEXMISSING and INDEXEMPTY support.
     Fields use native Redis types, with JSON encoding for unindexed HASH containers.
-    Caller-provided clients are borrowed and must use RESP2 with binary responses.
+    Clients must use database 0, strict UTF-8 encoding, and RESP2 with binary responses.
+    Caller-provided clients are borrowed.
 
     Scores are native distances, lower is better: DEFAULT/cosine_distance use
     COSINE, euclidean_squared_distance uses L2, and redis.ip uses 1 - dot product.
@@ -366,7 +399,7 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
             raise ValueError("storage_type must be 'hash' or 'json'.")
         self.storage_type: Literal["hash", "json"] = storage_type
         self.namespace = namespace
-        self.index_name, self.key_prefix = _prepare_collection_names(namespace, self.collection_name)
+        self.index_name, self.key_prefix = _RedisNamespaceNames(namespace).for_collection(self.collection_name)
         self._indexed_fields: dict[str, VectorStoreField] = {}
         for field in self.definition.fields:
             name = field.storage_name or field.name
@@ -916,21 +949,12 @@ class RedisStore(BaseVectorStore):
         if self._closed:
             raise RuntimeError("The Redis store is closed.")
         mark_feature_used(FeatureIndex.REDIS)
-        prefix = f"af:vector:{_prepare_namespace_component(self.namespace)}:index:".encode("ascii")
+        namespace_names = _RedisNamespaceNames(self.namespace)
         names: list[str] = []
         indexes = cast(list[bytes], await self.redis_client.execute_command("FT._LIST"))  # pyright: ignore[reportUnknownMemberType]
         for index_name in indexes:
-            if not index_name.startswith(prefix):
-                continue
-            encoded_name = index_name[len(prefix) :]
-            if not 2 <= len(encoded_name) <= 512:
-                continue
-            try:
-                name = bytes.fromhex(encoded_name.decode("ascii")).decode("utf-8")
-                canonical_name = _prepare_namespace_component(name).encode("ascii")
-            except ValueError:
-                continue
-            if encoded_name == canonical_name:
+            name = namespace_names.try_parse_index_name(index_name)
+            if name is not None:
                 names.append(name)
         return sorted(names)
 
@@ -938,7 +962,7 @@ class RedisStore(BaseVectorStore):
         self, collection_name: str, *, operation_options: Mapping[str, Any] | None = None
     ) -> None:
         _validate_operation_options(operation_options)
-        index_name, key_prefix = _prepare_collection_names(self.namespace, collection_name)
+        index_name, key_prefix = _RedisNamespaceNames(self.namespace).for_collection(collection_name)
         existing = await AsyncSearchIndex.from_existing(  # pyright: ignore[reportUnknownMemberType]
             index_name, redis_client=self.redis_client
         )

--- a/python/packages/redis/agent_framework_redis/_vector_store.py
+++ b/python/packages/redis/agent_framework_redis/_vector_store.py
@@ -1,0 +1,959 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Redis HASH and JSON vector collections using Redis Search."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar, Generic, Literal, cast
+from uuid import uuid4
+from weakref import WeakSet
+
+import msgspec
+import numpy as np
+from agent_framework import (
+    BaseVectorCollection,
+    BaseVectorSearch,
+    BaseVectorStore,
+    Filter,
+    FilterGroup,
+    SearchResults,
+    SearchType,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    load_settings,
+)
+from agent_framework._feature_stage import ExperimentalFeature, experimental
+from agent_framework._telemetry import mark_feature_used
+from agent_framework._vector_filters import FilterExpression
+from agent_framework._vectors import EmbeddingClient, Vector
+from agent_framework.exceptions import (
+    IntegrationException,
+    IntegrationInitializationError,
+    IntegrationInvalidResponseException,
+)
+from redis.asyncio import Redis
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+from redis.commands.search.query import Query
+from redis.exceptions import RedisError, ResponseError
+from redisvl.exceptions import RedisSearchError
+from redisvl.index import AsyncSearchIndex
+from redisvl.schema import IndexSchema
+from redisvl.utils.token_escaper import TokenEscaper
+from typing_extensions import TypedDict, TypeVar
+
+from ._feature_usage import FeatureIndex
+
+ModelT = TypeVar("ModelT", default=Any)
+_METRICS = {
+    "DEFAULT": "COSINE",
+    "cosine_distance": "COSINE",
+    "euclidean_squared_distance": "L2",
+    "redis.ip": "IP",
+}
+_DTYPES = {"float": "<f4", "float32": "<f4", "float64": "<f8", "bytes": "<f4"}
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}\Z")
+_BATCH_SIZE = 100
+_TAG_SEPARATOR = "\x1f"
+_ESCAPER = TokenEscaper(re.compile(r"[^\w]", re.UNICODE))
+_INDEXED_TYPES = {"str", "bool", "int", "float", "list", "tuple"}
+
+
+class RedisSettings(TypedDict, total=False):
+    """Connection settings resolved by the shared settings loader.
+
+    Explicit overrides take precedence over an explicitly supplied .env file,
+    then environment variables with the ``REDIS_`` prefix.
+
+    Keys:
+        url: Redis connection URL, including optional credentials. Loaded from
+            ``REDIS_URL`` and masked as a SecretString.
+    """
+
+    url: SecretString | None
+
+
+def _create_client(
+    redis_url: str | SecretString | None,
+    redis_client: Redis | None,
+    *,
+    env_file_path: str | None,
+    env_file_encoding: str | None,
+) -> Redis:
+    if redis_client is None:
+        settings = load_settings(
+            RedisSettings,
+            env_prefix="REDIS_",
+            url=redis_url,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+        )
+        url = settings.get("url")
+        redis_client = Redis.from_url(  # pyright: ignore[reportUnknownMemberType]
+            url.get_secret_value() if url is not None else "redis://localhost:6379",
+            decode_responses=False,
+            protocol=2,
+        )
+    if not isinstance(redis_client, Redis):
+        raise TypeError("Redis vector stores require a standalone redis.asyncio.Redis client.")
+    kwargs = cast(dict[str, Any], redis_client.connection_pool.connection_kwargs)  # pyright: ignore[reportUnknownMemberType]
+    if kwargs.get("decode_responses", False) or kwargs.get("protocol", 2) != 2:
+        raise ValueError("Redis vector stores require decode_responses=False and RESP protocol=2.")
+    return redis_client
+
+
+def _validate_operation_options(options: Mapping[str, Any] | None) -> None:
+    if options:
+        raise NotImplementedError("Redis vector stores do not support operation_options.")
+
+
+def _prepare_namespace_component(value: str) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > 256:
+        raise ValueError("Redis namespace and collection names must contain 1 to 256 UTF-8 bytes.")
+    return value.encode("utf-8").hex()
+
+
+def _prepare_collection_names(namespace: str, collection_name: str) -> tuple[str, str]:
+    base = f"af:vector:{_prepare_namespace_component(namespace)}:"
+    collection = _prepare_namespace_component(collection_name)
+    return f"{base}index:{collection}", f"{base}data:{collection}:"
+
+
+def _prepare_vector(value: Any, field: VectorStoreField) -> np.ndarray[Any, np.dtype[Any]]:
+    dtype = np.dtype(_DTYPES[field.type_ or "float32"])
+    if field.dimensions is None:
+        raise ValueError("Redis vector fields require dimensions.")
+    if isinstance(value, (bytes, bytearray)):
+        if len(value) != field.dimensions * dtype.itemsize:
+            raise ValueError(f"Binary vector '{field.name}' has an invalid byte length.")
+        result = np.frombuffer(value, dtype=dtype)
+    else:
+        source = np.asarray(value)
+        if isinstance(value, Sequence) and any(isinstance(item, bool) for item in cast(Sequence[Any], value)):
+            raise TypeError(f"Vector '{field.name}' must not contain booleans.")
+        if source.dtype.kind not in ("i", "u", "f"):
+            raise TypeError(f"Vector '{field.name}' must contain numbers, not booleans or strings.")
+        with np.errstate(over="ignore"):
+            result = source.astype(dtype)
+    if result.ndim != 1 or result.size != field.dimensions:
+        raise ValueError(f"Vector '{field.name}' must contain exactly {field.dimensions} dimensions.")
+    if not np.isfinite(result).all():
+        raise ValueError(f"Vector '{field.name}' must contain only finite values representable in its datatype.")
+    if _METRICS[field.distance_function or "DEFAULT"] == "COSINE" and not np.any(result):
+        raise ValueError(f"Cosine vector '{field.name}' must have a nonzero magnitude.")
+    return result
+
+
+def _validate_json_value(value: Any) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Redis JSON data must contain finite numbers.")
+        return
+    if isinstance(value, list):
+        for item in cast(list[Any], value):
+            _validate_json_value(item)
+        return
+    if isinstance(value, dict):
+        for key, item in cast(dict[Any, Any], value).items():
+            if not isinstance(key, str):
+                raise TypeError("Redis JSON object keys must be strings.")
+            _validate_json_value(item)
+        return
+    raise TypeError("Redis JSON data must be JSON-compatible; use HASH or a custom codec for binary data.")
+
+
+def _prepare_schema_signature(schema: IndexSchema) -> dict[str, Any]:
+    data = schema.to_dict()
+    return {
+        "prefix": data["index"]["prefix"],
+        "storage_type": data["index"]["storage_type"],
+        "fields": {
+            field["name"]: {
+                "path": field.get("path") or field["name"],
+                "type": field["type"],
+                "attrs": field.get("attrs", {}),
+            }
+            for field in data["fields"]
+        },
+    }
+
+
+def _prepare_numeric_value(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("Redis numeric filters and indexed values require numbers, not booleans.")
+    if (isinstance(value, int) and abs(value) > 2**53) or not math.isfinite(value):
+        raise ValueError("Redis indexed numbers must be finite; integers must be within [-2**53, 2**53].")
+    return float(value)
+
+
+def _prepare_tag_value(value: Any) -> str:
+    if not isinstance(value, str):
+        raise TypeError("Redis string TAG values must be strings.")
+    if value != value.strip() or _TAG_SEPARATOR in value or "\x00" in value:
+        raise ValueError("Indexed Redis strings cannot have surrounding whitespace, NUL, or the TAG separator U+001F.")
+    if len(value.encode("utf-8")) > 4096:
+        raise ValueError("Redis TAG values cannot exceed the native 4096-byte term limit.")
+    return value
+
+
+def _prepare_tag_filter(name: str, value: str) -> str:
+    # RedisVL's Tag equality turns an empty string into '*'; INDEXEMPTY needs an explicit empty TAG.
+    return f'@{name}:{{""}}' if value == "" else f"@{name}:{{{_ESCAPER.escape(value)}}}"
+
+
+def _prepare_filter_and(parts: Sequence[str]) -> str:
+    return "(" + " ".join(parts) + ")" if parts else "*"
+
+
+def _prepare_filter_or(parts: Sequence[str]) -> str:
+    if not parts:
+        raise ValueError("Redis OR expressions require at least one operand.")
+    return "(" + " | ".join(parts) + ")"
+
+
+def _prepare_filter_not(part: str) -> str:
+    return f"(-({part}))"
+
+
+def _prepare_filter_false(name: str) -> str:
+    return f"(ismissing(@{name}) -ismissing(@{name}))"
+
+
+def _prepare_non_null_filter(name: str, kind: str, storage_type: str) -> str:
+    if storage_type == "hash":
+        return _prepare_filter_not(f"ismissing(@{name})")
+    if kind in ("int", "float"):
+        return f"@{name}:[-inf +inf]"
+    if kind == "bool":
+        return f"@{name}:{{true|false}}"
+    raise NotImplementedError(
+        "Redis JSON TAG indexes cannot distinguish null from all non-null string/collection values "
+        "without enumerating terms; this operator is unsupported."
+    )
+
+
+def _prepare_filter_equality(name: str, kind: str, value: Any) -> str:
+    if value is None:
+        raise ValueError("Use is_null/is_not_null instead of equality with None.")
+    if kind in ("list", "tuple"):
+        raise NotImplementedError("Redis supports string collection membership, not whole-collection equality.")
+    if kind in ("int", "float"):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return _prepare_filter_false(name)
+        number = _prepare_numeric_value(value)
+        return f"@{name}:[{number} {number}]"
+    if kind == "bool":
+        return _prepare_tag_filter(name, str(value).lower()) if isinstance(value, bool) else _prepare_filter_false(name)
+    return (
+        _prepare_tag_filter(name, _prepare_tag_value(value)) if isinstance(value, str) else _prepare_filter_false(name)
+    )
+
+
+def _prepare_filter_condition(filter: Filter, field: VectorStoreField, storage_type: str) -> str:
+    name = field.storage_name or field.name
+    kind = field.type_ or "str"
+    op, value = filter.operator, filter.value
+    present = _prepare_filter_not(f"ismissing(@{name})")
+    if op == "exists":
+        return present
+    if op in ("is_null", "is_not_null"):
+        nonnull = _prepare_non_null_filter(name, kind, storage_type)
+        return nonnull if op == "is_not_null" else _prepare_filter_and([present, _prepare_filter_not(nonnull)])
+    if op in ("eq", "ne"):
+        equals = _prepare_filter_equality(name, kind, value)
+        return equals if op == "eq" else _prepare_filter_and([present, _prepare_filter_not(equals)])
+    if op in ("in", "not_in"):
+        # Portable membership never matches an actual null, including when None is in the supplied sequence.
+        parts = [_prepare_filter_equality(name, kind, item) for item in cast(Sequence[Any], value) if item is not None]
+        matches = _prepare_filter_or(parts) if parts else _prepare_filter_false(name)
+        return (
+            matches
+            if op == "in"
+            else _prepare_filter_and([_prepare_non_null_filter(name, kind, storage_type), _prepare_filter_not(matches)])
+        )
+    if op in ("gt", "gte", "lt", "lte", "between"):
+        if kind not in ("int", "float"):
+            raise NotImplementedError("Redis ordered comparisons require a numeric indexed field.")
+        if op == "between":
+            lower, upper = cast(Sequence[Any], value)
+            return f"@{name}:[{_prepare_numeric_value(lower)} {_prepare_numeric_value(upper)}]"
+        number = _prepare_numeric_value(value)
+        match op:
+            case "gt":
+                return f"@{name}:[({number} +inf]"
+            case "gte":
+                return f"@{name}:[{number} +inf]"
+            case "lt":
+                return f"@{name}:[-inf ({number}]"
+            case _:
+                return f"@{name}:[-inf {number}]"
+    if op in ("contains", "contains_any", "contains_all"):
+        if kind not in ("list", "tuple"):
+            raise NotImplementedError("Redis collection membership requires an indexed list or tuple of strings.")
+        values = [value] if op == "contains" else cast(Sequence[Any], value)
+        if not values and op == "contains_all":
+            raise NotImplementedError("Redis cannot distinguish null from an empty TAG array for contains_all=[].")
+        parts = [_prepare_tag_filter(name, _prepare_tag_value(item)) for item in values]
+        if not parts:
+            return _prepare_filter_false(name)
+        return _prepare_filter_and(parts) if op == "contains_all" else _prepare_filter_or(parts)
+    raise NotImplementedError(
+        f"Redis does not support portable operator '{op}'; TEXT tokenization is not literal string matching."
+    )
+
+
+@experimental(feature_id=ExperimentalFeature.VECTOR_STORES)
+class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, ModelT], Generic[ModelT]):
+    """Store and search records in Redis HASH or JSON documents.
+
+    Tested with Redis 8.0.3+ including Search and, for JSON, RedisJSON.
+    Index creation requires INDEXMISSING and INDEXEMPTY support.
+    Fields use native Redis types, with JSON encoding for unindexed HASH containers.
+    Caller-provided clients are borrowed and must use RESP2 with binary responses.
+
+    Scores are native distances, lower is better: DEFAULT/cosine_distance use
+    COSINE, euclidean_squared_distance uses L2, and redis.ip uses 1 - dot product.
+    Score thresholds are maximum distances, executed as native vector ranges.
+    Keyword-hybrid and literal text filters are deliberately unsupported.
+    """
+
+    supported_key_types: ClassVar[set[str] | None] = {"str"}
+    supported_vector_types: ClassVar[set[str] | None] = set(_DTYPES)
+    supported_search_types: ClassVar[set[SearchType]] = {"vector"}
+
+    def __init__(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        redis_url: str | SecretString | None = None,
+        redis_client: Redis | None = None,
+        storage_type: Literal["hash", "json"] = "hash",
+        namespace: str = "default",
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a collection without connecting or creating an index.
+
+        Args:
+            record_type: Registered model type, or dict with an explicit definition.
+            definition: Collection schema for dictionary records.
+            collection_name: Name overriding the model's collection name.
+            embedding_generator: Optional local embedding generator.
+            redis_url: Connection URL override. Otherwise resolved from REDIS_URL in an explicit .env file or the
+                environment, then defaults to redis://localhost:6379. Used only when no client is supplied.
+            redis_client: Borrowed async Redis client; the caller owns its lifetime.
+            storage_type: Use binary-vector HASH documents or JSON vector arrays.
+            namespace: Isolates index names and document prefixes from other stores.
+            env_file_path: Optional .env file for connection settings when creating a client.
+            env_file_encoding: Encoding for the .env file; defaults to UTF-8.
+        """
+        super().__init__(
+            record_type,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator,
+            managed_client=redis_client is None,
+        )
+        if storage_type not in ("hash", "json"):
+            raise ValueError("storage_type must be 'hash' or 'json'.")
+        self.storage_type: Literal["hash", "json"] = storage_type
+        self.namespace = namespace
+        self.index_name, self.key_prefix = _prepare_collection_names(namespace, self.collection_name)
+        self._indexed_fields: dict[str, VectorStoreField] = {}
+        for field in self.definition.fields:
+            name = field.storage_name or field.name
+            if not _IDENTIFIER.fullmatch(name) or name.startswith("_af_"):
+                raise ValueError("Redis storage names must be ASCII identifiers (up to 128 chars), excluding '_af_'.")
+            if field.is_full_text_indexed:
+                raise NotImplementedError("RedisCollection does not expose tokenized full-text or hybrid search.")
+            if field.provider_annotations:
+                raise NotImplementedError("RedisCollection does not support provider_annotations.")
+            if field.field_type == "vector":
+                if field.index_kind not in ("default", "flat", "hnsw"):
+                    raise NotImplementedError(f"Redis does not support index kind '{field.index_kind}'.")
+                if field.distance_function not in _METRICS:
+                    raise NotImplementedError(f"Redis does not support distance function '{field.distance_function}'.")
+            else:
+                if field.type_ not in (None, "str", "bool", "int", "float", "list", "tuple", "dict", "bytes"):
+                    raise NotImplementedError(f"Redis does not support data type '{field.type_}'.")
+                if field.field_type == "key" or field.is_indexed:
+                    if (field.type_ or "str") not in _INDEXED_TYPES:
+                        raise NotImplementedError(f"Redis cannot index field '{field.name}' of type '{field.type_}'.")
+                    self._indexed_fields[field.name] = field
+        self.redis_client = _create_client(
+            redis_url, redis_client, env_file_path=env_file_path, env_file_encoding=env_file_encoding
+        )
+        self._closed = False
+        self._validated = False
+        self._index = AsyncSearchIndex(self._prepare_schema(), redis_client=self.redis_client)
+
+    def _prepare_schema(self) -> IndexSchema:
+        fields: list[dict[str, Any]] = []
+
+        def add(name: str, kind: str, attrs: dict[str, Any]) -> None:
+            item: dict[str, Any] = {"name": name, "type": kind, "attrs": attrs}
+            if self.storage_type == "json":
+                item["path"] = f"$.{name}"
+            fields.append(item)
+
+        for indexed in self._indexed_fields.values():
+            name = indexed.storage_name or indexed.name
+            if indexed.type_ in ("int", "float"):
+                add(name, "numeric", {"sortable": True, "index_missing": True})
+            else:
+                add(
+                    name,
+                    "tag",
+                    {
+                        "case_sensitive": True,
+                        "separator": _TAG_SEPARATOR,
+                        "sortable": indexed.type_ not in ("list", "tuple"),
+                        "index_missing": True,
+                        "index_empty": True,
+                    },
+                )
+        for field in self.definition.vector_fields:
+            add(
+                field.storage_name or field.name,
+                "vector",
+                {
+                    "algorithm": "hnsw" if field.index_kind == "default" else field.index_kind,
+                    "dims": field.dimensions,
+                    "distance_metric": _METRICS[field.distance_function or "DEFAULT"],
+                    "datatype": "float64" if field.type_ == "float64" else "float32",
+                },
+            )
+        return IndexSchema.from_dict({
+            "index": {
+                "name": self.index_name,
+                "prefix": self.key_prefix,
+                "key_separator": "",
+                "storage_type": self.storage_type,
+            },
+            "fields": fields,
+        })
+
+    def _check_open(self, options: Mapping[str, Any] | None) -> None:
+        _validate_operation_options(options)
+        if self._closed:
+            raise RuntimeError("The Redis collection is closed.")
+        mark_feature_used(FeatureIndex.REDIS)
+
+    async def _validate_schema(self) -> None:
+        existing = await AsyncSearchIndex.from_existing(  # pyright: ignore[reportUnknownMemberType]
+            self.index_name, redis_client=self.redis_client
+        )
+        if _prepare_schema_signature(existing.schema) != _prepare_schema_signature(self._index.schema):
+            raise ValueError(f"Redis index '{self.index_name}' has an incompatible schema or document prefix.")
+
+    async def _require_index(self) -> None:
+        if not self._validated:
+            if not await self._index.exists():
+                raise IntegrationException("Redis collection does not exist; call ensure_collection_exists() first.")
+            await self._validate_schema()
+            self._validated = True
+
+    async def ensure_collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Create or validate the index; never overwrite an existing index."""
+        self._check_open(operation_options)
+        try:
+            if self.storage_type == "json":
+                # Read-only capability probe; PING alone does not establish RedisJSON support.
+                await self.redis_client.execute_command(  # pyright: ignore[reportUnknownMemberType]
+                    "JSON.TYPE", self.key_prefix + "_af_capability_probe", "$"
+                )
+            if not await self._index.exists():
+                fields = self._index.schema.redis_fields
+                for field in fields:
+                    # RedisVL 0.11 emits these after SORTABLE, which Redis's parser rejects.
+                    early = {"INDEXEMPTY", "INDEXMISSING"}
+                    suffix = cast(list[str], field.args_suffix)  # pyright: ignore[reportUnknownMemberType]
+                    field.args_suffix = [arg for arg in suffix if arg in early] + [
+                        arg for arg in suffix if arg not in early
+                    ]
+                try:
+                    await self.redis_client.ft(self.index_name).create_index(  # pyright: ignore[reportUnknownMemberType]
+                        fields,
+                        definition=IndexDefinition(
+                            prefix=[self.key_prefix],
+                            index_type=IndexType.HASH if self.storage_type == "hash" else IndexType.JSON,
+                        ),
+                    )
+                except ResponseError as exc:
+                    if str(exc) != "Index already exists":
+                        raise
+            await self._validate_schema()
+        except (RedisError, RedisSearchError) as exc:
+            raise IntegrationInitializationError(
+                "Redis vector index initialization failed. Requires Redis Search with INDEXMISSING/INDEXEMPTY "
+                "and RedisJSON for JSON storage (tested minimum Redis 8.0.3)."
+            ) from exc
+        self._validated = True
+
+    async def collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> bool:
+        """Check index existence using Redis Search, not merely server connectivity."""
+        self._check_open(operation_options)
+        return await self._index.exists()
+
+    async def ensure_collection_deleted(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Delete a compatible index and its documents; do not touch other prefixes."""
+        self._check_open(operation_options)
+        if await self._index.exists():
+            await self._validate_schema()
+            await self._index.delete(drop=True)
+        self._validated = False
+
+    async def close(self) -> None:
+        """Close this handle and its client only when the client is owned."""
+        if not self._closed:
+            self._closed = True
+            if self.managed_client:
+                await self.redis_client.aclose()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the collection without deleting its data."""
+        await self.close()
+
+    def _prepare_key(self, key: str) -> str:
+        if not isinstance(key, str) or not key:
+            raise ValueError("Redis record keys must be nonempty strings.")
+        return self.key_prefix + key
+
+    def _serialize_dicts_to_store_models(
+        self,
+        records: Sequence[dict[str, Any]],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        _validate_operation_options(context)
+        prepared: list[dict[str, Any]] = []
+        for source in records:
+            record = dict(source)
+            key_name = self.definition.key_field_storage_name
+            if key_name not in record and self.definition.key_field.is_auto_generated:
+                record[key_name] = str(uuid4())
+            self._prepare_key(record[key_name])
+            document: dict[str, Any] = {}
+            for field in self.definition.fields:
+                name = field.storage_name or field.name
+                if name not in record:
+                    continue
+                value = record[name]
+                if field.field_type == "vector" and value is not None:
+                    array = _prepare_vector(value, field)
+                    value = array.tobytes() if self.storage_type == "hash" else array.tolist()
+                else:
+                    value = self._prepare_data_value(value, field)
+                document[name] = value
+            prepared.append(document)
+        return prepared
+
+    def _prepare_data_value(self, value: Any, field: VectorStoreField) -> Any:
+        if value is None:
+            if self.storage_type == "hash":
+                raise NotImplementedError("Redis HASH has no native null value; use JSON storage for nullable fields.")
+            return None
+        kind = field.type_ or "str"
+        expected = {
+            "str": (str,),
+            "bool": (bool,),
+            "int": (int,),
+            "float": (int, float),
+            "list": (list, tuple),
+            "tuple": (list, tuple),
+            "dict": (dict,),
+            "bytes": (bytes,),
+        }
+        if field.field_type != "vector" and type(value) not in expected[kind]:
+            raise TypeError(f"Redis field '{field.name}' requires {kind} values.")
+        if field.name in self._indexed_fields:
+            if kind in ("int", "float"):
+                _prepare_numeric_value(value)
+            elif kind == "str":
+                _prepare_tag_value(value)
+            elif kind in ("list", "tuple"):
+                value = [_prepare_tag_value(item) for item in value]
+                if self.storage_type == "hash":
+                    if not value or any(item == "" for item in value):
+                        raise NotImplementedError(
+                            "Redis HASH TAG arrays cannot preserve empty arrays or empty elements."
+                        )
+                    return _TAG_SEPARATOR.join(value)
+        if self.storage_type == "json":
+            _validate_json_value(value)
+            return value
+        if kind == "bool":
+            return str(value).lower()
+        if kind in ("list", "tuple", "dict"):
+            _validate_json_value(value)
+            return msgspec.json.encode(value)
+        return value
+
+    def _deserialize_store_models_to_dicts(
+        self, records: Sequence[Any], *, context: Mapping[str, Any] | None = None
+    ) -> Sequence[dict[str, Any]]:
+        _validate_operation_options(context)
+        decoded: list[dict[str, Any]] = []
+        for source in records:
+            record: dict[str, Any] = {}
+            for field in self.definition.fields:
+                name = field.storage_name or field.name
+                if name not in source:
+                    continue
+                value = source[name]
+                if field.field_type == "vector":
+                    value = self._decode_vector(value, field)
+                elif self.storage_type == "hash":
+                    value = self._decode_hash_data(value, field)
+                record[name] = value
+            decoded.append(record)
+        return decoded
+
+    def _decode_vector(self, value: Any, field: VectorStoreField) -> Any:
+        if value is None:
+            return None
+        array = _prepare_vector(value, field)
+        return array.tobytes() if field.type_ == "bytes" else array.tolist()
+
+    def _decode_hash_data(self, value: Any, field: VectorStoreField) -> Any:
+        kind = field.type_ or "str"
+        if kind == "bytes":
+            return value
+        text = value.decode("utf-8") if isinstance(value, bytes) else str(value)
+        if kind == "str":
+            return text
+        if kind == "int":
+            return int(text)
+        if kind == "float":
+            return float(text)
+        if kind == "bool":
+            if text not in ("true", "false"):
+                raise IntegrationInvalidResponseException("Redis boolean HASH fields must contain 'true' or 'false'.")
+            return text == "true"
+        if field.name in self._indexed_fields:
+            return text.split(_TAG_SEPARATOR)
+        return msgspec.json.decode(value)
+
+    def _prepare_filter(self, filter: FilterExpression | None) -> str:
+        """Validate Redis filter support and translate the core snapshot into a native query."""
+        if filter is None:
+            return "*"
+        if isinstance(filter, FilterGroup):
+            parts = [self._prepare_filter(child) for child in filter.filters]
+            match filter.operator:
+                case "and":
+                    return _prepare_filter_and(parts)
+                case "or":
+                    return _prepare_filter_or(parts)
+                case "not":
+                    return _prepare_filter_not(parts[0])
+                case _:
+                    raise ValueError(f"Unknown filter group operator '{filter.operator}'.")
+        field = self._indexed_fields.get(filter.field_name)
+        if field is None:
+            raise NotImplementedError(
+                f"Redis filters require a declared, indexed, non-vector field; got '{filter.field_name}'."
+            )
+        return _prepare_filter_condition(filter, field, self.storage_type)
+
+    async def _execute_query(self, query: Query, params: Mapping[str, Any] | None = None) -> list[Any]:
+        args: list[Any] = ["FT.SEARCH", self.index_name, *query.get_args()]
+        if params:
+            args.extend(["PARAMS", 2 * len(params)])
+            for name, value in params.items():
+                args.extend([name, value])
+        return cast(list[Any], await self.redis_client.execute_command(*args))  # pyright: ignore[reportUnknownMemberType]
+
+    async def _fetch_records(self, keys: Sequence[str], *, include_vectors: bool) -> list[dict[str, Any] | None]:
+        fields = [f for f in self.definition.fields if include_vectors or f.field_type != "vector"]
+        names = [field.storage_name or field.name for field in fields]
+        records: list[dict[str, Any] | None] = []
+        for start in range(0, len(keys), _BATCH_SIZE):
+            async with self.redis_client.pipeline(transaction=False) as pipeline:
+                for key in keys[start : start + _BATCH_SIZE]:
+                    if not key.startswith(self.key_prefix):
+                        raise IntegrationInvalidResponseException("Redis returned a key outside the collection prefix.")
+                    if self.storage_type == "hash":
+                        pipeline.exists(key)
+                        pipeline.hmget(key, names)  # pyright: ignore[reportUnknownMemberType]
+                    else:
+                        pipeline.execute_command(  # pyright: ignore[reportUnknownMemberType]
+                            "JSON.GET", key, *[f"$.{name}" for name in names]
+                        )
+                responses = await pipeline.execute()
+            if self.storage_type == "hash":
+                responses = [
+                    values if exists else None for exists, values in zip(responses[::2], responses[1::2], strict=True)
+                ]
+            for response in responses:
+                if response is None:
+                    records.append(None)
+                    continue
+                record: dict[str, Any] = {}
+                if self.storage_type == "hash":
+                    record = {name: value for name, value in zip(names, response, strict=True) if value is not None}
+                else:
+                    values = msgspec.json.decode(response)
+                    if len(names) == 1:
+                        values = {f"$.{names[0]}": values}
+                    for name in names:
+                        matches = values.get(f"$.{name}", [])
+                        if matches:
+                            record[name] = matches[0]
+                records.append(record)
+        return records
+
+    async def _inner_upsert(
+        self, records: Sequence[Any], *, operation_options: Mapping[str, Any] | None = None
+    ) -> Sequence[str]:
+        self._check_open(operation_options)
+        if not records:
+            return []
+        keys = [record[self.definition.key_field_storage_name] for record in records]
+        redis_keys = [self._prepare_key(key) for key in keys]
+        await self._require_index()
+        for start in range(0, len(records), _BATCH_SIZE):
+            async with self.redis_client.pipeline(transaction=True) as pipeline:
+                for key, record in zip(
+                    redis_keys[start : start + _BATCH_SIZE], records[start : start + _BATCH_SIZE], strict=True
+                ):
+                    if self.storage_type == "hash":
+                        pipeline.delete(key)
+                        pipeline.hset(key, mapping=record)  # pyright: ignore[reportUnknownMemberType]
+                    else:
+                        pipeline.execute_command(  # pyright: ignore[reportUnknownMemberType]
+                            "JSON.SET", key, "$", msgspec.json.encode(record)
+                        )
+                await pipeline.execute()
+        return keys
+
+    async def _inner_get(
+        self,
+        *,
+        keys: Sequence[str] | None = None,
+        filter: FilterExpression | None = None,
+        top: int = 10,
+        skip: int = 0,
+        order_by: Mapping[str, bool] | None = None,
+        include_vectors: bool = False,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[Any]:
+        self._check_open(operation_options)
+        if keys is not None and not keys:
+            return []
+        query: Query | None = None
+        redis_keys: list[str] = []
+        if keys is not None:
+            if order_by:
+                raise NotImplementedError(
+                    "Redis key lookup preserves input order; order_by requires filtered retrieval."
+                )
+            redis_keys = [self._prepare_key(key) for key in keys]
+        else:
+            ordering = order_by or {self.definition.key_field.name: True}
+            if len(ordering) != 1:
+                raise NotImplementedError("Redis filtered retrieval supports exactly one order_by field.")
+            name, ascending = next(iter(ordering.items()))
+            field = self._indexed_fields.get(name)
+            if field is None or field.type_ in ("list", "tuple"):
+                raise NotImplementedError("Redis ordering requires an indexed scalar field.")
+            if not isinstance(ascending, bool):
+                raise TypeError("order_by values must be booleans.")
+            query = Query(self._prepare_filter(filter)).no_content().paging(skip, top)
+            query.sort_by(field.storage_name or field.name, asc=ascending)
+        await self._require_index()
+        if query is not None:
+            response = await self._execute_query(query)
+            redis_keys = [key.decode("utf-8") for key in response[1:]]
+        return [
+            record
+            for record in await self._fetch_records(redis_keys, include_vectors=include_vectors)
+            if record is not None
+        ]
+
+    async def _inner_delete(self, keys: Sequence[str], *, operation_options: Mapping[str, Any] | None = None) -> None:
+        self._check_open(operation_options)
+        redis_keys = [self._prepare_key(key) for key in keys]
+        if redis_keys:
+            await self._require_index()
+        for start in range(0, len(redis_keys), _BATCH_SIZE):
+            await self.redis_client.delete(*redis_keys[start : start + _BATCH_SIZE])
+
+    async def _inner_search(
+        self,
+        *,
+        search_type: SearchType,
+        filter: FilterExpression | None = None,
+        values: Any | None = None,
+        vector: Vector | None = None,
+        top: int = 3,
+        skip: int = 0,
+        include_vectors: bool = False,
+        vector_property_name: str | None = None,
+        additional_property_name: str | None = None,
+        score_threshold: float | None = None,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> SearchResults[Any]:
+        self._check_open(operation_options)
+        if search_type != "vector" or additional_property_name is not None:
+            raise NotImplementedError("RedisCollection supports dense vector search only.")
+        field = self.definition.try_get_vector_field(vector_property_name)
+        if field is None or vector is None:
+            raise ValueError("Redis search requires a vector field and a vector or local embedding generator.")
+        name = field.storage_name or field.name
+        params: dict[str, Any] = {"vector": _prepare_vector(vector, field).tobytes()}
+        predicate = self._prepare_filter(filter)
+        if score_threshold is None:
+            query_text = f"({predicate})=>[KNN {top + skip} @{name} $vector AS _af_distance]"
+        else:
+            if isinstance(score_threshold, bool) or not math.isfinite(score_threshold):
+                raise ValueError("Redis score_threshold must be a finite distance.")
+            if score_threshold < 0:
+                raise NotImplementedError("Redis VECTOR_RANGE requires a non-negative distance threshold.")
+            params["radius"] = score_threshold
+            range_query = f"@{name}:[VECTOR_RANGE $radius $vector]=>{{$yield_distance_as: _af_distance}}"
+            query_text = range_query if predicate == "*" else f"({range_query} {predicate})"
+        query = Query(query_text).return_fields("_af_distance").sort_by("_af_distance").paging(skip, top)  # pyright: ignore[reportUnknownMemberType]
+        await self._require_index()
+        response = await self._execute_query(query, params)
+        keys: list[str] = []
+        scores: list[float] = []
+        for position in range(1, len(response), 2):
+            keys.append(response[position].decode("utf-8"))
+            attributes = response[position + 1]
+            attributes = dict(zip(attributes[::2], attributes[1::2], strict=True))
+            score = float(attributes[b"_af_distance"])
+            if not math.isfinite(score):
+                raise IntegrationInvalidResponseException("Redis returned a non-finite vector distance.")
+            scores.append(score)
+        records = await self._fetch_records(keys, include_vectors=include_vectors)
+        return SearchResults(
+            [
+                {"record": record, "score": score}
+                for record, score in zip(records, scores, strict=True)
+                if record is not None
+            ],
+            metadata={"distance_metric": _METRICS[field.distance_function or "DEFAULT"], "score_direction": "lower"},
+        )
+
+    def _get_record_from_result(self, result: Any) -> Any:
+        return result["record"]
+
+    def _get_score_from_result(self, result: Any) -> float:
+        return result["score"]
+
+
+@experimental(feature_id=ExperimentalFeature.VECTOR_STORES)
+class RedisStore(BaseVectorStore):
+    """Factory for Redis collections sharing an isolated namespace and async client."""
+
+    def __init__(
+        self,
+        *,
+        redis_url: str | SecretString | None = None,
+        redis_client: Redis | None = None,
+        storage_type: Literal["hash", "json"] = "hash",
+        namespace: str = "default",
+        embedding_generator: EmbeddingClient | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a store; a supplied client is borrowed, never closed by the store.
+
+        Args:
+            redis_url: Connection URL override. Otherwise resolved from REDIS_URL in an explicit .env file or the
+                environment, then defaults to redis://localhost:6379. Used only when no client is supplied.
+            redis_client: Borrowed standalone async Redis client.
+            storage_type: Default HASH or JSON format for collection handles.
+            namespace: Isolates collection indexes and document keys.
+            embedding_generator: Default local embedding generator for collections.
+            env_file_path: Optional .env file for connection settings when creating a client.
+            env_file_encoding: Encoding for the .env file; defaults to UTF-8.
+        """
+        super().__init__(embedding_generator=embedding_generator, managed_client=redis_client is None)
+        if storage_type not in ("hash", "json"):
+            raise ValueError("storage_type must be 'hash' or 'json'.")
+        _prepare_namespace_component(namespace)
+        self.storage_type: Literal["hash", "json"] = storage_type
+        self.namespace = namespace
+        self.redis_client = _create_client(
+            redis_url, redis_client, env_file_path=env_file_path, env_file_encoding=env_file_encoding
+        )
+        self._closed = False
+        self._collections: WeakSet[RedisCollection[Any]] = WeakSet()
+
+    def get_collection(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        storage_type: Literal["hash", "json"] | None = None,
+    ) -> RedisCollection[ModelT]:
+        """Create a borrowed collection handle, optionally overriding the store's storage format."""
+        if self._closed:
+            raise RuntimeError("The Redis store is closed.")
+        collection = RedisCollection(
+            record_type,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator or self.embedding_generator,
+            redis_client=self.redis_client,
+            namespace=self.namespace,
+            storage_type=storage_type or self.storage_type,
+        )
+        self._collections.add(collection)
+        return collection
+
+    async def list_collection_names(self, *, operation_options: Mapping[str, Any] | None = None) -> Sequence[str]:
+        """List Search indexes belonging to this namespace, regardless of HASH/JSON format."""
+        _validate_operation_options(operation_options)
+        if self._closed:
+            raise RuntimeError("The Redis store is closed.")
+        mark_feature_used(FeatureIndex.REDIS)
+        prefix = f"af:vector:{_prepare_namespace_component(self.namespace)}:index:"
+        names: list[str] = []
+        indexes = cast(list[bytes], await self.redis_client.execute_command("FT._LIST"))  # pyright: ignore[reportUnknownMemberType]
+        for name in indexes:
+            index_name = name.decode("utf-8")
+            if index_name.startswith(prefix):
+                names.append(bytes.fromhex(index_name[len(prefix) :]).decode("utf-8"))
+        return sorted(names)
+
+    async def _inner_ensure_collection_deleted(
+        self, collection_name: str, *, operation_options: Mapping[str, Any] | None = None
+    ) -> None:
+        _validate_operation_options(operation_options)
+        index_name, key_prefix = _prepare_collection_names(self.namespace, collection_name)
+        existing = await AsyncSearchIndex.from_existing(  # pyright: ignore[reportUnknownMemberType]
+            index_name, redis_client=self.redis_client
+        )
+        if existing.schema.index.prefix != key_prefix:
+            raise ValueError("Refusing to delete a Redis index with a different document prefix.")
+        await existing.delete(drop=True)
+        for collection in self._collections:
+            if collection.collection_name == collection_name:
+                collection._validated = False  # pyright: ignore[reportPrivateUsage]
+
+    async def close(self) -> None:
+        """Close the store's owned client without deleting collections."""
+        if not self._closed:
+            self._closed = True
+            for collection in self._collections:
+                await collection.close()
+            self._collections.clear()
+            if self.managed_client:
+                await self.redis_client.aclose()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the store on context exit."""
+        await self.close()

--- a/python/packages/redis/agent_framework_redis/_vector_store.py
+++ b/python/packages/redis/agent_framework_redis/_vector_store.py
@@ -392,7 +392,6 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
             redis_url, redis_client, env_file_path=env_file_path, env_file_encoding=env_file_encoding
         )
         self._closed = False
-        self._validated = False
         self._index = AsyncSearchIndex(self._prepare_schema(), redis_client=self.redis_client)
 
     def _prepare_schema(self) -> IndexSchema:
@@ -455,11 +454,10 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
             raise ValueError(f"Redis index '{self.index_name}' has an incompatible schema or document prefix.")
 
     async def _require_index(self) -> None:
-        if not self._validated:
-            if not await self._index.exists():
-                raise IntegrationException("Redis collection does not exist; call ensure_collection_exists() first.")
-            await self._validate_schema()
-            self._validated = True
+        # Observe completed external lifecycle changes; validation and subsequent I/O are not atomic.
+        if not await self._index.exists():
+            raise IntegrationException("Redis collection does not exist; call ensure_collection_exists() first.")
+        await self._validate_schema()
 
     async def ensure_collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
         """Create or validate the index; never overwrite an existing index."""
@@ -496,7 +494,6 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
                 "Redis vector index initialization failed. Requires Redis Search with INDEXMISSING/INDEXEMPTY "
                 "and RedisJSON for JSON storage (tested minimum Redis 8.0.3)."
             ) from exc
-        self._validated = True
 
     async def collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> bool:
         """Check index existence using Redis Search, not merely server connectivity."""
@@ -509,7 +506,6 @@ class RedisCollection(BaseVectorCollection[str, ModelT], BaseVectorSearch[str, M
         if await self._index.exists():
             await self._validate_schema()
             await self._index.delete(drop=True)
-        self._validated = False
 
     async def close(self) -> None:
         """Close this handle and its client only when the client is owned."""
@@ -906,27 +902,36 @@ class RedisStore(BaseVectorStore):
             record_type,
             definition=definition,
             collection_name=collection_name,
-            embedding_generator=embedding_generator or self.embedding_generator,
+            embedding_generator=self.embedding_generator if embedding_generator is None else embedding_generator,
             redis_client=self.redis_client,
             namespace=self.namespace,
-            storage_type=storage_type or self.storage_type,
+            storage_type=self.storage_type if storage_type is None else storage_type,
         )
         self._collections.add(collection)
         return collection
 
     async def list_collection_names(self, *, operation_options: Mapping[str, Any] | None = None) -> Sequence[str]:
-        """List Search indexes belonging to this namespace, regardless of HASH/JSON format."""
+        """List canonical collection index names in this namespace, ignoring foreign index names."""
         _validate_operation_options(operation_options)
         if self._closed:
             raise RuntimeError("The Redis store is closed.")
         mark_feature_used(FeatureIndex.REDIS)
-        prefix = f"af:vector:{_prepare_namespace_component(self.namespace)}:index:"
+        prefix = f"af:vector:{_prepare_namespace_component(self.namespace)}:index:".encode("ascii")
         names: list[str] = []
         indexes = cast(list[bytes], await self.redis_client.execute_command("FT._LIST"))  # pyright: ignore[reportUnknownMemberType]
-        for name in indexes:
-            index_name = name.decode("utf-8")
-            if index_name.startswith(prefix):
-                names.append(bytes.fromhex(index_name[len(prefix) :]).decode("utf-8"))
+        for index_name in indexes:
+            if not index_name.startswith(prefix):
+                continue
+            encoded_name = index_name[len(prefix) :]
+            if not 2 <= len(encoded_name) <= 512:
+                continue
+            try:
+                name = bytes.fromhex(encoded_name.decode("ascii")).decode("utf-8")
+                canonical_name = _prepare_namespace_component(name).encode("ascii")
+            except ValueError:
+                continue
+            if encoded_name == canonical_name:
+                names.append(name)
         return sorted(names)
 
     async def _inner_ensure_collection_deleted(
@@ -940,9 +945,6 @@ class RedisStore(BaseVectorStore):
         if existing.schema.index.prefix != key_prefix:
             raise ValueError("Refusing to delete a Redis index with a different document prefix.")
         await existing.delete(drop=True)
-        for collection in self._collections:
-            if collection.collection_name == collection_name:
-                collection._validated = False  # pyright: ignore[reportPrivateUsage]
 
     async def close(self) -> None:
         """Close the store's owned client without deleting collections."""

--- a/python/packages/redis/tests/test_vector_settings.py
+++ b/python/packages/redis/tests/test_vector_settings.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from functools import partial
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlencode
 
 import pytest
 from agent_framework import SecretString, VectorStoreCollectionDefinition, VectorStoreField, load_settings
@@ -32,38 +33,41 @@ async def test_default_connection_settings(factory):
         assert kwargs["port"] == 6379
         assert kwargs["decode_responses"] is False
         assert kwargs["protocol"] == 2
+        assert kwargs.get("db", 0) == 0
+        assert kwargs.get("encoding", "utf-8") == "utf-8"
+        assert kwargs.get("encoding_errors", "strict") == "strict"
 
 
 async def test_connection_settings_from_environment(factory, monkeypatch):
-    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/0")
     async with factory() as owner:
         kwargs = owner.redis_client.connection_pool.connection_kwargs
         assert kwargs["host"] == "environment"
         assert kwargs["port"] == 6380
-        assert kwargs["db"] == 2
+        assert kwargs["db"] == 0
 
 
-@pytest.mark.parametrize("override", ["redis://explicit:6381/3", SecretString("redis://explicit:6381/3")])
+@pytest.mark.parametrize("override", ["redis://explicit:6381/0", SecretString("redis://explicit:6381/0")])
 async def test_explicit_url_overrides_environment_and_file(factory, monkeypatch, tmp_path, override):
-    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/0")
     env_file = tmp_path / "redis.env"
-    env_file.write_text("REDIS_URL=redis://file:6382/4\n", encoding="utf-8")
+    env_file.write_text("REDIS_URL=redis://file:6382/0\n", encoding="utf-8")
     async with factory(redis_url=override, env_file_path=str(env_file)) as owner:
         kwargs = owner.redis_client.connection_pool.connection_kwargs
         assert kwargs["host"] == "explicit"
         assert kwargs["port"] == 6381
-        assert kwargs["db"] == 3
+        assert kwargs["db"] == 0
 
 
 async def test_explicit_env_file_overrides_environment(factory, monkeypatch, tmp_path):
-    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/0")
     env_file = tmp_path / "redis.env"
-    env_file.write_text("REDIS_URL=redis://file:6382/4\n", encoding="utf-16")
+    env_file.write_text("REDIS_URL=redis://file:6382/0\n", encoding="utf-16")
     async with factory(redis_url=None, env_file_path=str(env_file), env_file_encoding="utf-16") as owner:
         kwargs = owner.redis_client.connection_pool.connection_kwargs
         assert kwargs["host"] == "file"
         assert kwargs["port"] == 6382
-        assert kwargs["db"] == 4
+        assert kwargs["db"] == 0
 
 
 def test_explicit_missing_env_file_fails(factory, tmp_path):
@@ -83,6 +87,76 @@ def test_invalid_url_override_type(factory):
         factory(redis_url=123)
 
 
+@pytest.mark.parametrize("source", ["url", "borrowed"])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"encoding": "ascii", "encoding_errors": "ignore"},
+        {"encoding": "latin-1"},
+        {"encoding": "utf-8-sig"},
+        {"encoding": "not-an-encoding"},
+        {"encoding_errors": "ignore"},
+        {"encoding_errors": "replace"},
+        {"encoding_errors": "surrogatepass"},
+    ],
+)
+async def test_incompatible_client_encoding_rejected_before_io(factory, source, kwargs):
+    borrowed = Redis(**kwargs) if source == "borrowed" else None
+    try:
+        with (
+            patch.object(Redis, "execute_command", new_callable=AsyncMock) as execute,
+            patch.object(Redis, "aclose", new_callable=AsyncMock) as close,
+        ):
+            with pytest.raises(ValueError, match="strict UTF-8"):
+                if borrowed is not None:
+                    factory(redis_client=borrowed)
+                else:
+                    factory(redis_url=f"redis://localhost:6379?{urlencode(kwargs)}")
+            execute.assert_not_awaited()
+            close.assert_not_awaited()
+    finally:
+        if borrowed is not None:
+            await borrowed.aclose()
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf8", "UTF_8"])
+async def test_strict_utf8_aliases_accepted(factory, encoding):
+    async with factory(redis_url=f"redis://localhost:6379/0?encoding={encoding}&encoding_errors=strict") as owner:
+        assert owner.redis_client.get_encoder().encode("a\u00e9b\u00e9c") == "a\u00e9b\u00e9c".encode()
+    async with Redis(encoding=encoding) as borrowed, factory(redis_client=borrowed) as owner:
+        assert owner.redis_client is borrowed
+        assert borrowed.get_encoder().encode("a\u00e9b\u00e9c") != borrowed.get_encoder().encode("abc")
+
+
+@pytest.mark.parametrize("source", ["path", "query", "borrowed"])
+@pytest.mark.parametrize("db", [-1, 1, 2, 3, 4])
+async def test_nonzero_database_rejected_before_io(factory, source, db):
+    borrowed = Redis(db=db) if source == "borrowed" else None
+    try:
+        with (
+            patch.object(Redis, "execute_command", new_callable=AsyncMock) as execute,
+            patch.object(Redis, "aclose", new_callable=AsyncMock) as close,
+        ):
+            with pytest.raises(ValueError, match="require database 0"):
+                if borrowed is not None:
+                    factory(redis_client=borrowed)
+                elif source == "path":
+                    factory(redis_url=f"redis://localhost:6379/{db}")
+                else:
+                    factory(redis_url=f"redis://localhost:6379/0?db={db}")
+            execute.assert_not_awaited()
+            close.assert_not_awaited()
+    finally:
+        if borrowed is not None:
+            await borrowed.aclose()
+
+
+@pytest.mark.parametrize("url", ["redis://localhost:6379/0", "redis://localhost:6379/2?db=0"])
+async def test_resolved_database_zero_accepted(factory, url):
+    async with factory(redis_url=url) as owner:
+        assert owner.redis_client.connection_pool.connection_kwargs["db"] == 0
+
+
 async def test_borrowed_client_bypasses_settings_and_is_not_closed(factory, monkeypatch, tmp_path):
     monkeypatch.setenv("REDIS_URL", "invalid")
     borrowed = Redis(host="borrowed")
@@ -94,7 +168,7 @@ async def test_borrowed_client_bypasses_settings_and_is_not_closed(factory, monk
 
 
 async def test_store_created_collection_reuses_resolved_client(monkeypatch):
-    monkeypatch.setenv("REDIS_URL", "redis://initial:6380/2")
+    monkeypatch.setenv("REDIS_URL", "redis://initial:6380/0")
     async with RedisStore() as store:
         monkeypatch.setenv("REDIS_URL", "invalid")
         collection = store.get_collection(

--- a/python/packages/redis/tests/test_vector_settings.py
+++ b/python/packages/redis/tests/test_vector_settings.py
@@ -1,0 +1,120 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+from agent_framework import SecretString, VectorStoreCollectionDefinition, VectorStoreField, load_settings
+from redis.asyncio import Redis
+
+from agent_framework_redis import RedisCollection, RedisSettings, RedisStore
+
+
+@pytest.fixture(params=["collection", "store"])
+def factory(request, monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    if request.param == "store":
+        return RedisStore
+    return partial(
+        RedisCollection,
+        dict,
+        definition=VectorStoreCollectionDefinition(fields=[VectorStoreField("key", name="id", type_="str")]),
+        collection_name="settings",
+    )
+
+
+async def test_default_connection_settings(factory):
+    async with factory() as owner:
+        kwargs = owner.redis_client.connection_pool.connection_kwargs
+        assert kwargs["host"] == "localhost"
+        assert kwargs["port"] == 6379
+        assert kwargs["decode_responses"] is False
+        assert kwargs["protocol"] == 2
+
+
+async def test_connection_settings_from_environment(factory, monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    async with factory() as owner:
+        kwargs = owner.redis_client.connection_pool.connection_kwargs
+        assert kwargs["host"] == "environment"
+        assert kwargs["port"] == 6380
+        assert kwargs["db"] == 2
+
+
+@pytest.mark.parametrize("override", ["redis://explicit:6381/3", SecretString("redis://explicit:6381/3")])
+async def test_explicit_url_overrides_environment_and_file(factory, monkeypatch, tmp_path, override):
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    env_file = tmp_path / "redis.env"
+    env_file.write_text("REDIS_URL=redis://file:6382/4\n", encoding="utf-8")
+    async with factory(redis_url=override, env_file_path=str(env_file)) as owner:
+        kwargs = owner.redis_client.connection_pool.connection_kwargs
+        assert kwargs["host"] == "explicit"
+        assert kwargs["port"] == 6381
+        assert kwargs["db"] == 3
+
+
+async def test_explicit_env_file_overrides_environment(factory, monkeypatch, tmp_path):
+    monkeypatch.setenv("REDIS_URL", "redis://environment:6380/2")
+    env_file = tmp_path / "redis.env"
+    env_file.write_text("REDIS_URL=redis://file:6382/4\n", encoding="utf-16")
+    async with factory(redis_url=None, env_file_path=str(env_file), env_file_encoding="utf-16") as owner:
+        kwargs = owner.redis_client.connection_pool.connection_kwargs
+        assert kwargs["host"] == "file"
+        assert kwargs["port"] == 6382
+        assert kwargs["db"] == 4
+
+
+def test_explicit_missing_env_file_fails(factory, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        factory(env_file_path=str(tmp_path / "missing.env"))
+
+
+@pytest.mark.parametrize("url", ["", "not-a-redis-url"])
+def test_invalid_url_does_not_fall_back_to_localhost(factory, monkeypatch, url):
+    monkeypatch.setenv("REDIS_URL", url)
+    with pytest.raises(ValueError):
+        factory()
+
+
+def test_invalid_url_override_type(factory):
+    with pytest.raises(ValueError, match="url"):
+        factory(redis_url=123)
+
+
+async def test_borrowed_client_bypasses_settings_and_is_not_closed(factory, monkeypatch, tmp_path):
+    monkeypatch.setenv("REDIS_URL", "invalid")
+    borrowed = Redis(host="borrowed")
+    with patch.object(borrowed, "aclose") as close:
+        async with factory(redis_client=borrowed, env_file_path=str(tmp_path / "missing.env")) as owner:
+            assert owner.redis_client is borrowed
+        close.assert_not_awaited()
+    await borrowed.aclose()
+
+
+async def test_store_created_collection_reuses_resolved_client(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://initial:6380/2")
+    async with RedisStore() as store:
+        monkeypatch.setenv("REDIS_URL", "invalid")
+        collection = store.get_collection(
+            dict,
+            definition=VectorStoreCollectionDefinition(fields=[VectorStoreField("key", name="id", type_="str")]),
+            collection_name="settings",
+        )
+        assert collection.redis_client is store.redis_client
+        assert collection.redis_client.connection_pool.connection_kwargs["host"] == "initial"
+
+
+def test_settings_mask_credentials_and_export_namespace(monkeypatch):
+    from agent_framework.redis import RedisSettings as NamespaceSettings
+
+    from agent_framework_redis._vector_store import RedisSettings as ConnectorSettings
+
+    monkeypatch.setenv("REDIS_URL", "redis://user:dummy-password@localhost:6379")
+    settings = load_settings(RedisSettings, env_prefix="REDIS_")
+    assert isinstance(settings["url"], SecretString)
+    assert "dummy-password" not in repr(settings)
+    assert settings["url"].get_secret_value() == "redis://user:dummy-password@localhost:6379"
+    assert NamespaceSettings is RedisSettings
+    assert ConnectorSettings is RedisSettings

--- a/python/packages/redis/tests/test_vector_store.py
+++ b/python/packages/redis/tests/test_vector_store.py
@@ -115,7 +115,9 @@ async def test_binary_vectors_both_storage_types(storage_type):
     ) as c:
         raw = np.asarray([1.0, 0.0], dtype="<f4").tobytes()
         native = await c.serialize([record(vector=raw)], generate_vectors=False)
-        assert c.deserialize(native)[0]["vector"] == raw
+        deserialized = c.deserialize(native)
+        assert deserialized is not None
+        assert deserialized[0]["vector"] == raw
         with pytest.raises(ValueError, match="byte length"):
             await c.serialize([record(vector=b"bad")], generate_vectors=False)
 
@@ -302,11 +304,13 @@ async def test_owned_and_borrowed_client_lifecycle():
         await another.collection_exists()
     with pytest.raises(RuntimeError, match="closed"):
         store.get_collection(dict, definition=definition(), collection_name="late")
-    async with RedisStore() as owned:
-        owned.redis_client.aclose = AsyncMock()
-    owned.redis_client.aclose.assert_awaited_once()
-    await owned.close()
-    owned.redis_client.aclose.assert_awaited_once()
+    owned = RedisStore()
+    with patch.object(owned.redis_client, "aclose", new_callable=AsyncMock) as owned_close:
+        async with owned:
+            pass
+        owned_close.assert_awaited_once()
+        await owned.close()
+        owned_close.assert_awaited_once()
 
 
 @pytest.mark.parametrize("kwargs", [{"decode_responses": True}, {"protocol": 3}])
@@ -541,7 +545,9 @@ async def test_large_batch_codec_without_embedding_calls(collection):
             [record(str(i), vector=vector, other_vector=vector) for i in range(1000)], generate_vectors=False
         )
         assert len(native) == 1000
-        assert len(c.deserialize([native[999]])[0]["other_vector"]) == 1536
+        deserialized = c.deserialize([native[999]])
+        assert deserialized is not None
+        assert len(deserialized[0]["other_vector"]) == 1536
         assert len(native[0]["embedding"]) == (1536 * 4 if c.storage_type == "hash" else 1536)
         generator.get_embeddings.assert_not_awaited()
 
@@ -584,8 +590,8 @@ async def test_decorated_model_roundtrip_and_generated_keys(storage_type):
         definition=VectorStoreCollectionDefinition(
             fields=[VectorStoreField("key", name="id", type_="str", is_auto_generated=True)]
         ),
-    ) as c:
-        native = await c.serialize([{}, {}], generate_vectors=False)
+    ) as generated:
+        native = await generated.serialize([{}, {}], generate_vectors=False)
         assert native[0]["id"] != native[1]["id"]
 
 

--- a/python/packages/redis/tests/test_vector_store.py
+++ b/python/packages/redis/tests/test_vector_store.py
@@ -31,6 +31,7 @@ from redis.asyncio import Redis
 from redis.exceptions import ResponseError
 
 from agent_framework_redis import RedisCollection, RedisContextProvider, RedisHistoryProvider, RedisStore
+from agent_framework_redis._vector_store import _RedisNamespaceNames
 
 
 def definition(*, dimensions=2, metric="DEFAULT", vector_type="float32", index_kind="flat"):
@@ -606,10 +607,31 @@ async def test_store_lists_and_deletes_only_its_namespace(noncanonical_index_suf
             c._index.delete.assert_awaited_once_with(drop=True)
 
 
+@pytest.mark.parametrize(
+    "namespace,name,index_name,key_prefix",
+    [
+        ("scope", "one", "af:vector:73636f7065:index:6f6e65", "af:vector:73636f7065:data:6f6e65:"),
+        ("a:b", "\u00e9", "af:vector:613a62:index:c3a9", "af:vector:613a62:data:c3a9:"),
+        ("\u00e9", "a:b", "af:vector:c3a9:index:613a62", "af:vector:c3a9:data:613a62:"),
+    ],
+)
+def test_namespace_names_preserve_persisted_format(namespace, name, index_name, key_prefix):
+    names = _RedisNamespaceNames(namespace)
+    assert names.for_collection(name) == (index_name, key_prefix)
+    assert names.try_parse_index_name(index_name.encode()) == name
+    assert names.try_parse_index_name(key_prefix.encode()) is None
+    assert _RedisNamespaceNames(namespace + "other").try_parse_index_name(index_name.encode()) is None
+
+
+@pytest.mark.parametrize("namespace", ["default", "a:b", "\u00e9"])
 @pytest.mark.parametrize("name", ["one", "\u00e9", "a" * 256, "\u00e9" * 128])
-async def test_store_lists_canonical_unicode_and_boundary_names(name):
-    async with RedisStore() as store:
+async def test_store_lists_canonical_unicode_and_boundary_names(namespace, name):
+    names = _RedisNamespaceNames(namespace)
+    index_name, key_prefix = names.for_collection(name)
+    assert names.try_parse_index_name(index_name.encode()) == name
+    async with RedisStore(namespace=namespace) as store:
         collection = store.get_collection(dict, definition=definition(), collection_name=name)
+        assert (collection.index_name, collection.key_prefix) == (index_name, key_prefix)
         with patch.object(
             store.redis_client, "execute_command", AsyncMock(return_value=[collection.index_name.encode()])
         ):
@@ -834,6 +856,21 @@ async def test_live_scores_thresholds_and_paging(live_store, metric, expected):
     other = [r async for r in await c.search(vector=[0.0, 1.0], vector_property_name="other_vector")]
     assert all(r["score"] == 0.0 for r in other)
     assert [r["id"] for r in await c.get(order_by={"number": False}, skip=1, top=1)] == ["two"]
+
+
+@pytest.mark.integration
+async def test_live_unicode_keys_and_text_roundtrip(live_store):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="unicode:\u00e9")
+    await c.ensure_collection_exists()
+    source = [record("abc", text="Plain text"), record("a\u00e9b\u00e9c", text="Caf\u00e9 \u6f22\u5b57")]
+    assert await c.upsert(source, generate_vectors=False) == ["abc", "a\u00e9b\u00e9c"]
+    assert await c.get(["abc", "a\u00e9b\u00e9c"], include_vectors=True) == source
+    assert [r["id"] for r in await c.get(filter=Filter("text", "eq", "Caf\u00e9 \u6f22\u5b57"))] == ["a\u00e9b\u00e9c"]
+    assert await live_store.list_collection_names() == ["unicode:\u00e9"]
+    await c.delete(["abc"])
+    assert await c.get(["a\u00e9b\u00e9c"], include_vectors=True) == [source[1]]
+    await live_store.ensure_collection_deleted("unicode:\u00e9")
+    assert not await live_store.collection_exists("unicode:\u00e9")
 
 
 @pytest.mark.integration

--- a/python/packages/redis/tests/test_vector_store.py
+++ b/python/packages/redis/tests/test_vector_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -80,6 +80,23 @@ def record(key="one", **overrides):
 @pytest.fixture(params=["hash", "json"])
 def storage_type(request):
     return request.param
+
+
+@pytest.fixture
+def noncanonical_index_suffixes():
+    return [
+        b"",
+        b"not-hex",
+        b"6",
+        b"6F6E65",
+        b"6f 6e65",
+        b"6f6e65 ",
+        b"  ",
+        b"ff",
+        b"\xff",
+        b"eda080",
+        b"20" * 257,
+    ]
 
 
 @pytest.fixture
@@ -313,6 +330,37 @@ async def test_owned_and_borrowed_client_lifecycle():
         owned_close.assert_awaited_once()
 
 
+async def test_collection_overrides_only_default_when_none(storage_type):
+    default_generator = MagicMock()
+    falsey_generator = MagicMock()
+    falsey_generator.__bool__.return_value = False
+    async with RedisStore(storage_type=storage_type, embedding_generator=default_generator) as store:
+        inherited = store.get_collection(
+            dict, definition=definition(), collection_name="inherited", embedding_generator=None, storage_type=None
+        )
+        assert inherited.embedding_generator is default_generator
+        assert inherited.storage_type == storage_type
+        override_type: Literal["hash", "json"] = "json" if storage_type == "hash" else "hash"
+        overridden = store.get_collection(
+            dict,
+            definition=definition(),
+            collection_name="overridden",
+            embedding_generator=falsey_generator,
+            storage_type=override_type,
+        )
+        assert overridden.embedding_generator is falsey_generator
+        assert overridden.storage_type == override_type
+        default_generator.get_embeddings.assert_not_called()
+        falsey_generator.get_embeddings.assert_not_called()
+
+
+@pytest.mark.parametrize("override", [""])
+async def test_empty_collection_storage_override_is_rejected(override):
+    async with RedisStore() as store:
+        with pytest.raises(ValueError, match="storage_type"):
+            store.get_collection(dict, definition=definition(), collection_name="invalid", storage_type=override)
+
+
 @pytest.mark.parametrize("kwargs", [{"decode_responses": True}, {"protocol": 3}])
 def test_incompatible_borrowed_clients(kwargs):
     with pytest.raises(ValueError, match="RESP"):
@@ -387,7 +435,7 @@ async def test_search_tool_params_without_defaults(collection, required):
     collection._fetch_records = AsyncMock(return_value=[])
     parameter = Param("text", str, required=required)
     assert not parameter.has_default
-    assert parameter.default is parameter.default
+    assert parameter.default is Param("independent", str).default
     tool = create_vector_search_tool(
         collection,
         filter=FilterGroup("and", [Filter("enabled", "eq", True), Filter("text", "eq", parameter)]),
@@ -489,6 +537,25 @@ async def test_index_initialization_schema_validation_and_cleanup(collection):
         await collection.get()
 
 
+@pytest.mark.parametrize("change", ["deleted", "replaced"])
+async def test_index_validation_is_not_cached(collection, change):
+    with (
+        patch.object(collection._index, "exists", AsyncMock(return_value=True)) as exists,
+        patch.object(collection, "_validate_schema", new_callable=AsyncMock) as validate,
+    ):
+        await collection._require_index()
+        if change == "replaced":
+            validate.side_effect = ValueError("incompatible")
+        else:
+            exists.return_value = False
+        error = ValueError if change == "replaced" else IntegrationException
+        message = "incompatible" if change == "replaced" else "does not exist"
+        with pytest.raises(error, match=message):
+            await collection._require_index()
+        assert exists.await_count == 2
+        assert validate.await_count == (2 if change == "replaced" else 1)
+
+
 async def test_missing_server_capability_fails_at_initialization(collection):
     collection._index.exists = AsyncMock(side_effect=ResponseError("unknown command FT._LIST"))
     with (
@@ -510,25 +577,52 @@ async def test_key_delete_is_batched_and_validated_before_io(collection):
         delete.assert_not_awaited()
 
 
-async def test_store_lists_and_deletes_only_its_namespace():
+async def test_store_lists_and_deletes_only_its_namespace(noncanonical_index_suffixes):
     async with RedisStore(namespace="scope") as store:
         c = store.get_collection(dict, definition=definition(), collection_name="one")
-        c._validated = True
         c._index.delete = AsyncMock()
+        prefix = c.index_name.rsplit(":", 1)[0].encode() + b":"
         with (
             patch.object(
                 store.redis_client,
                 "execute_command",
-                AsyncMock(return_value=[c.index_name.encode(), b"unrelated:index"]),
+                AsyncMock(
+                    return_value=[
+                        c.index_name.encode(),
+                        b"unrelated:\xff",
+                        *(prefix + suffix for suffix in noncanonical_index_suffixes),
+                    ]
+                ),
             ),
             patch(
                 "agent_framework_redis._vector_store.AsyncSearchIndex.from_existing", AsyncMock(return_value=c._index)
-            ),
+            ) as from_existing,
         ):
             assert await store.list_collection_names() == ["one"]
+            assert await store.collection_exists("one")
+            assert not await store.collection_exists("missing")
             await store.ensure_collection_deleted("one")
+            from_existing.assert_awaited_once_with(c.index_name, redis_client=store.redis_client)
             c._index.delete.assert_awaited_once_with(drop=True)
-            assert not c._validated
+
+
+@pytest.mark.parametrize("name", ["one", "\u00e9", "a" * 256, "\u00e9" * 128])
+async def test_store_lists_canonical_unicode_and_boundary_names(name):
+    async with RedisStore() as store:
+        collection = store.get_collection(dict, definition=definition(), collection_name=name)
+        with patch.object(
+            store.redis_client, "execute_command", AsyncMock(return_value=[collection.index_name.encode()])
+        ):
+            assert await store.list_collection_names() == [name]
+
+
+async def test_store_listing_propagates_redis_errors():
+    async with RedisStore() as store:
+        with (
+            patch.object(store.redis_client, "execute_command", AsyncMock(side_effect=ResponseError("denied"))),
+            pytest.raises(ResponseError, match="denied"),
+        ):
+            await store.list_collection_names()
 
 
 async def test_large_batch_codec_without_embedding_calls(collection):
@@ -740,6 +834,77 @@ async def test_live_scores_thresholds_and_paging(live_store, metric, expected):
     other = [r async for r in await c.search(vector=[0.0, 1.0], vector_property_name="other_vector")]
     assert all(r["score"] == 0.0 for r in other)
     assert [r["id"] for r in await c.get(order_by={"number": False}, skip=1, top=1)] == ["two"]
+
+
+@pytest.mark.integration
+async def test_live_store_ignores_noncanonical_indexes(live_store, noncanonical_index_suffixes):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="one")
+    await c.ensure_collection_exists()
+    await c.upsert([record()], generate_vectors=False)
+    prefix = c.index_name.rsplit(":", 1)[0].encode() + b":"
+    foreign_prefix = "af-test-foreign:" + uuid4().hex + ":"
+    foreign_key = foreign_prefix + "one"
+    index_names = [prefix + suffix for suffix in noncanonical_index_suffixes]
+    index_names.append(foreign_prefix.encode() + b"\xff")
+    created = []
+    try:
+        await c.redis_client.hset(foreign_key, mapping={"text": "Foreign"})
+        for index_name in index_names:
+            await c.redis_client.execute_command(
+                "FT.CREATE", index_name, "ON", "HASH", "PREFIX", 1, foreign_prefix, "SCHEMA", "text", "TEXT"
+            )
+            created.append(index_name)
+        assert await live_store.list_collection_names() == ["one"]
+        assert await live_store.collection_exists("one")
+        assert not await live_store.collection_exists("missing")
+        await live_store.ensure_collection_deleted("one")
+        assert await live_store.list_collection_names() == []
+        assert not await live_store.collection_exists("one")
+        assert not await c.redis_client.exists(c.key_prefix + "one")
+        remaining = await c.redis_client.execute_command("FT._LIST")
+        assert set(index_names) <= set(remaining)
+        assert await c.redis_client.hgetall(foreign_key) == {b"text": b"Foreign"}
+    finally:
+        for index_name in created:
+            await c.redis_client.execute_command("FT.DROPINDEX", index_name)
+        await c.redis_client.delete(foreign_key)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("change", ["deleted", "replaced"])
+@pytest.mark.parametrize("operation", ["upsert", "get", "filtered_get", "delete", "search"])
+async def test_live_warm_handle_rechecks_index(live_store, change, operation):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="lifecycle")
+    await c.ensure_collection_exists()
+    await c.upsert([record()], generate_vectors=False)
+    key = c.key_prefix + "one"
+    snapshot = await c.redis_client.dump(key)
+    assert snapshot is not None
+    try:
+        await c.redis_client.ft(c.index_name).dropindex(delete_documents=False)
+        if change == "replaced":
+            replacement = live_store.get_collection(
+                dict, definition=definition(dimensions=3), collection_name="lifecycle"
+            )
+            await replacement.ensure_collection_exists()
+        error = ValueError if change == "replaced" and operation != "delete" else IntegrationException
+        message = "incompatible" if change == "replaced" else "does not exist"
+        with pytest.raises(error, match=message) as exc_info:
+            if operation == "upsert":
+                await c.upsert([record(text="Changed")], generate_vectors=False)
+            elif operation == "get":
+                await c.get(["one"])
+            elif operation == "filtered_get":
+                await c.get(filter=Filter("text", "eq", record()["text"]))
+            elif operation == "delete":
+                await c.delete(["one"])
+            else:
+                await c.search(vector=[1.0, 0.0])
+        if change == "replaced" and operation == "delete":
+            assert isinstance(exc_info.value.__cause__, ValueError)
+        assert await c.redis_client.dump(key) == snapshot
+    finally:
+        await c.redis_client.delete(key)
 
 
 @pytest.mark.integration

--- a/python/packages/redis/tests/test_vector_store.py
+++ b/python/packages/redis/tests/test_vector_store.py
@@ -1,0 +1,813 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Annotated
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import msgspec
+import numpy as np
+import pytest
+from agent_framework import (
+    Embedding,
+    Filter,
+    FilterGroup,
+    GeneratedEmbeddings,
+    Param,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    create_vector_search_tool,
+    vectorstoremodel,
+)
+from agent_framework.exceptions import (
+    IntegrationException,
+    IntegrationInitializationError,
+    IntegrationInvalidResponseException,
+)
+from redis.asyncio import Redis
+from redis.exceptions import ResponseError
+
+from agent_framework_redis import RedisCollection, RedisContextProvider, RedisHistoryProvider, RedisStore
+
+
+def definition(*, dimensions=2, metric="DEFAULT", vector_type="float32", index_kind="flat"):
+    return VectorStoreCollectionDefinition(
+        fields=[
+            VectorStoreField("key", name="id", type_="str", storage_name="record_id"),
+            VectorStoreField("data", name="text", type_="str", storage_name="content", is_indexed=True),
+            VectorStoreField("data", name="number", type_="float", is_indexed=True),
+            VectorStoreField("data", name="enabled", type_="bool", is_indexed=True),
+            VectorStoreField("data", name="tags", type_="list", is_indexed=True),
+            VectorStoreField("data", name="payload", type_="dict"),
+            VectorStoreField(
+                "vector",
+                name="vector",
+                storage_name="embedding",
+                type_=vector_type,
+                dimensions=dimensions,
+                index_kind=index_kind,
+                distance_function=metric,
+            ),
+            VectorStoreField(
+                "vector",
+                name="other_vector",
+                type_="float64",
+                dimensions=dimensions,
+                index_kind=index_kind,
+                distance_function="euclidean_squared_distance",
+            ),
+        ]
+    )
+
+
+def record(key="one", **overrides):
+    return {
+        "id": key,
+        "text": "Hello, world*",
+        "number": 1.5,
+        "enabled": True,
+        "tags": ["red", "blue"],
+        "payload": {"nested": [True, None, 1]},
+        "vector": [1.0, 0.0],
+        "other_vector": [0.0, 1.0],
+        **overrides,
+    }
+
+
+@pytest.fixture(params=["hash", "json"])
+def storage_type(request):
+    return request.param
+
+
+@pytest.fixture
+async def collection(storage_type):
+    async with RedisCollection(dict, definition=definition(), collection_name="unit", storage_type=storage_type) as c:
+        yield c
+
+
+async def test_native_codecs_and_multiple_vectors(collection, storage_type):
+    source = record()
+    native = await collection.serialize([source], generate_vectors=False)
+    assert set(native[0]) == set(collection.definition.storage_names)
+    assert native[0]["content"] == source["text"]
+    assert native[0]["number"] == 1.5
+    assert native[0]["enabled"] == ("true" if storage_type == "hash" else True)
+    if storage_type == "hash":
+        assert np.frombuffer(native[0]["embedding"], dtype="<f4").tolist() == [1.0, 0.0]
+        assert np.frombuffer(native[0]["other_vector"], dtype="<f8").tolist() == [0.0, 1.0]
+        assert msgspec.json.decode(native[0]["payload"]) == source["payload"]
+    else:
+        assert native[0]["embedding"] == [1.0, 0.0]
+        assert native[0]["other_vector"] == [0.0, 1.0]
+    assert collection.deserialize(native) == [source]
+    assert collection.deserialize(native, include_vectors=False) == [
+        {k: v for k, v in source.items() if k not in ("vector", "other_vector")}
+    ]
+    assert source == record()
+
+
+async def test_binary_vectors_both_storage_types(storage_type):
+    async with RedisCollection(
+        dict, definition=definition(vector_type="bytes"), collection_name="binary", storage_type=storage_type
+    ) as c:
+        raw = np.asarray([1.0, 0.0], dtype="<f4").tobytes()
+        native = await c.serialize([record(vector=raw)], generate_vectors=False)
+        assert c.deserialize(native)[0]["vector"] == raw
+        with pytest.raises(ValueError, match="byte length"):
+            await c.serialize([record(vector=b"bad")], generate_vectors=False)
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [[True, 0.0], ["1", "0"], [float("nan"), 0], [float("inf"), 0], [1e100, 0], [0.0, 0.0], [1.0], [[1.0, 0.0]]],
+)
+async def test_invalid_vectors_reject_entire_batch(collection, vector):
+    collection._inner_upsert = AsyncMock()
+    with pytest.raises((ValueError, TypeError)):
+        await collection.upsert([record(), record("two", vector=vector)], generate_vectors=False)
+    collection._inner_upsert.assert_not_awaited()
+
+
+async def test_selected_embedding_generation(collection):
+    generator = MagicMock()
+    generator.get_embeddings = AsyncMock(return_value=GeneratedEmbeddings([Embedding(vector=[0.5, 0.5])]))
+    collection.embedding_generator = generator
+    encoded = await collection.serialize([record(vector="source")], generate_vectors=["vector"])
+    result = collection.deserialize(encoded)[0]
+    assert result["vector"] == [0.5, 0.5]
+    assert result["other_vector"] == [0.0, 1.0]
+    generator.get_embeddings.assert_awaited_once_with(["source"], options={"dimensions": 2})
+    generator.get_embeddings.reset_mock()
+    await collection.serialize([record()], generate_vectors=True)
+    assert generator.get_embeddings.await_count == 2
+    generator.get_embeddings.reset_mock()
+    await collection.serialize([record()], generate_vectors=False)
+    generator.get_embeddings.assert_not_awaited()
+
+
+@pytest.mark.parametrize("value", [" leading", "trailing ", "\x00", "a\x1fb", "a" * 4097])
+async def test_lossy_tag_values_rejected(collection, value):
+    with pytest.raises(ValueError):
+        await collection.serialize([record(text=value)], generate_vectors=False)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("number", True), ("number", 2**53 + 1), ("number", float("nan")), ("enabled", 1), ("tags", ["ok", 1])],
+)
+async def test_indexed_field_types_reject_lossy_values(collection, field, value):
+    with pytest.raises((TypeError, ValueError)):
+        await collection.serialize([record(**{field: value})], generate_vectors=False)
+
+
+async def test_json_null_and_hash_rejection(collection, storage_type):
+    if storage_type == "hash":
+        with pytest.raises(NotImplementedError, match="no native null"):
+            await collection.serialize([record(text=None)], generate_vectors=False)
+    else:
+        encoded = await collection.serialize(
+            [record(text=None, number=None, enabled=None, vector=None)], generate_vectors=False
+        )
+        assert collection.deserialize(encoded)[0]["text"] is None
+        assert collection.deserialize(encoded)[0]["vector"] is None
+    with pytest.raises(ValueError, match="missing"):
+        await collection.serialize([{"id": "missing"}], generate_vectors=False)
+    with pytest.raises(IntegrationInvalidResponseException, match="missing"):
+        collection.deserialize([{"record_id": b"missing"}])
+
+
+async def test_unindexed_data_is_not_subject_to_tag_restrictions(collection):
+    value = {"text": " whitespace\x1f", "large": "x" * 8000}
+    assert (
+        collection.deserialize(await collection.serialize([record(payload=value)], generate_vectors=False))[0][
+            "payload"
+        ]
+        == value
+    )
+
+
+def test_native_schema_and_names(collection, storage_type):
+    schema = collection._index.schema.to_dict()
+    fields = {field["name"]: field for field in schema["fields"]}
+    assert set(fields) == {"record_id", "content", "number", "enabled", "tags", "embedding", "other_vector"}
+    assert fields["content"]["attrs"]["case_sensitive"] is True
+    assert fields["content"]["attrs"]["index_empty"] is True
+    assert fields["content"]["attrs"]["index_missing"] is True
+    assert fields["embedding"]["attrs"]["distance_metric"] == "cosine"
+    assert fields["other_vector"]["attrs"]["distance_metric"] == "l2"
+    if storage_type == "json":
+        assert fields["embedding"]["path"] == "$.embedding"
+    assert collection._prepare_key("key:with:separators").startswith(collection.key_prefix)
+    assert collection.key_prefix.endswith(":")
+
+
+@pytest.mark.parametrize(
+    "expression,fragment",
+    [
+        (Filter("text", "eq", "Hello,*|{a}\\$"), r"@content:{Hello\,\*\|\{a\}\\\$}"),
+        (Filter("text", "eq", ""), '@content:{""}'),
+        (Filter("number", "eq", True), "ismissing(@number) -ismissing(@number)"),
+        (Filter("enabled", "eq", 1), "ismissing(@enabled) -ismissing(@enabled)"),
+        (Filter("enabled", "eq", True), "@enabled:{true}"),
+        (Filter("number", "gt", 1), "@number:[(1.0 +inf]"),
+        (Filter("number", "between", [1, 2]), "@number:[1.0 2.0]"),
+        (Filter("text", "exists"), "ismissing(@content)"),
+        (Filter("text", "ne", "red"), "ismissing(@content)"),
+        (Filter("tags", "contains", "red"), "@tags:{red}"),
+    ],
+)
+def test_prepare_filter(collection, expression, fragment):
+    assert fragment in collection._prepare_filter(expression)
+
+
+@pytest.mark.parametrize("op", ["starts_with", "ends_with", "contains_text", "redis.raw"])
+def test_unsupported_text_and_native_filters(collection, op):
+    with pytest.raises(NotImplementedError):
+        collection._prepare_filter(Filter("text", op, "*"))
+
+
+@pytest.mark.parametrize("op,value", [("is_null", None), ("is_not_null", None), ("not_in", ["red"])])
+async def test_json_string_null_dependent_filters_rejected(op, value):
+    async with RedisCollection(dict, definition=definition(), collection_name="filters", storage_type="json") as c:
+        with pytest.raises(NotImplementedError, match="cannot distinguish null"):
+            c._prepare_filter(Filter("text", op, value))
+
+
+async def test_query_shape_threshold_and_paging(collection):
+    collection._require_index = AsyncMock()
+    collection._execute_query = AsyncMock(return_value=[0])
+    collection._fetch_records = AsyncMock(return_value=[])
+    await collection.search(vector=[1.0, 0.0], top=4, skip=3)
+    query, params = collection._execute_query.call_args.args
+    assert "KNN 7 @embedding $vector" in query.query_string()
+    assert query.get_args()[-3:] == ["LIMIT", 3, 4]
+    assert params["vector"] == np.asarray([1.0, 0.0], dtype="<f4").tobytes()
+    await collection.search(
+        vector=[0.0, 1.0],
+        vector_property_name="other_vector",
+        top=4,
+        skip=3,
+        score_threshold=2,
+        filter=Filter("number", "gte", 1),
+    )
+    query, params = collection._execute_query.call_args.args
+    assert "VECTOR_RANGE $radius $vector" in query.query_string()
+    assert "@other_vector" in query.query_string()
+    assert "@number:[1.0 +inf]" in query.query_string()
+    assert params["radius"] == 2
+    assert query.get_args()[-3:] == ["LIMIT", 3, 4]
+
+
+async def test_unsupported_operations_fail_explicitly(collection):
+    collection._require_index = AsyncMock()
+    with pytest.raises(NotImplementedError):
+        await collection.search("keyword", search_type="keyword_hybrid", vector=[1.0, 0.0])
+    with pytest.raises(NotImplementedError):
+        await collection.search(vector=[1.0, 0.0], score_threshold=-1)
+    with pytest.raises(ValueError):
+        await collection.search(vector=[1.0, 0.0], score_threshold=float("nan"))
+    with pytest.raises(ValueError):
+        await collection.search("no generator")
+    with pytest.raises(NotImplementedError):
+        await collection.get(order_by={"text": True, "number": False})
+    with pytest.raises(NotImplementedError):
+        await collection.get(operation_options={"ignored": True})
+
+
+@pytest.mark.parametrize("operation", ["get", "search"])
+async def test_unsupported_filters_fail_before_redis_io(collection, operation):
+    collection._require_index = AsyncMock()
+    with pytest.raises(NotImplementedError, match="contains_text"):
+        if operation == "get":
+            await collection.get(filter=Filter("text", "contains_text", "word"))
+        else:
+            await collection.search(vector=[1.0, 0.0], filter=Filter("text", "contains_text", "word"))
+    collection._require_index.assert_not_awaited()
+
+
+async def test_owned_and_borrowed_client_lifecycle():
+    borrowed = Redis()
+    with patch.object(borrowed, "aclose", new_callable=AsyncMock) as close:
+        async with RedisStore(redis_client=borrowed) as store:
+            handle = store.get_collection(dict, definition=definition(), collection_name="owned")
+            async with handle:
+                assert handle.redis_client is borrowed
+            close.assert_not_awaited()
+            another = store.get_collection(dict, definition=definition(), collection_name="another")
+        close.assert_not_awaited()
+    with pytest.raises(RuntimeError, match="closed"):
+        await another.collection_exists()
+    with pytest.raises(RuntimeError, match="closed"):
+        store.get_collection(dict, definition=definition(), collection_name="late")
+    async with RedisStore() as owned:
+        owned.redis_client.aclose = AsyncMock()
+    owned.redis_client.aclose.assert_awaited_once()
+    await owned.close()
+    owned.redis_client.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize("kwargs", [{"decode_responses": True}, {"protocol": 3}])
+def test_incompatible_borrowed_clients(kwargs):
+    with pytest.raises(ValueError, match="RESP"):
+        RedisStore(redis_client=Redis(**kwargs))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        VectorStoreField("data", name="bad", storage_name="field.with.path"),
+        VectorStoreField("data", name="bad", is_full_text_indexed=True),
+        VectorStoreField("data", name="bad", type_="dict", is_indexed=True),
+        VectorStoreField("data", name="bad", provider_annotations={"unhandled": True}),
+        VectorStoreField("vector", name="bad", dimensions=2, distance_function="cosine_similarity"),
+        VectorStoreField("vector", name="bad", dimensions=2, index_kind="ivf_flat"),
+    ],
+)
+def test_invalid_schema_fails_without_connecting(field):
+    with pytest.raises((ValueError, NotImplementedError)):
+        RedisCollection(
+            dict,
+            collection_name="bad",
+            definition=VectorStoreCollectionDefinition(fields=[VectorStoreField("key", name="id", type_="str"), field]),
+        )
+
+
+async def test_failed_pipeline_is_not_reported_as_success(collection):
+    collection._require_index = AsyncMock()
+    pipeline = MagicMock()
+    pipeline.__aenter__ = AsyncMock(return_value=pipeline)
+    pipeline.__aexit__ = AsyncMock(return_value=False)
+    pipeline.execute = AsyncMock(side_effect=ResponseError("partial EXEC failure"))
+    with (
+        patch.object(collection.redis_client, "pipeline", return_value=pipeline),
+        pytest.raises(IntegrationException, match="partial EXEC"),
+    ):
+        await collection.upsert([record()], generate_vectors=False)
+
+
+async def test_search_tool_resolves_and_prunes_params(collection):
+    generator = MagicMock()
+    generator.get_embeddings = AsyncMock(return_value=GeneratedEmbeddings([Embedding(vector=[1.0, 0.0])]))
+    collection.embedding_generator = generator
+    collection._require_index = AsyncMock()
+    collection._execute_query = AsyncMock(return_value=[0])
+    collection._fetch_records = AsyncMock(return_value=[])
+    tool = create_vector_search_tool(
+        collection,
+        filter=FilterGroup(
+            "and",
+            [
+                Filter("enabled", "eq", True),
+                Filter("text", "eq", Param("text", str | None, default=None, omit_if_none=True)),
+            ],
+        ),
+    )
+    await tool.invoke(arguments={"query": "query", "text": None})
+    query = collection._execute_query.call_args.args[0].query_string()
+    assert "@enabled:{true}" in query
+    assert "@content" not in query
+    await tool.invoke(arguments={"query": "query", "text": "a|b"})
+    assert r"@content:{a\|b}" in collection._execute_query.call_args.args[0].query_string()
+
+
+@pytest.mark.parametrize("required", [False, True])
+async def test_search_tool_params_without_defaults(collection, required):
+    generator = MagicMock()
+    generator.get_embeddings = AsyncMock(return_value=GeneratedEmbeddings([Embedding(vector=[1.0, 0.0])]))
+    collection.embedding_generator = generator
+    collection._require_index = AsyncMock()
+    collection._execute_query = AsyncMock(return_value=[0])
+    collection._fetch_records = AsyncMock(return_value=[])
+    parameter = Param("text", str, required=required)
+    assert not parameter.has_default
+    assert parameter.default is parameter.default
+    tool = create_vector_search_tool(
+        collection,
+        filter=FilterGroup("and", [Filter("enabled", "eq", True), Filter("text", "eq", parameter)]),
+    )
+    await tool(query="query", text="a|b")
+    query = collection._execute_query.call_args.args[0].query_string()
+    assert "@enabled:{true}" in query
+    assert r"@content:{a\|b}" in query
+    collection._execute_query.reset_mock()
+    if required:
+        with pytest.raises(TypeError, match=r"Missing required argument\(s\) for 'search': text"):
+            await tool(query="query")
+        collection._execute_query.assert_not_awaited()
+    else:
+        await tool(query="query")
+        query = collection._execute_query.call_args.args[0].query_string()
+        assert "@enabled:{true}" in query
+        assert "@content" not in query
+
+
+def mock_pipeline(responses):
+    pipeline = MagicMock()
+    pipeline.__aenter__ = AsyncMock(return_value=pipeline)
+    pipeline.__aexit__ = AsyncMock(return_value=False)
+    pipeline.execute = AsyncMock(return_value=responses)
+    return pipeline
+
+
+async def test_fetch_native_results_excludes_vector_payloads(collection, storage_type):
+    collection._require_index = AsyncMock()
+    native = (await collection.serialize([record()], generate_vectors=False))[0]
+    names = collection.definition.get_storage_names(include_vector_fields=False)
+    if storage_type == "hash":
+        native = {name: value if isinstance(value, bytes) else str(value).encode() for name, value in native.items()}
+        pipeline = mock_pipeline([1, [native[n] for n in names], 0, [None] * len(names)])
+    else:
+        pipeline = mock_pipeline([msgspec.json.encode({f"$.{name}": [native[name]] for name in names}), None])
+    with patch.object(collection.redis_client, "pipeline", return_value=pipeline):
+        result = await collection.get(["one", "missing"])
+    assert result == [{k: v for k, v in record().items() if k not in ("vector", "other_vector")}]
+    if storage_type == "hash":
+        assert "embedding" not in pipeline.hmget.call_args.args[1]
+    else:
+        assert "$.embedding" not in pipeline.execute_command.call_args.args
+
+
+async def test_missing_required_fields_are_not_silently_omitted(collection, storage_type):
+    collection._require_index = AsyncMock()
+    names = collection.definition.get_storage_names(include_vector_fields=False)
+    responses = [1, [None] * len(names)] if storage_type == "hash" else [b"{}"]
+    with (
+        patch.object(collection.redis_client, "pipeline", return_value=mock_pipeline(responses)),
+        pytest.raises(IntegrationInvalidResponseException, match="missing"),
+    ):
+        await collection.get(["malformed"])
+
+
+async def test_search_distance_stays_attached_to_record_after_concurrent_delete(collection):
+    collection._require_index = AsyncMock()
+    native = (await collection.serialize([record("two")], generate_vectors=False))[0]
+    collection._fetch_records = AsyncMock(return_value=[None, native])
+    response = [
+        2,
+        (collection.key_prefix + "gone").encode(),
+        [b"_af_distance", b"0.0"],
+        (collection.key_prefix + "two").encode(),
+        [b"_af_distance", b"0.5"],
+    ]
+    with patch.object(collection.redis_client, "execute_command", AsyncMock(return_value=response)) as execute:
+        results = [r async for r in await collection.search(vector=[1.0, 0.0], include_vectors=True)]
+    assert results == [{"record": record("two"), "score": 0.5}]
+    assert execute.call_args.args[-4:] == ("PARAMS", 2, "vector", np.asarray([1.0, 0.0], dtype="<f4").tobytes())
+
+
+async def test_index_initialization_schema_validation_and_cleanup(collection):
+    collection._index.exists = AsyncMock(return_value=False)
+    search = MagicMock()
+    search.create_index = AsyncMock()
+    with (
+        patch.object(collection.redis_client, "ft", return_value=search),
+        patch.object(collection.redis_client, "execute_command", AsyncMock(return_value=None)),
+        patch(
+            "agent_framework_redis._vector_store.AsyncSearchIndex.from_existing",
+            AsyncMock(return_value=collection._index),
+        ),
+    ):
+        await collection.ensure_collection_exists()
+        for field in search.create_index.call_args.args[0]:
+            suffix = field.args_suffix
+            if "SORTABLE" in suffix and "INDEXMISSING" in suffix:
+                assert suffix.index("INDEXMISSING") < suffix.index("SORTABLE")
+        collection._index.exists.return_value = True
+        assert await collection.collection_exists()
+        collection._index.delete = AsyncMock()
+        await collection.ensure_collection_deleted()
+        collection._index.delete.assert_awaited_once_with(drop=True)
+    collection._index.exists.return_value = False
+    with pytest.raises(IntegrationException, match="does not exist"):
+        await collection.get()
+
+
+async def test_missing_server_capability_fails_at_initialization(collection):
+    collection._index.exists = AsyncMock(side_effect=ResponseError("unknown command FT._LIST"))
+    with (
+        patch.object(collection.redis_client, "execute_command", AsyncMock(side_effect=ResponseError("JSON.TYPE"))),
+        pytest.raises(IntegrationInitializationError, match="INDEXMISSING"),
+    ):
+        await collection.ensure_collection_exists()
+
+
+async def test_key_delete_is_batched_and_validated_before_io(collection):
+    collection._require_index = AsyncMock()
+    with patch.object(collection.redis_client, "delete", new_callable=AsyncMock) as delete:
+        await collection.delete([str(i) for i in range(201)])
+        assert delete.await_count == 3
+        assert all(key.startswith(collection.key_prefix) for call in delete.call_args_list for key in call.args)
+        delete.reset_mock()
+        with pytest.raises(IntegrationException, match="nonempty strings"):
+            await collection.delete(["valid", ""])
+        delete.assert_not_awaited()
+
+
+async def test_store_lists_and_deletes_only_its_namespace():
+    async with RedisStore(namespace="scope") as store:
+        c = store.get_collection(dict, definition=definition(), collection_name="one")
+        c._validated = True
+        c._index.delete = AsyncMock()
+        with (
+            patch.object(
+                store.redis_client,
+                "execute_command",
+                AsyncMock(return_value=[c.index_name.encode(), b"unrelated:index"]),
+            ),
+            patch(
+                "agent_framework_redis._vector_store.AsyncSearchIndex.from_existing", AsyncMock(return_value=c._index)
+            ),
+        ):
+            assert await store.list_collection_names() == ["one"]
+            await store.ensure_collection_deleted("one")
+            c._index.delete.assert_awaited_once_with(drop=True)
+            assert not c._validated
+
+
+async def test_large_batch_codec_without_embedding_calls(collection):
+    generator = MagicMock(get_embeddings=AsyncMock())
+    async with RedisCollection(
+        dict,
+        definition=definition(dimensions=1536),
+        collection_name="large",
+        storage_type=collection.storage_type,
+        embedding_generator=generator,
+    ) as c:
+        vector = [0.01] * 1536
+        native = await c.serialize(
+            [record(str(i), vector=vector, other_vector=vector) for i in range(1000)], generate_vectors=False
+        )
+        assert len(native) == 1000
+        assert len(c.deserialize([native[999]])[0]["other_vector"]) == 1536
+        assert len(native[0]["embedding"]) == (1536 * 4 if c.storage_type == "hash" else 1536)
+        generator.get_embeddings.assert_not_awaited()
+
+
+async def test_empty_batches_do_not_contact_redis(collection):
+    with patch.object(collection, "_require_index", new_callable=AsyncMock) as require:
+        assert await collection.upsert([], generate_vectors=False) == []
+        assert await collection.get([]) == []
+        await collection.delete([])
+        require.assert_not_awaited()
+
+
+def test_public_namespace_and_existing_providers():
+    from agent_framework.redis import RedisCollection as LazyCollection
+    from agent_framework.redis import RedisStore as LazyStore
+
+    assert LazyCollection is RedisCollection
+    assert LazyStore is RedisStore
+    assert RedisContextProvider is not None
+    assert RedisHistoryProvider is not None
+
+
+@vectorstoremodel
+@dataclass
+class VectorRecord:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    vector: Annotated[list[float] | None, VectorStoreField("vector", dimensions=2)] = None
+
+
+async def test_decorated_model_roundtrip_and_generated_keys(storage_type):
+    async with RedisCollection(VectorRecord, collection_name="models", storage_type=storage_type) as c:
+        native = await c.serialize([VectorRecord("one", "Text", [1.0, 0.0])], generate_vectors=False)
+        assert c.deserialize(native) == [VectorRecord("one", "Text", [1.0, 0.0])]
+        assert c.deserialize(native, include_vectors=False) == [VectorRecord("one", "Text")]
+    async with RedisCollection(
+        dict,
+        collection_name="generated",
+        storage_type=storage_type,
+        definition=VectorStoreCollectionDefinition(
+            fields=[VectorStoreField("key", name="id", type_="str", is_auto_generated=True)]
+        ),
+    ) as c:
+        native = await c.serialize([{}, {}], generate_vectors=False)
+        assert native[0]["id"] != native[1]["id"]
+
+
+@pytest.fixture
+async def live_store(storage_type):
+    url = os.getenv("REDIS_VECTOR_TEST_URL")
+    if not url:
+        pytest.skip("Set REDIS_VECTOR_TEST_URL to a disposable Redis Search 2.10+ and RedisJSON server.")
+    async with RedisStore(redis_url=url, storage_type=storage_type, namespace="af-test-" + uuid4().hex) as store:
+        try:
+            # A configured but insufficient server must fail, not be silently skipped.
+            await store.list_collection_names()
+            yield store
+        finally:
+            for name in await store.list_collection_names():
+                await store.ensure_collection_deleted(name)
+
+
+@pytest.mark.integration
+async def test_live_crud_native_storage_and_isolation(live_store, storage_type):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="one")
+    neighbor = live_store.get_collection(dict, definition=definition(), collection_name="one:two")
+    assert not await c.collection_exists()
+    await c.ensure_collection_exists()
+    await c.ensure_collection_exists()
+    await neighbor.ensure_collection_exists()
+    assert await c.upsert([record("same"), record("two")], generate_vectors=False) == ["same", "two"]
+    await neighbor.upsert([record("same", text="Neighbor")], generate_vectors=False)
+    assert [r["id"] for r in await c.get(["two", "missing", "same"])] == ["two", "same"]
+    assert "vector" not in (await c.get(["same"]))[0]
+    assert (await c.get(["same"], include_vectors=True))[0] == record("same")
+    assert (await neighbor.get(["same"]))[0]["text"] == "Neighbor"
+    if storage_type == "hash":
+        raw = await c.redis_client.hgetall(c.key_prefix + "same")
+        assert raw[b"content"] == b"Hello, world*"
+        assert raw[b"enabled"] == b"true"
+        assert {key.decode() for key in raw} == set(c.definition.storage_names)
+    else:
+        raw = msgspec.json.decode(await c.redis_client.execute_command("JSON.GET", c.key_prefix + "same"))
+        assert raw["embedding"] == [1.0, 0.0]
+        assert raw["enabled"] is True
+    await c.upsert([record("same", text="Replaced")], generate_vectors=False)
+    assert not await c.get(filter=Filter("text", "eq", "Hello, world*"), top=1, skip=1)
+    await c.delete(["two", "missing"])
+    assert not await c.get(["two"])
+    await c.ensure_collection_deleted()
+    assert await neighbor.collection_exists()
+    assert await neighbor.get(["same"])
+
+
+@pytest.mark.integration
+async def test_live_native_filters_and_literal_escaping(live_store, storage_type):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="filters")
+    await c.ensure_collection_exists()
+    values = ["", "Case", "case", "a,b|c{}[]()@:$!\\*?~-'\"+=<>/%#", "inside space", "é漢字"]
+    await c.upsert(
+        [record(str(i), text=text, number=i, enabled=i % 2 == 0) for i, text in enumerate(values)],
+        generate_vectors=False,
+    )
+    for i, text in enumerate(values):
+        assert [r["id"] for r in await c.get(filter=Filter("text", "eq", text))] == [str(i)]
+    assert not await c.get(filter=Filter("number", "eq", True))
+    assert not await c.get(filter=Filter("enabled", "eq", 1))
+    assert len(await c.get(filter=Filter("enabled", "eq", True))) == 3
+    assert [r["id"] for r in await c.get(filter=Filter("number", "between", [1, 3]))] == ["1", "2", "3"]
+    assert [r["id"] for r in await c.get(filter=Filter("number", "in", [None, 1, 3]))] == ["1", "3"]
+    assert [r["id"] for r in await c.get(filter=Filter("number", "not_in", [1, 3]))] == ["0", "2", "4", "5"]
+    group = FilterGroup(
+        "and",
+        [
+            FilterGroup("or", [Filter("number", "lt", 1), Filter("number", "gt", 3)]),
+            FilterGroup("not", [Filter("enabled", "eq", False)]),
+        ],
+    )
+    assert [r["id"] for r in await c.get(filter=group)] == ["0", "4"]
+    assert len(await c.get(filter=Filter("tags", "contains_all", ["red", "blue"]))) == len(values)
+    assert not await c.get(filter=Filter("tags", "contains_any", []))
+    assert len(await c.get(filter=Filter("text", "exists"))) == len(values)
+    if storage_type == "json":
+        await c.upsert([record("null", text=None, number=None, enabled=None)], generate_vectors=False)
+        assert [r["id"] for r in await c.get(filter=Filter("number", "is_null"))] == ["null"]
+        assert [r["id"] for r in await c.get(filter=Filter("enabled", "is_null"))] == ["null"]
+        assert len(await c.get(filter=Filter("number", "is_not_null"))) == len(values)
+        assert len(await c.get(filter=Filter("text", "exists"))) == len(values) + 1
+        assert "null" in [r["id"] for r in await c.get(filter=Filter("text", "ne", "Case"))]
+
+
+@pytest.mark.integration
+async def test_live_missing_fields_are_not_null(live_store, storage_type):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="missing")
+    await c.ensure_collection_exists()
+    await c.upsert([record("complete"), record("missing")], generate_vectors=False)
+    if storage_type == "hash":
+        await c.redis_client.hdel(c.key_prefix + "missing", "number")
+    else:
+        await c.redis_client.execute_command("JSON.DEL", c.key_prefix + "missing", "$.number")
+    assert [r["id"] for r in await c.get(filter=Filter("number", "exists"))] == ["complete"]
+    assert [r["id"] for r in await c.get(filter=Filter("number", "ne", 999))] == ["complete"]
+    assert not await c.get(filter=Filter("number", "is_null"))
+    with pytest.raises(IntegrationInvalidResponseException, match="missing"):
+        await c.get(["missing"])
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "metric,expected",
+    [
+        ("DEFAULT", [0.0, 0.292893218, 1.0]),
+        ("cosine_distance", [0.0, 0.292893218, 1.0]),
+        ("euclidean_squared_distance", [0.0, 1.0, 2.0]),
+        ("redis.ip", [0.0, 0.0, 1.0]),
+    ],
+)
+async def test_live_scores_thresholds_and_paging(live_store, metric, expected):
+    c = live_store.get_collection(dict, definition=definition(metric=metric), collection_name="scores")
+    await c.ensure_collection_exists()
+    await c.upsert(
+        [
+            record("one", vector=[1.0, 0.0], number=0),
+            record("two", vector=[1.0, 1.0], number=1),
+            record("three", vector=[0.0, 1.0], number=2),
+        ],
+        generate_vectors=False,
+    )
+    results = [r async for r in await c.search(vector=[1.0, 0.0], top=10)]
+    assert [r["score"] for r in results] == pytest.approx(expected)
+    page = [r async for r in await c.search(vector=[1.0, 0.0], top=1, skip=1)]
+    assert page[0]["score"] == pytest.approx(expected[1])
+    bounded = [
+        r
+        async for r in await c.search(
+            vector=[1.0, 0.0], score_threshold=expected[1] + 1e-6, skip=1, top=5, include_vectors=True
+        )
+    ]
+    assert len(bounded) == 1
+    assert "vector" in bounded[0]["record"]
+    assert not [r async for r in await c.search(vector=[1.0, 0.0], score_threshold=expected[1] + 1e-6, skip=2, top=5)]
+    filtered = [
+        r
+        async for r in await c.search(
+            vector=[1.0, 0.0], filter=Filter("number", "gt", 0), score_threshold=expected[1] + 1e-6
+        )
+    ]
+    assert len(filtered) == 1
+    assert len([r async for r in await c.search(vector=[1.0, 0.0], score_threshold=0.0)]) >= 1
+    other = [r async for r in await c.search(vector=[0.0, 1.0], vector_property_name="other_vector")]
+    assert all(r["score"] == 0.0 for r in other)
+    assert [r["id"] for r in await c.get(order_by={"number": False}, skip=1, top=1)] == ["two"]
+
+
+@pytest.mark.integration
+async def test_live_schema_mismatch_is_nondestructive(live_store):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="schema")
+    await c.ensure_collection_exists()
+    await c.upsert([record()], generate_vectors=False)
+    incompatible = live_store.get_collection(dict, definition=definition(dimensions=3), collection_name="schema")
+    with pytest.raises(ValueError, match="incompatible"):
+        await incompatible.ensure_collection_exists()
+    with pytest.raises(ValueError, match="incompatible"):
+        await incompatible.ensure_collection_deleted()
+    with pytest.raises(ValueError, match="incompatible"):
+        await incompatible.upsert([record(vector=[1, 0, 0], other_vector=[0, 1, 0])], generate_vectors=False)
+    assert (await c.get(["one"]))[0]["id"] == "one"
+
+
+@pytest.mark.integration
+async def test_live_hnsw_and_native_tag_boundary(live_store):
+    c = live_store.get_collection(dict, definition=definition(index_kind="hnsw"), collection_name="hnsw")
+    await c.ensure_collection_exists()
+    text = "x" * 4096
+    await c.upsert([record(text=text)], generate_vectors=False)
+    assert [r["id"] for r in await c.get(filter=Filter("text", "eq", text))] == ["one"]
+    assert len([r async for r in await c.search(vector=[1.0, 0.0])]) == 1
+    assert len([r async for r in await c.search(vector=[1.0, 0.0], score_threshold=0.0)]) == 1
+
+
+@pytest.mark.integration
+async def test_live_native_json_null_vectors_and_empty_arrays(live_store, storage_type):
+    c = live_store.get_collection(dict, definition=definition(), collection_name="null-vectors")
+    await c.ensure_collection_exists()
+    if storage_type == "hash":
+        with pytest.raises(NotImplementedError, match="no native null"):
+            await c.upsert([record(vector=None)], generate_vectors=False)
+        assert not await c.get()
+        return
+    await c.upsert([record(vector=None, tags=[])], generate_vectors=False)
+    assert (await c.get(["one"], include_vectors=True))[0]["vector"] is None
+    assert len(await c.get(filter=Filter("tags", "exists"))) == 1
+    assert not await c.get(filter=Filter("tags", "contains", "red"))
+    assert not [r async for r in await c.search(vector=[1.0, 0.0])]
+    await c.upsert([record(tags=[""])], generate_vectors=False)
+    assert len(await c.get(filter=Filter("tags", "contains", ""))) == 1
+
+
+@pytest.mark.integration
+async def test_live_json_partial_batch_failure_is_explicit(live_store, storage_type):
+    if storage_type != "json":
+        pytest.skip("JSON.SET can fail on a preexisting non-JSON key; HASH replacement uses DEL/HSET.")
+    c = live_store.get_collection(dict, definition=definition(), collection_name="partial")
+    await c.ensure_collection_exists()
+    await c.redis_client.set(c.key_prefix + "bad", "wrong type")
+    try:
+        with pytest.raises(IntegrationException):
+            await c.upsert([record("good"), record("bad")], generate_vectors=False)
+        assert await c.get(["good"])
+        assert await c.redis_client.get(c.key_prefix + "bad") == b"wrong type"
+    finally:
+        await c.redis_client.delete(c.key_prefix + "bad")
+
+
+@pytest.mark.integration
+async def test_live_1000_records_multiple_1536_vectors(live_store):
+    c = live_store.get_collection(dict, definition=definition(dimensions=1536), collection_name="large")
+    await c.ensure_collection_exists()
+    vector = [0.01] * 1536
+    keys = await c.upsert(
+        [record(str(i), number=i, vector=vector, other_vector=vector) for i in range(1000)], generate_vectors=False
+    )
+    assert len(keys) == 1000
+    assert len(await c.get(top=1000)) == 1000
+    assert len((await c.get(["999"], include_vectors=True))[0]["other_vector"]) == 1536
+    assert len([r async for r in await c.search(vector=vector, top=5, skip=10)]) == 5
+    assert len(await c.get(filter=Filter("number", "gte", 990), top=20)) == 10
+    await c.delete(keys)
+    assert not await c.get(top=1)

--- a/python/samples/02-agents/vector_stores/README.md
+++ b/python/samples/02-agents/vector_stores/README.md
@@ -8,7 +8,7 @@ explicit definition and codecs. Dictionaries use a collection-specific
 definition; DataFrames and other containers can convert to row dictionaries
 before calling the batch API.
 
-No database is needed for these examples. The model, format, and direct
+No database is needed for the in-memory examples. The model, format, and direct
 in-memory filter samples need no credentials. The search-tool sample loads the
 existing Azure AI Search hotel dataset and uses OpenAI for embeddings and the
 agent; set `OPENAI_API_KEY` before running it.
@@ -19,6 +19,11 @@ agent; set `OPENAI_API_KEY` before running it.
 | [`optimized_data_formats.py`](optimized_data_formats.py) | Keeping NumPy vector fields and adapting pandas DataFrames to the batch record API. |
 | [`in_memory_filters.py`](in_memory_filters.py) | Direct vector search with `Filter` and `FilterGroup`. |
 | [`in_memory_search_tool.py`](in_memory_search_tool.py) | Model-set filter values with native typed `Param` declarations. |
+| [`redis_store.py`](redis_store.py) | Native HASH and JSON storage, vector search, filtering, and lifecycle with a disposable Redis server. |
+
+The Redis example requires Redis 8.0.3+ with Search and RedisJSON, but no
+embedding API. See the [Redis package documentation](../../../packages/redis/README.md)
+for setup and supported filter/score semantics.
 
 The first section shows the two equivalent custom-codec registration forms.
 `@vectorstoremodel` derives the definition from annotations and registers it;

--- a/python/samples/02-agents/vector_stores/redis_store.py
+++ b/python/samples/02-agents/vector_stores/redis_store.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+from uuid import uuid4
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+from agent_framework.redis import RedisStore
+
+"""
+Store and search the same model using both native Redis HASH and JSON storage.
+
+Requires agent-framework-redis and Redis 8.0.3+ with Search and RedisJSON.
+
+Start a disposable server:
+    docker run --rm --name af-redis-sample -p 127.0.0.1:6379:6379 redis:8.0.3
+
+Vectors are supplied directly; no embedding API or credentials are required.
+The example uses a unique namespace and removes only its own collections.
+"""
+
+
+@vectorstoremodel
+@dataclass
+class Document:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    category: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=2, index_kind="flat", distance_function="cosine_distance"),
+    ] = None
+
+
+async def main() -> None:
+    # 1. One store can create both storage formats, with shared client ownership.
+    async with RedisStore(redis_url="redis://localhost:6379", namespace="sample-" + uuid4().hex) as store:
+        for storage_type in ("hash", "json"):
+            collection = store.get_collection(Document, collection_name=storage_type, storage_type=storage_type)
+            await collection.ensure_collection_exists()
+            try:
+                # 2. CRUD is batch-only. False preserves the supplied vectors.
+                await collection.upsert(
+                    [
+                        Document("one", "A guide to Redis", "database", [1.0, 0.0]),
+                        Document("two", "A guide to gardening", "garden", [0.0, 1.0]),
+                    ],
+                    generate_vectors=False,
+                )
+                # 3. Native filtering and a maximum COSINE distance happen before paging.
+                results = await collection.search(
+                    vector=[1.0, 0.0],
+                    filter=Filter("category", "eq", "database"),
+                    score_threshold=0.25,
+                    top=3,
+                )
+                async for result in results:
+                    print(storage_type, result["record"].text, result["score"])
+                # Vectors are excluded by default; request them when needed.
+                loaded = await collection.get(["one"], include_vectors=True)
+                print("Stored vector:", loaded[0].vector)
+            finally:
+                await collection.ensure_collection_deleted()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+"""
+Expected output:
+hash A guide to Redis 0.0
+Stored vector: [1.0, 0.0]
+json A guide to Redis 0.0
+Stored vector: [1.0, 0.0]
+"""


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Applications using Redis need to store and search their own typed documents and embeddings through the shared vector-store APIs, independently of conversation-history persistence and context retrieval. This adds the Redis connector portion of the broader native vector-database effort, using Redis Search over native HASH and JSON documents.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** Adds experimental `RedisCollection`, `RedisStore`, and `RedisSettings` together in `_vector_store.py`, with exports through `agent_framework.redis` and `agent_framework_redis`. The connector uses the Agent Framework settings loader and `SecretString`, native HASH/JSON serialization without a shadow-field format, FLAT/HNSW indexes, multiple vector fields, batch CRUD, and dense vector search. Supported literal filters translate to native Redis queries. Search returns native distances, with lower scores better and maximum-distance thresholds applied before paging. Client lifecycle distinguishes borrowed from owned connections. Package documentation covers PyPI installation and Azure Managed Redis, Redis Cloud, and local Docker hosting; a sample demonstrates both formats. Unit and real-service coverage accompanies Redis 8.0.3 jobs in the paired integration/merge workflows, with the Redis path filter limited to the Redis package and its core namespace.
- **What is the impact of these changes?** Adds an opt-in Redis implementation of the shared experimental vector-store APIs without changing existing history/context providers, dependency manifests, lockfiles, versions, or feature-usage declarations. Vector collections require Redis Search with `INDEXMISSING`/`INDEXEMPTY`; JSON also requires RedisJSON. HASH rejects null values, including `vector=None`. JSON preserves null, but indexed null-filter support is type-dependent: numeric and boolean fields are supported, strings and arrays are not. Hybrid/full-text and literal substring/prefix/suffix search are unsupported and rejected. Indexed strings retain native TAG constraints: no surrounding whitespace, NUL, or U+001F, and a 4096-byte limit. Only standalone binary-response RESP2 clients are supported.
- **What do you want reviewers to focus on?** Native HASH/JSON round trips and their null/type restrictions; the supported filter subset and TAG literal handling; native-distance thresholds before paging; index compatibility and namespace isolation; and borrowed/owned client cleanup. Also review public imports, the consumer-facing setup documentation, and real-service CI coverage.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Related to #4167 and #1188. This implements only the Redis connector portion alongside the Azure AI Search, Qdrant, and PostgreSQL work; neither umbrella issue should close with this PR. No duplicate Redis vector-connector PR was found. Existing #7845 changes `RedisHistoryProvider` history-key scoping and is separate from this vector-store implementation.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.