### PR TITLE
Python: preserve empty signed Anthropic thinking blocks on streaming replay

### DIFF
--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -550,6 +550,95 @@ def test_prepare_message_for_anthropic_attaches_signature_only_reasoning(
     ]
 
 
+def test_prepare_message_for_anthropic_empty_signed_thinking_is_replayed(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Empty signed thinking blocks must serialize as thinking, not be skipped.
+
+    Anthropic requires thinking blocks (including empty thinking text) to be
+    replayed unchanged before tool results. See microsoft/agent-framework#8168.
+    """
+    client = create_test_anthropic_client(mock_anthropic_client)
+    message = Message(
+        role="assistant",
+        contents=[
+            Content.from_text_reasoning(text="", protected_data="synthetic-signature"),
+            Content.from_function_call(
+                call_id="toolu_test",
+                name="lookup",
+                arguments={},
+            ),
+        ],
+    )
+
+    result = client._prepare_message_for_anthropic(message)
+
+    assert result["content"][0] == {
+        "type": "thinking",
+        "thinking": "",
+        "signature": "synthetic-signature",
+    }
+    assert result["content"][1]["type"] == "tool_use"
+    assert result["content"][1]["id"] == "toolu_test"
+
+
+def test_streaming_replay_preserves_empty_signed_thinking_block(
+    mock_anthropic_client: MagicMock,
+) -> None:
+    """Stream empty thinking + signature_delta + tool_use, then replay via from_updates.
+
+    Offline synthetic SDK events — no network. Regression for #8168.
+    """
+    from anthropic.types.beta import (
+        BetaRawContentBlockDeltaEvent,
+        BetaRawContentBlockStartEvent,
+    )
+
+    client = create_test_anthropic_client(mock_anthropic_client)
+
+    events = [
+        BetaRawContentBlockStartEvent.model_validate(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+            }
+        ),
+        BetaRawContentBlockDeltaEvent.model_validate(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "synthetic-signature"},
+            }
+        ),
+        BetaRawContentBlockStartEvent.model_validate(
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_test",
+                    "name": "lookup",
+                    "input": {},
+                },
+            }
+        ),
+    ]
+
+    updates = [client._process_stream_event(event) for event in events]
+    response = ChatResponse.from_updates([u for u in updates if u is not None])
+    message = response.messages[0]
+    reasoning = next(c for c in message.contents if c.type == "text_reasoning")
+    assert reasoning.text == ""
+    assert reasoning.protected_data == "synthetic-signature"
+
+    prepared = client._prepare_message_for_anthropic(message)
+    assert prepared["content"][0]["type"] == "thinking"
+    assert prepared["content"][0]["thinking"] == ""
+    assert prepared["content"][0]["signature"] == "synthetic-signature"
+    assert prepared["content"][1]["type"] == "tool_use"
+
+
 def test_prepare_message_for_anthropic_skips_orphan_signature_only_reasoning(
     mock_anthropic_client: MagicMock,
 ) -> None:

--- a/python/packages/anthropic/tests/test_anthropic_client.py
+++ b/python/packages/anthropic/tests/test_anthropic_client.py
@@ -592,11 +592,12 @@ def test_streaming_replay_preserves_empty_signed_thinking_block(
     from anthropic.types.beta import (
         BetaRawContentBlockDeltaEvent,
         BetaRawContentBlockStartEvent,
+        BetaRawMessageStreamEvent,
     )
 
     client = create_test_anthropic_client(mock_anthropic_client)
 
-    events = [
+    events: list[BetaRawMessageStreamEvent] = [
         BetaRawContentBlockStartEvent.model_validate(
             {
                 "type": "content_block_start",

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1558,7 +1558,11 @@ class Content:
             )
         combined_id = self.id or other.id
 
-        # Concatenate text, handling None values
+        # Concatenate text, handling None values.
+        # Preserve empty string "" as distinct from None. Anthropic can emit a thinking
+        # block with thinking="" followed by a signature_delta; collapsing "" to None
+        # makes a real empty signed thinking block look like an orphan signature and
+        # gets dropped on replay (see microsoft/agent-framework#8168).
         self_text = self.text or ""
         other_text = other.text or ""
         if (
@@ -1567,7 +1571,10 @@ class Content:
             and ("reasoning_text" in self.additional_properties) != ("reasoning_text" in other.additional_properties)
         ):
             raise AdditionItemMismatch("Cannot merge reasoning text with a reasoning summary")
-        combined_text = self_text + other_text if (self_text or other_text) else None
+        if self.text is None and other.text is None:
+            combined_text = None
+        else:
+            combined_text = self_text + other_text
 
         # Handle protected_data replacement
         protected_data = other.protected_data if other.protected_data is not None else self.protected_data

--- a/python/packages/core/agent_framework/_types.py
+++ b/python/packages/core/agent_framework/_types.py
@@ -1571,10 +1571,7 @@ class Content:
             and ("reasoning_text" in self.additional_properties) != ("reasoning_text" in other.additional_properties)
         ):
             raise AdditionItemMismatch("Cannot merge reasoning text with a reasoning summary")
-        if self.text is None and other.text is None:
-            combined_text = None
-        else:
-            combined_text = self_text + other_text
+        combined_text = None if self.text is None and other.text is None else self_text + other_text
 
         # Handle protected_data replacement
         protected_data = other.protected_data if other.protected_data is not None else self.protected_data

--- a/python/packages/core/tests/core/test_types.py
+++ b/python/packages/core/tests/core/test_types.py
@@ -2133,6 +2133,27 @@ def test_text_reasoning_content_add_conflicting_ids_raises():
         _ = t1 + t2
 
 
+def test_text_reasoning_content_add_preserves_empty_text_with_signature():
+    """Empty thinking text plus a signature delta must keep text="" (not None).
+
+    Regression for microsoft/agent-framework#8168: collapsing "" to None makes a
+    real empty signed Anthropic thinking block look like an orphan signature.
+    """
+
+    empty_thinking = Content.from_text_reasoning(text="")
+    signature_only = Content.from_text_reasoning(text=None, protected_data="synthetic-signature")
+
+    result = empty_thinking + signature_only
+    assert result.text == ""
+    assert result.protected_data == "synthetic-signature"
+
+    both_none = Content.from_text_reasoning(text=None) + Content.from_text_reasoning(
+        text=None, protected_data="orphan-sig"
+    )
+    assert both_none.text is None
+    assert both_none.protected_data == "orphan-sig"
+
+
 def test_text_reasoning_content_add_neither_has_id():
     """Test that coalescing text_reasoning Content when neither has an id results in None id."""
 


### PR DESCRIPTION
### Motivation & Context

Anthropic can emit a thinking block with `thinking=""` followed by a `signature_delta`. Stream aggregation was collapsing empty string to `None`, so the Anthropic serializer treated a real empty signed thinking block as an orphan signature and dropped it before tool-result replay. Nonempty thinking text was already preserved.

Fixes #8168

### Description & Review Guide

- **What are the major changes?** Keep `""` distinct from `None` in `Content._add_text_reasoning_content` when merging reasoning text, so empty signed Anthropic thinking survives aggregation and replay.
- **What is the impact of these changes?** Replay emits `{"type": "thinking", "thinking": "", "signature": ...}` before the tool call when that is what the stream produced. Both-`None` still stays `None`.
- **What do you want reviewers to focus on?** The merge semantics in `_types.py` (`""` vs `None`) and the Anthropic streaming replay regression.

### Related Issue

Fixes #8168

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
