### PR TITLE
Python: Add Azure DocumentDB vector store connector

### DIFF
--- a/python/PACKAGE_STATUS.md
+++ b/python/PACKAGE_STATUS.md
@@ -20,6 +20,7 @@ Status is grouped into these buckets:
 | `agent-framework-anthropic` | `python/packages/anthropic` | `beta` |
 | `agent-framework-azure-contentunderstanding` | `python/packages/azure-contentunderstanding` | `beta` |
 | `agent-framework-azure-ai-search` | `python/packages/azure-ai-search` | `beta` |
+| `agent-framework-azure-documentdb` | `python/packages/azure-documentdb` | `alpha` |
 | `agent-framework-azure-cosmos` | `python/packages/azure-cosmos` | `beta` |
 | `agent-framework-azure-cosmos-memory` | `python/packages/azure-cosmos-memory` | `alpha` |
 | `agent-framework-bedrock` | `python/packages/bedrock` | `beta` |

--- a/python/packages/azure-documentdb/LICENSE
+++ b/python/packages/azure-documentdb/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/python/packages/azure-documentdb/README.md
+++ b/python/packages/azure-documentdb/README.md
@@ -99,12 +99,13 @@ standard-vector contract. Azure DocumentDB also offers higher limits with
 half-precision or product quantization; those distinct index/storage options are
 outside this connector.
 
-`score_threshold` is a minimum native score applied after `$search` selects its
-`k` candidates and before `$skip`/`$limit`. Set a larger
-`operation_options={"k": ...}` candidate window when needed. Thresholded ANN
-search can return fewer than `top`; the connector does not fetch or filter a
-client-side prefix. Algorithm tuning uses `n_probes`, `ef_search`, or `l_search`
-for IVF, HNSW, or DiskANN respectively.
+`score_threshold` uses native metric units after `$search` selects its `k`
+candidates and before `$skip`/`$limit`. It is a minimum for cosine and inner
+product scores, where larger is better, and a maximum for Euclidean distance,
+where smaller is better. Set a larger `operation_options={"k": ...}` candidate
+window when needed. Thresholded ANN search can return fewer than `top`; the
+connector does not fetch or filter a client-side prefix. Algorithm tuning uses
+`n_probes`, `ef_search`, or `l_search` for IVF, HNSW, or DiskANN respectively.
 
 See the
 [Azure DocumentDB vector search guide](https://learn.microsoft.com/azure/documentdb/vector-search),

--- a/python/packages/azure-documentdb/README.md
+++ b/python/packages/azure-documentdb/README.md
@@ -1,0 +1,113 @@
+# Agent Framework Azure DocumentDB
+
+Store and search vector records in
+[Azure DocumentDB](https://learn.microsoft.com/azure/documentdb/) with this
+alpha integration for
+[Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/).
+The package uses PyMongo's stable asynchronous API and Azure DocumentDB's
+Mongo-compatible `$search.cosmosSearch` dialect.
+
+- **`AzureDocumentDBCollection`** provides batch CRUD, metadata filters, index reconciliation, and vector search.
+- **`AzureDocumentDBStore`** creates collection clients sharing one resolved database.
+- **`AzureDocumentDBSettings`** defines the two Agent Framework-managed connection settings.
+
+## Installation
+
+```bash
+pip install agent-framework-azure-documentdb --pre
+```
+
+Requires Python 3.10+, PyMongo 4.13+, and an Azure DocumentDB cluster. IVF
+indexes are intended for smaller datasets and M10/M20 tiers. HNSW and DiskANN
+require M30 or higher; consult the current service documentation before choosing
+a production tier.
+
+## Authentication and setup
+
+Set `AZURE_DOCUMENTDB_CONNECTION_STRING` to the connection string from the
+Azure portal and `AZURE_DOCUMENTDB_DATABASE_NAME` to an existing or intended
+database. Settings precedence is explicit constructor value, selected `.env`
+file, then process environment. Connection strings are held in Agent Framework
+`SecretString` values.
+
+Connector-created clients enforce TLS, disable retryable writes, and set an
+application name. They are closed by `aclose()` or an async context manager.
+An injected PyMongo `AsyncMongoClient`, `AsyncDatabase`, or `AsyncCollection`
+remains caller-owned and bypasses settings loading.
+
+The identity running `ensure_collection_exists()` needs permission to create
+collections and indexes. Each filtered data field must declare
+`is_indexed=True`; the connector creates its ordinary ascending index alongside
+separate vector indexes.
+
+## Example
+
+```python
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+from agent_framework_azure_documentdb import AzureDocumentDBStore
+
+
+@vectorstoremodel(collection_name="articles")
+@dataclass
+class Article:
+    id: Annotated[str, VectorStoreField("key")]
+    category: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    embedding: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=3, index_kind="ivf_flat"),
+    ] = None
+
+
+async def main() -> None:
+    async with AzureDocumentDBStore() as store:
+        collection = store.get_collection(Article)
+        await collection.ensure_collection_exists()
+        await collection.upsert(
+            [Article("one", "database", [1.0, 0.0, 0.0])],
+            generate_vectors=False,
+        )
+        results = await collection.search(
+            vector=[1.0, 0.0, 0.0],
+            filter=Filter("category", "eq", "database"),
+        )
+        async for result in results:
+            print(result["record"], result["score"])
+
+
+asyncio.run(main())
+```
+
+## Limits
+
+The connector supports explicit string and signed 64-bit integer `_id` keys,
+multiple top-level dense vector fields, storage aliases, IVF/HNSW/DiskANN
+indexes, native metadata filters, server-side paging, and native `searchScore`
+values. Generated ObjectIds, ordered retrieval, hybrid/full-text search,
+sparse/binary vectors, nested field paths, compressed vectors, and automatic
+schema/index migration are not supported.
+
+The core `default` index kind maps to IVF so it does not silently require an
+M30+ tier. Select `hnsw` or `disk_ann` explicitly when those service contracts
+and cluster requirements are appropriate.
+
+Vector dimensions are conservatively limited to the service's 2,000-dimension
+standard-vector contract. Azure DocumentDB also offers higher limits with
+half-precision or product quantization; those distinct index/storage options are
+outside this connector.
+
+`score_threshold` is a minimum native score applied after `$search` selects its
+`k` candidates and before `$skip`/`$limit`. Set a larger
+`operation_options={"k": ...}` candidate window when needed. Thresholded ANN
+search can return fewer than `top`; the connector does not fetch or filter a
+client-side prefix. Algorithm tuning uses `n_probes`, `ef_search`, or `l_search`
+for IVF, HNSW, or DiskANN respectively.
+
+See the
+[Azure DocumentDB vector search guide](https://learn.microsoft.com/azure/documentdb/vector-search),
+[Azure DocumentDB limits](https://learn.microsoft.com/azure/documentdb/limitations),
+[PyMongo async API](https://pymongo.readthedocs.io/en/stable/api/pymongo/asynchronous/),
+and [Agent Framework documentation](https://learn.microsoft.com/agent-framework/).

--- a/python/packages/azure-documentdb/agent_framework_azure_documentdb/__init__.py
+++ b/python/packages/azure-documentdb/agent_framework_azure_documentdb/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Azure DocumentDB vector collections and stores."""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+from ._vector_store import AzureDocumentDBCollection, AzureDocumentDBSettings, AzureDocumentDBStore
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = [
+    "AzureDocumentDBCollection",
+    "AzureDocumentDBSettings",
+    "AzureDocumentDBStore",
+    "__version__",
+]

--- a/python/packages/azure-documentdb/agent_framework_azure_documentdb/_vector_store.py
+++ b/python/packages/azure-documentdb/agent_framework_azure_documentdb/_vector_store.py
@@ -1,0 +1,1202 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Async Azure DocumentDB collection lifecycle, CRUD, filters, and vector search."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Any, ClassVar, Generic, cast
+
+from agent_framework import (
+    BaseVectorCollection,
+    BaseVectorSearch,
+    BaseVectorStore,
+    FilterGroup,
+    SearchResults,
+    SecretString,
+    VectorStoreCollectionDefinition,
+    VectorStoreField,
+    load_settings,
+)
+from agent_framework._telemetry import FeatureIndex, mark_feature_used
+from agent_framework._vector_filters import FilterExpression
+from agent_framework._vectors import EmbeddingClient, SearchType, Vector
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from bson import BSON
+from bson.errors import InvalidDocument
+from pymongo import AsyncMongoClient, ReplaceOne
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import CollectionInvalid, OperationFailure, PyMongoError
+from typing_extensions import Self, TypedDict, TypeVar
+
+KeyT = TypeVar("KeyT", default=Any)
+ModelT = TypeVar("ModelT", default=Any)
+
+_Document = dict[str, Any]
+_ClientType = AsyncMongoClient[_Document]
+_DatabaseType = AsyncDatabase[_Document]
+_CollectionType = AsyncCollection[_Document]
+
+_MAX_DOCUMENT_BYTES = 16 * 1024 * 1024
+_MAX_ID_BYTES = 2 * 1024
+_MAX_INDEX_PATH_BYTES = 256
+_MAX_WRITES_PER_BATCH = 25_000
+_KEY_BATCH_SIZE = 1_000
+_INDEX_RACE_CODES = {68, 85, 86}
+_INDEX_RACE_NAMES = {"IndexAlreadyExists", "IndexKeySpecsConflict", "IndexOptionsConflict"}
+_NATIVE_SCORE_FIELD = "_af_documentdb_score"
+_CLIENT_OPTION_NAMES = {"appname", "retryWrites", "tls"}
+_INDEX_KINDS = {
+    "default": "vector-ivf",
+    "ivf_flat": "vector-ivf",
+    "hnsw": "vector-hnsw",
+    "disk_ann": "vector-diskann",
+}
+_METRICS = {
+    "DEFAULT": "COS",
+    "cosine_similarity": "COS",
+    "dot_prod": "IP",
+    "euclidean_distance": "L2",
+}
+_DATA_TYPES = {"str", "int", "float", "bool", "bytes", "list", "dict"}
+
+
+class AzureDocumentDBSettings(TypedDict, total=False):
+    """Connection settings resolved from explicit values, a selected file, or the process environment."""
+
+    connection_string: SecretString | None
+    """Azure DocumentDB MongoDB connection string from ``AZURE_DOCUMENTDB_CONNECTION_STRING``."""
+
+    database_name: str | None
+    """Database name from ``AZURE_DOCUMENTDB_DATABASE_NAME``."""
+
+
+def _validate_operation_options(
+    options: Mapping[str, Any] | None,
+    allowed: set[str] | None = None,
+) -> dict[str, Any]:
+    result = dict(options or {})
+    if unknown := result.keys() - (allowed or set()):
+        raise NotImplementedError(f"Unsupported Azure DocumentDB operation option(s): {', '.join(sorted(unknown))}.")
+    return result
+
+
+def _validate_integer(value: Any, name: str, minimum: int, maximum: int | None = None) -> int:
+    if type(value) is not int or value < minimum or (maximum is not None and value > maximum):
+        requirement = f"between {minimum} and {maximum}" if maximum is not None else f"at least {minimum}"
+        raise ValueError(f"{name} must be an integer {requirement}.")
+    return value
+
+
+def _validate_database_name(name: Any) -> str:
+    if not isinstance(name, str) or not name or len(name.encode("utf-8")) > 63:
+        raise ValueError("database_name must contain 1-63 UTF-8 bytes.")
+    if any(character in name for character in '/\\."$*<>:|?\0'):
+        raise ValueError("database_name contains a character unsupported by Azure DocumentDB.")
+    return name
+
+
+def _validate_collection_name(name: Any) -> str:
+    if not isinstance(name, str) or not name or len(name.encode("utf-8")) > 255:
+        raise ValueError("collection_name must contain 1-255 UTF-8 bytes.")
+    if "\0" in name or "$" in name or name.startswith("system."):
+        raise ValueError("collection_name contains a reserved Azure DocumentDB name or character.")
+    return name
+
+
+def _validate_storage_name(name: str, *, indexed: bool) -> str:
+    encoded = name.encode("utf-8")
+    if not name or "\0" in name or "." in name or name.startswith("$"):
+        raise ValueError("Azure DocumentDB fields must be non-empty top-level names without '.', '$' prefixes, or NUL.")
+    if indexed and len(encoded) > _MAX_INDEX_PATH_BYTES:
+        raise ValueError(f"Azure DocumentDB indexed field paths cannot exceed {_MAX_INDEX_PATH_BYTES} UTF-8 bytes.")
+    return name
+
+
+def _validate_client_options(options: Mapping[str, Any] | None) -> dict[str, Any]:
+    result = dict(options or {})
+    if unknown := result.keys() - _CLIENT_OPTION_NAMES:
+        raise NotImplementedError(f"Unsupported Azure DocumentDB client option(s): {', '.join(sorted(unknown))}.")
+    if "tls" in result and result["tls"] is not True:
+        raise ValueError("Azure DocumentDB requires client_options['tls'] to be True.")
+    if "retryWrites" in result and result["retryWrites"] is not False:
+        raise ValueError("Azure DocumentDB requires client_options['retryWrites'] to be False.")
+    if "appname" in result:
+        app_name = result["appname"]
+        if not isinstance(app_name, str) or not app_name or "\0" in app_name or len(app_name.encode()) > 128:
+            raise ValueError("client_options['appname'] must contain 1-128 UTF-8 bytes and no NUL.")
+    return {"tls": True, "retryWrites": False, "appname": "agent-framework-azure-documentdb", **result}
+
+
+class _Client:
+    """Own one connector-created client or borrow a caller's resolved database."""
+
+    def __init__(self, client: _ClientType, database: _DatabaseType, *, owned: bool) -> None:
+        self.client = client
+        self.database = database
+        self.owned = owned
+        self.closed = False
+
+    def ensure_open(self) -> None:
+        if self.closed:
+            raise RuntimeError("The Azure DocumentDB client is closed.")
+
+    async def close(self) -> None:
+        if not self.closed:
+            if self.owned:
+                await self.client.close()
+            self.closed = True
+
+
+def _create_client(
+    connection_string: str | SecretString | None,
+    database_name: str | None,
+    *,
+    client: _ClientType | None,
+    database: _DatabaseType | None,
+    client_options: Mapping[str, Any] | None,
+    env_file_path: str | None,
+    env_file_encoding: str | None,
+) -> _Client:
+    if database is not None:
+        if any(
+            value is not None
+            for value in (
+                connection_string,
+                database_name,
+                client,
+                client_options,
+                env_file_path,
+                env_file_encoding,
+            )
+        ):
+            raise ValueError("database cannot be combined with a client or connection settings.")
+        if not isinstance(database, AsyncDatabase):
+            raise TypeError("database must be a PyMongo AsyncDatabase.")
+        return _Client(database.client, database, owned=False)
+    if client is not None:
+        if any(value is not None for value in (connection_string, client_options, env_file_path, env_file_encoding)):
+            raise ValueError("client cannot be combined with connection settings or client_options.")
+        if not isinstance(client, AsyncMongoClient):
+            raise TypeError("client must be a PyMongo AsyncMongoClient.")
+        if database_name is None:
+            raise ValueError("database_name is required with an injected client.")
+        resolved_database_name = _validate_database_name(database_name)
+        return _Client(client, client[resolved_database_name], owned=False)
+
+    settings = load_settings(
+        AzureDocumentDBSettings,
+        env_prefix="AZURE_DOCUMENTDB_",
+        connection_string=connection_string,
+        database_name=database_name,
+        env_file_path=env_file_path,
+        env_file_encoding=env_file_encoding,
+    )
+    resolved_connection_string = settings.get("connection_string")
+    if (
+        not isinstance(resolved_connection_string, SecretString)
+        or not resolved_connection_string.get_secret_value().strip()
+    ):
+        raise ValueError("A non-empty Azure DocumentDB connection_string is required.")
+    resolved_database_name = _validate_database_name(settings.get("database_name"))
+    created_client: _ClientType = AsyncMongoClient(
+        resolved_connection_string.get_secret_value(),
+        **_validate_client_options(client_options),
+    )
+    return _Client(created_client, created_client[resolved_database_name], owned=True)
+
+
+def _prepare_key(value: Any, expected_type: str | None) -> str | int:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise TypeError("Azure DocumentDB keys must be strings or signed 64-bit integers, not booleans.")
+    if expected_type == "str" and not isinstance(value, str):
+        raise TypeError("Azure DocumentDB key must match its declared string type.")
+    if expected_type == "int" and type(value) is not int:
+        raise TypeError("Azure DocumentDB key must match its declared integer type.")
+    if isinstance(value, str):
+        if len(value.encode("utf-8")) > _MAX_ID_BYTES:
+            raise ValueError(f"Azure DocumentDB string keys cannot exceed {_MAX_ID_BYTES} UTF-8 bytes.")
+    elif not -(2**63) <= value < 2**63:
+        raise ValueError("Azure DocumentDB integer keys must fit a signed 64-bit BSON integer.")
+    return value
+
+
+def _prepare_untyped_bson_value(value: Any, *, path: str) -> Any:
+    if value is None or isinstance(value, (str, bytes, bool)):
+        return value
+    if isinstance(value, int):
+        if not -(2**63) <= value < 2**63:
+            raise ValueError(f"Field '{path}' contains an integer outside the signed 64-bit BSON range.")
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"Field '{path}' contains a non-finite number.")
+        return value
+    if isinstance(value, list):
+        return [_prepare_untyped_bson_value(item, path=f"{path}[]") for item in cast(list[Any], value)]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in cast(dict[Any, Any], value).items():
+            if not isinstance(key, str) or not key or "\0" in key or "." in key or key.startswith("$"):
+                raise TypeError(
+                    f"Field '{path}' requires non-empty string object keys without '.', '$' prefixes, or NUL."
+                )
+            result[key] = _prepare_untyped_bson_value(item, path=f"{path}.{key}")
+        return result
+    raise TypeError(f"Field '{path}' contains unsupported BSON value type '{type(value).__name__}'.")
+
+
+def _prepare_field_value(field: VectorStoreField, value: Any) -> Any:
+    if value is None:
+        return None
+    kind = field.type_
+    if kind == "str" and isinstance(value, str):
+        return value
+    if kind == "int" and type(value) is int:
+        return _prepare_untyped_bson_value(value, path=field.name)
+    if kind == "float" and type(value) in (int, float):
+        number = float(value)
+        if not math.isfinite(number):
+            raise ValueError(f"Field '{field.name}' requires a finite number.")
+        return number
+    if kind == "bool" and type(value) is bool:
+        return value
+    if kind == "bytes" and isinstance(value, bytes):
+        return value
+    if kind == "list" and isinstance(value, list):
+        return _prepare_untyped_bson_value(value, path=field.name)
+    if kind == "dict" and isinstance(value, dict):
+        return _prepare_untyped_bson_value(value, path=field.name)
+    raise TypeError(f"Azure DocumentDB field '{field.name}' requires declared type '{kind}'.")
+
+
+def _prepare_dense_vector(value: Any, field: VectorStoreField) -> list[float | int] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError(f"Vector field '{field.name}' requires a dense numeric sequence.")
+    result: list[float | int] = []
+    for item in cast(Sequence[Any], value):
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise TypeError(f"Vector field '{field.name}' must contain numbers, not booleans.")
+        if isinstance(item, int):
+            if not -(2**63) <= item < 2**63:
+                raise ValueError(f"Vector field '{field.name}' contains an integer outside the BSON range.")
+            result.append(item)
+        elif not math.isfinite(item):
+            raise ValueError(f"Vector field '{field.name}' must contain finite numbers.")
+        else:
+            result.append(item)
+    return result
+
+
+def _validate_bson_document(document: _Document) -> None:
+    try:
+        encoded = BSON.encode(document)
+    except (InvalidDocument, OverflowError) as exc:
+        raise TypeError("Azure DocumentDB records must be BSON encodable.") from exc
+    if len(encoded) > _MAX_DOCUMENT_BYTES:
+        raise ValueError(f"Azure DocumentDB records cannot exceed {_MAX_DOCUMENT_BYTES} encoded BSON bytes.")
+
+
+def _prepare_filter_field(
+    fields: Sequence[VectorStoreField],
+    definition: VectorStoreCollectionDefinition,
+    name: str,
+) -> tuple[VectorStoreField, str]:
+    if "." in name:
+        raise NotImplementedError("Azure DocumentDB filters support declared top-level logical fields only.")
+    logical_field = definition.try_get_field(name)
+    if logical_field is None:
+        raise ValueError(f"Unknown Azure DocumentDB field '{name}'.")
+    field = next(field for field in fields if field.name == logical_field.name)
+    if field.field_type == "vector":
+        raise NotImplementedError("Azure DocumentDB portable filters do not operate on vector fields.")
+    if field.field_type == "key":
+        return field, "_id"
+    if field.type_ == "dict":
+        raise NotImplementedError(
+            "Azure DocumentDB filters do not support dictionary fields because "
+            "BSON document equality is order-sensitive."
+        )
+    if field.is_indexed is not True:
+        raise NotImplementedError(f"Azure DocumentDB filter field '{field.name}' must declare is_indexed=True.")
+    return field, field.storage_name or field.name
+
+
+def _prepare_filter_operand(field: VectorStoreField, value: Any, *, ordered: bool = False) -> Any:
+    if value is None:
+        if ordered:
+            raise TypeError("Ordered Azure DocumentDB filter operands cannot be null.")
+        return None
+    kind = field.type_
+    if kind == "float" and type(value) in (int, float):
+        if not math.isfinite(value):
+            raise ValueError("Azure DocumentDB numeric filter operands must be finite.")
+        return value
+    if kind == "int" and type(value) in (int, float):
+        if isinstance(value, int) and not -(2**63) <= value < 2**63:
+            raise ValueError("Azure DocumentDB integer filter operands must fit signed 64-bit BSON integers.")
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("Azure DocumentDB numeric filter operands must be finite.")
+        return value
+    if ordered and kind not in {"str", "int", "float"}:
+        raise NotImplementedError("Ordered Azure DocumentDB filters require a string, int, or float field.")
+    if kind == "str" and isinstance(value, str):
+        return value
+    if kind == "bool" and type(value) is bool:
+        return value
+    if kind == "bytes" and isinstance(value, bytes):
+        return value
+    if kind == "list" and isinstance(value, list):
+        return _prepare_untyped_bson_value(value, path=field.name)
+    if kind == "dict" and isinstance(value, dict):
+        return _prepare_untyped_bson_value(value, path=field.name)
+    return _TYPE_MISMATCH
+
+
+class _TypeMismatch:
+    pass
+
+
+_TYPE_MISMATCH = _TypeMismatch()
+
+
+class _FilterCompiler:
+    """Translate a core filter snapshot to a BSON query without string interpolation."""
+
+    def __init__(
+        self,
+        fields: Sequence[VectorStoreField],
+        definition: VectorStoreCollectionDefinition,
+    ) -> None:
+        self.fields = fields
+        self.definition = definition
+
+    def compile(self, expression: FilterExpression) -> _Document:
+        return self._prepare_filter_condition(expression)
+
+    @staticmethod
+    def _false_filter() -> _Document:
+        return {"_id": {"$exists": False}}
+
+    def _prepare_filter_group(self, expression: FilterGroup) -> _Document:
+        children = [self._prepare_filter_condition(child) for child in expression.filters]
+        if expression.operator == "and":
+            return {"$and": children}
+        if expression.operator == "or":
+            return {"$or": children}
+        return {"$nor": children}
+
+    def _prepare_filter_condition(self, expression: FilterExpression) -> _Document:
+        if isinstance(expression, FilterGroup):
+            return self._prepare_filter_group(expression)
+        field, name = _prepare_filter_field(self.fields, self.definition, expression.field_name)
+        operator, value = expression.operator, expression.value
+        if operator == "exists":
+            return {name: {"$exists": True}}
+        if operator == "is_null":
+            return {"$and": [{name: {"$exists": True}}, {name: {"$eq": None}}]}
+        if operator == "is_not_null":
+            return {"$and": [{name: {"$exists": True}}, {name: {"$ne": None}}]}
+        if operator in {"eq", "ne"}:
+            operand = _prepare_filter_operand(field, value)
+            if operand is _TYPE_MISMATCH:
+                if operator == "eq":
+                    return self._false_filter()
+                return {name: {"$exists": True}}
+            condition = {name: {f"${operator}": operand}}
+            if operator == "ne" or operand is None:
+                return {"$and": [{name: {"$exists": True}}, condition]}
+            return condition
+        if operator in {"gt", "gte", "lt", "lte"}:
+            operand = _prepare_filter_operand(field, value, ordered=True)
+            if operand is _TYPE_MISMATCH:
+                raise TypeError(f"Ordered filter operand does not match field '{field.name}'.")
+            return {name: {f"${operator}": operand}}
+        if operator == "between":
+            lower = _prepare_filter_operand(field, value[0], ordered=True)
+            upper = _prepare_filter_operand(field, value[1], ordered=True)
+            if lower is _TYPE_MISMATCH or upper is _TYPE_MISMATCH:
+                raise TypeError(f"Between operands do not match field '{field.name}'.")
+            return {name: {"$gte": lower, "$lte": upper}}
+        if operator in {"in", "not_in"}:
+            if field.type_ == "list":
+                raise NotImplementedError(
+                    "Use contains, contains_any, or contains_all for Azure DocumentDB list fields."
+                )
+            operands = [_prepare_filter_operand(field, item) for item in value]
+            operands = [item for item in operands if item is not _TYPE_MISMATCH]
+            if not operands:
+                if operator == "in":
+                    return self._false_filter()
+                return {"$and": [{name: {"$exists": True}}, {name: {"$ne": None}}]}
+            condition = {name: {"$in" if operator == "in" else "$nin": operands}}
+            if operator == "not_in" or None in operands:
+                guards: list[_Document] = [{name: {"$exists": True}}]
+                if operator == "not_in":
+                    guards.append({name: {"$ne": None}})
+                guards.append(condition)
+                return {"$and": guards}
+            return condition
+        if operator in {"contains", "contains_any", "contains_all"}:
+            if field.type_ != "list":
+                raise TypeError("Azure DocumentDB collection membership requires a declared list field.")
+            operands = [value] if operator == "contains" else list(value)
+            if any(isinstance(item, (list, dict)) for item in operands):
+                raise NotImplementedError("Nested collection membership has ambiguous MongoDB array semantics.")
+            prepared = [_prepare_untyped_bson_value(item, path=f"{field.name}[]") for item in operands]
+            if not prepared:
+                return (
+                    {"$and": [{name: {"$exists": True}}, {name: {"$ne": None}}]}
+                    if operator == "contains_all"
+                    else self._false_filter()
+                )
+            native_operator = "$all" if operator == "contains_all" else "$in"
+            return {
+                "$and": [
+                    {name: {"$exists": True}},
+                    {name: {"$ne": None}},
+                    {name: {native_operator: prepared}},
+                ]
+            }
+        raise NotImplementedError(
+            f"Azure DocumentDB does not support portable filter operator '{operator}' in this connector. "
+            "Literal text operations are not equivalent to regular-expression or analyzed search."
+        )
+
+
+def _index_name(collection_name: str, field_name: str, kind: str) -> str:
+    digest = hashlib.sha256(f"{collection_name}\0{field_name}\0{kind}".encode()).hexdigest()[:32]
+    return f"af_{kind}_{digest}"
+
+
+def _vector_index_options(field: VectorStoreField) -> _Document:
+    kind = _INDEX_KINDS[cast(str, field.index_kind)]
+    annotations = field.provider_annotations
+    options: _Document = {
+        "kind": kind,
+        "dimensions": field.dimensions,
+        "similarity": _METRICS[cast(str, field.distance_function)],
+    }
+    if kind == "vector-ivf":
+        options["numLists"] = annotations.get("azure_documentdb.num_lists", 1)
+    elif kind == "vector-hnsw":
+        options["m"] = annotations.get("azure_documentdb.m", 16)
+        options["efConstruction"] = annotations.get("azure_documentdb.ef_construction", 64)
+    else:
+        options["maxDegree"] = annotations.get("azure_documentdb.max_degree", 32)
+        options["lBuild"] = annotations.get("azure_documentdb.l_build", 50)
+    return options
+
+
+def _vector_index_spec(collection_name: str, field: VectorStoreField) -> _Document:
+    path = field.storage_name or field.name
+    return {
+        "name": _index_name(collection_name, path, "vector"),
+        "key": {path: "cosmosSearch"},
+        "cosmosSearchOptions": _vector_index_options(field),
+    }
+
+
+def _data_index_spec(collection_name: str, field: VectorStoreField) -> _Document:
+    path = field.storage_name or field.name
+    return {"name": _index_name(collection_name, path, "filter"), "key": {path: 1}}
+
+
+def _canonical_vector_options(value: Mapping[str, Any]) -> _Document:
+    raw_kind = value.get("kind")
+    kind = raw_kind if isinstance(raw_kind, str) else None
+    common: set[str] = {"kind", "dimensions", "similarity"}
+    options_by_kind: Mapping[str, set[str]] = {
+        "vector-ivf": {"numLists"},
+        "vector-hnsw": {"m", "efConstruction"},
+        "vector-diskann": {"maxDegree", "lBuild"},
+    }
+    algorithm_options = options_by_kind.get(kind, set[str]()) if kind is not None else set[str]()
+    if unknown := value.keys() - common - algorithm_options:
+        raise ValueError(
+            f"Existing Azure DocumentDB vector index has unsupported option(s): {', '.join(sorted(unknown))}."
+        )
+    result: _Document = {
+        "kind": kind,
+        "dimensions": value.get("dimensions"),
+        "similarity": str(value.get("similarity", "")).upper(),
+    }
+    if kind == "vector-ivf":
+        result["numLists"] = value.get("numLists")
+    elif kind == "vector-hnsw":
+        result["m"] = value.get("m", 16)
+        result["efConstruction"] = value.get("efConstruction", 64)
+    elif kind == "vector-diskann":
+        result["maxDegree"] = value.get("maxDegree", 32)
+        result["lBuild"] = value.get("lBuild", 50)
+    return result
+
+
+def _matching_index(indexes: Sequence[Mapping[str, Any]], expected: Mapping[str, Any]) -> bool:
+    expected_name = expected["name"]
+    expected_key = expected["key"]
+    is_vector = "cosmosSearchOptions" in expected
+    for index in indexes:
+        same_name = index.get("name") == expected_name
+        same_key = index.get("key") == expected_key
+        if not same_name and not same_key:
+            continue
+        if not same_key:
+            raise ValueError(f"Existing Azure DocumentDB index '{expected_name}' has an incompatible key.")
+        if is_vector:
+            raw_options = index.get("cosmosSearch") or index.get("cosmosSearchOptions")
+            if not isinstance(raw_options, Mapping):
+                raise ValueError("Existing Azure DocumentDB vector index is missing cosmosSearch options.")
+            if _canonical_vector_options(cast(Mapping[str, Any], raw_options)) != _canonical_vector_options(
+                cast(Mapping[str, Any], expected["cosmosSearchOptions"])
+            ):
+                raise ValueError(
+                    f"Existing Azure DocumentDB vector index on '{next(iter(cast(Mapping[str, Any], expected_key)))}' "
+                    "is incompatible with the collection definition."
+                )
+        elif (
+            index.get("unique", False) is not False
+            or index.get("sparse", False) is not False
+            or "partialFilterExpression" in index
+            or "expireAfterSeconds" in index
+            or "collation" in index
+        ):
+            raise ValueError(
+                f"Existing Azure DocumentDB filter index on "
+                f"'{next(iter(cast(Mapping[str, Any], expected_key)))}' has incompatible options."
+            )
+        return True
+    return False
+
+
+class AzureDocumentDBCollection(
+    BaseVectorCollection[KeyT, ModelT],
+    BaseVectorSearch[KeyT, ModelT],
+    Generic[KeyT, ModelT],
+):
+    """Store typed BSON documents and search vectors through ``$search.cosmosSearch``.
+
+    Keys are explicit string or signed 64-bit integer ``_id`` values. Generated
+    ObjectIds are intentionally unsupported because converting them to a core key
+    type would not preserve identity. Scores retain Azure DocumentDB's native
+    ``searchScore`` units, where larger values rank first.
+    """
+
+    supported_key_types: ClassVar[set[str] | None] = {"str", "int"}
+    supported_vector_types: ClassVar[set[str] | None] = {"float", "float32", "float64"}
+    supported_search_types: ClassVar[set[SearchType]] = {"vector"}
+
+    def __init__(
+        self,
+        record_type: type[ModelT],
+        *,
+        connection_string: str | SecretString | None = None,
+        database_name: str | None = None,
+        client: _ClientType | None = None,
+        database: _DatabaseType | None = None,
+        collection: _CollectionType | None = None,
+        client_options: Mapping[str, Any] | None = None,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize an Azure DocumentDB collection without performing network I/O.
+
+        Args:
+            record_type: Registered model type, or ``dict`` with an explicit definition.
+            connection_string: MongoDB connection string for a connector-owned client.
+            database_name: Database selected for a created or injected client.
+            client: Caller-owned PyMongo async client. Requires ``database_name``.
+            database: Caller-owned resolved PyMongo async database.
+            collection: Caller-owned resolved PyMongo async collection.
+            client_options: Created-client options limited to ``tls``, ``retryWrites``, and ``appname``.
+            definition: Explicit dictionary schema.
+            collection_name: Collection name overriding the model definition.
+            embedding_generator: Default local embedding generator.
+            env_file_path: Optional selected settings file.
+            env_file_encoding: Encoding of the selected settings file.
+        """
+        if collection is not None:
+            if not isinstance(collection, AsyncCollection):
+                raise TypeError("collection must be a PyMongo AsyncCollection.")
+            if collection_name is not None and collection_name != collection.name:
+                raise ValueError("collection_name must match the injected collection.")
+            if any(
+                value is not None
+                for value in (
+                    connection_string,
+                    database_name,
+                    client,
+                    database,
+                    client_options,
+                    env_file_path,
+                    env_file_encoding,
+                )
+            ):
+                raise ValueError("collection cannot be combined with a client, database, or connection settings.")
+            resolved_collection_name = collection.name
+        else:
+            resolved_collection_name = collection_name
+        super().__init__(
+            record_type,
+            definition=definition,
+            collection_name=resolved_collection_name,
+            embedding_generator=embedding_generator,
+            managed_client=collection is None and client is None and database is None,
+        )
+        _validate_collection_name(self.collection_name)
+        self._fields = tuple(
+            replace(field, provider_annotations=field.provider_annotations) for field in self.definition.fields
+        )
+        if collection is not None:
+            self._client = _Client(collection.database.client, collection.database, owned=False)
+            self.collection = collection
+        else:
+            self._client = _create_client(
+                connection_string,
+                database_name,
+                client=client,
+                database=database,
+                client_options=client_options,
+                env_file_path=env_file_path,
+                env_file_encoding=env_file_encoding,
+            )
+            self.collection = self._client.database[self.collection_name]
+        self._shared_client = False
+
+    def _validate_data_model(self) -> None:
+        super()._validate_data_model()
+        if self.definition.key_field.is_auto_generated:
+            raise NotImplementedError(
+                "Azure DocumentDB generated ObjectId keys are unsupported; provide an explicit string or integer key."
+            )
+        for field in self.definition.fields:
+            name = "_id" if field.field_type == "key" else field.storage_name or field.name
+            _validate_storage_name(name, indexed=field.field_type == "vector" or field.is_indexed is True)
+            if field.field_type != "key" and name == "_id":
+                raise ValueError("Only the key field can map to Azure DocumentDB '_id'.")
+            if field.field_type != "key" and name == _NATIVE_SCORE_FIELD:
+                raise ValueError(f"Azure DocumentDB field name '{_NATIVE_SCORE_FIELD}' is reserved.")
+            if field.field_type == "data":
+                if field.type_ not in _DATA_TYPES:
+                    raise NotImplementedError(
+                        f"Azure DocumentDB data field '{field.name}' needs a supported explicit type; "
+                        f"got '{field.type_}'."
+                    )
+                if field.is_full_text_indexed:
+                    raise NotImplementedError("Azure DocumentDB full-text and hybrid search are not supported.")
+                if field.provider_annotations:
+                    raise NotImplementedError("Azure DocumentDB provider annotations apply only to vector fields.")
+                continue
+            if field.field_type == "key":
+                if field.provider_annotations:
+                    raise NotImplementedError("Azure DocumentDB key provider annotations are unsupported.")
+                continue
+            if type(field.dimensions) is not int or not 1 <= field.dimensions <= 2000:
+                raise ValueError("Azure DocumentDB standard vector dimensions must be an integer from 1 to 2000.")
+            if field.index_kind not in _INDEX_KINDS:
+                raise NotImplementedError(f"Unsupported Azure DocumentDB index kind '{field.index_kind}'.")
+            if field.distance_function not in _METRICS:
+                raise NotImplementedError(
+                    f"Unsupported Azure DocumentDB distance function '{field.distance_function}'."
+                )
+            annotations = field.provider_annotations
+            kind = _INDEX_KINDS[field.index_kind]
+            allowed: set[str]
+            if kind == "vector-ivf":
+                allowed = {"azure_documentdb.num_lists"}
+                _validate_integer(
+                    annotations.get("azure_documentdb.num_lists", 1),
+                    "azure_documentdb.num_lists",
+                    1,
+                )
+            elif kind == "vector-hnsw":
+                allowed = {"azure_documentdb.m", "azure_documentdb.ef_construction"}
+                m = _validate_integer(annotations.get("azure_documentdb.m", 16), "azure_documentdb.m", 2, 100)
+                _validate_integer(
+                    annotations.get("azure_documentdb.ef_construction", 64),
+                    "azure_documentdb.ef_construction",
+                    2 * m,
+                    1000,
+                )
+            else:
+                allowed = {"azure_documentdb.max_degree", "azure_documentdb.l_build"}
+                _validate_integer(
+                    annotations.get("azure_documentdb.max_degree", 32),
+                    "azure_documentdb.max_degree",
+                    20,
+                    2048,
+                )
+                _validate_integer(
+                    annotations.get("azure_documentdb.l_build", 50),
+                    "azure_documentdb.l_build",
+                    10,
+                    500,
+                )
+            if unknown := annotations.keys() - allowed:
+                raise NotImplementedError(
+                    f"Unsupported Azure DocumentDB vector annotation(s): {', '.join(sorted(unknown))}."
+                )
+
+    async def __aenter__(self) -> Self:
+        """Enter the collection context manager."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close resources owned directly by this collection."""
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close a directly owned client, never an injected or store-shared client."""
+        if not self._shared_client:
+            await self._client.close()
+
+    async def _list_indexes(self) -> list[_Document]:
+        cursor = await self.collection.list_indexes()
+        return [dict(index) async for index in cursor]
+
+    async def _ensure_index(self, expected: _Document, *, max_time_ms: int | None) -> None:
+        indexes = await self._list_indexes()
+        if _matching_index(indexes, expected):
+            return
+        command: _Document = {"createIndexes": self.collection_name, "indexes": [expected]}
+        if max_time_ms is not None:
+            command["maxTimeMS"] = max_time_ms
+        try:
+            await self._client.database.command(command)
+        except OperationFailure as exc:
+            details: Mapping[str, Any] = exc.details if isinstance(exc.details, Mapping) else {}
+            if exc.code not in _INDEX_RACE_CODES and details.get("codeName") not in _INDEX_RACE_NAMES:
+                raise
+        indexes = await self._list_indexes()
+        if not _matching_index(indexes, expected):
+            raise IntegrationInvalidResponseException(
+                f"Azure DocumentDB did not expose the requested index '{expected['name']}'."
+            )
+
+    async def ensure_collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Create the collection and reconcile compatible vector/filter indexes."""
+        options = _validate_operation_options(operation_options, {"create_indexes", "max_time_ms"})
+        self._client.ensure_open()
+        create_indexes = options.get("create_indexes", True)
+        if not isinstance(create_indexes, bool):
+            raise TypeError("create_indexes must be a boolean.")
+        max_time_ms = options.get("max_time_ms")
+        if max_time_ms is not None:
+            max_time_ms = _validate_integer(max_time_ms, "max_time_ms", 1)
+        if not await self.collection_exists():
+            try:
+                await self._client.database.create_collection(self.collection_name)
+            except CollectionInvalid:
+                if not await self.collection_exists():
+                    raise
+            except OperationFailure as exc:
+                if exc.code != 48 or not await self.collection_exists():
+                    raise
+        if not create_indexes:
+            return
+        for field in self._fields:
+            if field.field_type == "vector":
+                await self._ensure_index(_vector_index_spec(self.collection_name, field), max_time_ms=max_time_ms)
+            elif field.field_type == "data" and field.is_indexed:
+                await self._ensure_index(_data_index_spec(self.collection_name, field), max_time_ms=max_time_ms)
+
+    async def collection_exists(self, *, operation_options: Mapping[str, Any] | None = None) -> bool:
+        """Return whether the configured collection exists."""
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        return self.collection_name in await self._client.database.list_collection_names()
+
+    async def ensure_collection_deleted(self, *, operation_options: Mapping[str, Any] | None = None) -> None:
+        """Drop only the configured collection when it exists."""
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        if await self.collection_exists():
+            await self._client.database.drop_collection(self.collection_name)
+
+    def _serialize_dicts_to_store_models(
+        self,
+        records: Sequence[dict[str, Any]],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[_Document]:
+        result: list[_Document] = []
+        for record in records:
+            document: _Document = {}
+            for field in self._fields:
+                source_name = field.storage_name or field.name
+                if source_name not in record:
+                    raise ValueError(f"Record is missing Azure DocumentDB field '{field.name}'.")
+                if field.field_type == "key":
+                    document["_id"] = _prepare_key(record[source_name], field.type_)
+                elif field.field_type == "vector":
+                    document[source_name] = _prepare_dense_vector(record[source_name], field)
+                else:
+                    document[source_name] = _prepare_field_value(field, record[source_name])
+            _validate_bson_document(document)
+            result.append(document)
+        return result
+
+    def _deserialize_store_models_to_dicts(
+        self,
+        records: Sequence[Any],
+        *,
+        context: Mapping[str, Any] | None = None,
+    ) -> Sequence[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        key_name = self.definition.key_field_storage_name
+        for item in records:
+            if not isinstance(item, Mapping):
+                raise IntegrationInvalidResponseException("Azure DocumentDB returned a non-document record.")
+            document = dict(cast(Mapping[str, Any], item))
+            if "_id" not in document:
+                raise IntegrationInvalidResponseException("Azure DocumentDB returned a document without '_id'.")
+            document[key_name] = _prepare_key(document.pop("_id"), self.definition.key_field.type_)
+            result.append(document)
+        return result
+
+    def _prepare_filter(self, filter: FilterExpression | None) -> _Document:
+        if filter is None:
+            return {}
+        result = _FilterCompiler(self._fields, self.definition).compile(filter)
+        try:
+            encoded = BSON.encode(result)
+        except (InvalidDocument, OverflowError) as exc:
+            raise TypeError("Azure DocumentDB filters must be BSON encodable.") from exc
+        if len(encoded) > _MAX_DOCUMENT_BYTES:
+            raise ValueError(f"Azure DocumentDB filters cannot exceed {_MAX_DOCUMENT_BYTES} encoded BSON bytes.")
+        return result
+
+    def _projection(self, *, include_vectors: bool, score: bool = False) -> _Document:
+        projection: _Document = {"_id": 1}
+        for field in self._fields:
+            if field.field_type != "key" and (include_vectors or field.field_type != "vector"):
+                projection[field.storage_name or field.name] = 1
+        if score:
+            projection[_NATIVE_SCORE_FIELD] = {"$meta": "searchScore"}
+        return projection
+
+    async def _inner_upsert(
+        self,
+        records: Sequence[Any],
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[KeyT]:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        documents = [dict(cast(Mapping[str, Any], record)) for record in records]
+        for document in documents:
+            _validate_bson_document(document)
+            _prepare_key(document.get("_id"), self.definition.key_field.type_)
+        if not documents:
+            return []
+        completed = 0
+        try:
+            for start in range(0, len(documents), _MAX_WRITES_PER_BATCH):
+                batch = documents[start : start + _MAX_WRITES_PER_BATCH]
+                await self.collection.bulk_write(
+                    [ReplaceOne({"_id": document["_id"]}, document, upsert=True) for document in batch],
+                    ordered=True,
+                )
+                completed += len(batch)
+        except PyMongoError as exc:
+            raise IntegrationException(
+                "Azure DocumentDB upsert failed. "
+                f"{completed} records in earlier batches were applied; the failing batch may be partially applied."
+            ) from exc
+        return [cast(KeyT, document["_id"]) for document in documents]
+
+    async def _inner_get(
+        self,
+        *,
+        keys: Sequence[KeyT] | None = None,
+        filter: FilterExpression | None = None,
+        top: int = 10,
+        skip: int = 0,
+        order_by: Mapping[str, bool] | None = None,
+        include_vectors: bool = False,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[_Document]:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        if order_by:
+            raise NotImplementedError("Azure DocumentDB ordered retrieval is not supported.")
+        projection = self._projection(include_vectors=include_vectors)
+        if keys is None:
+            native_filter = self._prepare_filter(filter)
+            cursor = self.collection.find(native_filter, projection=projection).skip(skip).limit(top)
+            return [document async for document in cursor]
+        if skip:
+            raise ValueError("Azure DocumentDB key retrieval cannot be combined with skip.")
+        prepared_keys = [_prepare_key(key, self.definition.key_field.type_) for key in keys]
+        if not prepared_keys:
+            return []
+        documents: list[_Document] = []
+        for start in range(0, len(prepared_keys), _KEY_BATCH_SIZE):
+            cursor = self.collection.find(
+                {"_id": {"$in": prepared_keys[start : start + _KEY_BATCH_SIZE]}},
+                projection=projection,
+            )
+            documents.extend([document async for document in cursor])
+        by_key = {document["_id"]: document for document in documents}
+        return [by_key[key] for key in prepared_keys if key in by_key]
+
+    async def _inner_delete(
+        self,
+        keys: Sequence[KeyT],
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        prepared_keys = [_prepare_key(key, self.definition.key_field.type_) for key in keys]
+        completed = 0
+        try:
+            for start in range(0, len(prepared_keys), _KEY_BATCH_SIZE):
+                batch = prepared_keys[start : start + _KEY_BATCH_SIZE]
+                await self.collection.delete_many({"_id": {"$in": batch}})
+                completed += len(batch)
+        except PyMongoError as exc:
+            raise IntegrationException(
+                "Azure DocumentDB delete failed. "
+                f"{completed} keys in earlier batches were attempted; the failing batch may be partially applied."
+            ) from exc
+
+    def _search_options(
+        self,
+        field: VectorStoreField,
+        *,
+        top: int,
+        skip: int,
+        operation_options: Mapping[str, Any] | None,
+    ) -> tuple[_Document, int | None]:
+        options = _validate_operation_options(
+            operation_options,
+            {"ef_search", "k", "l_search", "max_time_ms", "n_probes"},
+        )
+        minimum_k = top + skip
+        k = _validate_integer(options.get("k", minimum_k), "k", minimum_k)
+        query: _Document = {"k": k}
+        kind = _INDEX_KINDS[cast(str, field.index_kind)]
+        if kind == "vector-ivf":
+            if "ef_search" in options or "l_search" in options:
+                raise ValueError("IVF search supports n_probes, not ef_search or l_search.")
+            if "n_probes" in options:
+                num_lists = cast(int, field.provider_annotations.get("azure_documentdb.num_lists", 1))
+                query["nProbes"] = _validate_integer(options["n_probes"], "n_probes", 1, num_lists)
+        elif kind == "vector-hnsw":
+            if "n_probes" in options or "l_search" in options:
+                raise ValueError("HNSW search supports ef_search, not n_probes or l_search.")
+            if "ef_search" in options:
+                query["efSearch"] = _validate_integer(options["ef_search"], "ef_search", 1)
+        else:
+            if "n_probes" in options or "ef_search" in options:
+                raise ValueError("DiskANN search supports l_search, not n_probes or ef_search.")
+            l_search = _validate_integer(options.get("l_search", max(40, k)), "l_search", 10, 1000)
+            if k > l_search:
+                raise ValueError("DiskANN search requires k to be less than or equal to l_search.")
+            query["lSearch"] = l_search
+        max_time_ms = options.get("max_time_ms")
+        if max_time_ms is not None:
+            max_time_ms = _validate_integer(max_time_ms, "max_time_ms", 1)
+        return query, max_time_ms
+
+    async def _inner_search(
+        self,
+        *,
+        search_type: SearchType,
+        filter: FilterExpression | None = None,
+        values: Any | None = None,
+        vector: Vector | None = None,
+        top: int = 3,
+        skip: int = 0,
+        include_vectors: bool = False,
+        vector_property_name: str | None = None,
+        additional_property_name: str | None = None,
+        score_threshold: float | None = None,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> SearchResults[Any]:
+        if search_type != "vector" or additional_property_name is not None:
+            raise NotImplementedError("Azure DocumentDB supports dense vector search only.")
+        if vector is None:
+            raise ValueError("Azure DocumentDB search requires a vector or configured embedding generator.")
+        self._client.ensure_open()
+        resolved = self.definition.try_get_vector_field(vector_property_name)
+        if resolved is None:
+            raise ValueError("Select a vector_property_name from the Azure DocumentDB collection definition.")
+        field = next(field for field in self._fields if field.name == resolved.name)
+        query_vector = _prepare_dense_vector(vector, field)
+        if query_vector is None:
+            raise ValueError("Azure DocumentDB query vectors cannot be null.")
+        native_options, max_time_ms = self._search_options(
+            field,
+            top=top,
+            skip=skip,
+            operation_options=operation_options,
+        )
+        cosmos_search: _Document = {
+            "path": field.storage_name or field.name,
+            "vector": query_vector,
+            **native_options,
+        }
+        native_filter = self._prepare_filter(filter)
+        if native_filter:
+            cosmos_search["filter"] = native_filter
+        pipeline: list[_Document] = [
+            {"$search": {"cosmosSearch": cosmos_search}},
+            {"$project": self._projection(include_vectors=include_vectors, score=True)},
+        ]
+        if score_threshold is not None:
+            if isinstance(score_threshold, bool) or not isinstance(score_threshold, (int, float)):
+                raise TypeError("Azure DocumentDB score_threshold must be a finite number.")
+            if not math.isfinite(score_threshold):
+                raise ValueError("Azure DocumentDB score_threshold must be a finite number.")
+            pipeline.append({"$match": {_NATIVE_SCORE_FIELD: {"$gte": score_threshold}}})
+        if skip:
+            pipeline.append({"$skip": skip})
+        pipeline.append({"$limit": top})
+        cursor = (
+            await self.collection.aggregate(pipeline, maxTimeMS=max_time_ms)
+            if max_time_ms is not None
+            else await self.collection.aggregate(pipeline)
+        )
+        return SearchResults(
+            cursor,
+            metadata={
+                "candidate_window": cosmos_search["k"],
+                "distance_function": field.distance_function or "DEFAULT",
+                "index_kind": field.index_kind,
+                "metric": _METRICS[cast(str, field.distance_function)],
+                "score_threshold_direction": "minimum",
+            },
+        )
+
+    def _get_record_from_result(self, result: Any) -> _Document:
+        if not isinstance(result, Mapping):
+            raise IntegrationInvalidResponseException("Azure DocumentDB returned a non-document search result.")
+        document = dict(cast(Mapping[str, Any], result))
+        if _NATIVE_SCORE_FIELD not in document:
+            raise IntegrationInvalidResponseException("Azure DocumentDB search result is missing searchScore.")
+        document.pop(_NATIVE_SCORE_FIELD)
+        return document
+
+    def _get_score_from_result(self, result: Any) -> float:
+        if not isinstance(result, Mapping):
+            raise IntegrationInvalidResponseException("Azure DocumentDB returned a non-document search result.")
+        score = cast(Mapping[str, Any], result).get(_NATIVE_SCORE_FIELD)
+        if isinstance(score, bool) or not isinstance(score, (int, float)) or not math.isfinite(score):
+            raise IntegrationInvalidResponseException("Azure DocumentDB returned an invalid searchScore.")
+        return float(score)
+
+
+class AzureDocumentDBStore(BaseVectorStore):
+    """Create collection clients that share one resolved Azure DocumentDB database."""
+
+    def __init__(
+        self,
+        *,
+        connection_string: str | SecretString | None = None,
+        database_name: str | None = None,
+        client: _ClientType | None = None,
+        database: _DatabaseType | None = None,
+        client_options: Mapping[str, Any] | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+        env_file_path: str | None = None,
+        env_file_encoding: str | None = None,
+    ) -> None:
+        """Initialize a store without performing network I/O.
+
+        Args:
+            connection_string: MongoDB connection string for a connector-owned client.
+            database_name: Database selected for a created or injected client.
+            client: Caller-owned PyMongo async client. Requires ``database_name``.
+            database: Caller-owned resolved PyMongo async database.
+            client_options: Created-client options limited to ``tls``, ``retryWrites``, and ``appname``.
+            embedding_generator: Default embedding generator for child collections.
+            env_file_path: Optional selected settings file.
+            env_file_encoding: Encoding of the selected settings file.
+        """
+        super().__init__(
+            embedding_generator=embedding_generator,
+            managed_client=client is None and database is None,
+        )
+        self._client = _create_client(
+            connection_string,
+            database_name,
+            client=client,
+            database=database,
+            client_options=client_options,
+            env_file_path=env_file_path,
+            env_file_encoding=env_file_encoding,
+        )
+
+    def get_collection(
+        self,
+        record_type: type[ModelT],
+        *,
+        definition: VectorStoreCollectionDefinition | None = None,
+        collection_name: str | None = None,
+        embedding_generator: EmbeddingClient | None = None,
+    ) -> AzureDocumentDBCollection[Any, ModelT]:
+        """Create a collection that borrows this store's resolved database."""
+        collection = AzureDocumentDBCollection(
+            record_type,
+            database=self._client.database,
+            definition=definition,
+            collection_name=collection_name,
+            embedding_generator=embedding_generator if embedding_generator is not None else self.embedding_generator,
+        )
+        collection._client = self._client  # pyright: ignore[reportPrivateUsage]
+        collection._shared_client = True  # pyright: ignore[reportPrivateUsage]
+        return collection
+
+    async def list_collection_names(
+        self,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> Sequence[str]:
+        """List collection names in the resolved database."""
+        _validate_operation_options(operation_options)
+        mark_feature_used(FeatureIndex.CORE_VECTOR_STORES)
+        self._client.ensure_open()
+        return await self._client.database.list_collection_names()
+
+    async def collection_exists(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> bool:
+        """Return whether one collection exists."""
+        _validate_operation_options(operation_options)
+        mark_feature_used(FeatureIndex.CORE_VECTOR_STORES)
+        self._client.ensure_open()
+        _validate_collection_name(collection_name)
+        return collection_name in await self._client.database.list_collection_names()
+
+    async def _inner_ensure_collection_deleted(
+        self,
+        collection_name: str,
+        *,
+        operation_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        _validate_operation_options(operation_options)
+        self._client.ensure_open()
+        _validate_collection_name(collection_name)
+        await self._client.database.drop_collection(collection_name)
+
+    async def aclose(self) -> None:
+        """Close the connector-owned client once, leaving injected clients open."""
+        await self._client.close()
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the connector-owned client on context exit."""
+        await self.aclose()

--- a/python/packages/azure-documentdb/agent_framework_azure_documentdb/_vector_store.py
+++ b/python/packages/azure-documentdb/agent_framework_azure_documentdb/_vector_store.py
@@ -1050,6 +1050,9 @@ class AzureDocumentDBCollection(
         native_filter = self._prepare_filter(filter)
         if native_filter:
             cosmos_search["filter"] = native_filter
+        metric = _METRICS[cast(str, field.distance_function)]
+        threshold_operator = "$lte" if metric == "L2" else "$gte"
+        threshold_direction = "maximum" if metric == "L2" else "minimum"
         pipeline: list[_Document] = [
             {"$search": {"cosmosSearch": cosmos_search}},
             {"$project": self._projection(include_vectors=include_vectors, score=True)},
@@ -1059,7 +1062,7 @@ class AzureDocumentDBCollection(
                 raise TypeError("Azure DocumentDB score_threshold must be a finite number.")
             if not math.isfinite(score_threshold):
                 raise ValueError("Azure DocumentDB score_threshold must be a finite number.")
-            pipeline.append({"$match": {_NATIVE_SCORE_FIELD: {"$gte": score_threshold}}})
+            pipeline.append({"$match": {_NATIVE_SCORE_FIELD: {threshold_operator: score_threshold}}})
         if skip:
             pipeline.append({"$skip": skip})
         pipeline.append({"$limit": top})
@@ -1074,8 +1077,8 @@ class AzureDocumentDBCollection(
                 "candidate_window": cosmos_search["k"],
                 "distance_function": field.distance_function or "DEFAULT",
                 "index_kind": field.index_kind,
-                "metric": _METRICS[cast(str, field.distance_function)],
-                "score_threshold_direction": "minimum",
+                "metric": metric,
+                "score_threshold_direction": threshold_direction,
             },
         )
 

--- a/python/packages/azure-documentdb/pyproject.toml
+++ b/python/packages/azure-documentdb/pyproject.toml
@@ -1,0 +1,66 @@
+[project]
+name = "agent-framework-azure-documentdb"
+description = "Azure DocumentDB vector stores for Microsoft Agent Framework."
+authors = [{ name = "Microsoft", email = "af-support@microsoft.com" }]
+readme = "README.md"
+requires-python = ">=3.10"
+version = "1.0.0a260909"
+license-files = ["LICENSE"]
+urls.homepage = "https://aka.ms/agent-framework"
+urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
+urls.issues = "https://github.com/microsoft/agent-framework/issues"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+dependencies = [
+    "agent-framework-core>=1.17.0,<2",
+    "pymongo>=4.13,<5",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra -q -r fEX"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 120
+markers = [
+    "flaky: marks tests that depend on external services",
+    "integration: requires an explicitly authorized Azure DocumentDB test database",
+]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.per-file-ignores]
+"samples/**" = ["D", "INP", "commented-out-code", "RUF", "S", "print", "CPY"]
+"tests/**" = ["D", "INP", "TD", "commented-out-code", "RUF", "S"]
+
+[tool.coverage.run]
+omit = ["**/__init__.py"]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["agent_framework_azure_documentdb"]
+
+[tool.poe]
+executor.type = "uv"
+include = "../../shared_tasks.toml"
+
+[tool.poe.tasks.test]
+cmd = 'pytest -m "not integration" --cov=agent_framework_azure_documentdb --cov-report=term-missing:skip-covered tests'
+
+[tool.poe.tasks.test-integration]
+cmd = "pytest -m integration tests"
+
+[build-system]
+requires = ["flit-core>=3.11,<4.0"]
+build-backend = "flit_core.buildapi"

--- a/python/packages/azure-documentdb/samples/README.md
+++ b/python/packages/azure-documentdb/samples/README.md
@@ -9,5 +9,6 @@ and index creation is authorized.
 Run it from `python/`:
 
 ```bash
-uv run packages/azure-documentdb/samples/azure_documentdb_vectors.py
+uv run --package agent-framework-azure-documentdb \
+    python packages/azure-documentdb/samples/azure_documentdb_vectors.py
 ```

--- a/python/packages/azure-documentdb/samples/README.md
+++ b/python/packages/azure-documentdb/samples/README.md
@@ -1,0 +1,13 @@
+# Azure DocumentDB vector store sample
+
+`azure_documentdb_vectors.py` creates one uniquely named collection, writes
+deterministic vectors, performs filtered searches across two vector fields, and
+deletes the collection. Set `AZURE_DOCUMENTDB_CONNECTION_STRING` and
+`AZURE_DOCUMENTDB_DATABASE_NAME` for a development database where collection
+and index creation is authorized.
+
+Run it from `python/`:
+
+```bash
+uv run packages/azure-documentdb/samples/azure_documentdb_vectors.py
+```

--- a/python/packages/azure-documentdb/samples/azure_documentdb_vectors.py
+++ b/python/packages/azure-documentdb/samples/azure_documentdb_vectors.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-framework-azure-documentdb",
+# ]
+# ///
+
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Annotated
+from uuid import uuid4
+
+from agent_framework import Filter, VectorStoreField, vectorstoremodel
+
+from agent_framework_azure_documentdb import AzureDocumentDBStore
+
+"""
+Use Azure DocumentDB with two top-level vector fields and an indexed metadata filter.
+
+This sample uses deterministic vectors, not an embedding API. It creates and
+deletes a uniquely named collection in the configured development database.
+"""
+
+
+@vectorstoremodel
+@dataclass
+class Note:
+    id: Annotated[str, VectorStoreField("key")]
+    text: Annotated[str, VectorStoreField("data")]
+    category: Annotated[str, VectorStoreField("data", is_indexed=True)]
+    title_vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=3, index_kind="ivf_flat"),
+    ] = None
+    body_vector: Annotated[
+        list[float] | None,
+        VectorStoreField("vector", dimensions=3, index_kind="ivf_flat"),
+    ] = None
+
+
+async def main() -> None:
+    # 1. The store resolves AF settings and owns the PyMongo async client.
+    async with AzureDocumentDBStore() as store:
+        collection = store.get_collection(Note, collection_name=f"af_demo_{uuid4().hex}")
+        await collection.ensure_collection_exists()
+        try:
+            # 2. Preserve the supplied vectors rather than calling an embedding API.
+            await collection.upsert(
+                [
+                    Note("documentdb", "Azure DocumentDB stores vectors", "database", [1, 0, 0], [0, 1, 0]),
+                    Note("travel", "A travel journal", "travel", [0, 1, 0], [1, 0, 0]),
+                ],
+                generate_vectors=False,
+            )
+
+            # 3. Select one vector path and apply the filter in cosmosSearch.
+            results = await collection.search(
+                vector=[1, 0, 0],
+                vector_property_name="title_vector",
+                filter=Filter("category", "eq", "database"),
+            )
+            async for result in results:
+                print(result["record"].text, result["score"])
+
+            # 4. Ordinary retrieval omits vectors unless explicitly requested.
+            notes = await collection.get(["documentdb"], include_vectors=True)
+            print(notes[0].body_vector)
+        finally:
+            await collection.ensure_collection_deleted()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# Expected output resembles:
+# Azure DocumentDB stores vectors 1.0
+# [0.0, 1.0, 0.0]

--- a/python/packages/azure-documentdb/samples/azure_documentdb_vectors.py
+++ b/python/packages/azure-documentdb/samples/azure_documentdb_vectors.py
@@ -1,10 +1,3 @@
-# /// script
-# requires-python = ">=3.10"
-# dependencies = [
-#     "agent-framework-azure-documentdb",
-# ]
-# ///
-
 # Copyright (c) Microsoft. All rights reserved.
 
 from __future__ import annotations

--- a/python/packages/azure-documentdb/tests/azure_documentdb/conftest.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/conftest.py
@@ -1,0 +1,148 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agent_framework import VectorStoreCollectionDefinition, VectorStoreField
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.asynchronous.database import AsyncDatabase
+
+from agent_framework_azure_documentdb import AzureDocumentDBCollection
+
+
+class AsyncCursor:
+    def __init__(self, values: Sequence[dict[str, Any]]) -> None:
+        self.values = list(values)
+        self.skip_value = 0
+        self.limit_value: int | None = None
+
+    def skip(self, value: int) -> AsyncCursor:
+        self.skip_value = value
+        return self
+
+    def limit(self, value: int) -> AsyncCursor:
+        self.limit_value = value
+        return self
+
+    def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        async def iterate() -> AsyncIterator[dict[str, Any]]:
+            end = None if self.limit_value is None else self.skip_value + self.limit_value
+            for value in self.values[self.skip_value : end]:
+                yield value
+
+        return iterate()
+
+
+@pytest.fixture
+def definition_factory():
+    def make(
+        *,
+        key_type: str = "str",
+        generated: bool = False,
+        dimensions: int = 3,
+        index_kind: str = "ivf_flat",
+        distance_function: str = "DEFAULT",
+        annotations: dict[str, Any] | None = None,
+        second_vector: bool = False,
+        category_indexed: bool = True,
+    ) -> VectorStoreCollectionDefinition:
+        fields = [
+            VectorStoreField("key", name="id", type_=key_type, storage_name="record_id", is_auto_generated=generated),
+            VectorStoreField("data", name="text", type_="str", storage_name="body"),
+            VectorStoreField("data", name="category", type_="str", is_indexed=category_indexed),
+            VectorStoreField("data", name="number", type_="int", is_indexed=True),
+            VectorStoreField("data", name="ratio", type_="float", is_indexed=True),
+            VectorStoreField("data", name="flag", type_="bool", is_indexed=True),
+            VectorStoreField("data", name="tags", type_="list", is_indexed=True),
+            VectorStoreField(
+                "vector",
+                name="embedding",
+                type_="float",
+                storage_name="contentVector",
+                dimensions=dimensions,
+                index_kind=index_kind,
+                distance_function=distance_function,
+                provider_annotations=annotations,
+            ),
+        ]
+        if second_vector:
+            fields.append(
+                VectorStoreField(
+                    "vector",
+                    name="secondary",
+                    type_="float",
+                    storage_name="titleVector",
+                    dimensions=dimensions,
+                    index_kind="ivf_flat",
+                )
+            )
+        return VectorStoreCollectionDefinition(fields, collection_name="documents")
+
+    return make
+
+
+@pytest.fixture
+def record_factory():
+    def make(
+        id: str | int = "one",
+        *,
+        text: str = "Azure DocumentDB",
+        category: str | None = "database",
+        number: Any = 1,
+        ratio: Any = 1.5,
+        flag: Any = True,
+        tags: Any = None,
+        embedding: Any = None,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        return {
+            "id": id,
+            "text": text,
+            "category": category,
+            "number": number,
+            "ratio": ratio,
+            "flag": flag,
+            "tags": ["azure", 1, True, None] if tags is None else tags,
+            "embedding": [1.0, 0.0, 0.0] if embedding is None else embedding,
+            **extra,
+        }
+
+    return make
+
+
+@pytest.fixture
+def pymongo_objects():
+    client = MagicMock(spec=AsyncMongoClient)
+    client.close = AsyncMock()
+    database = MagicMock(spec=AsyncDatabase)
+    database.name = "test_database"
+    database.client = client
+    database.list_collection_names = AsyncMock(return_value=["documents"])
+    database.create_collection = AsyncMock()
+    database.drop_collection = AsyncMock()
+    database.command = AsyncMock(return_value={"ok": 1})
+    collection = MagicMock(spec=AsyncCollection)
+    collection.name = "documents"
+    collection.database = database
+    collection.bulk_write = AsyncMock()
+    collection.delete_many = AsyncMock()
+    collection.list_indexes = AsyncMock(return_value=AsyncCursor([{"name": "_id_", "key": {"_id": 1}}]))
+    collection.aggregate = AsyncMock(return_value=AsyncCursor([]))
+    collection.find = MagicMock(return_value=AsyncCursor([]))
+    database.__getitem__.return_value = collection
+    client.__getitem__.return_value = database
+    return client, database, collection
+
+
+@pytest.fixture
+def collection(definition_factory, pymongo_objects):
+    return AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(),
+        collection=pymongo_objects[2],
+    )

--- a/python/packages/azure-documentdb/tests/azure_documentdb/test_integration.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/test_integration.py
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from agent_framework import Filter, VectorStoreCollectionDefinition, VectorStoreField
+
+from agent_framework_azure_documentdb import AzureDocumentDBCollection
+
+pytestmark = [pytest.mark.flaky, pytest.mark.integration]
+
+_CONNECTION_STRING = os.getenv("AZURE_DOCUMENTDB_TEST_CONNECTION_STRING")
+_DATABASE_NAME = os.getenv("AZURE_DOCUMENTDB_TEST_DATABASE_NAME")
+_WRITES_AUTHORIZED = os.getenv("AZURE_DOCUMENTDB_TEST_ALLOW_WRITES") == "true"
+skip_if_managed_tests_disabled = pytest.mark.skipif(
+    not _CONNECTION_STRING or not _DATABASE_NAME or not _WRITES_AUTHORIZED,
+    reason=(
+        "Set AZURE_DOCUMENTDB_TEST_CONNECTION_STRING, AZURE_DOCUMENTDB_TEST_DATABASE_NAME, and "
+        "AZURE_DOCUMENTDB_TEST_ALLOW_WRITES=true for an authorized disposable managed test database."
+    ),
+)
+
+
+def _vector(seed: int, *, dimensions: int = 1536) -> list[float]:
+    return [((seed * 17 + index * 31) % 997) / 997 for index in range(dimensions)]
+
+
+@skip_if_managed_tests_disabled
+async def test_managed_documentdb_two_vector_fields_with_1000_records() -> None:
+    assert _DATABASE_NAME is not None and "test" in _DATABASE_NAME.lower()
+    collection_name = os.getenv("AZURE_DOCUMENTDB_TEST_COLLECTION_NAME") or f"af_vector_test_{uuid4().hex}"
+    definition = VectorStoreCollectionDefinition(
+        [
+            VectorStoreField("key", name="id", type_="str"),
+            VectorStoreField("data", name="category", type_="str", is_indexed=True),
+            VectorStoreField(
+                "vector",
+                name="content_vector",
+                type_="float",
+                dimensions=1536,
+                index_kind="ivf_flat",
+                provider_annotations={"azure_documentdb.num_lists": 1},
+            ),
+            VectorStoreField(
+                "vector",
+                name="title_vector",
+                type_="float",
+                dimensions=1536,
+                index_kind="ivf_flat",
+                provider_annotations={"azure_documentdb.num_lists": 1},
+            ),
+        ],
+        collection_name=collection_name,
+    )
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition,
+        connection_string=_CONNECTION_STRING,
+        database_name=_DATABASE_NAME,
+    )
+    await connector.ensure_collection_exists()
+    try:
+        records = [
+            {
+                "id": f"record-{index:04d}",
+                "category": "even" if index % 2 == 0 else "odd",
+                "content_vector": _vector(index),
+                "title_vector": _vector(1000 - index),
+            }
+            for index in range(1000)
+        ]
+        keys = await connector.upsert(records, generate_vectors=False)
+        assert len(keys) == 1000
+
+        content_results = await connector.search(
+            vector=_vector(0),
+            vector_property_name="content_vector",
+            filter=Filter("category", "eq", "even"),
+            top=5,
+        )
+        content_page = [result async for result in content_results]
+        assert content_page and content_page[0]["record"]["id"] == "record-0000"
+
+        title_results = await connector.search(
+            vector=_vector(1),
+            vector_property_name="title_vector",
+            top=5,
+            include_vectors=True,
+        )
+        title_page = [result async for result in title_results]
+        assert title_page and len(title_page[0]["record"]["title_vector"]) == 1536
+    finally:
+        await connector.ensure_collection_deleted()
+        await connector.aclose()

--- a/python/packages/azure-documentdb/tests/azure_documentdb/test_integration.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/test_integration.py
@@ -84,6 +84,15 @@ async def test_managed_documentdb_two_vector_fields_with_1000_records() -> None:
         content_page = [result async for result in content_results]
         assert content_page and content_page[0]["record"]["id"] == "record-0000"
 
+        negative_filter_results = await connector.search(
+            vector=_vector(0),
+            vector_property_name="content_vector",
+            filter=Filter("category", "ne", "odd"),
+            top=5,
+        )
+        negative_filter_page = [result async for result in negative_filter_results]
+        assert negative_filter_page and all(result["record"]["category"] == "even" for result in negative_filter_page)
+
         title_results = await connector.search(
             vector=_vector(1),
             vector_property_name="title_vector",

--- a/python/packages/azure-documentdb/tests/azure_documentdb/test_settings.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/test_settings.py
@@ -1,0 +1,166 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+from typing import get_type_hints
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agent_framework import SecretString, load_settings
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+
+from agent_framework_azure_documentdb import (
+    AzureDocumentDBCollection,
+    AzureDocumentDBSettings,
+    AzureDocumentDBStore,
+)
+from agent_framework_azure_documentdb import _vector_store as module
+
+
+def test_public_settings_use_af_secret_string(monkeypatch):
+    monkeypatch.setenv("AZURE_DOCUMENTDB_CONNECTION_STRING", "mongodb://user:secret@example")
+    monkeypatch.setenv("AZURE_DOCUMENTDB_DATABASE_NAME", "environment_db")
+    assert get_type_hints(AzureDocumentDBSettings) == {
+        "connection_string": SecretString | None,
+        "database_name": str | None,
+    }
+    settings = load_settings(AzureDocumentDBSettings, env_prefix="AZURE_DOCUMENTDB_")
+    secret = settings["connection_string"]
+    assert isinstance(secret, SecretString)
+    assert secret.get_secret_value() == "mongodb://user:secret@example"
+    assert "secret" not in str(secret)
+    assert settings["database_name"] == "environment_db"
+
+
+def test_explicit_settings_precede_file_and_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("AZURE_DOCUMENTDB_CONNECTION_STRING", "mongodb://environment")
+    monkeypatch.setenv("AZURE_DOCUMENTDB_DATABASE_NAME", "environment_db")
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(
+        "AZURE_DOCUMENTDB_CONNECTION_STRING=mongodb://file\nAZURE_DOCUMENTDB_DATABASE_NAME=file_db\n",
+        encoding="utf-8",
+    )
+    created = MagicMock(spec=AsyncMongoClient)
+    created.close = AsyncMock()
+    with patch.object(module, "AsyncMongoClient", return_value=created) as client_type:
+        store = AzureDocumentDBStore(
+            connection_string=SecretString("mongodb://explicit"),
+            database_name="explicit_db",
+            env_file_path=str(env_file),
+        )
+    assert store._client.client is created
+    assert client_type.call_args.args == ("mongodb://explicit",)
+    assert client_type.call_args.kwargs == {
+        "appname": "agent-framework-azure-documentdb",
+        "retryWrites": False,
+        "tls": True,
+    }
+    created.__getitem__.assert_called_once_with("explicit_db")
+
+
+def test_selected_file_precedes_environment_and_uses_encoding(monkeypatch, tmp_path):
+    monkeypatch.setenv("AZURE_DOCUMENTDB_CONNECTION_STRING", "mongodb://environment")
+    monkeypatch.setenv("AZURE_DOCUMENTDB_DATABASE_NAME", "environment_db")
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(
+        "AZURE_DOCUMENTDB_CONNECTION_STRING=mongodb://file\nAZURE_DOCUMENTDB_DATABASE_NAME=file_db\n",
+        encoding="utf-16",
+    )
+    with patch.object(module, "AsyncMongoClient") as client_type:
+        AzureDocumentDBStore(env_file_path=str(env_file), env_file_encoding="utf-16")
+    assert client_type.call_args.args == ("mongodb://file",)
+    client_type.return_value.__getitem__.assert_called_once_with("file_db")
+
+
+def test_missing_or_empty_settings_rejected_before_client(monkeypatch):
+    monkeypatch.delenv("AZURE_DOCUMENTDB_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_DOCUMENTDB_DATABASE_NAME", raising=False)
+    with patch.object(module, "AsyncMongoClient") as client_type:
+        with pytest.raises(ValueError, match="connection_string"):
+            AzureDocumentDBStore()
+        with pytest.raises(ValueError, match="connection_string"):
+            AzureDocumentDBStore(connection_string="", database_name="db")
+    client_type.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"tls": False},
+        {"retryWrites": True},
+        {"appname": ""},
+        {"appname": "x\0y"},
+        {"password": "must-not-be-forwarded"},
+    ],
+)
+def test_client_options_rejected(options):
+    with patch.object(module, "AsyncMongoClient") as client_type, pytest.raises((ValueError, NotImplementedError)):
+        AzureDocumentDBStore(
+            connection_string="mongodb://explicit",
+            database_name="db",
+            client_options=options,
+        )
+    client_type.assert_not_called()
+
+
+async def test_injected_client_bypasses_settings_and_remains_caller_owned(monkeypatch):
+    monkeypatch.setenv("AZURE_DOCUMENTDB_CONNECTION_STRING", "must-not-be-read")
+    client = MagicMock(spec=AsyncMongoClient)
+    client.close = AsyncMock()
+    database = MagicMock(spec=AsyncDatabase)
+    client.__getitem__.return_value = database
+    with patch.object(module, "load_settings", side_effect=AssertionError("settings must be bypassed")):
+        store = AzureDocumentDBStore(client=client, database_name="borrowed")
+        await store.aclose()
+    assert store._client.database is database
+    assert not store.managed_client
+    client.close.assert_not_awaited()
+
+
+async def test_injected_database_and_collection_bypass_settings(definition_factory, pymongo_objects):
+    client, database, collection = pymongo_objects
+    with patch.object(module, "load_settings", side_effect=AssertionError("settings must be bypassed")):
+        store = AzureDocumentDBStore(database=database)
+        direct = AzureDocumentDBCollection(dict, definition=definition_factory(), collection=collection)
+        await store.aclose()
+        await direct.aclose()
+    client.close.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"connection_string": "mongodb://explicit"},
+        {"client_options": {"tls": True}},
+        {"env_file_path": "selected.env"},
+        {"env_file_encoding": "utf-16"},
+    ],
+)
+def test_injected_client_rejects_connection_settings(kwargs, pymongo_objects):
+    with (
+        patch.object(module, "load_settings", side_effect=AssertionError("settings must be bypassed")),
+        pytest.raises(ValueError, match="cannot be combined"),
+    ):
+        AzureDocumentDBStore(client=pymongo_objects[0], database_name="db", **kwargs)
+
+
+async def test_store_children_reuse_resolved_client(definition_factory, pymongo_objects):
+    store = AzureDocumentDBStore(database=pymongo_objects[1])
+    with patch.object(module, "load_settings", side_effect=AssertionError("children must reuse the database")):
+        child = store.get_collection(dict, definition=definition_factory())
+    assert child._client is store._client
+    await child.aclose()
+    pymongo_objects[0].close.assert_not_awaited()
+
+
+async def test_created_client_closes_once(monkeypatch):
+    monkeypatch.setenv("AZURE_DOCUMENTDB_CONNECTION_STRING", "mongodb://environment")
+    monkeypatch.setenv("AZURE_DOCUMENTDB_DATABASE_NAME", "environment_db")
+    created = MagicMock(spec=AsyncMongoClient)
+    created.close = AsyncMock()
+    with patch.object(module, "AsyncMongoClient", return_value=created):
+        store = AzureDocumentDBStore()
+        await store.aclose()
+        await store.aclose()
+    created.close.assert_awaited_once()

--- a/python/packages/azure-documentdb/tests/azure_documentdb/test_vector_store.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/test_vector_store.py
@@ -1,0 +1,653 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+from __future__ import annotations
+
+import math
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import replace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from agent_framework import Filter, FilterGroup, VectorStoreCollectionDefinition
+from agent_framework.exceptions import IntegrationException, IntegrationInvalidResponseException
+from bson import ObjectId
+from pymongo.errors import OperationFailure, PyMongoError
+
+from agent_framework_azure_documentdb import AzureDocumentDBCollection, AzureDocumentDBStore
+from agent_framework_azure_documentdb._vector_store import (
+    _data_index_spec,
+    _FilterCompiler,
+    _matching_index,
+    _vector_index_spec,
+)
+
+
+class AsyncCursor:
+    def __init__(self, values: Sequence[dict[str, Any]]) -> None:
+        self.values = list(values)
+        self.skip_value = 0
+        self.limit_value: int | None = None
+
+    def skip(self, value: int) -> AsyncCursor:
+        self.skip_value = value
+        return self
+
+    def limit(self, value: int) -> AsyncCursor:
+        self.limit_value = value
+        return self
+
+    def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        async def iterate() -> AsyncIterator[dict[str, Any]]:
+            end = None if self.limit_value is None else self.skip_value + self.limit_value
+            for value in self.values[self.skip_value : end]:
+                yield value
+
+        return iterate()
+
+
+def test_model_supports_multiple_vectors_and_aliases(definition_factory, pymongo_objects):
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(second_vector=True),
+        collection=pymongo_objects[2],
+    )
+    assert [field.storage_name for field in connector._fields[-2:]] == ["contentVector", "titleVector"]
+
+
+def test_reserved_score_alias_rejected(definition_factory, pymongo_objects):
+    definition = definition_factory()
+    fields = [
+        replace(field, storage_name="_af_documentdb_score" if field.name == "text" else field.storage_name)
+        for field in definition.fields
+    ]
+    with pytest.raises(ValueError, match="reserved"):
+        AzureDocumentDBCollection(
+            dict,
+            definition=VectorStoreCollectionDefinition(fields, collection_name="documents"),
+            collection=pymongo_objects[2],
+        )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"generated": True},
+        {"key_type": "UUID"},
+        {"dimensions": 0},
+        {"dimensions": 2001},
+        {"dimensions": True},
+        {"index_kind": "flat"},
+        {"distance_function": "cosine_distance"},
+        {"distance_function": "hamming"},
+        {"annotations": {"azure_documentdb.unknown": 1}},
+        {"index_kind": "ivf_flat", "annotations": {"azure_documentdb.num_lists": 0}},
+        {"index_kind": "hnsw", "annotations": {"azure_documentdb.m": 101}},
+        {
+            "index_kind": "hnsw",
+            "annotations": {"azure_documentdb.m": 40, "azure_documentdb.ef_construction": 64},
+        },
+        {"index_kind": "disk_ann", "annotations": {"azure_documentdb.max_degree": 19}},
+        {"index_kind": "disk_ann", "annotations": {"azure_documentdb.l_build": 501}},
+    ],
+)
+def test_model_capabilities_rejected_before_io(definition_factory, pymongo_objects, options):
+    with pytest.raises((ValueError, NotImplementedError)):
+        AzureDocumentDBCollection(
+            dict,
+            definition=definition_factory(**options),
+            collection=pymongo_objects[2],
+        )
+
+
+def test_key_and_data_storage_names_are_mapped(definition_factory, pymongo_objects, record_factory):
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(),
+        collection=pymongo_objects[2],
+    )
+    stored = connector._serialize_dicts_to_store_models([connector._serialize_record_to_dict(record_factory())])[0]
+    assert stored["_id"] == "one"
+    assert "record_id" not in stored
+    assert stored["body"] == "Azure DocumentDB"
+    restored = connector._deserialize_store_models_to_dicts([stored])[0]
+    assert restored["record_id"] == "one"
+
+
+@pytest.mark.parametrize("key", [True, 1.5, object(), 2**63, -(2**63) - 1, "x" * 2049])
+async def test_keys_are_strict_before_io(collection, pymongo_objects, record_factory, key):
+    with pytest.raises((TypeError, ValueError, NotImplementedError)):
+        await collection.upsert([record_factory(cast(Any, key))], generate_vectors=False)
+    with pytest.raises((TypeError, ValueError)):
+        await collection.get([cast(Any, key)])
+    pymongo_objects[2].bulk_write.assert_not_awaited()
+    pymongo_objects[2].find.assert_not_called()
+
+
+def test_object_id_response_is_not_implicitly_encoded(collection):
+    with pytest.raises(TypeError, match="strings or signed"):
+        collection._deserialize_store_models_to_dicts([{"_id": ObjectId()}])
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("number", True),
+        ("number", 2**63),
+        ("ratio", float("nan")),
+        ("flag", 1),
+        ("tags", ("tuple",)),
+        ("text", b"bytes"),
+    ],
+)
+async def test_record_values_are_type_checked_before_io(
+    collection,
+    pymongo_objects,
+    record_factory,
+    field,
+    value,
+):
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record_factory(**{field: value})], generate_vectors=False)
+    pymongo_objects[2].bulk_write.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        "not-a-vector",
+        b"bytes",
+        [1, True, 0],
+        [1, "0", 0],
+        [1, float("nan"), 0],
+        [1, 2**63, 0],
+    ],
+)
+async def test_vectors_are_validated_before_io(collection, pymongo_objects, record_factory, vector):
+    with pytest.raises((TypeError, ValueError)):
+        await collection.upsert([record_factory(embedding=vector)], generate_vectors=False)
+    pymongo_objects[2].bulk_write.assert_not_awaited()
+
+
+async def test_late_invalid_batch_performs_no_io(collection, pymongo_objects, record_factory):
+    with pytest.raises(TypeError):
+        await collection.upsert(
+            [record_factory("valid"), record_factory("invalid", embedding=[1, "invalid", 0])],
+            generate_vectors=False,
+        )
+    pymongo_objects[2].bulk_write.assert_not_awaited()
+
+
+async def test_document_size_preflight_performs_no_io(collection, pymongo_objects, record_factory):
+    with (
+        patch("agent_framework_azure_documentdb._vector_store._MAX_DOCUMENT_BYTES", 100),
+        pytest.raises(ValueError, match="encoded BSON"),
+    ):
+        await collection.upsert([record_factory(text="x" * 1_000)], generate_vectors=False)
+    pymongo_objects[2].bulk_write.assert_not_awaited()
+
+
+async def test_upsert_chunks_and_reports_partial_writes(collection, pymongo_objects, record_factory):
+    pymongo_objects[2].bulk_write.side_effect = [None, PyMongoError("failed")]
+    with (
+        patch("agent_framework_azure_documentdb._vector_store._MAX_WRITES_PER_BATCH", 2),
+        pytest.raises(IntegrationException, match="2 records in earlier batches"),
+    ):
+        await collection.upsert(
+            [record_factory(str(index)) for index in range(3)],
+            generate_vectors=False,
+        )
+    assert pymongo_objects[2].bulk_write.await_count == 2
+
+
+async def test_upsert_preserves_order_and_duplicate_keys(collection, pymongo_objects, record_factory):
+    keys = await collection.upsert(
+        [record_factory("same"), record_factory("same")],
+        generate_vectors=False,
+    )
+    assert keys == ["same", "same"]
+    requests = pymongo_objects[2].bulk_write.call_args.args[0]
+    assert len(requests) == 2
+
+
+@pytest.mark.parametrize(
+    "expression,expected",
+    [
+        (Filter("category", "eq", "database"), {"category": {"$eq": "database"}}),
+        (
+            Filter("category", "ne", "database"),
+            {"$and": [{"category": {"$exists": True}}, {"category": {"$ne": "database"}}]},
+        ),
+        (
+            Filter("category", "is_null"),
+            {"$and": [{"category": {"$exists": True}}, {"category": {"$eq": None}}]},
+        ),
+        (
+            Filter("category", "is_not_null"),
+            {"$and": [{"category": {"$exists": True}}, {"category": {"$ne": None}}]},
+        ),
+        (Filter("category", "exists"), {"category": {"$exists": True}}),
+        (Filter("number", "between", [1, 3]), {"number": {"$gte": 1, "$lte": 3}}),
+        (
+            Filter("number", "not_in", [1, 2]),
+            {
+                "$and": [
+                    {"number": {"$exists": True}},
+                    {"number": {"$ne": None}},
+                    {"number": {"$nin": [1, 2]}},
+                ]
+            },
+        ),
+        (
+            Filter("tags", "contains", "azure"),
+            {
+                "$and": [
+                    {"tags": {"$exists": True}},
+                    {"tags": {"$ne": None}},
+                    {"tags": {"$in": ["azure"]}},
+                ]
+            },
+        ),
+        (
+            Filter("tags", "contains_all", ["azure", 1]),
+            {
+                "$and": [
+                    {"tags": {"$exists": True}},
+                    {"tags": {"$ne": None}},
+                    {"tags": {"$all": ["azure", 1]}},
+                ]
+            },
+        ),
+    ],
+)
+def test_filter_compilation_uses_mongo_wire_operators(collection, expression, expected):
+    assert collection._prepare_filter(expression) == expected
+    assert "$neq" not in repr(expected)
+
+
+def test_filter_groups_and_values_remain_bson_documents(collection):
+    payload = "'; drop collection documents; --"
+    expression = FilterGroup(
+        "and",
+        [
+            Filter("category", "eq", payload),
+            FilterGroup("not", [Filter("flag", "eq", False)]),
+        ],
+    )
+    assert collection._prepare_filter(expression) == {
+        "$and": [
+            {"category": {"$eq": payload}},
+            {"$nor": [{"flag": {"$eq": False}}]},
+        ]
+    }
+
+
+def test_filter_bson_size_is_checked_before_io(collection):
+    with (
+        patch("agent_framework_azure_documentdb._vector_store._MAX_DOCUMENT_BYTES", 100),
+        pytest.raises(ValueError, match="filters cannot exceed"),
+    ):
+        collection._prepare_filter(Filter("category", "eq", "x" * 1_000))
+
+
+@pytest.mark.parametrize(
+    "expression,error",
+    [
+        (Filter("text", "eq", "not-indexed"), NotImplementedError),
+        (Filter("embedding", "is_null"), NotImplementedError),
+        (Filter("category.nested", "eq", "x"), NotImplementedError),
+        (Filter("category", "contains_text", "x"), NotImplementedError),
+        (Filter("category", "starts_with", "x"), NotImplementedError),
+        (Filter("category", "azure_documentdb.regex", "^x"), NotImplementedError),
+        (Filter("tags", "contains", ["nested"]), NotImplementedError),
+        (Filter("tags", "in", [["azure"]]), NotImplementedError),
+        (Filter("flag", "gt", True), NotImplementedError),
+    ],
+)
+def test_unsupported_filters_fail_before_io(collection, expression, error):
+    with pytest.raises(error):
+        collection._prepare_filter(expression)
+
+
+def test_empty_membership_semantics(collection):
+    assert collection._prepare_filter(Filter("number", "in", [])) == {"_id": {"$exists": False}}
+    assert collection._prepare_filter(Filter("number", "not_in", [])) == {
+        "$and": [{"number": {"$exists": True}}, {"number": {"$ne": None}}]
+    }
+    assert collection._prepare_filter(Filter("tags", "contains_any", [])) == {"_id": {"$exists": False}}
+    assert collection._prepare_filter(Filter("tags", "contains_all", [])) == {
+        "$and": [{"tags": {"$exists": True}}, {"tags": {"$ne": None}}]
+    }
+
+
+def test_filter_type_mismatches_preserve_bool_number_distinction(collection):
+    assert collection._prepare_filter(Filter("number", "eq", True)) == {"_id": {"$exists": False}}
+    assert collection._prepare_filter(Filter("flag", "eq", 1)) == {"_id": {"$exists": False}}
+    assert collection._prepare_filter(Filter("number", "ne", True)) == {"number": {"$exists": True}}
+
+
+async def test_filtered_get_uses_prepared_filter_and_server_paging(collection, pymongo_objects):
+    cursor = AsyncCursor([
+        {"_id": "zero", "body": "0", "category": "database", "number": 0, "ratio": 0.0, "flag": True, "tags": []},
+        {"_id": "one", "body": "1", "category": "database", "number": 1, "ratio": 1.0, "flag": True, "tags": []},
+        {"_id": "two", "body": "2", "category": "database", "number": 2, "ratio": 2.0, "flag": True, "tags": []},
+    ])
+    pymongo_objects[2].find.return_value = cursor
+    records = await collection.get(filter=Filter("category", "eq", "database"), skip=1, top=1)
+    assert [record["id"] for record in records] == ["one"]
+    assert pymongo_objects[2].find.call_args.args[0] == {"category": {"$eq": "database"}}
+    assert cursor.skip_value == 1 and cursor.limit_value == 1
+
+
+async def test_key_get_preserves_input_order_and_omits_missing(collection, pymongo_objects):
+    pymongo_objects[2].find.return_value = AsyncCursor([
+        {"_id": "two", "body": "2", "category": "db", "number": 2, "ratio": 2.0, "flag": True, "tags": []},
+        {"_id": "one", "body": "1", "category": "db", "number": 1, "ratio": 1.0, "flag": True, "tags": []},
+    ])
+    records = await collection.get(["one", "missing", "two", "one"])
+    assert [record["id"] for record in records] == ["one", "two", "one"]
+
+
+async def test_empty_key_batches_perform_no_io(collection, pymongo_objects):
+    assert await collection.get([]) == []
+    await collection.delete([])
+    pymongo_objects[2].find.assert_not_called()
+    pymongo_objects[2].delete_many.assert_not_awaited()
+
+
+async def test_delete_preflights_all_keys_before_io(collection, pymongo_objects):
+    with pytest.raises(IntegrationException):
+        await collection.delete(["valid", cast(Any, True)])
+    pymongo_objects[2].delete_many.assert_not_awaited()
+
+
+async def test_delete_reports_partial_batches(collection, pymongo_objects):
+    pymongo_objects[2].delete_many.side_effect = [None, PyMongoError("failed")]
+    with (
+        patch("agent_framework_azure_documentdb._vector_store._KEY_BATCH_SIZE", 2),
+        pytest.raises(IntegrationException, match="2 keys in earlier batches"),
+    ):
+        await collection.delete(["one", "two", "three"])
+
+
+async def test_search_pipeline_threshold_before_paging_and_vector_projection(
+    collection,
+    pymongo_objects,
+):
+    pymongo_objects[2].aggregate.return_value = AsyncCursor([
+        {
+            "_id": "one",
+            "body": "Azure",
+            "category": "database",
+            "number": 1,
+            "ratio": 1.0,
+            "flag": True,
+            "tags": [],
+            "_af_documentdb_score": 0.9,
+        }
+    ])
+    results = await collection.search(
+        vector=[1, 0, 0],
+        filter=Filter("category", "eq", "database"),
+        score_threshold=0.8,
+        top=2,
+        skip=1,
+        operation_options={"k": 10, "n_probes": 1, "max_time_ms": 5000},
+    )
+    pipeline = pymongo_objects[2].aggregate.call_args.args[0]
+    assert pipeline[0] == {
+        "$search": {
+            "cosmosSearch": {
+                "path": "contentVector",
+                "vector": [1, 0, 0],
+                "k": 10,
+                "nProbes": 1,
+                "filter": {"category": {"$eq": "database"}},
+            }
+        }
+    }
+    assert pipeline[1]["$project"]["_af_documentdb_score"] == {"$meta": "searchScore"}
+    assert "contentVector" not in pipeline[1]["$project"]
+    assert pipeline[2] == {"$match": {"_af_documentdb_score": {"$gte": 0.8}}}
+    assert pipeline[3:] == [{"$skip": 1}, {"$limit": 2}]
+    assert pymongo_objects[2].aggregate.call_args.kwargs == {"maxTimeMS": 5000}
+    assert results.metadata is not None and results.metadata["candidate_window"] == 10
+    responses = [response async for response in results]
+    assert len(responses) == 1 and responses[0]["score"] == 0.9
+    assert responses[0]["record"]["id"] == "one"
+
+
+async def test_empty_search_results_are_supported(collection, pymongo_objects):
+    results = await collection.search(vector=[1, 0, 0])
+    assert [result async for result in results] == []
+
+
+@pytest.mark.parametrize(
+    "definition_options,operation_options",
+    [
+        ({"index_kind": "ivf_flat"}, {"ef_search": 10}),
+        ({"index_kind": "ivf_flat"}, {"n_probes": 2}),
+        ({"index_kind": "hnsw"}, {"n_probes": 1}),
+        ({"index_kind": "disk_ann"}, {"ef_search": 40}),
+        ({"index_kind": "disk_ann"}, {"k": 1001}),
+        ({"index_kind": "disk_ann"}, {"k": 50, "l_search": 40}),
+        ({"index_kind": "disk_ann"}, {"l_search": 9}),
+    ],
+)
+async def test_search_option_bounds_fail_before_io(
+    definition_factory,
+    pymongo_objects,
+    definition_options,
+    operation_options,
+):
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(**definition_options),
+        collection=pymongo_objects[2],
+    )
+    with pytest.raises(ValueError):
+        await connector.search(vector=[1, 0, 0], operation_options=operation_options)
+    pymongo_objects[2].aggregate.assert_not_awaited()
+
+
+async def test_hnsw_and_diskann_search_options_use_service_names(definition_factory, pymongo_objects):
+    hnsw = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(index_kind="hnsw"),
+        collection=pymongo_objects[2],
+    )
+    await hnsw.search(vector=[1, 0, 0], operation_options={"ef_search": 75})
+    assert pymongo_objects[2].aggregate.call_args.args[0][0]["$search"]["cosmosSearch"]["efSearch"] == 75
+
+    diskann = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(index_kind="disk_ann"),
+        collection=pymongo_objects[2],
+    )
+    await diskann.search(vector=[1, 0, 0], operation_options={"l_search": 80})
+    assert pymongo_objects[2].aggregate.call_args.args[0][0]["$search"]["cosmosSearch"]["lSearch"] == 80
+
+
+def test_index_specs_use_documentdb_commands(definition_factory):
+    definition = definition_factory(
+        index_kind="hnsw",
+        distance_function="dot_prod",
+        annotations={"azure_documentdb.m": 12, "azure_documentdb.ef_construction": 48},
+    )
+    vector_spec = _vector_index_spec("documents", definition.vector_fields[0])
+    assert vector_spec["key"] == {"contentVector": "cosmosSearch"}
+    assert vector_spec["cosmosSearchOptions"] == {
+        "kind": "vector-hnsw",
+        "dimensions": 3,
+        "similarity": "IP",
+        "m": 12,
+        "efConstruction": 48,
+    }
+    assert _data_index_spec("documents", definition.data_fields[1])["key"] == {"category": 1}
+
+
+def test_index_compatibility_canonicalizes_documented_defaults(definition_factory):
+    expected = _vector_index_spec(
+        "documents",
+        definition_factory(index_kind="hnsw").vector_fields[0],
+    )
+    existing: list[dict[str, Any]] = [
+        {
+            "name": "administrator_name",
+            "key": {"contentVector": "cosmosSearch"},
+            "cosmosSearch": {
+                "kind": "vector-hnsw",
+                "dimensions": 3,
+                "similarity": "cos",
+            },
+        }
+    ]
+    assert _matching_index(existing, expected)
+    cast(dict[str, Any], existing[0]["cosmosSearch"])["m"] = 32
+    with pytest.raises(ValueError, match="incompatible"):
+        _matching_index(existing, expected)
+
+
+def test_filter_index_compatibility_rejects_semantic_options(definition_factory):
+    expected = _data_index_spec("documents", definition_factory().data_fields[1])
+    assert _matching_index([{"name": "existing", "key": {"category": 1}}], expected)
+    for option in (
+        {"unique": True},
+        {"sparse": True},
+        {"partialFilterExpression": {"category": {"$exists": True}}},
+        {"expireAfterSeconds": 60},
+        {"collation": {"locale": "en"}},
+    ):
+        with pytest.raises(ValueError, match="incompatible options"):
+            _matching_index([{"name": "existing", "key": {"category": 1}, **option}], expected)
+
+
+async def test_ensure_index_command_and_narrow_race_revalidation(
+    collection,
+    pymongo_objects,
+    definition_factory,
+):
+    expected = _vector_index_spec("documents", definition_factory().vector_fields[0])
+    existing = {
+        "name": expected["name"],
+        "key": expected["key"],
+        "cosmosSearch": expected["cosmosSearchOptions"],
+    }
+    pymongo_objects[2].list_indexes.side_effect = [
+        AsyncCursor([{"name": "_id_", "key": {"_id": 1}}]),
+        AsyncCursor([{"name": "_id_", "key": {"_id": 1}}, existing]),
+    ]
+    pymongo_objects[1].command.side_effect = OperationFailure(
+        "index raced",
+        code=85,
+        details={"codeName": "IndexOptionsConflict"},
+    )
+    await collection._ensure_index(expected, max_time_ms=5000)
+    assert pymongo_objects[1].command.call_args.args[0] == {
+        "createIndexes": "documents",
+        "indexes": [expected],
+        "maxTimeMS": 5000,
+    }
+
+
+async def test_unrelated_index_failure_is_not_suppressed(
+    collection,
+    pymongo_objects,
+    definition_factory,
+):
+    expected = _vector_index_spec("documents", definition_factory().vector_fields[0])
+    pymongo_objects[1].command.side_effect = OperationFailure("forbidden", code=13)
+    with pytest.raises(OperationFailure):
+        await collection._ensure_index(expected, max_time_ms=None)
+
+
+async def test_ensure_collection_reconciles_each_vector_and_filter_index(
+    definition_factory,
+    pymongo_objects,
+):
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(second_vector=True),
+        collection=pymongo_objects[2],
+    )
+    with patch.object(connector, "_ensure_index", new_callable=AsyncMock) as ensure:
+        await connector.ensure_collection_exists()
+    specs = [call.args[0] for call in ensure.call_args_list]
+    assert [spec["key"] for spec in specs if "cosmosSearchOptions" in spec] == [
+        {"contentVector": "cosmosSearch"},
+        {"titleVector": "cosmosSearch"},
+    ]
+    assert {"category": 1} in [spec["key"] for spec in specs]
+
+
+async def test_incompatible_existing_index_is_not_replaced(
+    collection,
+    pymongo_objects,
+    definition_factory,
+):
+    expected = _vector_index_spec("documents", definition_factory().vector_fields[0])
+    pymongo_objects[2].list_indexes.return_value = AsyncCursor([
+        {
+            "name": "existing",
+            "key": expected["key"],
+            "cosmosSearch": {
+                **expected["cosmosSearchOptions"],
+                "dimensions": 4,
+            },
+        }
+    ])
+    with pytest.raises(ValueError, match="incompatible"):
+        await collection._ensure_index(expected, max_time_ms=None)
+    pymongo_objects[1].command.assert_not_awaited()
+
+
+async def test_store_lifecycle_is_database_scoped(definition_factory, pymongo_objects):
+    store = AzureDocumentDBStore(database=pymongo_objects[1])
+    assert await store.list_collection_names() == ["documents"]
+    assert await store.collection_exists("documents")
+    await store.ensure_collection_deleted("documents")
+    pymongo_objects[1].drop_collection.assert_awaited_once_with("documents")
+
+
+async def test_invalid_search_result_is_reported_during_iteration(collection, pymongo_objects):
+    pymongo_objects[2].aggregate.return_value = AsyncCursor([
+        {"_id": "one", "body": "text", "category": "db", "number": 1, "ratio": 1.0, "flag": True, "tags": []}
+    ])
+    results = await collection.search(vector=[1, 0, 0])
+    with pytest.raises(IntegrationInvalidResponseException, match="searchScore"):
+        _ = [result async for result in results]
+
+
+def test_filter_compiler_calls_are_isolated(definition_factory):
+    definition = definition_factory()
+    compiler = _FilterCompiler(definition.fields, definition)
+    first = compiler.compile(Filter("number", "eq", 1))
+    second = compiler.compile(Filter("number", "eq", 2))
+    assert first == {"number": {"$eq": 1}}
+    assert second == {"number": {"$eq": 2}}
+
+
+@pytest.mark.parametrize("score", [True, float("nan"), float("inf"), "0.5"])
+async def test_invalid_native_scores_rejected(collection, pymongo_objects, score):
+    pymongo_objects[2].aggregate.return_value = AsyncCursor([
+        {
+            "_id": "one",
+            "body": "text",
+            "category": "db",
+            "number": 1,
+            "ratio": 1.0,
+            "flag": True,
+            "tags": [],
+            "_af_documentdb_score": score,
+        }
+    ])
+    results = await collection.search(vector=[1, 0, 0])
+    with pytest.raises(IntegrationInvalidResponseException):
+        _ = [result async for result in results]
+
+
+def test_score_threshold_requires_finite_number(collection):
+    for threshold in (True, float("nan"), float("inf"), "0.5"):
+        with pytest.raises(IntegrationInvalidResponseException):
+            collection._get_score_from_result({"_af_documentdb_score": threshold})
+    assert math.isclose(collection._get_score_from_result({"_af_documentdb_score": 0.5}), 0.5)

--- a/python/packages/azure-documentdb/tests/azure_documentdb/test_vector_store.py
+++ b/python/packages/azure-documentdb/tests/azure_documentdb/test_vector_store.py
@@ -412,9 +412,31 @@ async def test_search_pipeline_threshold_before_paging_and_vector_projection(
     assert pipeline[3:] == [{"$skip": 1}, {"$limit": 2}]
     assert pymongo_objects[2].aggregate.call_args.kwargs == {"maxTimeMS": 5000}
     assert results.metadata is not None and results.metadata["candidate_window"] == 10
+    assert results.metadata["metric"] == "COS"
+    assert results.metadata["score_threshold_direction"] == "minimum"
     responses = [response async for response in results]
     assert len(responses) == 1 and responses[0]["score"] == 0.9
     assert responses[0]["record"]["id"] == "one"
+
+
+async def test_euclidean_threshold_is_maximum_before_paging(definition_factory, pymongo_objects):
+    connector = AzureDocumentDBCollection(
+        dict,
+        definition=definition_factory(distance_function="euclidean_distance"),
+        collection=pymongo_objects[2],
+    )
+    results = await connector.search(
+        vector=[1, 0, 0],
+        score_threshold=0.5,
+        top=2,
+        skip=1,
+    )
+    pipeline = pymongo_objects[2].aggregate.call_args.args[0]
+    assert pipeline[2] == {"$match": {"_af_documentdb_score": {"$lte": 0.5}}}
+    assert pipeline[3:] == [{"$skip": 1}, {"$limit": 2}]
+    assert results.metadata is not None
+    assert results.metadata["metric"] == "L2"
+    assert results.metadata["score_threshold_direction"] == "maximum"
 
 
 async def test_empty_search_results_are_supported(collection, pymongo_objects):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -78,6 +78,7 @@ agent-framework-core = { workspace = true }
 agent-framework-a2a = { workspace = true }
 agent-framework-ag-ui = { workspace = true }
 agent-framework-azure-ai-search = { workspace = true }
+agent-framework-azure-documentdb = { workspace = true }
 agent-framework-azure-cosmos = { workspace = true }
 agent-framework-anthropic = { workspace = true }
 agent-framework-bedrock = { workspace = true }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -37,6 +37,7 @@ members = [
     "agent-framework-azure-contentunderstanding",
     "agent-framework-azure-cosmos",
     "agent-framework-azure-cosmos-memory",
+    "agent-framework-azure-documentdb",
     "agent-framework-bedrock",
     "agent-framework-chatkit",
     "agent-framework-claude",
@@ -338,6 +339,21 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+]
+
+[[package]]
+name = "agent-framework-azure-documentdb"
+version = "1.0.0a260909"
+source = { editable = "packages/azure-documentdb" }
+dependencies = [
+    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pymongo", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-framework-core", editable = "packages/core" },
+    { name = "pymongo", specifier = ">=4.13,<5" },
 ]
 
 [[package]]
@@ -2001,6 +2017,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -4885,6 +4910,67 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/0a/d4daac76f66c466c20f00215064d43f4eb4b0aba8f2d8ecabdcc13102bc5/pymongo-4.18.0.tar.gz", hash = "sha256:6f33cd2033e8ea216d3069b5ebea79ded74ef2a93f69a93b26cf310082f9b5b9", size = 2741743, upload-time = "2026-09-03T16:01:06.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a8/2dd2627a1bb8e9b7cc137464b8b494b3b857c6a4c668d544892feeb66b02/pymongo-4.18.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:232629980d2286644fcfdab89d6f16990a4b34f9c11f8e94184491895c84f652", size = 818176, upload-time = "2026-09-03T15:59:06.646Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f8/7da63e0961009dab27a74424c054dc802dee526de2660a41443323bdb320/pymongo-4.18.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d478d036b15a7b421bd663290fbdcf2ba6a6072943cdd6cb90274832c40534b", size = 818709, upload-time = "2026-09-03T15:59:08.412Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/1c/1af393729126c9999daa4703d9b52c699878a73a4e6c4636061069655fae/pymongo-4.18.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:065f8c5d5a8c677cfefc2dd59fe55b649827255375675f9061b459163735e123", size = 1022755, upload-time = "2026-09-03T15:59:10.274Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/9eac4d41ea1cfcad75db29e89942cd2eea21339647e71805979805e85d8b/pymongo-4.18.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a376caecb6cf32d0b27190a304e884e6db68b05d3bdf3ee3a7e780081745efbe", size = 1031177, upload-time = "2026-09-03T15:59:12.23Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ee/79749c0c936845539b0acede9ced62c2720d41d6a438a32e448907437620/pymongo-4.18.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5277ec3804d6c174953aab6e960f6590d7ed43ee932c4c29183a4123881762e5", size = 1053410, upload-time = "2026-09-03T15:59:13.997Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ca/814fe3f7bac4c84c6400dc34b7b73bcca8f5eff60e52ea9e0e7e9ad8b723/pymongo-4.18.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ee6af1a764a563bf82ac49b54b38cf7e34615ddb709c974aa7a9105a9b9d24e", size = 1046128, upload-time = "2026-09-03T15:59:15.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/c21e7fe8f480538c58f718b49bd1370e81f2ebaae91c6b4844378d17c24e/pymongo-4.18.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3ef22f72013934c1a688f42c3dc629b2c8215d03e313ec45f00e4f9a80ef2c8", size = 1032499, upload-time = "2026-09-03T15:59:17.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0b/b2883d8cc6ea4dbe089d613bb3f480d37c2c60d5b6fc5811bbf359709b3e/pymongo-4.18.0-cp311-cp311-win32.whl", hash = "sha256:fb0ad64ed30b8ad268ebcafebefe00750868c23d4d62b137da3316f26f3361b1", size = 813895, upload-time = "2026-09-03T15:59:19.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/93/588e44ab0db8a016d052f9e225e987c2709fe36111b975baf47d31ae1efd/pymongo-4.18.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac4029c949f8141ea5600e34e12cc400507d664e2746cda4fa4f2895959bebed", size = 819706, upload-time = "2026-09-03T15:59:21.401Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b4/03a75f77a129a3f8ec33c28d6abac23198a4c18a455ecc02a5bbf336c07e/pymongo-4.18.0-cp311-cp311-win_arm64.whl", hash = "sha256:d22465d4798d4fbfc6992de089d07ca33821fcaaf876a15942a9cc2e99441ad4", size = 815044, upload-time = "2026-09-03T15:59:23.137Z" },
+    { url = "https://files.pythonhosted.org/packages/71/45/b0d2f2c463d4c74eec652bb4bfaa7107c0ccc0880ad06d3d384f6c393aab/pymongo-4.18.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:209aa073b8939bfbdae0e74d76c85db4ad8681aa4ec157d6db3aa5e0ada6ec8d", size = 818678, upload-time = "2026-09-03T15:59:24.918Z" },
+    { url = "https://files.pythonhosted.org/packages/00/6a/c08d9c0131ea86fc13837d8b4c90264ace36c2c6823a65e2af07819c24e3/pymongo-4.18.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd37241ae704da14b71961da2b6a862a6100bfa83419782de3c3e2336a5d330e", size = 819107, upload-time = "2026-09-03T15:59:26.718Z" },
+    { url = "https://files.pythonhosted.org/packages/37/50/f5204dc860cf219b744e70f8c69b8ae7b08093acb200d56c3fd7b10b59b5/pymongo-4.18.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:47f443322528b03106c7bcc4784288ae35fe5d7bf4cf99a9d79cb4b582a3ecdc", size = 1039079, upload-time = "2026-09-03T15:59:28.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3f/7a4a9d3f8d0dfed987914dcd77bf87e2091889b1b1b5076b73deddf2ccf4/pymongo-4.18.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:751c2cc268e0a43e53ed6d41d3c36ca23f048b35714a9e1c83a3b3216bda37af", size = 1050403, upload-time = "2026-09-03T15:59:30.501Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/9916952952bebc37b0cc1b7544e494da33ebe779581dc7d5ceca020eac8e/pymongo-4.18.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b48d37852d45673a6ef38cc91fdee6ad59eef74d1f24691c6f19069a5de936ac", size = 1075134, upload-time = "2026-09-03T15:59:32.509Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/57/54b5f915b3daa31fe4a93f04700bd0f17570fabc90a7d7c107aa3da14248/pymongo-4.18.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e84103297ac0d1f3079ba6891b1f5f3f9459cbe1a61ad5465643c311021bec6a", size = 1068019, upload-time = "2026-09-03T15:59:34.859Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a5/9987c5b2f909f9b7796de7e3c5ea3f9d7ebe3e3454862904e80bd6c37654/pymongo-4.18.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21a0b97c0fcb9ce63895e37642e64dbb119b27053f7b5292ca9dfb597c1bca5f", size = 1049555, upload-time = "2026-09-03T15:59:36.573Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/ce8c73aaf26461232efe31659b448699f46f29dfa7fd2726e582bf9b6ec8/pymongo-4.18.0-cp312-cp312-win32.whl", hash = "sha256:7ab8e8f9d636a199a60c01427eff854b52d3bec5023e7ed516b3b0e26ee088f6", size = 814802, upload-time = "2026-09-03T15:59:38.308Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ae/ab46e8a875675b9b0ab76f04e30267f8d56988b776977c29584a2ae3f0be/pymongo-4.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:96bd084e388afa10eda7ea7e2e2c7b070589ff180ae7a61b7af9039747c2848f", size = 820395, upload-time = "2026-09-03T15:59:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a3/81e90bba3e5e011ba818854f84efc5480386349aa8039f85b5ed196f7264/pymongo-4.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:9a50d8ad7310b87e09d34ddf398c3d347d1ab28599b7f181d432a59ce89cb6ac", size = 815303, upload-time = "2026-09-03T15:59:41.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b1/6602487d94f6aef7677b18fe149bb0693fa209acf3b339a44ad8bc4060b2/pymongo-4.18.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:29c60dce70a300a09c0af39c2dbebd1a0199db9eb4d3ef03a4eeb587e7675668", size = 818600, upload-time = "2026-09-03T15:59:43.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/eb/c5beaf94967ef5c9aaf9db65fbe1d82337f7cf9c6b6df6c0e8d4c70f9e13/pymongo-4.18.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0d821ca5865e88c2dc29e259a191d770a53093c6749c6b228f18b078cb598faf", size = 818942, upload-time = "2026-09-03T15:59:45.515Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/3a19ece4d253e6be1d5e293701c2948330927a7e91d19372e9c4a04e2139/pymongo-4.18.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0a61148df54b254b4157aaba2139cb8fc97b8232281d783e0b7b2d58cb000fcb", size = 1039154, upload-time = "2026-09-03T15:59:47.222Z" },
+    { url = "https://files.pythonhosted.org/packages/50/95/944159a0c4bd68c40f3a96c617d3d1815768e23cd0cb0b730827c7a9115b/pymongo-4.18.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eda647930ecf0419fb3cecc448c40020e3871adbae523b302d15d2c49d22c866", size = 1050185, upload-time = "2026-09-03T15:59:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/90/70faae774a27545f6e9d085877a1acc884e48b0e7afadf51d2f17eab15ae/pymongo-4.18.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04766d0930bc06dc99e3274a800fb81e85f2629f27ba7bc326e2d4d13ea449d5", size = 1074933, upload-time = "2026-09-03T15:59:51.246Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e1/fb0807668b8ffc0ffbe92786cb0ed6c10e70c32be5123fd49ff4ff2006e2/pymongo-4.18.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:368cd67dd1d3ead5836c20457b84d674256f27b3e99c332d085081680c8465b9", size = 1067686, upload-time = "2026-09-03T15:59:52.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dc/7c620995d4dff3eb1fdf62236844f3cb67d3042ed1a6d4f4059ef5dc79a6/pymongo-4.18.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9b8e25f672f5b2b30c6b834e162454e721cf1f782e753f0e9ea3bca225900f3", size = 1049459, upload-time = "2026-09-03T15:59:54.958Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/25/a317ab554f604ce30fa778af82264627a7784c4a750c3d8459589f751cf4/pymongo-4.18.0-cp313-cp313-win32.whl", hash = "sha256:f15feb666fa56a43e4b318471eff7fba6facbfc3b2555185a0fef871f6b9ccf1", size = 814841, upload-time = "2026-09-03T15:59:56.657Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/58/a2a4b209a3066db88d82c9b44e5b75286aa5a00172dbca357af20bb8b1e4/pymongo-4.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:a2d96ad52eca16939564cbae9c91ffa92a9705ad46cb8d5de26b95dba0d40793", size = 820431, upload-time = "2026-09-03T15:59:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/8cd86494c9001f8e5331f51384b187962696bac3188fcbe05f7edf8dceed/pymongo-4.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:b230196ea62fc4542d9d6b78ddd9dbf0c9437ac2fde5810f7305377ae50fed11", size = 815328, upload-time = "2026-09-03T16:00:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/db/86/6c79e21ddad4a9165f5023c723220f23c68012949efaa89a02d13a684bff/pymongo-4.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4343c06f00fafdd8c8d73521ed8b4c468aa74e1b8f65cd757fb5f6ac3df685b3", size = 818495, upload-time = "2026-09-03T16:00:02.951Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/5b783fa8d6cb08d9590e56969accab39194e801f35a174c77d494dcefb94/pymongo-4.18.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:277e61864ad6a064d75d7efbf5ce0e57378c420e48af6b7bad63e8356dcb22e1", size = 819063, upload-time = "2026-09-03T16:00:04.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/19/f671bdb2533ef47ba49bd1cd2a65c16c2e5540abd9f48f0c8661a7243c56/pymongo-4.18.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b43545a785e4054db2f712ae7d2a640874500a2352e705dbe49c8a1b90de87f2", size = 1040923, upload-time = "2026-09-03T16:00:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/36/3c4d10c334f76dcd135313ca21d3a902f13a3e46438b36bbea9413ab7fbf/pymongo-4.18.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34f3c9adcc26dbfdc50cbb27da5c369588e6862241ea5cf96d33139f57fd9e0b", size = 1050899, upload-time = "2026-09-03T16:00:08.976Z" },
+    { url = "https://files.pythonhosted.org/packages/76/80/f7f686185a7e386dd1d9ad4bde0353a5150b7a1129957beed764bcf900fa/pymongo-4.18.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cd7577d4f28c882b42b356f86f7cf7566698beb347b75dcd742ffe5aac3c3462", size = 1074920, upload-time = "2026-09-03T16:00:11.099Z" },
+    { url = "https://files.pythonhosted.org/packages/19/5e/072839ec02e1a11518120bcc81e59a60f2e3d3629e760f05e0a1c3b7344a/pymongo-4.18.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c50998113e17737fc2048e0184eda8c3aef465acc5a554fb76e2b0266805278", size = 1064362, upload-time = "2026-09-03T16:00:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/6e56a573977a60047fb8bf3646eb5eb121c689678fce4eb2f6ddd5cfbe2b/pymongo-4.18.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b88f2dfa33e1680e8990b45036c7cdb79c5c5e0b1f08b2e5c942893d76853eb6", size = 1049153, upload-time = "2026-09-03T16:00:15.047Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6b/bf0bc7eab0df3e7ef0669ceadbf25528f41fe304979335e49d79c4012515/pymongo-4.18.0-cp314-cp314-win32.whl", hash = "sha256:13b1ad2110fbc8ec151e996ae8ea22727db8b2bd48515141d76d4fb54bd07da3", size = 815986, upload-time = "2026-09-03T16:00:16.919Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9f/630977caf0b8022c8a6b2a55c242c7d264ce519bb5a68d8736de338866ce/pymongo-4.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:e11e86c9a0f81d23cdd0d0a42a9312c888139d7d330ddd744973d79fec87630c", size = 821904, upload-time = "2026-09-03T16:00:18.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/8a6de9d310207a070ebbf78e93bcda6e1cf9cf137368b73efc2d2b83c704/pymongo-4.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:4c6f85e33ef338148cd70bc682fc73bfd202a1cde554057d807905d2310767ad", size = 816438, upload-time = "2026-09-03T16:00:20.935Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d6/a2ae13bad8d503115ea4f900802c07e0cc5d897e60c5ab04fb6a36044afc/pymongo-4.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:03de6fdfbcd4ad0634313956bffcced13abc9e575b9c74dec70f69cc248b501c", size = 821472, upload-time = "2026-09-03T16:00:22.873Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/0600e7c3bdfc8fc9166ae25272751f2a47e436ad451e45e8d0152227e869/pymongo-4.18.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e8dd4a0c2bd52dd9f78d8808578d5f2ecf1b0fab41a4a169400c969a3e06ae65", size = 821909, upload-time = "2026-09-03T16:00:24.839Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4c/dc1121d8c949f50f010c15a521a424042322087c553c649b42c16ca15e6b/pymongo-4.18.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5a0e70d348d87e50406bc932f7998a40cc6cfdd4b0628dd0c00ff2470f07e3b1", size = 1105313, upload-time = "2026-09-03T16:00:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0e/37dc8e6cbb25777dfaadb478fee6d5672ebd14eec1ac74eafb8bcda8b2bd/pymongo-4.18.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7ed67136ee8e69c53c657253dbfe19486edd9560a3d8363cc0ee3614b52297", size = 1125099, upload-time = "2026-09-03T16:00:29.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/15/0c5e21f6d257c5876632aea3b1a38440577f089d94811d757256e773d98d/pymongo-4.18.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:abd0db088de3935b87aa27398d6fa98718c3a1d84e36ffbb927a353a9d76a032", size = 1144554, upload-time = "2026-09-03T16:00:31.121Z" },
+    { url = "https://files.pythonhosted.org/packages/93/15/1d57e1a4f922de348ffd6595488f7855a46f7d2152a9ca991d0b878657d2/pymongo-4.18.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:721f9b1a378d5bbf1bc2b9de2b7d3eeb4466d2878c7f430d483af7e3f580c935", size = 1136309, upload-time = "2026-09-03T16:00:32.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/74392c9eaeea549c25a7e0304116cdfde79b7320bd55d652a03914b53d10/pymongo-4.18.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d971ee533dbd7b836abec1e4ceefaeb9f6637c262561614482f213b8a19085be", size = 1117086, upload-time = "2026-09-03T16:00:35.314Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3e/4dd06523d3784b9229059f8812cbed292ad36136adedf32db106796258db/pymongo-4.18.0-cp314-cp314t-win32.whl", hash = "sha256:996a87a5b9c048e3dddf497acde55c7955748572091c70e1424d3c4779171526", size = 818741, upload-time = "2026-09-03T16:00:37.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d3/7f5ed7d37cd026b0d59b2504e4015b1370c79359f1e81ca5e3eb0428e8e1/pymongo-4.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47627909a177036117b91a3378df8634dc8e93cf4ccd66b22086b0098d3c72de", size = 826081, upload-time = "2026-09-03T16:00:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/64/02/b2606ddf52fa615d4ff3edb2aa05fb064337fa871f99ebb184a39e051cc8/pymongo-4.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4a81d166a43e8af1e5152b6854a263ba0a8831f7dd2ca1badc716f219f4f1bc0", size = 817605, upload-time = "2026-09-03T16:00:41.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

Agent Framework needs a first-class Azure DocumentDB vector-store connector so Python applications can keep embeddings and source documents together while using the service's Mongo-compatible transport and DocumentDB-specific vector-search dialect. This contributes typed CRUD, metadata filtering, and dense retrieval for RAG and agent-memory scenarios without treating Azure DocumentDB as MongoDB Atlas or Azure Cosmos DB for NoSQL.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?** Adds the alpha `agent-framework-azure-documentdb` package with direct imports, PyMongo's stable `AsyncMongoClient` transport, `createIndexes`/`cosmosSearchOptions` lifecycle support for IVF, HNSW, and DiskANN, and `$search.cosmosSearch` query pipelines. The collection supports explicit BSON string/integer keys, multiple vector paths, storage aliases, type-aware BSON metadata filters, native score thresholds before server-side paging, bounded/chunked batch operations, settings precedence, and caller-owned client/database/collection injection. The package also includes a concise consumer README, a package-local sample, workspace/package-status/lock registration, unit and command-capture coverage, and a credential-gated managed integration scenario.
- **What is the impact of these changes?** Python users can opt into Azure DocumentDB vector storage without changing the stable core install surface; the alpha package is intentionally excluded from `core[all]` and lazy namespaces. Existing applications are unaffected. The connector rejects unsupported key coercion, hybrid/full-text search, nested filter paths, compressed vectors, and incompatible existing indexes rather than silently changing semantics. It uses the existing Python package syntax, unit, typing, and build CI paths; no fake-green managed-service job is added.
- **What do you want reviewers to focus on?** Please focus on the DocumentDB-specific index reconciliation and `$search.cosmosSearch` pipeline, portable filter missing/null/bool-number semantics, native threshold/paging behavior, batch preflight/partial-write reporting, and created-versus-injected client ownership. Managed ARM provisioning was exercised successfully on disposable M10/server-8.0 resources, but the restricted data-plane TLS handshake could not be established; all resources were deleted, and this PR does not claim managed query execution validation.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Related to #4168 and #1188.

This is the Azure DocumentDB-only partial contribution and intentionally does not close either umbrella because other Phase 6 connectors remain. The open #8184 covers the separate MongoDB connector and does not overlap this package or service contract. The issue-exclusivity checklist item remains unchecked because these umbrella issues intentionally have parallel independent connector PRs.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above). This is intentionally unchecked because #4168 and #1188 are umbrella issues with parallel connector contributions.
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
