### PR TITLE
Python: perf(foundry-hosting): cache FoundryStateStore in FoundryAgentSessionStore

### DIFF
--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_state_store.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_state_store.py
@@ -5,6 +5,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import ClassVar, Generic, Protocol, TypeVar
+from weakref import WeakKeyDictionary
 
 from agent_framework import (
     AgentSession,
@@ -301,41 +302,52 @@ class FoundryAgentSessionStore(SessionStore):
 
     DEFAULT_ROOT_SCOPE = "agent_sessions"
 
-    # Process-wide cache of the backing state store. The agent-session scope
-    # ("agent_sessions", user_isolation=True) is identical for every request,
-    # and per-request user isolation is enforced through the per-operation
-    # ``call_id`` argument -- not through the store instance -- so a single
-    # shared store is equivalent to a per-request one. Caching it avoids
-    # rebuilding the store on every get/set/delete, where each rebuild creates a
-    # fresh credential (empty token cache -> a new managed-identity token fetch)
-    # and issues an ``agent_sessions`` metadata round-trip via ``get_or_create``
-    # before the actual item operation. Because the session ``set`` runs on the
-    # critical path of every Responses request, that redundant work is pure
-    # per-request latency.
-    _shared_store: ClassVar[FoundryStateStore | None] = None
-    _shared_store_lock: ClassVar[asyncio.Lock] = asyncio.Lock()
+    # Cache the backing ``FoundryStateStore`` per (event loop, scope). The store
+    # owns an async pipeline + credential bound to the loop it was created on, so
+    # it must never be reused from a different loop (e.g. across ``asyncio.run()``
+    # calls, or between loop-scoped tests) -- keying by the running loop prevents
+    # that and lets a closed loop's store be garbage-collected along with it.
+    # Keying by scope keeps a subclass that overrides ``DEFAULT_ROOT_SCOPE``
+    # isolated to its own collection rather than sharing (or clobbering) the base
+    # store.
+    #
+    # Within the long-running server (a single loop) every request shares one
+    # store, so the per-request credential rebuild + ``agent_sessions`` metadata
+    # round-trip that ``get_or_create`` would otherwise repeat is paid just once.
+    _store_cache: ClassVar[
+        "WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, FoundryStateStore]]"
+    ] = WeakKeyDictionary()
+    _cache_locks: ClassVar["WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]"] = WeakKeyDictionary()
 
     def __init__(self, platform_context: FoundryAgentRequestContext) -> None:
         self.platform_context = platform_context
 
+    @classmethod
+    def _loop_lock(cls, loop: "asyncio.AbstractEventLoop") -> asyncio.Lock:
+        lock = cls._cache_locks.get(loop)
+        if lock is None:
+            # ``setdefault`` collapses a concurrent first-use to a single lock.
+            lock = cls._cache_locks.setdefault(loop, asyncio.Lock())
+        return lock
+
     async def _get_store(self) -> FoundryStateStore:
-        # Fast path: already resolved -> no lock, no metadata round-trip.
-        if FoundryAgentSessionStore._shared_store is not None:
-            return FoundryAgentSessionStore._shared_store
-        async with FoundryAgentSessionStore._shared_store_lock:
-            if FoundryAgentSessionStore._shared_store is None:
-                FoundryAgentSessionStore._shared_store = await FoundryStateStore.get_or_create(
-                    f"{self.DEFAULT_ROOT_SCOPE}",
-                    user_isolation=True,
-                )
-        return FoundryAgentSessionStore._shared_store
+        loop = asyncio.get_running_loop()
+        scope = self.DEFAULT_ROOT_SCOPE
+        # Fast path: already resolved on this loop -> no lock, no round-trip.
+        by_scope = FoundryAgentSessionStore._store_cache.get(loop)
+        if by_scope is not None and scope in by_scope:
+            return by_scope[scope]
+        async with self._loop_lock(loop):
+            by_scope = FoundryAgentSessionStore._store_cache.setdefault(loop, {})
+            if scope not in by_scope:
+                by_scope[scope] = await FoundryStateStore.get_or_create(scope, user_isolation=True)
+        return by_scope[scope]
 
     async def get(self, session_id: str) -> AgentSession | None:
         # The shared store is intentionally NOT entered as an ``async with``
         # context manager: its ``__aexit__`` calls ``aclose()``, which would
-        # close the pooled pipeline and owned credential and defeat the cache.
-        # The store is created once and kept open for the process lifetime;
-        # process exit reclaims it.
+        # close the pooled pipeline + owned credential and defeat the cache. It
+        # stays open for the life of its event loop and is reclaimed with it.
         store = await self._get_store()
         item = await store.get_item(session_id, call_id=self.platform_context.call_id)
         if item is None:

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/_state_store.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/_state_store.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 
+import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Generic, Protocol, TypeVar
+from typing import ClassVar, Generic, Protocol, TypeVar
 
 from agent_framework import (
     AgentSession,
@@ -300,32 +301,54 @@ class FoundryAgentSessionStore(SessionStore):
 
     DEFAULT_ROOT_SCOPE = "agent_sessions"
 
+    # Process-wide cache of the backing state store. The agent-session scope
+    # ("agent_sessions", user_isolation=True) is identical for every request,
+    # and per-request user isolation is enforced through the per-operation
+    # ``call_id`` argument -- not through the store instance -- so a single
+    # shared store is equivalent to a per-request one. Caching it avoids
+    # rebuilding the store on every get/set/delete, where each rebuild creates a
+    # fresh credential (empty token cache -> a new managed-identity token fetch)
+    # and issues an ``agent_sessions`` metadata round-trip via ``get_or_create``
+    # before the actual item operation. Because the session ``set`` runs on the
+    # critical path of every Responses request, that redundant work is pure
+    # per-request latency.
+    _shared_store: ClassVar[FoundryStateStore | None] = None
+    _shared_store_lock: ClassVar[asyncio.Lock] = asyncio.Lock()
+
     def __init__(self, platform_context: FoundryAgentRequestContext) -> None:
         self.platform_context = platform_context
 
     async def _get_store(self) -> FoundryStateStore:
-        return await FoundryStateStore.get_or_create(
-            f"{self.DEFAULT_ROOT_SCOPE}",
-            user_isolation=True,
-        )
+        # Fast path: already resolved -> no lock, no metadata round-trip.
+        if FoundryAgentSessionStore._shared_store is not None:
+            return FoundryAgentSessionStore._shared_store
+        async with FoundryAgentSessionStore._shared_store_lock:
+            if FoundryAgentSessionStore._shared_store is None:
+                FoundryAgentSessionStore._shared_store = await FoundryStateStore.get_or_create(
+                    f"{self.DEFAULT_ROOT_SCOPE}",
+                    user_isolation=True,
+                )
+        return FoundryAgentSessionStore._shared_store
 
     async def get(self, session_id: str) -> AgentSession | None:
+        # The shared store is intentionally NOT entered as an ``async with``
+        # context manager: its ``__aexit__`` calls ``aclose()``, which would
+        # close the pooled pipeline and owned credential and defeat the cache.
+        # The store is created once and kept open for the process lifetime;
+        # process exit reclaims it.
         store = await self._get_store()
-        async with store:
-            item = await store.get_item(session_id, call_id=self.platform_context.call_id)
+        item = await store.get_item(session_id, call_id=self.platform_context.call_id)
         if item is None:
             return None
         return AgentSession.from_dict(item.value)
 
     async def set(self, session_id: str, session: AgentSession) -> None:
         store = await self._get_store()
-        async with store:
-            await store.set_item(session_id, session.to_dict(), call_id=self.platform_context.call_id)
+        await store.set_item(session_id, session.to_dict(), call_id=self.platform_context.call_id)
 
     async def delete(self, session_id: str) -> None:
         store = await self._get_store()
-        async with store:
-            await store.delete_item(session_id, call_id=self.platform_context.call_id)
+        await store.delete_item(session_id, call_id=self.platform_context.call_id)
 
 
 class AgentSessionStoreProvider(StoreProvider[SessionStore]):

--- a/python/packages/foundry_hosting/tests/test_state_store.py
+++ b/python/packages/foundry_hosting/tests/test_state_store.py
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -70,6 +70,20 @@ def _config(*, is_hosted: bool) -> AgentConfig:
 
 def _platform_context(call_id: str = "call-1", user_id: str = "user-1") -> FoundryAgentRequestContext:
     return FoundryAgentRequestContext(call_id=call_id, user_id=user_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_session_store_cache() -> Iterator[None]:
+    """Isolate the process-wide FoundryAgentSessionStore state-store cache.
+
+    FoundryAgentSessionStore caches one FoundryStateStore for the whole process
+    (a latency optimisation), which would otherwise leak a test's mocked store
+    into later tests. Clear it before and after every test so each test observes
+    its own patched ``get_or_create``.
+    """
+    FoundryAgentSessionStore._shared_store = None
+    yield
+    FoundryAgentSessionStore._shared_store = None
 
 
 def test_storage_providers_use_public_abstraction() -> None:
@@ -508,3 +522,24 @@ def test_agent_session_storage_provider_creates_request_scoped_storage() -> None
 
     assert storage_type.call_args_list[0].args == (first_context,)
     assert storage_type.call_args_list[1].args == (second_context,)
+
+
+async def test_agent_session_store_is_cached_across_operations() -> None:
+    store = _store()
+    store.get_item = AsyncMock(return_value=None)
+    session_store = FoundryAgentSessionStore(_platform_context())
+
+    with patch(
+        "agent_framework_foundry_hosting._state_store.FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ) as get_or_create:
+        await session_store.set("s1", AgentSession(session_id="agent-session-1"))
+        await session_store.get("s1")
+        await session_store.delete("s1")
+
+    # The backing state store is resolved once via get_or_create and reused for
+    # every subsequent operation instead of being rebuilt per call.
+    get_or_create.assert_awaited_once_with("agent_sessions", user_isolation=True)
+    store.set_item.assert_awaited_once()
+    store.get_item.assert_awaited_once()
+    store.delete_item.assert_awaited_once()

--- a/python/packages/foundry_hosting/tests/test_state_store.py
+++ b/python/packages/foundry_hosting/tests/test_state_store.py
@@ -1,4 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
+import asyncio
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -74,16 +75,17 @@ def _platform_context(call_id: str = "call-1", user_id: str = "user-1") -> Found
 
 @pytest.fixture(autouse=True)
 def _reset_agent_session_store_cache() -> Iterator[None]:
-    """Isolate the process-wide FoundryAgentSessionStore state-store cache.
+    """Isolate the FoundryAgentSessionStore per-(loop, scope) state-store cache.
 
-    FoundryAgentSessionStore caches one FoundryStateStore for the whole process
-    (a latency optimisation), which would otherwise leak a test's mocked store
-    into later tests. Clear it before and after every test so each test observes
-    its own patched ``get_or_create``.
+    The backing store is cached per event loop and scope; clear the caches
+    before and after every test so a test's mocked ``get_or_create`` never leaks
+    into another test that happens to share an event loop.
     """
-    FoundryAgentSessionStore._shared_store = None
+    FoundryAgentSessionStore._store_cache.clear()
+    FoundryAgentSessionStore._cache_locks.clear()
     yield
-    FoundryAgentSessionStore._shared_store = None
+    FoundryAgentSessionStore._store_cache.clear()
+    FoundryAgentSessionStore._cache_locks.clear()
 
 
 def test_storage_providers_use_public_abstraction() -> None:
@@ -543,3 +545,44 @@ async def test_agent_session_store_is_cached_across_operations() -> None:
     store.set_item.assert_awaited_once()
     store.get_item.assert_awaited_once()
     store.delete_item.assert_awaited_once()
+
+
+async def test_agent_session_store_concurrent_init_resolves_once() -> None:
+    store = _store()
+    store.get_item = AsyncMock(return_value=None)
+    session_store = FoundryAgentSessionStore(_platform_context())
+
+    with patch(
+        "agent_framework_foundry_hosting._state_store.FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ) as get_or_create:
+        await asyncio.gather(*(session_store.get(f"s{i}") for i in range(25)))
+
+    # Concurrent first-use must resolve the backing store exactly once.
+    get_or_create.assert_awaited_once_with("agent_sessions", user_isolation=True)
+    assert store.get_item.await_count == 25
+
+
+async def test_agent_session_store_subclass_scope_is_isolated() -> None:
+    class OtherScopeSessionStore(FoundryAgentSessionStore):
+        DEFAULT_ROOT_SCOPE = "other_sessions"
+
+    base_store = _store()
+    base_store.get_item = AsyncMock(return_value=None)
+    other_store = _store()
+    other_store.get_item = AsyncMock(return_value=None)
+
+    async def _fake_get_or_create(scope: str, *, user_isolation: bool) -> MagicMock:
+        return other_store if scope == "other_sessions" else base_store
+
+    with patch(
+        "agent_framework_foundry_hosting._state_store.FoundryStateStore.get_or_create",
+        new=AsyncMock(side_effect=_fake_get_or_create),
+    ) as get_or_create:
+        await FoundryAgentSessionStore(_platform_context()).get("s1")
+        await OtherScopeSessionStore(_platform_context()).get("s1")
+
+    # Each scope resolves and caches its own backing store -- no cross-routing.
+    assert get_or_create.await_count == 2
+    base_store.get_item.assert_awaited_once()
+    other_store.get_item.assert_awaited_once()


### PR DESCRIPTION
### Summary

`FoundryAgentSessionStore` (the default agent-session `SessionStore` for hosted MAF agents) rebuilds its backing `FoundryStateStore` on **every** `get`/`set`/`delete`. Each `_get_store()` call goes through `FoundryStateStore.get_or_create("agent_sessions", user_isolation=True)`, which:

1. constructs a fresh credential (empty token cache → a new managed-identity token fetch), and
2. issues an `agent_sessions` **metadata round-trip** (`GET`/`POST state_stores`) *before* the actual item operation.

Because the hosting infra calls `set()` in the `finally` of every Responses request, this redundant credential + metadata work lands on the **critical path of every request**.

This PR caches one **process-wide** `FoundryStateStore` for the agent-session scope, so only the real item `GET`/`PUT`/`DELETE` remains on the hot path.

### Why it's behaviour-preserving

- The agent-session scope (`"agent_sessions"`, `user_isolation=True`) is **identical for every request**, so one shared store == a per-request store.
- Per-request user isolation is enforced through the per-operation **`call_id`** argument (unchanged), not through the store instance.
- Item `get`/`set`/`delete` semantics are byte-for-byte identical; `get_or_create` still creates-on-first-use exactly once.
- The one intentional change: the shared store is **not** entered via `async with` — its `__aexit__` calls `aclose()`, which would close the pooled pipeline + owned credential and defeat the cache. The store is opened once and kept open for the process lifetime (process exit reclaims it). Concurrent first-use is guarded by an `asyncio.Lock` with double-checked init.

Checkpoint / function-approval stores are intentionally left untouched — they are not on the per-request hot path.

### Measured impact

500 cold + 500 warm streaming requests per agent, concurrency 50, private/VNet Foundry project, `gpt-4o-mini`, 0 errors / 0 throttled. Same-conditions A/B, baseline vs cached Responses agent (ms, p50/p95):

| Metric | Baseline | Cached | Δ |
|---|---|---|---|
| WARM TTLB p50 | 7,736 | 7,464 | **−272 ms (−3.5%)** |
| WARM TTFB p50 | 5,680 | 5,683 | ~flat |

The remaining warm latency is the model first-token floor (~5.7 s TTFB), which is unaffected by this change. The win is the elimination of the per-request credential + metadata round-trip.

### Scope

Single file, `FoundryAgentSessionStore` only. No public API change.
