### PR TITLE
Python: fix: make FileCheckpointStorage tmp filename unique per save

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint.py
@@ -328,7 +328,10 @@ class FileCheckpointStorage:
         encoded_checkpoint = encode_checkpoint_value(checkpoint_dict)
 
         def _write_atomic() -> None:
-            tmp_path = file_path.with_name(f"{file_path.name}.{uuid.uuid4().hex}.tmp")
+            # Short, id-independent temp name: embeds no checkpoint id, so a
+            # checkpoint id accepted by _validate_file_path can never push the
+            # temp name over the filesystem's filename-length limit.
+            tmp_path = file_path.with_name(f".maf-ckpt-{uuid.uuid4().hex}.tmp")
             try:
                 with open(tmp_path, "w") as f:
                     json.dump(encoded_checkpoint, f, indent=2, ensure_ascii=False)

--- a/python/packages/core/agent_framework/_workflows/_checkpoint.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint.py
@@ -328,10 +328,17 @@ class FileCheckpointStorage:
         encoded_checkpoint = encode_checkpoint_value(checkpoint_dict)
 
         def _write_atomic() -> None:
-            tmp_path = file_path.with_suffix(".json.tmp")
-            with open(tmp_path, "w") as f:
-                json.dump(encoded_checkpoint, f, indent=2, ensure_ascii=False)
-            os.replace(tmp_path, file_path)
+            tmp_path = file_path.with_name(f"{file_path.name}.{uuid.uuid4().hex}.tmp")
+            try:
+                with open(tmp_path, "w") as f:
+                    json.dump(encoded_checkpoint, f, indent=2, ensure_ascii=False)
+                os.replace(tmp_path, file_path)
+            finally:
+                # best-effort cleanup if replace failed or the write raised
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
         await asyncio.to_thread(_write_atomic)
 

--- a/python/packages/core/tests/workflow/test_checkpoint.py
+++ b/python/packages/core/tests/workflow/test_checkpoint.py
@@ -1843,4 +1843,20 @@ async def test_file_checkpoint_storage_roundtrip_empty_collections():
         assert loaded.pending_request_info_events == {}
 
 
+async def test_file_checkpoint_storage_concurrent_saves_same_id(tmp_path):
+    """Concurrent saves of the same checkpoint id must not race on a shared tmp file."""
+    import asyncio
+
+    storage = FileCheckpointStorage(tmp_path)
+    checkpoint = WorkflowCheckpoint(workflow_name="test-workflow", graph_signature_hash="test-hash")
+
+    await asyncio.gather(*(storage.save(checkpoint) for _ in range(8)))
+
+    loaded = await storage.load(checkpoint.checkpoint_id)
+    assert loaded.checkpoint_id == checkpoint.checkpoint_id
+    assert loaded.workflow_name == checkpoint.workflow_name
+    assert loaded.state == checkpoint.state
+    assert list(Path(storage.storage_path).glob("*.tmp")) == []
+
+
 # endregion


### PR DESCRIPTION
### Motivation & Context

`FileCheckpointStorage.save` writes atomically via a FIXED temp filename (`file_path.with_suffix(".json.tmp")`) per checkpoint id. Two concurrent saves of the same checkpoint id both write the same `.tmp` path and both call `os.replace(tmp, final)`; whichever replace runs first consumes the tmp file and the other save dies with a raw `FileNotFoundError` — neither `WorkflowCheckpointException` nor a documented failure.

Fixes #8182

### Description & Review Guide

- **What are the major changes?** `_write_atomic` now uses a unique per-save temp filename (`{file_path.name}.{uuid.uuid4().hex}.tmp`) and best-effort cleanup in a `finally` block, so concurrent saves of the same checkpoint id never share a tmp file. `os.replace` remains the atomic commit point.
- **What is the impact of these changes?** Concurrent saves of the same id no longer race; a crashed writer leaves at most a uniquely-named orphan `.tmp` file (removed best-effort), never a torn checkpoint.
- **What do you want reviewers to focus on?** The tmp naming scheme and the best-effort cleanup semantics (deliberately swallows OSError so cleanup can never mask a real write failure).

### Related Issue

Fixes #8182 — verified no open PR exists for it.

### AI-Generated Code Disclosure

This change was implemented with AI assistance (OpenCode + muse-spark) and reviewed for correctness, security, and license compatibility.

### Verification

- New test: `test_file_checkpoint_storage_concurrent_saves_same_id` — 8 concurrent saves of the same id via `asyncio.gather`; before the fix this raises `FileNotFoundError` (confirmed by mutation check: reverting to the fixed name reproduces the crash).
- Local: 115 passed (`test_checkpoint`, `test_checkpoint_storage_conformance`, `test_checkpoint_encode`, `test_checkpoint_decode`, `test_checkpoint_validation`).