### PR TITLE
Python: docs: add capsule-emit to the observability samples README

### DIFF
--- a/python/samples/02-agents/observability/README.md
+++ b/python/samples/02-agents/observability/README.md
@@ -172,6 +172,24 @@ configure_otel_providers(exporters=[exporter])
 enable_sensitive_telemetry()
 ```
 
+Or with [capsule-emit](https://github.com/action-state-group/capsule-emit/blob/main/docs/adapters/msft-agent-framework.md):
+
+```python
+# pip install "capsule-emit[msft-agent-framework]"
+from agent_framework import Agent
+
+from capsule_emit.adapters.msft_agent_framework import capsule_middleware
+
+# Writes a local, hash-chained ledger of each agent run and tool call it observes —
+# no account or endpoint to configure. See the docs for what it does and doesn't prove.
+agent = Agent(
+    chat_client,
+    tools=[...],
+    middleware=capsule_middleware(operator="acme-co", developer="my-agent@v1"),
+)
+```
+
+
 **4. Manual setup**
 
 For full control, set up providers and exporters yourself. See [advanced_manual_setup_console_output.py](./advanced_manual_setup_console_output.py) for a complete example that sends traces, logs, and metrics to the console. The `create_resource()` helper in `agent_framework.observability` can build a resource with the appropriate service name and version from environment variables (or sensible defaults), although the sample does not use it.


### PR DESCRIPTION
Adds a `capsule-emit` entry to the observability samples README, in the same shape as the Langfuse / Comet Opik / MLflow blocks (appended after MLflow, before **4. Manual setup**).

capsule-emit's Agent Framework middleware seals a hash-chained, offline-re-checkable record of each agent run and tool call it observes to a local ledger — inputs and outputs digested, never stored; observation-only (it never alters a result or blocks a call). Because it writes a local ledger (no account, no auth), the block is shorter than the OTLP vendors' — closest in shape to the Langfuse block (imports, then one constructed object wired into the caller's `Agent(...)`).

Docs-only, one file (~+17/−0), modeled on #3940 (Comet Opik, +16/−0). No new `setup_observability_with_*.py` sample — per #1135 the substance stays on our docs and the upstream artifact is a snippet + link.

- Install: `pip install "capsule-emit[msft-agent-framework]"`
- Docs (documents the middleware, and what it does and does not prove): https://github.com/action-state-group/capsule-emit/blob/main/docs/adapters/msft-agent-framework.md
