### PR TITLE
.NET: fix: do not forward headers on redirect

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -148,14 +148,9 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
                 .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveToken)
                 .ConfigureAwait(false);
 
-            if (TryCreateRedirectRequest(httpResponse, currentRequest, currentUri, out HttpRequestInfo? redirectRequest, out Uri? redirectUri))
+            if (providedClient is null &&
+                TryCreateRedirectRequest(httpResponse, currentRequest, currentUri, out HttpRequestInfo? redirectRequest, out Uri? redirectUri))
             {
-                if (providedClient is not null)
-                {
-                    throw new InvalidOperationException(
-                        "DefaultHttpRequestHandler cannot safely follow redirects when using a caller-supplied HttpClient because the client's redirect behavior is opaque. Use the handler-owned client for redirect handling, or handle redirects with an origin-pinned transport before returning the response.");
-                }
-
                 currentRequest = redirectRequest;
                 currentUri = redirectUri;
                 continue;

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -291,6 +291,10 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
         }
 
         bool rewriteToGet = ShouldRewriteRedirectMethodToGet(response.StatusCode, currentRequest.Method);
+        if (!rewriteToGet && currentRequest.Body is not null && !HaveSameOrigin(currentUri, redirectUri))
+        {
+            throw new HttpRequestException("Redirects that preserve the request body to a different origin are not allowed.");
+        }
 
         redirectRequest = new HttpRequestInfo
         {
@@ -321,6 +325,14 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
     private static bool IsHttpsToHttpRedirect(Uri currentUri, Uri redirectUri) =>
         string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
+
+    private static bool HaveSameOrigin(Uri currentUri, Uri redirectUri) =>
+        Uri.Compare(
+            currentUri,
+            redirectUri,
+            UriComponents.SchemeAndServer,
+            UriFormat.Unescaped,
+            StringComparison.OrdinalIgnoreCase) == 0;
 
     private static HttpMethod ResolveMethod(string method)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -284,6 +284,11 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
             ? response.Headers.Location
             : new Uri(currentUri, response.Headers.Location);
 
+        if (IsHttpsToHttpRedirect(currentUri, redirectUri))
+        {
+            throw new HttpRequestException("Redirects from HTTPS to HTTP are not allowed.");
+        }
+
         bool rewriteToGet = ShouldRewriteRedirectMethodToGet(response.StatusCode, currentRequest.Method);
 
         redirectRequest = new HttpRequestInfo
@@ -311,6 +316,10 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
         int code = (int)statusCode;
         return code == 303 || ((code == 301 || code == 302) && string.Equals(normalized, "POST", StringComparison.Ordinal));
     }
+
+    private static bool IsHttpsToHttpRedirect(Uri currentUri, Uri redirectUri) =>
+        string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
 
     private static void ThrowIfUnsafeProvidedClientHeaders(HttpClient providedClient, HttpRequestInfo request)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// <para>
 /// Redirects are handled by this handler only when using its internally owned client, which disables automatic
 /// redirects so per-request headers are not forwarded to redirect destinations. If a supplied client returns a
-/// redirect response, this handler rejects it because the client's redirect behavior is opaque. Supplied clients
-/// should disable automatic redirects and handle redirect responses before returning them to this handler.
+/// redirect response, this handler does not follow it because the client's redirect behavior is opaque. Supplied
+/// clients should disable automatic redirects and handle redirect responses before returning them to this handler.
 /// </para>
 /// </remarks>
 public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDisposable

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// so it does not mutate <see cref="HttpClient.Timeout"/> on shared instances.
 /// </para>
 /// <para>
-/// Redirects are handled by this handler so per-request headers are not forwarded to redirect destinations. The
-/// internally owned client disables automatic redirects. Supplied clients should also disable automatic
-/// redirects and handle redirect responses before returning them to this handler because their redirect behavior
-/// is opaque to this handler.
+/// Redirects are handled by this handler only when using its internally owned client, which disables automatic
+/// redirects so per-request headers are not forwarded to redirect destinations. If a supplied client returns a
+/// redirect response, this handler rejects it because the client's redirect behavior is opaque. Supplied clients
+/// should disable automatic redirects and handle redirect responses before returning them to this handler.
 /// </para>
 /// </remarks>
 public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDisposable

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// <para>
 /// Redirects are handled by this handler so per-request headers are not forwarded to redirect destinations. The
 /// internally owned client disables automatic redirects. Supplied clients should also disable automatic
-/// redirects; clients with credential-bearing default headers are rejected because their redirect behavior is
-/// opaque to this handler.
+/// redirects and handle redirect responses before returning them to this handler because their redirect behavior
+/// is opaque to this handler.
 /// </para>
 /// </remarks>
 public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDisposable
@@ -140,11 +140,6 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
                 providedClient = await this._httpClientProvider(currentRequest, effectiveToken).ConfigureAwait(false);
             }
 
-            if (providedClient is not null && redirectCount > 0)
-            {
-                ThrowIfUnsafeProvidedClientHeaders(providedClient, currentRequest);
-            }
-
             HttpClient client = providedClient ?? this._ownedHttpClient.Value;
 
             using HttpRequestMessage httpRequest = BuildHttpRequestMessage(currentRequest);
@@ -155,6 +150,12 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
 
             if (TryCreateRedirectRequest(httpResponse, currentRequest, currentUri, out HttpRequestInfo? redirectRequest, out Uri? redirectUri))
             {
+                if (providedClient is not null)
+                {
+                    throw new InvalidOperationException(
+                        "DefaultHttpRequestHandler cannot safely follow redirects when using a caller-supplied HttpClient because the client's redirect behavior is opaque. Use the handler-owned client for redirect handling, or handle redirects with an origin-pinned transport before returning the response.");
+                }
+
                 currentRequest = redirectRequest;
                 currentUri = redirectUri;
                 continue;
@@ -320,33 +321,6 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
     private static bool IsHttpsToHttpRedirect(Uri currentUri, Uri redirectUri) =>
         string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
-
-    private static void ThrowIfUnsafeProvidedClientHeaders(HttpClient providedClient, HttpRequestInfo request)
-    {
-        if (providedClient.DefaultRequestHeaders.Any(header => IsSensitiveHeaderName(header.Key)))
-        {
-            throw new InvalidOperationException(
-                "DefaultHttpRequestHandler cannot safely use a provided HttpClient with credential-bearing DefaultRequestHeaders because the client may forward them during automatic redirects. Configure credentials with an origin-pinning handler that disables automatic redirects.");
-        }
-
-        if (request.Headers?.Keys.Any(IsCustomCredentialHeaderName) == true)
-        {
-            throw new InvalidOperationException(
-                "DefaultHttpRequestHandler cannot safely send credential-bearing request headers through a provided HttpClient because the client may forward them during automatic redirects. Use the handler-owned client or configure an origin-pinning handler that disables automatic redirects.");
-        }
-    }
-
-    private static bool IsSensitiveHeaderName(string headerName) =>
-        string.Equals(headerName, "Authorization", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(headerName, "Proxy-Authorization", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(headerName, "Cookie", StringComparison.OrdinalIgnoreCase) ||
-        IsCustomCredentialHeaderName(headerName);
-
-    private static bool IsCustomCredentialHeaderName(string headerName) =>
-        headerName.Contains("Api-Key", StringComparison.OrdinalIgnoreCase) ||
-        headerName.Contains("Token", StringComparison.OrdinalIgnoreCase) ||
-        headerName.Contains("Secret", StringComparison.OrdinalIgnoreCase) ||
-        headerName.Contains("Credential", StringComparison.OrdinalIgnoreCase);
 
     private static HttpMethod ResolveMethod(string method)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// The handler applies the per-request <see cref="HttpRequestInfo.Timeout"/> using a linked <see cref="CancellationTokenSource"/>
 /// so it does not mutate <see cref="HttpClient.Timeout"/> on shared instances.
 /// </para>
+/// <para>
 /// Redirects are handled by this handler so per-request headers are not forwarded to redirect destinations. The
 /// internally owned client disables automatic redirects. Supplied clients should also disable automatic
 /// redirects; clients with credential-bearing default headers are rejected because their redirect behavior is

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -24,9 +26,17 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// The handler applies the per-request <see cref="HttpRequestInfo.Timeout"/> using a linked <see cref="CancellationTokenSource"/>
 /// so it does not mutate <see cref="HttpClient.Timeout"/> on shared instances.
 /// </para>
+/// <para>
+/// Redirects are handled by this handler so request credentials are not forwarded to a different origin. The
+/// internally owned client disables automatic redirects. Supplied clients should also disable automatic
+/// redirects; clients with credential-bearing default headers are rejected because their redirect behavior is
+/// opaque to this handler.
+/// </para>
 /// </remarks>
 public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDisposable
 {
+    private const int MaxAutomaticRedirections = 50;
+
     private readonly Func<HttpRequestInfo, CancellationToken, Task<HttpClient?>>? _httpClientProvider;
     private readonly Lazy<HttpClient> _ownedHttpClient;
 
@@ -80,7 +90,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
     public DefaultHttpRequestHandler(Func<HttpRequestInfo, CancellationToken, Task<HttpClient?>>? httpClientProvider)
     {
         this._httpClientProvider = httpClientProvider;
-        this._ownedHttpClient = new Lazy<HttpClient>(() => new HttpClient(), LazyThreadSafetyMode.ExecutionAndPublication);
+        this._ownedHttpClient = new Lazy<HttpClient>(CreateOwnedHttpClient, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     private static Func<HttpRequestInfo, CancellationToken, Task<HttpClient?>> CreateSingleClientProvider(HttpClient httpClient)
@@ -111,50 +121,70 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
             throw new ArgumentException("Request method must be provided.", nameof(request));
         }
 
-        HttpClient? providedClient = null;
-        if (this._httpClientProvider is not null)
+        HttpRequestInfo currentRequest = request;
+        Uri currentUri = CreateAbsoluteUri(ResolveRequestUri(request));
+
+        for (int redirectCount = 0; redirectCount <= MaxAutomaticRedirections; redirectCount++)
         {
-            providedClient = await this._httpClientProvider(request, cancellationToken).ConfigureAwait(false);
-        }
+            HttpClient? providedClient = null;
+            if (this._httpClientProvider is not null)
+            {
+                providedClient = await this._httpClientProvider(currentRequest, cancellationToken).ConfigureAwait(false);
+            }
 
-        HttpClient client = providedClient ?? this._ownedHttpClient.Value;
+            if (providedClient is not null)
+            {
+                ThrowIfUnsafeProvidedClientHeaders(providedClient, currentRequest);
+            }
 
-        using HttpRequestMessage httpRequest = BuildHttpRequestMessage(request);
+            HttpClient client = providedClient ?? this._ownedHttpClient.Value;
 
-        using CancellationTokenSource? timeoutCts = request.Timeout is { } timeout && timeout > TimeSpan.Zero
-            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-            : null;
+            using HttpRequestMessage httpRequest = BuildHttpRequestMessage(currentRequest);
 
-        timeoutCts?.CancelAfter(request.Timeout!.Value);
+            using CancellationTokenSource? timeoutCts = currentRequest.Timeout is { } timeout && timeout > TimeSpan.Zero
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : null;
 
-        CancellationToken effectiveToken = timeoutCts?.Token ?? cancellationToken;
+            timeoutCts?.CancelAfter(currentRequest.Timeout!.Value);
 
-        using HttpResponseMessage httpResponse = await client
-            .SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead, effectiveToken)
-            .ConfigureAwait(false);
+            CancellationToken effectiveToken = timeoutCts?.Token ?? cancellationToken;
 
-        string? body = httpResponse.Content is null
-            ? null
+            using HttpResponseMessage httpResponse = await client
+                .SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead, effectiveToken)
+                .ConfigureAwait(false);
+
+            if (TryCreateRedirectRequest(httpResponse, currentRequest, currentUri, out HttpRequestInfo? redirectRequest, out Uri? redirectUri))
+            {
+                currentRequest = redirectRequest;
+                currentUri = redirectUri;
+                continue;
+            }
+
+            string? body = httpResponse.Content is null
+                ? null
 #if NET
-            : await httpResponse.Content.ReadAsStringAsync(effectiveToken).ConfigureAwait(false);
+                : await httpResponse.Content.ReadAsStringAsync(effectiveToken).ConfigureAwait(false);
 #else
-            : await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                : await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
 
-        Dictionary<string, IReadOnlyList<string>> headers = new(StringComparer.OrdinalIgnoreCase);
-        AppendHeaders(headers, httpResponse.Headers);
-        if (httpResponse.Content is not null)
-        {
-            AppendHeaders(headers, httpResponse.Content.Headers);
+            Dictionary<string, IReadOnlyList<string>> headers = new(StringComparer.OrdinalIgnoreCase);
+            AppendHeaders(headers, httpResponse.Headers);
+            if (httpResponse.Content is not null)
+            {
+                AppendHeaders(headers, httpResponse.Content.Headers);
+            }
+
+            return new HttpRequestResult
+            {
+                StatusCode = (int)httpResponse.StatusCode,
+                IsSuccessStatusCode = httpResponse.IsSuccessStatusCode,
+                Body = body,
+                Headers = headers,
+            };
         }
 
-        return new HttpRequestResult
-        {
-            StatusCode = (int)httpResponse.StatusCode,
-            IsSuccessStatusCode = httpResponse.IsSuccessStatusCode,
-            Body = body,
-            Headers = headers,
-        };
+        throw new HttpRequestException($"The maximum number of HTTP redirects ({MaxAutomaticRedirections}) was exceeded.");
     }
 
     /// <inheritdoc/>
@@ -212,6 +242,102 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
 
         return httpRequest;
     }
+
+    private static HttpClient CreateOwnedHttpClient()
+    {
+        HttpClientHandler handler = new()
+        {
+            AllowAutoRedirect = false,
+            UseCookies = false,
+            CheckCertificateRevocationList = true
+        };
+
+        return new HttpClient(handler);
+    }
+
+    private static Uri CreateAbsoluteUri(string requestUri)
+    {
+        if (!Uri.TryCreate(requestUri, UriKind.Absolute, out Uri? uri))
+        {
+            throw new ArgumentException("Request URL must be an absolute URL.");
+        }
+
+        return uri;
+    }
+
+    private static bool TryCreateRedirectRequest(
+        HttpResponseMessage response,
+        HttpRequestInfo currentRequest,
+        Uri currentUri,
+        [NotNullWhen(true)] out HttpRequestInfo? redirectRequest,
+        [NotNullWhen(true)] out Uri? redirectUri)
+    {
+        redirectRequest = null;
+        redirectUri = null;
+
+        if (!IsRedirectStatusCode(response.StatusCode) || response.Headers.Location is null)
+        {
+            return false;
+        }
+
+        redirectUri = response.Headers.Location.IsAbsoluteUri
+            ? response.Headers.Location
+            : new Uri(currentUri, response.Headers.Location);
+
+        bool rewriteToGet = ShouldRewriteRedirectMethodToGet(response.StatusCode, currentRequest.Method);
+
+        redirectRequest = new HttpRequestInfo
+        {
+            Method = rewriteToGet ? "GET" : currentRequest.Method,
+            Url = redirectUri.ToString(),
+            Body = rewriteToGet ? null : currentRequest.Body,
+            BodyContentType = rewriteToGet ? null : currentRequest.BodyContentType,
+            Timeout = currentRequest.Timeout,
+            ConnectionName = currentRequest.ConnectionName,
+        };
+
+        return true;
+    }
+
+    private static bool IsRedirectStatusCode(HttpStatusCode statusCode)
+    {
+        int code = (int)statusCode;
+        return code is 301 or 302 or 303 or 307 or 308;
+    }
+
+    private static bool ShouldRewriteRedirectMethodToGet(HttpStatusCode statusCode, string method)
+    {
+        string normalized = method.Trim().ToUpperInvariant();
+        int code = (int)statusCode;
+        return code == 303 || ((code == 301 || code == 302) && string.Equals(normalized, "POST", StringComparison.Ordinal));
+    }
+
+    private static void ThrowIfUnsafeProvidedClientHeaders(HttpClient providedClient, HttpRequestInfo request)
+    {
+        if (providedClient.DefaultRequestHeaders.Any(header => IsSensitiveHeaderName(header.Key)))
+        {
+            throw new InvalidOperationException(
+                "DefaultHttpRequestHandler cannot safely use a provided HttpClient with credential-bearing DefaultRequestHeaders because the client may forward them during automatic redirects. Configure credentials with an origin-pinning handler that disables automatic redirects.");
+        }
+
+        if (request.Headers?.Keys.Any(IsCustomCredentialHeaderName) == true)
+        {
+            throw new InvalidOperationException(
+                "DefaultHttpRequestHandler cannot safely send credential-bearing request headers through a provided HttpClient because the client may forward them during automatic redirects. Use the handler-owned client or configure an origin-pinning handler that disables automatic redirects.");
+        }
+    }
+
+    private static bool IsSensitiveHeaderName(string headerName) =>
+        string.Equals(headerName, "Authorization", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(headerName, "Proxy-Authorization", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(headerName, "Cookie", StringComparison.OrdinalIgnoreCase) ||
+        IsCustomCredentialHeaderName(headerName);
+
+    private static bool IsCustomCredentialHeaderName(string headerName) =>
+        headerName.Contains("Api-Key", StringComparison.OrdinalIgnoreCase) ||
+        headerName.Contains("Token", StringComparison.OrdinalIgnoreCase) ||
+        headerName.Contains("Secret", StringComparison.OrdinalIgnoreCase) ||
+        headerName.Contains("Credential", StringComparison.OrdinalIgnoreCase);
 
     private static HttpMethod ResolveMethod(string method)
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -163,11 +163,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
 
             string? body = httpResponse.Content is null
                 ? null
-#if NET
-                : await httpResponse.Content.ReadAsStringAsync(effectiveToken).ConfigureAwait(false);
-#else
-                : await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-#endif
+                : await ReadResponseBodyAsStringAsync(httpResponse.Content, effectiveToken).ConfigureAwait(false);
 
             Dictionary<string, IReadOnlyList<string>> headers = new(StringComparer.OrdinalIgnoreCase);
             AppendHeaders(headers, httpResponse.Headers);
@@ -186,6 +182,31 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
         }
 
         throw new HttpRequestException($"The maximum number of HTTP redirects ({MaxAutomaticRedirections}) was exceeded.");
+    }
+
+    private static async Task<string> ReadResponseBodyAsStringAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+#if NET
+        return await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+        Task<string> readTask = content.ReadAsStringAsync();
+        Task cancellationTask = Task.Delay(Timeout.Infinite, cancellationToken);
+        Task completedTask = await Task.WhenAny(readTask, cancellationTask).ConfigureAwait(false);
+        if (completedTask == readTask)
+        {
+            return await readTask.ConfigureAwait(false);
+        }
+
+        content.Dispose();
+        _ = readTask.ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        throw new OperationCanceledException(cancellationToken);
+#endif
     }
 
     /// <inheritdoc/>

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -140,7 +140,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
                 providedClient = await this._httpClientProvider(currentRequest, effectiveToken).ConfigureAwait(false);
             }
 
-            if (providedClient is not null)
+            if (providedClient is not null && redirectCount > 0)
             {
                 ThrowIfUnsafeProvidedClientHeaders(providedClient, currentRequest);
             }

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -150,7 +150,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
             CancellationToken effectiveToken = timeoutCts?.Token ?? cancellationToken;
 
             using HttpResponseMessage httpResponse = await client
-                .SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead, effectiveToken)
+                .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveToken)
                 .ConfigureAwait(false);
 
             if (TryCreateRedirectRequest(httpResponse, currentRequest, currentUri, out HttpRequestInfo? redirectRequest, out Uri? redirectUri))

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -258,7 +258,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
     {
         if (!Uri.TryCreate(requestUri, UriKind.Absolute, out Uri? uri))
         {
-            throw new ArgumentException("Request URL must be an absolute URL.");
+            throw new ArgumentException("Request URL must be an absolute URL.", nameof(requestUri));
         }
 
         return uri;

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Agents.AI.Workflows.Declarative;
 /// The handler applies the per-request <see cref="HttpRequestInfo.Timeout"/> using a linked <see cref="CancellationTokenSource"/>
 /// so it does not mutate <see cref="HttpClient.Timeout"/> on shared instances.
 /// </para>
-/// <para>
-/// Redirects are handled by this handler so request credentials are not forwarded to a different origin. The
+/// Redirects are handled by this handler so per-request headers are not forwarded to redirect destinations. The
 /// internally owned client disables automatic redirects. Supplied clients should also disable automatic
 /// redirects; clients with credential-bearing default headers are rejected because their redirect behavior is
 /// opaque to this handler.

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -124,12 +124,20 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
         HttpRequestInfo currentRequest = request;
         Uri currentUri = CreateAbsoluteUri(ResolveRequestUri(request));
 
+        using CancellationTokenSource? timeoutCts = request.Timeout is { } timeout && timeout > TimeSpan.Zero
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : null;
+
+        timeoutCts?.CancelAfter(request.Timeout!.Value);
+
+        CancellationToken effectiveToken = timeoutCts?.Token ?? cancellationToken;
+
         for (int redirectCount = 0; redirectCount <= MaxAutomaticRedirections; redirectCount++)
         {
             HttpClient? providedClient = null;
             if (this._httpClientProvider is not null)
             {
-                providedClient = await this._httpClientProvider(currentRequest, cancellationToken).ConfigureAwait(false);
+                providedClient = await this._httpClientProvider(currentRequest, effectiveToken).ConfigureAwait(false);
             }
 
             if (providedClient is not null)
@@ -140,14 +148,6 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
             HttpClient client = providedClient ?? this._ownedHttpClient.Value;
 
             using HttpRequestMessage httpRequest = BuildHttpRequestMessage(currentRequest);
-
-            using CancellationTokenSource? timeoutCts = currentRequest.Timeout is { } timeout && timeout > TimeSpan.Zero
-                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
-                : null;
-
-            timeoutCts?.CancelAfter(currentRequest.Timeout!.Value);
-
-            CancellationToken effectiveToken = timeoutCts?.Token ?? cancellationToken;
 
             using HttpResponseMessage httpResponse = await client
                 .SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, effectiveToken)

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -508,7 +508,9 @@ public sealed class DefaultHttpRequestHandlerTests
             };
 
             createdResponses.Add(response);
+#pragma warning disable CA2025
             return Task.FromResult(response);
+#pragma warning restore CA2025
         });
 
         try

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -838,7 +838,7 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
-    public async Task SendAsyncSuppliedClientRejectsRedirectResponseAsync()
+    public async Task SendAsyncSuppliedClientReturnsRedirectResponseAsync()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
@@ -869,11 +869,13 @@ public sealed class DefaultHttpRequestHandlerTests
         };
 
         // Act
-        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
 
         // Assert
-        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(actAsync);
-        Assert.Contains("caller-supplied HttpClient", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(307, result.StatusCode);
+        Assert.False(result.IsSuccessStatusCode);
+        Assert.NotNull(result.Headers);
+        Assert.Equal("https://secondary.example.test/next", Assert.Single(result.Headers!["Location"]));
         Assert.Equal(1, providerCallCount);
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -366,6 +366,48 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
+    public async Task SendAsyncTimeoutAppliesAcrossRedirectsAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        int requestCount = 0;
+        TestHttpMessageHandler messageHandler = new(async (req, ct) =>
+        {
+            requestCount++;
+            await Task.Delay(TimeSpan.FromMilliseconds(200), ct).ConfigureAwait(false);
+
+            if (requestCount == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+                {
+                    Headers = { Location = new Uri("https://api.example.test/next") },
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
+            };
+        });
+
+        using HttpClient client = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new(client);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+            Timeout = TimeSpan.FromMilliseconds(300),
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(actAsync);
+        Assert.Equal(2, requestCount);
+    }
+
+    [Fact]
     public async Task SendAsyncFallsBackToOwnedClientWhenProviderReturnsNullAsync()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -498,29 +498,43 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         int requestCount = 0;
+        List<HttpResponseMessage> createdResponses = [];
         TestHttpMessageHandler messageHandler = new((_, _) =>
         {
             requestCount++;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect)
             {
                 Headers = { Location = new Uri($"https://api.example.test/redirect/{requestCount}") },
-            });
+            };
+
+            createdResponses.Add(response);
+            return Task.FromResult(response);
         });
 
-        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
-        HttpRequestInfo request = new()
+        try
         {
-            Method = "GET",
-            Url = TestUrl,
-        };
+            await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
+            HttpRequestInfo request = new()
+            {
+                Method = "GET",
+                Url = TestUrl,
+            };
 
-        // Act
-        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+            // Act
+            async Task actAsync() => await handler.SendAsync(request, cancellationToken);
 
-        // Assert
-        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(actAsync);
-        Assert.Contains("maximum number of HTTP redirects", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(51, requestCount);
+            // Assert
+            HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(actAsync);
+            Assert.Contains("maximum number of HTTP redirects", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(51, requestCount);
+        }
+        finally
+        {
+            foreach (HttpResponseMessage response in createdResponses)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -381,7 +381,8 @@ public sealed class DefaultHttpRequestHandlerTests
             });
         });
 
-        await using DefaultHttpRequestHandler handler = new((_, _) => Task.FromResult<HttpClient?>(new HttpClient(messageHandler)));
+        using HttpClient httpClient = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new((_, _) => Task.FromResult<HttpClient?>(httpClient));
         HttpRequestInfo request = new()
         {
             Method = "GET",

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -392,8 +393,7 @@ public sealed class DefaultHttpRequestHandlerTests
             return okResponse;
         });
 
-        using HttpClient client = new(messageHandler);
-        await using DefaultHttpRequestHandler handler = new(client);
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
         HttpRequestInfo request = new()
         {
             Method = "GET",
@@ -457,8 +457,7 @@ public sealed class DefaultHttpRequestHandlerTests
         });
 #pragma warning restore CA2025
 
-        using HttpClient client = new(messageHandler);
-        await using DefaultHttpRequestHandler handler = new(client);
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
         HttpRequestInfo request = new()
         {
             Method = "GET",
@@ -483,6 +482,7 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         List<bool> requestsWithHeader = [];
+        List<string> requestUrls = [];
         using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
         {
             Headers = { Location = new Uri("https://secondary.example.test/next") },
@@ -492,29 +492,15 @@ public sealed class DefaultHttpRequestHandlerTests
             Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
         };
 #pragma warning disable CA2025
-        TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
+        TestHttpMessageHandler messageHandler = new((req, _) =>
         {
+            requestUrls.Add(req.RequestUri!.ToString());
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
-            return Task.FromResult(redirectResponse);
-        });
-        TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
-        {
-            requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
-            return Task.FromResult(okResponse);
+            return Task.FromResult(requestUrls.Count == 1 ? redirectResponse : okResponse);
         });
 #pragma warning restore CA2025
 
-        using HttpClient primaryClient = new(primaryMessageHandler);
-        using HttpClient secondaryClient = new(secondaryMessageHandler);
-#pragma warning disable CA2025
-        await using DefaultHttpRequestHandler handler = new((info, _) =>
-        {
-            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
-                ? primaryClient
-                : secondaryClient;
-            return Task.FromResult<HttpClient?>(client);
-        });
-#pragma warning restore CA2025
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
 
         HttpRequestInfo request = new()
         {
@@ -532,6 +518,7 @@ public sealed class DefaultHttpRequestHandlerTests
         // Assert
         Assert.Equal("redirected", result.Body);
         Assert.Equal([true, false], requestsWithHeader);
+        Assert.Equal([TestUrl, "https://secondary.example.test/next"], requestUrls);
     }
 
     [Fact]
@@ -561,8 +548,7 @@ public sealed class DefaultHttpRequestHandlerTests
         });
 #pragma warning restore CA2025
 
-        using HttpClient client = new(messageHandler);
-        await using DefaultHttpRequestHandler handler = new(client);
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
         HttpRequestInfo request = new()
         {
             Method = "GET",
@@ -595,8 +581,7 @@ public sealed class DefaultHttpRequestHandlerTests
         });
 #pragma warning restore CA2025
 
-        using HttpClient client = new(messageHandler);
-        await using DefaultHttpRequestHandler handler = new(client);
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
         HttpRequestInfo request = new()
         {
             Method = "POST",
@@ -654,7 +639,7 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
-    public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersOnRedirectedRequestAsync()
+    public async Task SendAsyncSuppliedClientRejectsRedirectResponseAsync()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
@@ -667,18 +652,14 @@ public sealed class DefaultHttpRequestHandlerTests
             Task.FromResult(redirectResponse));
 #pragma warning restore CA2025
         using HttpClient primaryClient = new(primaryMessageHandler);
-        using HttpClient secondaryClient = new();
-        secondaryClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
+        primaryClient.DefaultRequestHeaders.TryAddWithoutValidation("Ocp-Apim-Subscription-Key", "provider-header-value");
 
         int providerCallCount = 0;
 #pragma warning disable CA2025
-        await using DefaultHttpRequestHandler handler = new((info, _) =>
+        await using DefaultHttpRequestHandler handler = new((_, _) =>
         {
             providerCallCount++;
-            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
-                ? primaryClient
-                : secondaryClient;
-            return Task.FromResult<HttpClient?>(client);
+            return Task.FromResult<HttpClient?>(primaryClient);
         });
 #pragma warning restore CA2025
 
@@ -693,8 +674,8 @@ public sealed class DefaultHttpRequestHandlerTests
 
         // Assert
         InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(actAsync);
-        Assert.Contains("DefaultRequestHeaders", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(2, providerCallCount);
+        Assert.Contains("caller-supplied HttpClient", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, providerCallCount);
     }
 
     [Fact]
@@ -702,6 +683,8 @@ public sealed class DefaultHttpRequestHandlerTests
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        List<string> providerUrls = [];
+        List<string> requestUrls = [];
         using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
         {
             Headers = { Location = new Uri("https://secondary.example.test/next") },
@@ -711,25 +694,18 @@ public sealed class DefaultHttpRequestHandlerTests
             Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
         };
 #pragma warning disable CA2025
-        TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
-            Task.FromResult(redirectResponse));
-        TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
-            Task.FromResult(okResponse));
-#pragma warning restore CA2025
-
-        using HttpClient primaryClient = new(primaryMessageHandler);
-        using HttpClient secondaryClient = new(secondaryMessageHandler);
-        List<string> providerUrls = [];
-#pragma warning disable CA2025
-        await using DefaultHttpRequestHandler handler = new((info, _) =>
+        TestHttpMessageHandler messageHandler = new((req, _) =>
         {
-            providerUrls.Add(info.Url);
-            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
-                ? primaryClient
-                : secondaryClient;
-            return Task.FromResult<HttpClient?>(client);
+            requestUrls.Add(req.RequestUri!.ToString());
+            return Task.FromResult(requestUrls.Count == 1 ? redirectResponse : okResponse);
         });
 #pragma warning restore CA2025
+
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler, (info, _) =>
+        {
+            providerUrls.Add(info.Url);
+            return Task.FromResult<HttpClient?>(null);
+        });
 
         HttpRequestInfo request = new()
         {
@@ -745,6 +721,7 @@ public sealed class DefaultHttpRequestHandlerTests
         Assert.Equal(2, providerUrls.Count);
         Assert.Equal(TestUrl, providerUrls[0]);
         Assert.Equal("https://secondary.example.test/next", providerUrls[1]);
+        Assert.Equal(providerUrls, requestUrls);
     }
 
     #endregion
@@ -837,6 +814,16 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     #endregion
+
+    private static DefaultHttpRequestHandler CreateHandlerWithOwnedMessageHandler(
+        HttpMessageHandler ownedHttpMessageHandler,
+        Func<HttpRequestInfo, CancellationToken, Task<HttpClient?>>? httpClientProvider = null)
+    {
+        DefaultHttpRequestHandler handler = new(httpClientProvider);
+        FieldInfo ownedHttpClientField = typeof(DefaultHttpRequestHandler).GetField("_ownedHttpClient", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        ownedHttpClientField.SetValue(handler, new Lazy<HttpClient>(() => new HttpClient(ownedHttpMessageHandler), LazyThreadSafetyMode.ExecutionAndPublication));
+        return handler;
+    }
 
     private sealed class TestHttpMessageHandler : HttpMessageHandler
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -367,6 +367,37 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
+    public async Task SendAsyncTimeoutCancelsResponseBodyReadAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        int requestCount = 0;
+        TestHttpMessageHandler messageHandler = new((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StallingContent(),
+            });
+        });
+
+        await using DefaultHttpRequestHandler handler = new((_, _) => Task.FromResult<HttpClient?>(new HttpClient(messageHandler)));
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+            Timeout = TimeSpan.FromMilliseconds(50),
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(actAsync);
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
     public async Task SendAsyncTimeoutAppliesAcrossRedirectsAsync()
     {
         // Arrange
@@ -1057,6 +1088,23 @@ public sealed class DefaultHttpRequestHandlerTests
         {
             length = Encoding.UTF8.GetByteCount(this._content);
             return true;
+        }
+    }
+
+    private sealed class StallingContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.Delay(Timeout.Infinite);
+
+#if NET
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
+            Task.Delay(Timeout.Infinite, cancellationToken);
+#endif
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -570,6 +570,42 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
+    public async Task SendAsyncRejectsHttpsToHttpRedirectAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        int requestCount = 0;
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((req, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri("http://api.example.test/next") },
+            });
+        });
+#pragma warning restore CA2025
+
+        using HttpClient client = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new(client);
+        HttpRequestInfo request = new()
+        {
+            Method = "POST",
+            Url = TestUrl,
+            Body = "request-body",
+            BodyContentType = "text/plain",
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(actAsync);
+        Assert.Contains("HTTPS to HTTP", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
     public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersAsync()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -492,6 +492,44 @@ public sealed class DefaultHttpRequestHandlerTests
         Assert.Equal(["request-body", "request-body"], messageHandler.RequestBodies);
     }
 
+    [Theory]
+    [InlineData(307)]
+    [InlineData(308)]
+    public async Task SendAsyncPostPreserveMethodRedirectToDifferentOriginWithBodyThrowsAsync(int redirectStatusCode)
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        int requestCount = 0;
+        using HttpResponseMessage redirectResponse = new((HttpStatusCode)redirectStatusCode)
+        {
+            Headers = { Location = new Uri("https://secondary.example.test/next") },
+        };
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(redirectResponse);
+        });
+#pragma warning restore CA2025
+
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
+        HttpRequestInfo request = new()
+        {
+            Method = "POST",
+            Url = TestUrl,
+            Body = "request-body",
+            BodyContentType = "text/plain",
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(actAsync);
+        Assert.Contains("preserve the request body to a different origin", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, requestCount);
+    }
+
     [Fact]
     public async Task SendAsyncTooManyRedirectsThrowsAsync()
     {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -397,9 +397,10 @@ public sealed class DefaultHttpRequestHandlerTests
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
             if (requestsWithHeader.Count == 1)
             {
-                HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
-                response.Headers.Location = new Uri("https://api.example.test/next");
-                return Task.FromResult(response);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+                {
+                    Headers = { Location = new Uri("https://api.example.test/next") },
+                });
             }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
@@ -439,9 +440,10 @@ public sealed class DefaultHttpRequestHandlerTests
         TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
         {
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
-            HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
-            response.Headers.Location = new Uri("https://secondary.example.test/next");
-            return Task.FromResult(response);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri("https://secondary.example.test/next") },
+            });
         });
         TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
         {
@@ -523,9 +525,10 @@ public sealed class DefaultHttpRequestHandlerTests
 #pragma warning disable CA2025
         TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
         {
-            HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
-            response.Headers.Location = new Uri("https://secondary.example.test/next");
-            return Task.FromResult(response);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri("https://secondary.example.test/next") },
+            });
         });
         TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -1095,8 +1095,10 @@ public sealed class DefaultHttpRequestHandlerTests
 
     private sealed class StallingContent : HttpContent
     {
+        private readonly TaskCompletionSource<object?> _stall = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            Task.Delay(Timeout.Infinite);
+            this._stall.Task;
 
 #if NET
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
@@ -1107,6 +1109,16 @@ public sealed class DefaultHttpRequestHandlerTests
         {
             length = 0;
             return false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this._stall.TrySetCanceled();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -486,6 +487,47 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
+    public async Task SendAsyncDoesNotReadRedirectedResponseBodyAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        TrackingContent redirectedContent = new("not returned");
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((req, _) =>
+        {
+            if (req.RequestUri!.AbsolutePath == "/resource")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+                {
+                    Content = redirectedContent,
+                    Headers = { Location = new Uri("https://api.example.test/next") },
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+            });
+        });
+#pragma warning restore CA2025
+
+        using HttpClient client = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new(client);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.False(redirectedContent.WasRead);
+    }
+
+    [Fact]
     public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersAsync()
     {
         // Arrange
@@ -686,6 +728,31 @@ public sealed class DefaultHttpRequestHandlerTests
                 this.LastRequestContentType = request.Content.Headers.ContentType?.MediaType;
             }
             return await this._responseFactory(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class TrackingContent : HttpContent
+    {
+        private readonly string _content;
+
+        public TrackingContent(string content)
+        {
+            this._content = content;
+        }
+
+        public bool WasRead { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            this.WasRead = true;
+            byte[] bytes = Encoding.UTF8.GetBytes(this._content);
+            return stream.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Encoding.UTF8.GetByteCount(this._content);
+            return true;
         }
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -385,6 +386,173 @@ public sealed class DefaultHttpRequestHandlerTests
         Assert.Equal(1, providerCallCount);
     }
 
+    [Fact]
+    public async Task SendAsyncOwnedClientDoesNotForwardRequestHeadersToRedirectedEndpointAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        const string HeaderValue = "request-header-value";
+        List<string> forwardedHeaderValues = [];
+        await using LoopbackServer secondaryEndpoint = await LoopbackServer.StartAsync(async (context, ct) =>
+        {
+            forwardedHeaderValues.AddRange(context.Request.Headers.GetValues("X-Request-Token") ?? []);
+            await WriteResponseAsync(context, HttpStatusCode.OK, "redirect-ok", ct);
+        }, cancellationToken);
+
+        await using LoopbackServer primaryEndpoint = await LoopbackServer.StartAsync((context, _) =>
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
+            context.Response.RedirectLocation = new Uri(secondaryEndpoint.BaseUri, "next").ToString();
+            context.Response.Close();
+            return Task.CompletedTask;
+        }, cancellationToken);
+
+        await using DefaultHttpRequestHandler handler = new();
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = new Uri(primaryEndpoint.BaseUri, "redirect").ToString(),
+            Headers = new Dictionary<string, string>
+            {
+                ["X-Request-Token"] = HeaderValue,
+            },
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+        await Task.WhenAll(primaryEndpoint.Completion, secondaryEndpoint.Completion);
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal("redirect-ok", result.Body);
+        Assert.Empty(forwardedHeaderValues);
+    }
+
+    [Fact]
+    public async Task SendAsyncDoesNotApplyRequestHeadersToRedirectedEndpointAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        List<bool> requestsWithHeader = [];
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((req, _) =>
+        {
+            requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
+            if (requestsWithHeader.Count == 1)
+            {
+                HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
+                response.Headers.Location = new Uri("https://api.example.test/next");
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+            });
+        });
+#pragma warning restore CA2025
+
+        using HttpClient client = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new(client);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+            Headers = new Dictionary<string, string>
+            {
+                ["X-Trace-Id"] = "trace-1",
+            },
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.Equal([true, false], requestsWithHeader);
+    }
+
+    [Fact]
+    public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpClient providerClient = new();
+        providerClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
+
+        int providerCallCount = 0;
+#pragma warning disable CA2025
+        await using DefaultHttpRequestHandler handler = new((_, _) =>
+        {
+            providerCallCount++;
+            return Task.FromResult<HttpClient?>(providerClient);
+        });
+#pragma warning restore CA2025
+
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(actAsync);
+        Assert.Contains("DefaultRequestHeaders", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, providerCallCount);
+    }
+
+    [Fact]
+    public async Task SendAsyncInvokesProviderForRedirectDestinationAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+#pragma warning disable CA2025
+        TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
+        {
+            HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
+            response.Headers.Location = new Uri("https://secondary.example.test/next");
+            return Task.FromResult(response);
+        });
+        TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+            }));
+#pragma warning restore CA2025
+
+        using HttpClient primaryClient = new(primaryMessageHandler);
+        using HttpClient secondaryClient = new(secondaryMessageHandler);
+        List<string> providerUrls = [];
+#pragma warning disable CA2025
+        await using DefaultHttpRequestHandler handler = new((info, _) =>
+        {
+            providerUrls.Add(info.Url);
+            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
+                ? primaryClient
+                : secondaryClient;
+            return Task.FromResult<HttpClient?>(client);
+        });
+#pragma warning restore CA2025
+
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.Equal(2, providerUrls.Count);
+        Assert.Equal(TestUrl, providerUrls[0]);
+        Assert.Equal("https://secondary.example.test/next", providerUrls[1]);
+    }
+
     #endregion
 
     #region DisposeAsync
@@ -505,5 +673,89 @@ public sealed class DefaultHttpRequestHandlerTests
             }
             return await this._responseFactory(request, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private sealed class LoopbackServer : IAsyncDisposable
+    {
+        private readonly HttpListener _listener;
+
+        private LoopbackServer(HttpListener listener, Uri baseUri, Task completion)
+        {
+            this._listener = listener;
+            this.BaseUri = baseUri;
+            this.Completion = completion;
+        }
+
+        public Uri BaseUri { get; }
+
+        public Task Completion { get; }
+
+        public static Task<LoopbackServer> StartAsync(
+            Func<HttpListenerContext, CancellationToken, Task> handler,
+            CancellationToken cancellationToken)
+        {
+            int port = GetAvailablePort();
+            Uri baseUri = new($"http://127.0.0.1:{port}/");
+            HttpListener listener = new();
+            listener.Prefixes.Add(baseUri.ToString());
+            listener.Start();
+            Task completion = HandleSingleRequestAsync(listener, handler, cancellationToken);
+            return Task.FromResult(new LoopbackServer(listener, baseUri, completion));
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            this._listener.Close();
+
+            try
+            {
+                await this.Completion.ConfigureAwait(false);
+            }
+            catch (HttpListenerException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        private static async Task HandleSingleRequestAsync(
+            HttpListener listener,
+            Func<HttpListenerContext, CancellationToken, Task> handler,
+            CancellationToken cancellationToken)
+        {
+            using CancellationTokenRegistration registration = cancellationToken.Register(
+                static state => ((HttpListener)state!).Close(),
+                listener);
+            HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
+            await handler(context, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static int GetAvailablePort()
+        {
+            TcpListener listener = new(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+
+    private static async Task WriteResponseAsync(
+        HttpListenerContext context,
+        HttpStatusCode statusCode,
+        string body,
+        CancellationToken cancellationToken)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(body);
+        context.Response.StatusCode = (int)statusCode;
+        context.Response.ContentType = "text/plain";
+        context.Response.ContentLength64 = bytes.Length;
+#if NET
+        await context.Response.OutputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+#else
+        await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+#endif
+        context.Response.Close();
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -606,11 +606,16 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
-    public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersAsync()
+    public async Task SendAsyncProviderClientAllowsScopedDefaultHeadersOnInitialRequestAsync()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        using HttpClient providerClient = new();
+        TestHttpMessageHandler messageHandler = new((req, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
+            }));
+        using HttpClient providerClient = new(messageHandler);
         providerClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
 
         int providerCallCount = 0;
@@ -629,12 +634,52 @@ public sealed class DefaultHttpRequestHandlerTests
         };
 
         // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("ok", result.Body);
+        Assert.Equal(1, providerCallCount);
+    }
+
+    [Fact]
+    public async Task SendAsyncProviderClientRejectsScopedDefaultHeadersOnRedirectedRequestAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri("https://secondary.example.test/next") },
+            }));
+        using HttpClient primaryClient = new(primaryMessageHandler);
+        using HttpClient secondaryClient = new();
+        secondaryClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
+
+        int providerCallCount = 0;
+#pragma warning disable CA2025
+        await using DefaultHttpRequestHandler handler = new((info, _) =>
+        {
+            providerCallCount++;
+            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
+                ? primaryClient
+                : secondaryClient;
+            return Task.FromResult<HttpClient?>(client);
+        });
+#pragma warning restore CA2025
+
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+        };
+
+        // Act
         async Task actAsync() => await handler.SendAsync(request, cancellationToken);
 
         // Assert
         InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(actAsync);
         Assert.Contains("DefaultRequestHeaders", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(1, providerCallCount);
+        Assert.Equal(2, providerCallCount);
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -387,48 +386,6 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
-    public async Task SendAsyncOwnedClientDoesNotForwardRequestHeadersToRedirectedEndpointAsync()
-    {
-        // Arrange
-        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        const string HeaderValue = "request-header-value";
-        List<string> forwardedHeaderValues = [];
-        await using LoopbackServer secondaryEndpoint = await LoopbackServer.StartAsync(async (context, ct) =>
-        {
-            forwardedHeaderValues.AddRange(context.Request.Headers.GetValues("X-Request-Token") ?? []);
-            await WriteResponseAsync(context, HttpStatusCode.OK, "redirect-ok", ct);
-        }, cancellationToken);
-
-        await using LoopbackServer primaryEndpoint = await LoopbackServer.StartAsync((context, _) =>
-        {
-            context.Response.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
-            context.Response.RedirectLocation = new Uri(secondaryEndpoint.BaseUri, "next").ToString();
-            context.Response.Close();
-            return Task.CompletedTask;
-        }, cancellationToken);
-
-        await using DefaultHttpRequestHandler handler = new();
-        HttpRequestInfo request = new()
-        {
-            Method = "GET",
-            Url = new Uri(primaryEndpoint.BaseUri, "redirect").ToString(),
-            Headers = new Dictionary<string, string>
-            {
-                ["X-Request-Token"] = HeaderValue,
-            },
-        };
-
-        // Act
-        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
-        await Task.WhenAll(primaryEndpoint.Completion, secondaryEndpoint.Completion);
-
-        // Assert
-        Assert.Equal(200, result.StatusCode);
-        Assert.Equal("redirect-ok", result.Body);
-        Assert.Empty(forwardedHeaderValues);
-    }
-
-    [Fact]
     public async Task SendAsyncDoesNotApplyRequestHeadersToRedirectedEndpointAsync()
     {
         // Arrange
@@ -454,6 +411,60 @@ public sealed class DefaultHttpRequestHandlerTests
 
         using HttpClient client = new(messageHandler);
         await using DefaultHttpRequestHandler handler = new(client);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+            Headers = new Dictionary<string, string>
+            {
+                ["X-Trace-Id"] = "trace-1",
+            },
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.Equal([true, false], requestsWithHeader);
+    }
+
+    [Fact]
+    public async Task SendAsyncDoesNotApplyRequestHeadersToDifferentRedirectedEndpointAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        List<bool> requestsWithHeader = [];
+#pragma warning disable CA2025
+        TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
+        {
+            requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
+            HttpResponseMessage response = new(HttpStatusCode.TemporaryRedirect);
+            response.Headers.Location = new Uri("https://secondary.example.test/next");
+            return Task.FromResult(response);
+        });
+        TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
+        {
+            requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+            });
+        });
+#pragma warning restore CA2025
+
+        using HttpClient primaryClient = new(primaryMessageHandler);
+        using HttpClient secondaryClient = new(secondaryMessageHandler);
+#pragma warning disable CA2025
+        await using DefaultHttpRequestHandler handler = new((info, _) =>
+        {
+            HttpClient client = info.Url.StartsWith("https://api.example.test/", StringComparison.Ordinal)
+                ? primaryClient
+                : secondaryClient;
+            return Task.FromResult<HttpClient?>(client);
+        });
+#pragma warning restore CA2025
+
         HttpRequestInfo request = new()
         {
             Method = "GET",
@@ -673,89 +684,5 @@ public sealed class DefaultHttpRequestHandlerTests
             }
             return await this._responseFactory(request, cancellationToken).ConfigureAwait(false);
         }
-    }
-
-    private sealed class LoopbackServer : IAsyncDisposable
-    {
-        private readonly HttpListener _listener;
-
-        private LoopbackServer(HttpListener listener, Uri baseUri, Task completion)
-        {
-            this._listener = listener;
-            this.BaseUri = baseUri;
-            this.Completion = completion;
-        }
-
-        public Uri BaseUri { get; }
-
-        public Task Completion { get; }
-
-        public static Task<LoopbackServer> StartAsync(
-            Func<HttpListenerContext, CancellationToken, Task> handler,
-            CancellationToken cancellationToken)
-        {
-            int port = GetAvailablePort();
-            Uri baseUri = new($"http://127.0.0.1:{port}/");
-            HttpListener listener = new();
-            listener.Prefixes.Add(baseUri.ToString());
-            listener.Start();
-            Task completion = HandleSingleRequestAsync(listener, handler, cancellationToken);
-            return Task.FromResult(new LoopbackServer(listener, baseUri, completion));
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            this._listener.Close();
-
-            try
-            {
-                await this.Completion.ConfigureAwait(false);
-            }
-            catch (HttpListenerException)
-            {
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-        }
-
-        private static async Task HandleSingleRequestAsync(
-            HttpListener listener,
-            Func<HttpListenerContext, CancellationToken, Task> handler,
-            CancellationToken cancellationToken)
-        {
-            using CancellationTokenRegistration registration = cancellationToken.Register(
-                static state => ((HttpListener)state!).Close(),
-                listener);
-            HttpListenerContext context = await listener.GetContextAsync().ConfigureAwait(false);
-            await handler(context, cancellationToken).ConfigureAwait(false);
-        }
-
-        private static int GetAvailablePort()
-        {
-            TcpListener listener = new(IPAddress.Loopback, 0);
-            listener.Start();
-            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
-        }
-    }
-
-    private static async Task WriteResponseAsync(
-        HttpListenerContext context,
-        HttpStatusCode statusCode,
-        string body,
-        CancellationToken cancellationToken)
-    {
-        byte[] bytes = Encoding.UTF8.GetBytes(body);
-        context.Response.StatusCode = (int)statusCode;
-        context.Response.ContentType = "text/plain";
-        context.Response.ContentLength64 = bytes.Length;
-#if NET
-        await context.Response.OutputStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
-#else
-        await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
-#endif
-        context.Response.Close();
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -372,17 +372,22 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         int requestCount = 0;
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StallingContent(),
+        };
         TestHttpMessageHandler messageHandler = new((_, _) =>
         {
             requestCount++;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StallingContent(),
-            });
+#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
+            return Task.FromResult(response);
+#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
         });
 
         using HttpClient httpClient = new(messageHandler);
+#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
         await using DefaultHttpRequestHandler handler = new((_, _) => Task.FromResult<HttpClient?>(httpClient));
+#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
         HttpRequestInfo request = new()
         {
             Method = "GET",

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -371,6 +371,14 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         int requestCount = 0;
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("https://api.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
+        };
         TestHttpMessageHandler messageHandler = new(async (req, ct) =>
         {
             requestCount++;
@@ -378,16 +386,10 @@ public sealed class DefaultHttpRequestHandlerTests
 
             if (requestCount == 1)
             {
-                return new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-                {
-                    Headers = { Location = new Uri("https://api.example.test/next") },
-                };
+                return redirectResponse;
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
-            };
+            return okResponse;
         });
 
         using HttpClient client = new(messageHandler);
@@ -434,22 +436,24 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         List<bool> requestsWithHeader = [];
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("https://api.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
 #pragma warning disable CA2025
         TestHttpMessageHandler messageHandler = new((req, _) =>
         {
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
             if (requestsWithHeader.Count == 1)
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-                {
-                    Headers = { Location = new Uri("https://api.example.test/next") },
-                });
+                return Task.FromResult(redirectResponse);
             }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
-            });
+            return Task.FromResult(okResponse);
         });
 #pragma warning restore CA2025
 
@@ -479,22 +483,24 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         List<bool> requestsWithHeader = [];
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("https://secondary.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
 #pragma warning disable CA2025
         TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
         {
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-            {
-                Headers = { Location = new Uri("https://secondary.example.test/next") },
-            });
+            return Task.FromResult(redirectResponse);
         });
         TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
         {
             requestsWithHeader.Add(req.Headers.Contains("X-Trace-Id"));
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
-            });
+            return Task.FromResult(okResponse);
         });
 #pragma warning restore CA2025
 
@@ -534,22 +540,24 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         TrackingContent redirectedContent = new("not returned");
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Content = redirectedContent,
+            Headers = { Location = new Uri("https://api.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
 #pragma warning disable CA2025
         TestHttpMessageHandler messageHandler = new((req, _) =>
         {
             if (req.RequestUri!.AbsolutePath == "/resource")
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-                {
-                    Content = redirectedContent,
-                    Headers = { Location = new Uri("https://api.example.test/next") },
-                });
+                return Task.FromResult(redirectResponse);
             }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
-            });
+            return Task.FromResult(okResponse);
         });
 #pragma warning restore CA2025
 
@@ -575,14 +583,15 @@ public sealed class DefaultHttpRequestHandlerTests
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         int requestCount = 0;
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("http://api.example.test/next") },
+        };
 #pragma warning disable CA2025
         TestHttpMessageHandler messageHandler = new((req, _) =>
         {
             requestCount++;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-            {
-                Headers = { Location = new Uri("http://api.example.test/next") },
-            });
+            return Task.FromResult(redirectResponse);
         });
 #pragma warning restore CA2025
 
@@ -610,11 +619,14 @@ public sealed class DefaultHttpRequestHandlerTests
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
+        };
+#pragma warning disable CA2025
         TestHttpMessageHandler messageHandler = new((req, _) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("ok", Encoding.UTF8, "text/plain"),
-            }));
+            Task.FromResult(okResponse));
+#pragma warning restore CA2025
         using HttpClient providerClient = new(messageHandler);
         providerClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
 
@@ -646,11 +658,14 @@ public sealed class DefaultHttpRequestHandlerTests
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("https://secondary.example.test/next") },
+        };
+#pragma warning disable CA2025
         TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-            {
-                Headers = { Location = new Uri("https://secondary.example.test/next") },
-            }));
+            Task.FromResult(redirectResponse));
+#pragma warning restore CA2025
         using HttpClient primaryClient = new(primaryMessageHandler);
         using HttpClient secondaryClient = new();
         secondaryClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Client-Token", "provider-header-value");
@@ -687,19 +702,19 @@ public sealed class DefaultHttpRequestHandlerTests
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers = { Location = new Uri("https://secondary.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
 #pragma warning disable CA2025
         TestHttpMessageHandler primaryMessageHandler = new((req, _) =>
-        {
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
-            {
-                Headers = { Location = new Uri("https://secondary.example.test/next") },
-            });
-        });
+            Task.FromResult(redirectResponse));
         TestHttpMessageHandler secondaryMessageHandler = new((req, _) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
-            }));
+            Task.FromResult(okResponse));
 #pragma warning restore CA2025
 
         using HttpClient primaryClient = new(primaryMessageHandler);

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -383,7 +383,8 @@ public sealed class DefaultHttpRequestHandlerTests
         TestHttpMessageHandler messageHandler = new(async (req, ct) =>
         {
             requestCount++;
-            await Task.Delay(TimeSpan.FromMilliseconds(200), ct).ConfigureAwait(false);
+            TimeSpan delay = requestCount == 1 ? TimeSpan.FromMilliseconds(1) : TimeSpan.FromSeconds(5);
+            await Task.Delay(delay, ct).ConfigureAwait(false);
 
             if (requestCount == 1)
             {
@@ -407,6 +408,119 @@ public sealed class DefaultHttpRequestHandlerTests
         // Assert
         await Assert.ThrowsAnyAsync<OperationCanceledException>(actAsync);
         Assert.Equal(2, requestCount);
+    }
+
+    [Fact]
+    public async Task SendAsyncPostFoundRedirectRewritesToGetAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpResponseMessage redirectResponse = new(HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("https://api.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
+        int requestCount = 0;
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(requestCount == 1 ? redirectResponse : okResponse);
+        });
+#pragma warning restore CA2025
+
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
+        HttpRequestInfo request = new()
+        {
+            Method = "POST",
+            Url = TestUrl,
+            Body = "request-body",
+            BodyContentType = "text/plain",
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.Equal(["POST", "GET"], messageHandler.RequestMethods);
+        Assert.Equal(["request-body", null], messageHandler.RequestBodies);
+    }
+
+    [Theory]
+    [InlineData(307)]
+    [InlineData(308)]
+    public async Task SendAsyncPostPreserveMethodRedirectPreservesBodyAsync(int redirectStatusCode)
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpResponseMessage redirectResponse = new((HttpStatusCode)redirectStatusCode)
+        {
+            Headers = { Location = new Uri("https://api.example.test/next") },
+        };
+        using HttpResponseMessage okResponse = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("redirected", Encoding.UTF8, "text/plain"),
+        };
+        int requestCount = 0;
+#pragma warning disable CA2025
+        TestHttpMessageHandler messageHandler = new((req, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(requestCount == 1 ? redirectResponse : okResponse);
+        });
+#pragma warning restore CA2025
+
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
+        HttpRequestInfo request = new()
+        {
+            Method = "POST",
+            Url = TestUrl,
+            Body = "request-body",
+            BodyContentType = "text/plain",
+        };
+
+        // Act
+        HttpRequestResult result = await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal("redirected", result.Body);
+        Assert.Equal(["POST", "POST"], messageHandler.RequestMethods);
+        Assert.Equal(["request-body", "request-body"], messageHandler.RequestBodies);
+    }
+
+    [Fact]
+    public async Task SendAsyncTooManyRedirectsThrowsAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        int requestCount = 0;
+        TestHttpMessageHandler messageHandler = new((_, _) =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri($"https://api.example.test/redirect/{requestCount}") },
+            });
+        });
+
+        await using DefaultHttpRequestHandler handler = CreateHandlerWithOwnedMessageHandler(messageHandler);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = TestUrl,
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request, cancellationToken);
+
+        // Assert
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(actAsync);
+        Assert.Contains("maximum number of HTTP redirects", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(51, requestCount);
     }
 
     [Fact]
@@ -820,7 +934,8 @@ public sealed class DefaultHttpRequestHandlerTests
         Func<HttpRequestInfo, CancellationToken, Task<HttpClient?>>? httpClientProvider = null)
     {
         DefaultHttpRequestHandler handler = new(httpClientProvider);
-        FieldInfo ownedHttpClientField = typeof(DefaultHttpRequestHandler).GetField("_ownedHttpClient", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo? ownedHttpClientField = typeof(DefaultHttpRequestHandler).GetField("_ownedHttpClient", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(ownedHttpClientField);
         ownedHttpClientField.SetValue(handler, new Lazy<HttpClient>(() => new HttpClient(ownedHttpMessageHandler), LazyThreadSafetyMode.ExecutionAndPublication));
         return handler;
     }
@@ -840,9 +955,14 @@ public sealed class DefaultHttpRequestHandlerTests
 
         public string? LastRequestContentType { get; private set; }
 
+        public List<string> RequestMethods { get; } = [];
+
+        public List<string?> RequestBodies { get; } = [];
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             this.LastRequest = request;
+            this.RequestMethods.Add(request.Method.Method);
             if (request.Content is not null)
             {
 #if NET
@@ -850,7 +970,12 @@ public sealed class DefaultHttpRequestHandlerTests
 #else
                 this.LastRequestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
+                this.RequestBodies.Add(this.LastRequestBody);
                 this.LastRequestContentType = request.Content.Headers.ContentType?.MediaType;
+            }
+            else
+            {
+                this.RequestBodies.Add(null);
             }
             return await this._responseFactory(request, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
This prevents forwarding requests headers to subsequent requests on location for 3XX responses and prescribed by RFC 9110