### PR TITLE
Python: Validate on_checkpoint_save returns dict at save time (#8183)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -401,6 +401,11 @@ class RunnerImpl:
             # Try the updated behavior only if backward compatibility did not yield state
             try:
                 state_dict = await executor.on_checkpoint_save()
+                # Validate at save time so restore cannot fail later on a non-dict payload (#8183).
+                if not isinstance(state_dict, dict) or not all(isinstance(k, str) for k in state_dict):
+                    raise WorkflowCheckpointException(
+                        f"Executor state for {exec_id} is not a dict[str, Any]. Unable to save."
+                    )
                 await self._set_executor_state(exec_id, state_dict)
             except WorkflowCheckpointException:
                 raise

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -567,6 +567,26 @@ async def test_runner_capture_and_restore_checkpoint_object_roundtrip():
     assert runner._previous_checkpoint_id == checkpoint.checkpoint_id  # pyright: ignore[reportPrivateUsage]
 
 
+async def test_save_executor_states_rejects_non_dict_on_checkpoint_save():
+    """Issue #8183: non-dict on_checkpoint_save must fail at save, not only at restore."""
+
+    class BadStateExecutor(Executor):
+        @handler
+        async def handle(self, message: MockMessage, ctx: WorkflowContext[Any, int]) -> None:
+            await ctx.yield_output(message.data)
+
+        async def on_checkpoint_save(self) -> dict[str, Any]:
+            return ["not", "a", "dict"]  # type: ignore[return-value]
+
+    executor = BadStateExecutor(id="bad")
+    state = State()
+    ctx = InProcRunnerContext()
+    runner = Runner([], {executor.id: executor}, state, ctx, "test_name", graph_signature_hash="test_hash")
+
+    with pytest.raises(WorkflowCheckpointException, match="is not a dict\\[str, Any\\]. Unable to save"):
+        await runner._save_executor_states()  # pyright: ignore[reportPrivateUsage]
+
+
 class CollectingExecutor(Executor):
     """A fan-in target that records every aggregated batch it receives."""
 


### PR DESCRIPTION
## Summary
- In `_save_executor_states`, reject non-`dict[str, Any]` return values from `on_checkpoint_save` with `WorkflowCheckpointException` at save time (same contract as restore).

Closes #8183

## Test plan
- [x] `test_save_executor_states_rejects_non_dict_on_checkpoint_save`
- [x] `test_runner_capture_and_restore_checkpoint_object_roundtrip`