### PR TITLE
[BREAKING] .NET: Isolate LocalCodeAct subprocess environment

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Internal/ProcessBridge.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/Internal/ProcessBridge.cs
@@ -106,18 +106,14 @@ internal sealed class ProcessBridge
 
     private void ConfigureEnvironment(ProcessStartInfo startInfo)
     {
-        // Null => inherit the parent environment (documented contract on
-        // LocalCodeActProviderOptions.Environment). Callers wanting a scrubbed
-        // environment pass an empty dictionary.
-        if (this._environment is null)
-        {
-            return;
-        }
-
         startInfo.Environment.Clear();
-        foreach (var kvp in this._environment)
+
+        if (this._environment is not null)
         {
-            startInfo.Environment[kvp.Key] = kvp.Value;
+            foreach (var kvp in this._environment)
+            {
+                startInfo.Environment[kvp.Key] = kvp.Value;
+            }
         }
 
         // Without these on Windows, Python may fail to load its standard library.

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProviderOptions.cs
@@ -27,10 +27,9 @@ public sealed class LocalCodeActProviderOptions
     /// Gets or sets environment variables passed to the subprocess.
     /// </summary>
     /// <remarks>
-    /// When <see langword="null"/>, the subprocess inherits the parent process environment
-    /// (the default <see cref="System.Diagnostics.ProcessStartInfo"/> behavior). To run with
-    /// a restricted environment, supply a dictionary containing only the variables the
-    /// subprocess should see — pass an empty dictionary for a fully scrubbed environment.
+    /// The subprocess does not inherit the parent process environment. When this property is
+    /// <see langword="null"/> or empty, the subprocess runs with a scrubbed environment.
+    /// Otherwise, the subprocess receives only the variables in the supplied dictionary.
     /// On Windows, a small set of system variables (SYSTEMROOT, SYSTEMDRIVE, COMSPEC,
     /// PATHEXT, TEMP, TMP) is back-filled from the parent environment when not already
     /// present so Python can locate its standard library.

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/README.md
@@ -156,7 +156,8 @@ scanned for **new** files after execution, and those files are returned as
 ## Environment Variables
 
 Pass environment variables explicitly. The subprocess does NOT inherit the host
-environment by default:
+environment by default. On Windows, the system variables required for Python to
+load its standard library are retained:
 
 ```csharp
 using var provider = new LocalCodeActProvider("/usr/bin/python3", new LocalCodeActProviderOptions

--- a/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/LocalExecuteCodeFunctionIntegrationTests.cs
@@ -109,6 +109,84 @@ public sealed class LocalExecuteCodeFunctionIntegrationTests
     }
 
     [Fact]
+    public async Task ExecuteCode_DefaultEnvironmentDoesNotInheritParentVariablesAsync()
+    {
+        SkipIfNoPython();
+
+        // Arrange
+        var variableName = $"AF_LOCALCODEACT_PARENT_{Guid.NewGuid():N}";
+        var parentValue = $"parent-value-{Guid.NewGuid():N}";
+        var originalValue = Environment.GetEnvironmentVariable(variableName);
+        Environment.SetEnvironmentVariable(variableName, parentValue);
+
+        try
+        {
+            var function = new LocalExecuteCodeFunction(s_python!);
+            var args = new AIFunctionArguments
+            {
+                ["code"] = $"import os\nprint(os.environ.get('{variableName}', 'NOT_FOUND'))",
+            };
+
+            // Act
+            var result = await function.InvokeAsync(args, CancellationToken.None);
+
+            // Assert
+            var combined = GetResultText(result);
+            Assert.Contains("NOT_FOUND", combined, StringComparison.Ordinal);
+            Assert.DoesNotContain(parentValue, combined, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, originalValue);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteCode_ExplicitEnvironmentDoesNotInheritOtherParentVariablesAsync()
+    {
+        SkipIfNoPython();
+
+        // Arrange
+        var parentVariableName = $"AF_LOCALCODEACT_PARENT_{Guid.NewGuid():N}";
+        var childVariableName = $"AF_LOCALCODEACT_CHILD_{Guid.NewGuid():N}";
+        var parentValue = $"parent-value-{Guid.NewGuid():N}";
+        var childValue = $"child-value-{Guid.NewGuid():N}";
+        var originalValue = Environment.GetEnvironmentVariable(parentVariableName);
+        Environment.SetEnvironmentVariable(parentVariableName, parentValue);
+
+        try
+        {
+            var options = new LocalCodeActProviderOptions
+            {
+                Environment = new Dictionary<string, string>
+                {
+                    [childVariableName] = childValue,
+                },
+            };
+            var function = new LocalExecuteCodeFunction(s_python!, options);
+            var args = new AIFunctionArguments
+            {
+                ["code"] =
+                    $"import os\nprint(os.environ.get('{childVariableName}', 'NOT_FOUND'))\n" +
+                    $"print(os.environ.get('{parentVariableName}', 'NOT_FOUND'))",
+            };
+
+            // Act
+            var result = await function.InvokeAsync(args, CancellationToken.None);
+
+            // Assert
+            var combined = GetResultText(result);
+            Assert.Contains(childValue, combined, StringComparison.Ordinal);
+            Assert.Contains("NOT_FOUND", combined, StringComparison.Ordinal);
+            Assert.DoesNotContain(parentValue, combined, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(parentVariableName, originalValue);
+        }
+    }
+
+    [Fact]
     public async Task ExecuteCode_CapturesFilesInWritableMountAsync()
     {
         SkipIfNoPython();


### PR DESCRIPTION
### Motivation & Context

LocalCodeAct documents subprocesses as receiving only explicitly provided environment variables. Process startup should consistently honor that contract for both default and configured usage.

### Description & Review Guide

- **What are the major changes?** Clear the subprocess environment before applying explicitly configured variables, retain the narrow set of Windows variables required for Python startup, align the public option documentation, and add regression coverage for default and explicit environments.
- **What is the impact of these changes?** Subprocesses no longer inherit the parent environment by default. Callers that require environment variables must provide them through `LocalCodeActProviderOptions.Environment`.
- **What do you want reviewers to focus on?** The environment setup in `ProcessBridge` and the Windows bootstrap-variable compatibility behavior.

### Related Issue

N/A

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [ ] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.