### PR TITLE
Python: Scope AG-UI internal session IDs

### DIFF
--- a/python/packages/ag-ui/AGENTS.md
+++ b/python/packages/ag-ui/AGENTS.md
@@ -50,6 +50,9 @@ AG-UI protocol integration for building agent UIs with the AG-UI standard.
 - AG-UI Thread and Run ids are client-owned protocol correlation ids. Service-session mode stores provider conversation
   or response ids privately in the thread snapshot. Set `service_session_id_from_thread_id=True` only for compatibility
   when the application intentionally uses a provider continuation id as its AG-UI Thread id.
+- A configured Snapshot Scope and the client-owned Thread id are combined into a deterministic internal
+  `AgentSession.session_id`. Keep the raw Thread id for protocol events and snapshot addressing so equal Thread ids
+  in different trusted scopes cannot collide in context-provider state.
 - `confirm_changes` snapshot cleanup resolves the synthetic confirmation back to its original `function_call_id`;
   it must never concatenate unrelated tool results or record accepted changes without a matching real result.
 - SSE keepalive is endpoint-owned transport behavior configured through

--- a/python/packages/ag-ui/AGENTS.md
+++ b/python/packages/ag-ui/AGENTS.md
@@ -52,7 +52,9 @@ AG-UI protocol integration for building agent UIs with the AG-UI standard.
   when the application intentionally uses a provider continuation id as its AG-UI Thread id.
 - A configured Snapshot Scope and the client-owned Thread id are combined into a deterministic internal
   `AgentSession.session_id`. Keep the raw Thread id for protocol events and snapshot addressing so equal Thread ids
-  in different trusted scopes cannot collide in context-provider state.
+  in different trusted scopes cannot collide in context-provider state. The deprecated
+  `legacy_session_id_from_thread_id=True` compatibility option preserves raw provider keys only for explicit
+  migrations and must warn because it disables that isolation.
 - `confirm_changes` snapshot cleanup resolves the synthetic confirmation back to its original `function_call_id`;
   it must never concatenate unrelated tool results or record accepted changes without a matching real result.
 - SSE keepalive is endpoint-owned transport behavior configured through

--- a/python/packages/ag-ui/README.md
+++ b/python/packages/ag-ui/README.md
@@ -378,10 +378,12 @@ A frontend can then hydrate the latest stored snapshot for the scoped thread:
 
 Endpoint configuration requires `snapshot_scope_resolver` whenever a snapshot store is configured, including when
 the store is already set on a pre-wrapped `AgentFrameworkAgent` or `AgentFrameworkWorkflow`. The resolver returns
-the application-defined Snapshot Scope used with the AG-UI Thread id as the storage key. When using
-`AgentFrameworkWorkflow(workflow_factory=...)`, the same resolver also scopes the in-memory workflow cache even
-without a snapshot store; provide it in multi-user deployments so two users who submit the same `threadId` do not
-share a live `Workflow` instance.
+the application-defined Snapshot Scope used with the AG-UI Thread id as the storage key. The endpoint also derives
+the internal `AgentSession.session_id` from this trusted scope and the client-owned Thread id, so context providers
+cannot merge server-side state for equal Thread ids in different scopes. The raw Thread id remains unchanged in
+AG-UI events and snapshot operations. When using `AgentFrameworkWorkflow(workflow_factory=...)`, the same resolver
+also scopes the in-memory workflow cache even without a snapshot store; provide it in multi-user deployments so two
+users who submit the same `threadId` do not share a live `Workflow` instance.
 
 For hosted agents, request Shared State is also available through `AgentSession.state` during that run, whether or
 not snapshot persistence is configured. Request values are untrusted per-run context: they overlay ordinary restored

--- a/python/packages/ag-ui/README.md
+++ b/python/packages/ag-ui/README.md
@@ -385,6 +385,12 @@ AG-UI events and snapshot operations. When using `AgentFrameworkWorkflow(workflo
 also scopes the in-memory workflow cache even without a snapshot store; provide it in multi-user deployments so two
 users who submit the same `threadId` do not share a live `Workflow` instance.
 
+Existing applications that need time to migrate provider records from raw Thread-id keys can temporarily wrap the
+agent with `AgentFrameworkAgent(..., legacy_session_id_from_thread_id=True)`. This deprecated compatibility option
+emits a `DeprecationWarning` and disables Snapshot Scope isolation for context-provider state. Remove it after
+migrating only records whose scope provenance can be established; do not merge or fall back to legacy records that
+may already contain data from multiple scopes.
+
 For hosted agents, request Shared State is also available through `AgentSession.state` during that run, whether or
 not snapshot persistence is configured. Request values are untrusted per-run context: they overlay ordinary restored
 values, are not passed through typed session restoration, and are excluded from private Session Continuation State.

--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent.py
@@ -2,6 +2,7 @@
 
 """AgentFrameworkAgent wrapper for AG-UI protocol."""
 
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, cast
 
@@ -28,6 +29,7 @@ class AgentConfig:
         a2ui_config: dict[str, Any] | None = None,
         service_session_id_from_thread_id: bool = False,
         emit_messages_snapshot: bool = True,
+        legacy_session_id_from_thread_id: bool = False,
     ):
         """Initialize agent configuration.
 
@@ -49,6 +51,8 @@ class AgentConfig:
             emit_messages_snapshot: Whether to emit a terminal MessagesSnapshotEvent at the end of runs.
                 Defaults to True for backward compatibility. Set to False when using HistoryProvider
                 to prevent redundant full-transcript rewrites on the client.
+            legacy_session_id_from_thread_id: Deprecated compatibility option that uses the client-owned
+                AG-UI Thread id directly as the internal Agent Session id.
         """
         self.state_schema = self._normalize_state_schema(state_schema)
         self.predict_state_config = predict_state_config or {}
@@ -58,6 +62,7 @@ class AgentConfig:
         self.snapshot_store = snapshot_store
         self.a2ui_config = a2ui_config
         self.emit_messages_snapshot = emit_messages_snapshot
+        self.legacy_session_id_from_thread_id = legacy_session_id_from_thread_id
 
     @staticmethod
     def _normalize_state_schema(state_schema: Any | None) -> dict[str, Any]:
@@ -107,6 +112,7 @@ class AgentFrameworkAgent:
         a2ui_config: dict[str, Any] | None = None,
         service_session_id_from_thread_id: bool = False,
         emit_messages_snapshot: bool = True,
+        legacy_session_id_from_thread_id: bool = False,
     ):
         """Initialize the AG-UI compatible agent wrapper.
 
@@ -128,7 +134,19 @@ class AgentFrameworkAgent:
             a2ui_config: Optional backend A2UI config consumed by auto-injection.
             emit_messages_snapshot: Whether to emit a terminal MessagesSnapshotEvent at the end of runs.
                 Defaults to True. Set to False when using HistoryProvider.
+            legacy_session_id_from_thread_id: Deprecated compatibility option that uses the client-owned
+                AG-UI Thread id directly as the internal Agent Session id. This disables Snapshot Scope
+                isolation for context-provider state.
         """
+        if legacy_session_id_from_thread_id:
+            warnings.warn(
+                "legacy_session_id_from_thread_id=True is deprecated because client-owned AG-UI Thread ids "
+                "do not isolate server-side state. Migrate provider state to scoped session ids and remove "
+                "this option.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.agent = agent
         self.name = name or getattr(agent, "name", "agent")
         self.description = description or getattr(agent, "description", "")
@@ -142,6 +160,7 @@ class AgentFrameworkAgent:
             snapshot_store=snapshot_store,
             a2ui_config=a2ui_config,
             emit_messages_snapshot=emit_messages_snapshot,
+            legacy_session_id_from_thread_id=legacy_session_id_from_thread_id,
         )
 
         # Server-side Approval State. Populated when approval requests are emitted

--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -2433,7 +2433,11 @@ async def run_agent_stream(
     thread_id = supplied_thread_id or str(uuid.uuid4())
     run_id = supplied_run_id or str(uuid.uuid4())
     snapshot_scope = cast(str | None, input_data.get(_SNAPSHOT_SCOPE_INPUT_KEY))
-    session_id = _session_id_for_thread(scope=snapshot_scope, thread_id=thread_id)
+    session_id = _session_id_for_thread(
+        scope=snapshot_scope,
+        thread_id=thread_id,
+        legacy_session_id_from_thread_id=config.legacy_session_id_from_thread_id,
+    )
     approval_scope = cast(str | None, input_data.get(_APPROVAL_SCOPE_INPUT_KEY))
     approval_thread_id = approval_state_thread_id(scope=approval_scope, thread_id=thread_id)
     if approval_state_store is None:

--- a/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_agent_run.py
@@ -98,6 +98,7 @@ from ._run_common import (
 from ._snapshots import (
     _DEFAULT_STATE_INPUT_KEY,
     _SNAPSHOT_SCOPE_INPUT_KEY,
+    _session_id_for_thread,
     AGUIThreadSnapshot,
 )
 from ._snapshot_session import ThreadSnapshotSession, _event_messages_to_snapshot_dicts
@@ -2432,6 +2433,7 @@ async def run_agent_stream(
     thread_id = supplied_thread_id or str(uuid.uuid4())
     run_id = supplied_run_id or str(uuid.uuid4())
     snapshot_scope = cast(str | None, input_data.get(_SNAPSHOT_SCOPE_INPUT_KEY))
+    session_id = _session_id_for_thread(scope=snapshot_scope, thread_id=thread_id)
     approval_scope = cast(str | None, input_data.get(_APPROVAL_SCOPE_INPUT_KEY))
     approval_thread_id = approval_state_thread_id(scope=approval_scope, thread_id=thread_id)
     if approval_state_store is None:
@@ -2721,7 +2723,7 @@ async def run_agent_stream(
                 "use_service_session=True requires snapshot persistence unless service_session_id_from_thread_id=True."
             )
         service_session_id = supplied_thread_id if config.service_session_id_from_thread_id else None
-        session = AgentSession(session_id=thread_id, service_session_id=service_session_id)
+        session = AgentSession(session_id=session_id, service_session_id=service_session_id)
         stored_service_session_id = (
             stored_snapshot.session_state.get(_PROVIDER_SERVICE_SESSION_ID_STATE_KEY)
             if stored_snapshot is not None and stored_snapshot.session_state is not None
@@ -2733,14 +2735,14 @@ async def run_agent_stream(
             and stored_service_session_id is None
             and callable(create_conversation)
         ):
-            created_session = create_conversation(session_id=thread_id)
+            created_session = create_conversation(session_id=session_id)
             if isinstance(created_session, Awaitable):
                 created_session = await created_session
             if not isinstance(created_session, AgentSession):
                 raise TypeError("agent.create_conversation() must return AgentSession")
             session = created_session
     else:
-        session = AgentSession(session_id=thread_id)
+        session = AgentSession(session_id=session_id)
     _restore_session_continuation_state(
         session,
         stored_snapshot,

--- a/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_endpoint.py
@@ -114,7 +114,8 @@ def add_agent_framework_fastapi_endpoint(
             explicit Snapshot Scope resolver.
         snapshot_scope_resolver: Optional resolver for the application-defined Snapshot Scope. Required whenever
             a snapshot store is configured because an AG-UI Thread id is not an authorization boundary. Also scopes
-            in-memory workflow_factory instances when provided without a snapshot store.
+            the internal Agent Session id used by context providers and in-memory workflow_factory instances when
+            provided without a snapshot store.
         checkpoint_storage: Optional workflow checkpoint storage, applied when the endpoint exposes a workflow.
             When provided, each run creates a checkpoint at the end of every superstep, and a run may resume from
             a persisted checkpoint by supplying its id in the AG-UI forwarded props

--- a/python/packages/ag-ui/agent_framework_ag_ui/_snapshots.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_snapshots.py
@@ -24,19 +24,34 @@ AGUIThreadID: TypeAlias = str
 SnapshotScopeResolver: TypeAlias = Callable[["AGUIRequest"], str | Awaitable[str]]
 """Callable that resolves the trusted Snapshot Scope for an AG-UI endpoint request."""
 
-_SCOPED_SESSION_ID_VERSION = 1
-_SCOPED_SESSION_ID_PREFIX = f"ag-ui:v{_SCOPED_SESSION_ID_VERSION}:"
+_SESSION_ID_VERSION = 1
+_SESSION_ID_PREFIX = f"ag-ui:v{_SESSION_ID_VERSION}:"
+_SCOPED_SESSION_ID_PREFIX = f"{_SESSION_ID_PREFIX}scoped:"
+_UNSCOPED_SESSION_ID_PREFIX = f"{_SESSION_ID_PREFIX}unscoped:"
 
 
-def _session_id_for_thread(*, scope: SnapshotScope | None, thread_id: AGUIThreadID) -> str:
+def _session_id_for_thread(
+    *,
+    scope: SnapshotScope | None,
+    thread_id: AGUIThreadID,
+    legacy_session_id_from_thread_id: bool = False,
+) -> str:
     """Return the scope-isolated internal session ID for an AG-UI thread."""
-    if scope is None:
+    if legacy_session_id_from_thread_id:
         return thread_id
 
-    identity = (_SCOPED_SESSION_ID_VERSION, scope, thread_id)
+    if scope is None and not thread_id.startswith(_SESSION_ID_PREFIX):
+        return thread_id
+
+    identity = (
+        (_SESSION_ID_VERSION, "scoped", scope, thread_id)
+        if scope is not None
+        else (_SESSION_ID_VERSION, "unscoped", thread_id)
+    )
     encoded_identity = json.dumps(identity, ensure_ascii=True, separators=(",", ":")).encode("ascii")
     digest = hashlib.sha256(encoded_identity).hexdigest()
-    return f"{_SCOPED_SESSION_ID_PREFIX}{digest}"
+    prefix = _SCOPED_SESSION_ID_PREFIX if scope is not None else _UNSCOPED_SESSION_ID_PREFIX
+    return f"{prefix}{digest}"
 
 
 _SnapshotKey: TypeAlias = tuple[SnapshotScope, AGUIThreadID]

--- a/python/packages/ag-ui/agent_framework_ag_ui/_snapshots.py
+++ b/python/packages/ag-ui/agent_framework_ag_ui/_snapshots.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import copy
+import hashlib
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -14,13 +16,28 @@ if TYPE_CHECKING:
     from ._types import AGUIRequest
 
 SnapshotScope: TypeAlias = str
-"""Application-defined scope for authorizing access to AG-UI Thread Snapshots."""
+"""Application-defined authorization scope for server-side AG-UI Thread state."""
 
 AGUIThreadID: TypeAlias = str
 """AG-UI Thread identifier within a Snapshot Scope."""
 
 SnapshotScopeResolver: TypeAlias = Callable[["AGUIRequest"], str | Awaitable[str]]
-"""Callable that resolves the Snapshot Scope for an AG-UI endpoint request."""
+"""Callable that resolves the trusted Snapshot Scope for an AG-UI endpoint request."""
+
+_SCOPED_SESSION_ID_VERSION = 1
+_SCOPED_SESSION_ID_PREFIX = f"ag-ui:v{_SCOPED_SESSION_ID_VERSION}:"
+
+
+def _session_id_for_thread(*, scope: SnapshotScope | None, thread_id: AGUIThreadID) -> str:
+    """Return the scope-isolated internal session ID for an AG-UI thread."""
+    if scope is None:
+        return thread_id
+
+    identity = (_SCOPED_SESSION_ID_VERSION, scope, thread_id)
+    encoded_identity = json.dumps(identity, ensure_ascii=True, separators=(",", ":")).encode("ascii")
+    digest = hashlib.sha256(encoded_identity).hexdigest()
+    return f"{_SCOPED_SESSION_ID_PREFIX}{digest}"
+
 
 _SnapshotKey: TypeAlias = tuple[SnapshotScope, AGUIThreadID]
 

--- a/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
@@ -2139,7 +2139,7 @@ async def test_endpoint_request_collision_evicts_prior_private_value(streaming_c
 async def test_endpoint_scopes_history_provider_session_ids_by_trusted_snapshot_scope(
     streaming_chat_client_stub,
 ):
-    """Trusted Snapshot Scopes isolate internal history while AG-UI keeps the raw thread id."""
+    """Trusted scopes isolate history from other scopes and the unscoped client-id namespace."""
 
     class RecordingHistoryProvider(HistoryProvider):
         def __init__(self) -> None:
@@ -2197,6 +2197,12 @@ async def test_endpoint_scopes_history_provider_session_ids_by_trusted_snapshot_
         snapshot_scope_resolver=lambda request: cast("dict[str, Any]", request.forwarded_props)["scope"],
         keepalive_seconds=None,
     )
+    add_agent_framework_fastapi_endpoint(
+        app,
+        agent,
+        path="/unscoped-history",
+        keepalive_seconds=None,
+    )
     client = TestClient(app)
 
     raw_thread_id = "shared-client-thread"
@@ -2221,14 +2227,35 @@ async def test_endpoint_scopes_history_provider_session_ids_by_trusted_snapshot_
     tenant_a_session_id, repeated_tenant_a_session_id, tenant_b_session_id = history.saved_session_ids
     assert tenant_a_session_id == repeated_tenant_a_session_id
     assert tenant_a_session_id != tenant_b_session_id
-    assert set(history.messages_by_session) == {tenant_a_session_id, tenant_b_session_id}
+
+    collision_response = client.post(
+        "/unscoped-history",
+        json={
+            "thread_id": tenant_a_session_id,
+            "messages": [{"role": "user", "content": "unscoped collision attempt"}],
+        },
+    )
+    assert collision_response.status_code == 200
+    unscoped_session_id = history.saved_session_ids[-1]
+    assert unscoped_session_id != tenant_a_session_id
+
+    assert set(history.messages_by_session) == {
+        tenant_a_session_id,
+        tenant_b_session_id,
+        unscoped_session_id,
+    }
     assert all("tenant-b" not in message.text for message in history.messages_by_session[tenant_a_session_id])
     assert all("tenant-a" not in message.text for message in history.messages_by_session[tenant_b_session_id])
+    assert all("unscoped" not in message.text for message in history.messages_by_session[tenant_a_session_id])
+    assert all("tenant-a" not in message.text for message in history.messages_by_session[unscoped_session_id])
 
     for response in responses:
         events = _decode_sse_events(response)
         assert events[0]["threadId"] == raw_thread_id
         assert events[-1]["threadId"] == raw_thread_id
+    collision_events = _decode_sse_events(collision_response)
+    assert collision_events[0]["threadId"] == tenant_a_session_id
+    assert collision_events[-1]["threadId"] == tenant_a_session_id
 
 
 async def test_endpoint_excludes_history_provider_state_from_continuation(streaming_chat_client_stub):

--- a/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_endpoint.py
@@ -8,7 +8,7 @@ import logging
 import subprocess
 import sys
 from collections import Counter
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
 from inspect import signature
 from typing import Any, cast
@@ -25,6 +25,7 @@ from agent_framework import (
     ContextProvider,
     Executor,
     FunctionTool,
+    HistoryProvider,
     InMemoryCheckpointStorage,
     InMemoryHistoryProvider,
     Message,
@@ -2133,6 +2134,101 @@ async def test_endpoint_request_collision_evicts_prior_private_value(streaming_c
         if event.get("type") == "TEXT_MESSAGE_CONTENT"
     ]
     assert observed == ["mode=None", "mode=request", "mode=request"]
+
+
+async def test_endpoint_scopes_history_provider_session_ids_by_trusted_snapshot_scope(
+    streaming_chat_client_stub,
+):
+    """Trusted Snapshot Scopes isolate internal history while AG-UI keeps the raw thread id."""
+
+    class RecordingHistoryProvider(HistoryProvider):
+        def __init__(self) -> None:
+            super().__init__(source_id="recording-history", load_messages=False)
+            self.saved_session_ids: list[str] = []
+            self.messages_by_session: dict[str, list[Message]] = {}
+
+        async def get_messages(
+            self,
+            session_id: str | None,
+            *,
+            state: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> list[Message]:
+            del state, kwargs
+            if session_id is None:
+                return []
+            return list(self.messages_by_session.get(session_id, []))
+
+        async def save_messages(
+            self,
+            session_id: str | None,
+            messages: Sequence[Message],
+            *,
+            state: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> None:
+            del state, kwargs
+            assert session_id is not None
+            self.saved_session_ids.append(session_id)
+            self.messages_by_session.setdefault(session_id, []).extend(messages)
+
+    async def stream_fn(
+        messages: list[Message],
+        options: dict[str, Any],
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatResponseUpdate]:
+        del options, kwargs
+        latest_user_text = next(message.text for message in reversed(messages) if message.role == "user")
+        yield ChatResponseUpdate(contents=[Content.from_text(text=f"Reply to {latest_user_text}")])
+
+    history = RecordingHistoryProvider()
+    agent = Agent(
+        name="test",
+        instructions=None,
+        client=streaming_chat_client_stub(stream_fn),
+        context_providers=[history],
+    )
+    app = FastAPI()
+    add_agent_framework_fastapi_endpoint(
+        app,
+        agent,
+        path="/scoped-history",
+        snapshot_store=InMemoryAGUIThreadSnapshotStore(),
+        snapshot_scope_resolver=lambda request: cast("dict[str, Any]", request.forwarded_props)["scope"],
+        keepalive_seconds=None,
+    )
+    client = TestClient(app)
+
+    raw_thread_id = "shared-client-thread"
+    requests = [
+        ("tenant-a", "tenant-a first"),
+        ("tenant-a", "tenant-a second"),
+        ("tenant-b", "tenant-b first"),
+    ]
+    responses = [
+        client.post(
+            "/scoped-history",
+            json={
+                "thread_id": raw_thread_id,
+                "messages": [{"role": "user", "content": content}],
+                "forwardedProps": {"scope": scope},
+            },
+        )
+        for scope, content in requests
+    ]
+
+    assert all(response.status_code == 200 for response in responses)
+    tenant_a_session_id, repeated_tenant_a_session_id, tenant_b_session_id = history.saved_session_ids
+    assert tenant_a_session_id == repeated_tenant_a_session_id
+    assert tenant_a_session_id != tenant_b_session_id
+    assert set(history.messages_by_session) == {tenant_a_session_id, tenant_b_session_id}
+    assert all("tenant-b" not in message.text for message in history.messages_by_session[tenant_a_session_id])
+    assert all("tenant-a" not in message.text for message in history.messages_by_session[tenant_b_session_id])
+
+    for response in responses:
+        events = _decode_sse_events(response)
+        assert events[0]["threadId"] == raw_thread_id
+        assert events[-1]["threadId"] == raw_thread_id
 
 
 async def test_endpoint_excludes_history_provider_state_from_continuation(streaming_chat_client_stub):

--- a/python/packages/ag-ui/tests/ag_ui/test_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run.py
@@ -2720,6 +2720,33 @@ async def test_scoped_session_id_preserves_service_session_id_thread_compatibili
     assert events[-1].thread_id == "service-thread-789"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
 
+async def test_scoped_session_id_supports_deprecated_legacy_mapping():
+    """The explicit migration escape hatch warns and preserves the raw internal session id."""
+    from conftest import StubAgent  # pyrefly: ignore[missing-import] # pyright: ignore[reportMissingImports]
+
+    from agent_framework_ag_ui import AgentFrameworkAgent, InMemoryAGUIThreadSnapshotStore
+
+    stub = StubAgent()
+    with pytest.warns(DeprecationWarning, match="legacy_session_id_from_thread_id=True is deprecated"):
+        agent = AgentFrameworkAgent(
+            agent=stub,
+            snapshot_store=InMemoryAGUIThreadSnapshotStore(),
+            legacy_session_id_from_thread_id=True,
+        )
+
+    payload = {
+        "thread_id": "legacy-thread",
+        "run_id": "run-legacy-session",
+        "__ag_ui_snapshot_scope": "tenant-a",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    _ = [event async for event in agent.run(payload)]
+
+    assert stub.last_session is not None
+    assert stub.last_session.session_id == "legacy-thread"
+
+
 async def test_scoped_session_id_is_used_to_create_service_conversation():
     """Provider-owned conversation creation uses the scope-isolated internal session id."""
     from agent_framework import AgentSession

--- a/python/packages/ag-ui/tests/ag_ui/test_run.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_run.py
@@ -2690,6 +2690,71 @@ async def test_session_id_matches_thread_id_with_service_session():
     assert stub.last_session.service_session_id == "service-thread-789"
 
 
+async def test_scoped_session_id_preserves_service_session_id_thread_compatibility():
+    """Trusted scope changes internal identity without changing the provider continuation compatibility id."""
+    from conftest import StubAgent  # pyrefly: ignore[missing-import] # pyright: ignore[reportMissingImports]
+
+    from agent_framework_ag_ui import AgentFrameworkAgent, InMemoryAGUIThreadSnapshotStore
+
+    stub = StubAgent()
+    agent = AgentFrameworkAgent(
+        agent=stub,
+        use_service_session=True,
+        service_session_id_from_thread_id=True,
+        snapshot_store=InMemoryAGUIThreadSnapshotStore(),
+    )
+
+    payload = {
+        "thread_id": "service-thread-789",
+        "run_id": "run-scoped-service",
+        "__ag_ui_snapshot_scope": "tenant-a",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    events = [event async for event in agent.run(payload)]
+
+    assert stub.last_session is not None
+    assert stub.last_session.session_id != "service-thread-789"
+    assert stub.last_session.service_session_id == "service-thread-789"
+    assert events[0].thread_id == "service-thread-789"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+    assert events[-1].thread_id == "service-thread-789"  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+
+
+async def test_scoped_session_id_is_used_to_create_service_conversation():
+    """Provider-owned conversation creation uses the scope-isolated internal session id."""
+    from agent_framework import AgentSession
+
+    from agent_framework_ag_ui import AgentFrameworkAgent, InMemoryAGUIThreadSnapshotStore
+
+    stub = StubAgent()
+    created_session_ids: list[str] = []
+
+    def create_conversation(*, session_id: str) -> AgentSession:
+        created_session_ids.append(session_id)
+        return AgentSession(session_id=session_id, service_session_id="provider-conversation")
+
+    setattr(stub, "create_conversation", create_conversation)
+    agent = AgentFrameworkAgent(
+        agent=stub,
+        use_service_session=True,
+        snapshot_store=InMemoryAGUIThreadSnapshotStore(),
+    )
+    payload = {
+        "thread_id": "service-thread-789",
+        "run_id": "run-create-scoped-service",
+        "__ag_ui_snapshot_scope": "tenant-a",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    _ = [event async for event in agent.run(payload)]
+
+    assert len(created_session_ids) == 1
+    assert created_session_ids[0] != "service-thread-789"
+    assert stub.last_session is not None
+    assert stub.last_session.session_id == created_session_ids[0]
+    assert stub.last_session.service_session_id == "provider-conversation"
+
+
 async def test_session_id_generated_when_no_thread_id():
     """Session gets a generated UUID as session_id when no thread_id is provided."""
     import uuid

--- a/python/packages/ag-ui/tests/ag_ui/test_snapshots.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_snapshots.py
@@ -15,10 +15,32 @@ def test_internal_session_id_is_stable_scoped_and_unambiguous() -> None:
 
     assert _session_id_for_thread(scope=None, thread_id=raw_thread_id) == raw_thread_id
     assert scoped_session_id == _session_id_for_thread(scope="tenant-a", thread_id=raw_thread_id)
-    assert scoped_session_id.startswith("ag-ui:v1:")
-    assert len(scoped_session_id.removeprefix("ag-ui:v1:")) == 64
+    assert scoped_session_id.startswith("ag-ui:v1:scoped:")
+    assert len(scoped_session_id.removeprefix("ag-ui:v1:scoped:")) == 64
     assert scoped_session_id != _session_id_for_thread(scope="tenant-b", thread_id=raw_thread_id)
     assert _session_id_for_thread(scope="ab", thread_id="c") != _session_id_for_thread(scope="a", thread_id="bc")
+
+
+def test_internal_session_id_keeps_scoped_and_unscoped_namespaces_disjoint() -> None:
+    """A client cannot use a scoped internal ID as an unscoped raw Thread ID."""
+    scoped_session_id = _session_id_for_thread(scope="tenant-a", thread_id="shared-thread")
+    unscoped_session_id = _session_id_for_thread(scope=None, thread_id=scoped_session_id)
+
+    assert unscoped_session_id.startswith("ag-ui:v1:unscoped:")
+    assert unscoped_session_id != scoped_session_id
+    assert unscoped_session_id == _session_id_for_thread(scope=None, thread_id=scoped_session_id)
+
+
+def test_internal_session_id_supports_deprecated_legacy_mapping() -> None:
+    """The explicit migration escape hatch preserves the legacy raw provider key."""
+    assert (
+        _session_id_for_thread(
+            scope="tenant-a",
+            thread_id="shared-thread",
+            legacy_session_id_from_thread_id=True,
+        )
+        == "shared-thread"
+    )
 
 
 def test_thread_snapshot_model_contains_replayable_and_private_snapshot_fields() -> None:

--- a/python/packages/ag-ui/tests/ag_ui/test_snapshots.py
+++ b/python/packages/ag-ui/tests/ag_ui/test_snapshots.py
@@ -5,6 +5,20 @@
 from dataclasses import fields
 
 from agent_framework_ag_ui import AGUIThreadSnapshot, AGUIThreadSnapshotStore, InMemoryAGUIThreadSnapshotStore
+from agent_framework_ag_ui._snapshots import _session_id_for_thread
+
+
+def test_internal_session_id_is_stable_scoped_and_unambiguous() -> None:
+    """Internal session identity preserves raw IDs only when no trusted scope is present."""
+    raw_thread_id = "shared-thread"
+    scoped_session_id = _session_id_for_thread(scope="tenant-a", thread_id=raw_thread_id)
+
+    assert _session_id_for_thread(scope=None, thread_id=raw_thread_id) == raw_thread_id
+    assert scoped_session_id == _session_id_for_thread(scope="tenant-a", thread_id=raw_thread_id)
+    assert scoped_session_id.startswith("ag-ui:v1:")
+    assert len(scoped_session_id.removeprefix("ag-ui:v1:")) == 64
+    assert scoped_session_id != _session_id_for_thread(scope="tenant-b", thread_id=raw_thread_id)
+    assert _session_id_for_thread(scope="ab", thread_id="c") != _session_id_for_thread(scope="a", thread_id="bc")
 
 
 def test_thread_snapshot_model_contains_replayable_and_private_snapshot_fields() -> None:


### PR DESCRIPTION
### Motivation & Context

AG-UI Thread ids are client-owned protocol correlation ids rather than authorization boundaries. Although `SnapshotScope` already isolates snapshots and workflow instances, AG-UI passed the raw Thread id into `AgentSession.session_id`, allowing server-side context providers to merge state when two authenticated scopes used the same Thread id.

This change applies the trusted AG-UI scope consistently at the agent-session boundary so durable context providers inherit the endpoint's authorization partitioning.

### Description & Review Guide

- **What are the major changes?** AG-UI derives a deterministic internal session id from a versioned, canonical `(SnapshotScope, threadId)` tuple and SHA-256 digest. Scoped and unscoped generated identifiers use disjoint reserved namespaces. Regular sessions, service sessions, and provider conversation creation use the internal id, while protocol events, snapshots, and `service_session_id_from_thread_id` retain the raw Thread id. A deprecated `legacy_session_id_from_thread_id=True` escape hatch preserves existing raw provider keys during migration and emits a `DeprecationWarning`.
- **What is the impact of these changes?** Endpoints with a configured `snapshot_scope_resolver` isolate context-provider state across scopes even when clients reuse a Thread id. Ordinary unscoped Thread ids retain the existing raw mapping; values in AG-UI's reserved internal namespace are escaped to prevent mixed-endpoint collisions. Applications needing uninterrupted access to legacy raw provider keys can opt into the deprecated compatibility mode while migrating records with trusted scope provenance.
- **What do you want reviewers to focus on?** Please review the disjoint identity domains and compatibility boundary: trusted scopes change only the internal session id, client-visible AG-UI identifiers remain unchanged, and legacy raw provider keys require an explicit warning-emitting opt-out.

### Related Issue

No public issue tracks this security hardening. Related history-composition context: #8075 and #7802. No open PR addresses this session-identity collision.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.