### PR TITLE
Python: Agent Framework & AIML API

### DIFF
--- a/python/samples/02-agents/providers/README.md
+++ b/python/samples/02-agents/providers/README.md
@@ -4,8 +4,8 @@ This directory groups provider-specific samples for Agent Framework.
 
 | Folder | What you will find |
 | --- | --- |
-| [`aimlapi/`](aimlapi/) | aimlapi.com samples using `OpenAIChatCompletionClient` with a base-URL override, including streaming and multi-turn tool calling. |
 | [`anthropic/`](anthropic/) | Anthropic Claude samples using both `AnthropicClient` and `ClaudeAgent`, including tools, MCP, sessions, and Foundry Anthropic integration. |
+| [`aimlapi/`](aimlapi/) | aimlapi.com samples using `OpenAIChatCompletionClient` with a base-URL override, including streaming and multi-turn tool calling. |
 | [`amazon/`](amazon/) | AWS Bedrock samples using `BedrockChatClient`, including tool-enabled agent usage. |
 | [`azure/`](azure/) | Azure OpenAI chat completion samples using `OpenAIChatCompletionClient`, including basic usage, explicit configuration, tools, and sessions. |
 | [`copilotstudio/`](copilotstudio/) | Microsoft Copilot Studio agent samples, including required environment/app registration setup and explicit authentication patterns. |

--- a/python/samples/02-agents/providers/README.md
+++ b/python/samples/02-agents/providers/README.md
@@ -5,6 +5,7 @@ This directory groups provider-specific samples for Agent Framework.
 | Folder | What you will find |
 | --- | --- |
 | [`anthropic/`](anthropic/) | Anthropic Claude samples using both `AnthropicClient` and `ClaudeAgent`, including tools, MCP, sessions, and Foundry Anthropic integration. |
+| [`aimlapi/`](aimlapi/) | aimlapi.com samples using `OpenAIChatCompletionClient` with a base-URL override, including streaming and multi-turn tool calling. |
 | [`amazon/`](amazon/) | AWS Bedrock samples using `BedrockChatClient`, including tool-enabled agent usage. |
 | [`azure/`](azure/) | Azure OpenAI chat completion samples using `OpenAIChatCompletionClient`, including basic usage, explicit configuration, tools, and sessions. |
 | [`copilotstudio/`](copilotstudio/) | Microsoft Copilot Studio agent samples, including required environment/app registration setup and explicit authentication patterns. |

--- a/python/samples/02-agents/providers/README.md
+++ b/python/samples/02-agents/providers/README.md
@@ -4,8 +4,8 @@ This directory groups provider-specific samples for Agent Framework.
 
 | Folder | What you will find |
 | --- | --- |
-| [`anthropic/`](anthropic/) | Anthropic Claude samples using both `AnthropicClient` and `ClaudeAgent`, including tools, MCP, sessions, and Foundry Anthropic integration. |
 | [`aimlapi/`](aimlapi/) | aimlapi.com samples using `OpenAIChatCompletionClient` with a base-URL override, including streaming and multi-turn tool calling. |
+| [`anthropic/`](anthropic/) | Anthropic Claude samples using both `AnthropicClient` and `ClaudeAgent`, including tools, MCP, sessions, and Foundry Anthropic integration. |
 | [`amazon/`](amazon/) | AWS Bedrock samples using `BedrockChatClient`, including tool-enabled agent usage. |
 | [`azure/`](azure/) | Azure OpenAI chat completion samples using `OpenAIChatCompletionClient`, including basic usage, explicit configuration, tools, and sessions. |
 | [`copilotstudio/`](copilotstudio/) | Microsoft Copilot Studio agent samples, including required environment/app registration setup and explicit authentication patterns. |

--- a/python/samples/02-agents/providers/aimlapi/README.md
+++ b/python/samples/02-agents/providers/aimlapi/README.md
@@ -1,0 +1,77 @@
+# aimlapi.com Examples
+
+This folder contains examples demonstrating how to use models served by
+[aimlapi.com](https://aimlapi.com) with the Agent Framework.
+
+## Approach
+
+aimlapi.com is an aggregator that exposes a plain OpenAI Chat Completions endpoint at
+`https://api.aimlapi.com/v1`, so it needs no provider-specific client. The samples use
+`OpenAIChatCompletionClient` with a base URL override — the route documented in
+[`python/packages/openai/AGENTS.md`](../../../../packages/openai/AGENTS.md) for
+OpenAI-compatible endpoints that do not diverge from the wire format.
+
+Only `/v1/chat/completions` and `/v1/responses` exist on this endpoint; there is no
+`/v1/completions`.
+
+## Prerequisites
+
+1. **Get an API key**: create one at [aimlapi.com/app/keys](https://aimlapi.com/app/keys).
+2. **Pick a model**: model ids are namespaced, e.g. `openai/gpt-4o-mini`,
+   `anthropic/claude-sonnet-4.6`, `google/gemini-2.5-flash`. The catalog is public and
+   needs no key:
+
+   ```bash
+   curl 'https://api.aimlapi.com/v1/models?include=all'
+   ```
+
+   The response is `{"object": "list", "data": [...]}`; chat models carry
+   `"type": "openai/chat-completions"`. A model id may appear either as an `id` or in
+   another entry's `aliases`, so check both. `?include=all` adds `capabilities`,
+   `modalities`, `pricing` and `providers`, none of which appear in the default response.
+
+> **Note**: `capabilities` is advisory, not authoritative in either direction — some
+> models that do not advertise `tools` or `vision` support them, and a few that advertise
+> them do not. Verify a model against your own workload before relying on a flag.
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| [`aimlapi_chat_completion_client_basic.py`](aimlapi_chat_completion_client_basic.py) | Basic agent using `OpenAIChatCompletionClient` against aimlapi.com. Shows both streaming and non-streaming responses. |
+| [`aimlapi_chat_completion_client_with_function_tools.py`](aimlapi_chat_completion_client_with_function_tools.py) | Function tool calling across two turns of one session. |
+
+## Environment Variables
+
+- `AIMLAPI_API_KEY`: Your aimlapi.com API key (required)
+  - Example: `export AIMLAPI_API_KEY="..."`
+- `AIMLAPI_MODEL`: The model id to use (optional, defaults to `openai/gpt-4o-mini`)
+  - Example: `export AIMLAPI_MODEL="anthropic/claude-sonnet-4.6"`
+
+The base URL is not configurable from the environment in these samples: it is a module
+constant so the attribution headers described below can only ever reach aimlapi.com.
+
+## Attribution headers
+
+Both samples pass four headers via the client's `default_headers` argument:
+
+| Header | Value | Purpose |
+|---|---|---|
+| `HTTP-Referer` | `https://github.com/microsoft/agent-framework` | Identifies the calling project (OpenRouter convention) |
+| `X-Title` | `Microsoft Agent Framework` | Identifies the calling project |
+| `X-AIMLAPI-Partner-ID` | `part_agentframework` | Integration attribution |
+| `X-AIMLAPI-Source` | `agent/agent-framework` | Channel attribution |
+
+`default_headers` is a first-class constructor argument on `OpenAIChatCompletionClient`,
+so this needs no framework changes. The headers are scoped to the client instance, which
+is pinned to `https://api.aimlapi.com/v1`, and each client gets a fresh copy of the
+dictionary rather than the module constant itself.
+
+## Notes on usage reporting
+
+- On some models `completion_tokens` excludes reasoning tokens, so metering spend from
+  `completion_tokens` alone under-reports. Read `usage.total_tokens` where available.
+- `max_tokens` does not reliably bound reasoning tokens on every model; a few return well
+  past the cap with `finish_reason: "stop"`. Do not treat it as a cost ceiling.
+- 79 models publish tiered `pricing.thresholds[]` above a context boundary, which a single
+  flat `$/M` figure cannot express.

--- a/python/samples/02-agents/providers/aimlapi/README.md
+++ b/python/samples/02-agents/providers/aimlapi/README.md
@@ -59,7 +59,7 @@ Both samples pass four headers via the client's `default_headers` argument:
 |---|---|---|
 | `HTTP-Referer` | `https://github.com/microsoft/agent-framework` | Identifies the calling project (OpenRouter convention) |
 | `X-Title` | `Microsoft Agent Framework` | Identifies the calling project |
-| `X-AIMLAPI-Partner-ID` | `part_agentframework` | Integration attribution |
+| `X-AIMLAPI-Partner-ID` | `part_eIXDWUdHyVKVaVSZNotgkTZ5` | Integration attribution |
 | `X-AIMLAPI-Source` | `agent/agent-framework` | Channel attribution |
 
 `default_headers` is a first-class constructor argument on `OpenAIChatCompletionClient`,

--- a/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_basic.py
+++ b/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_basic.py
@@ -41,7 +41,7 @@ AIMLAPI_DEFAULT_MODEL = "openai/gpt-4o-mini"
 AIMLAPI_ATTRIBUTION_HEADERS = {
     "HTTP-Referer": "https://github.com/microsoft/agent-framework",
     "X-Title": "Microsoft Agent Framework",
-    "X-AIMLAPI-Partner-ID": "part_agentframework",
+    "X-AIMLAPI-Partner-ID": "part_eIXDWUdHyVKVaVSZNotgkTZ5",
     "X-AIMLAPI-Source": "agent/agent-framework",
 }
 

--- a/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_basic.py
+++ b/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_basic.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import os
+
+from agent_framework import Agent
+from agent_framework.openai import OpenAIChatCompletionClient
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+"""
+aimlapi.com Chat Completion Client Basic Example
+
+This sample demonstrates using models served by aimlapi.com through
+`OpenAIChatCompletionClient` by overriding the base URL. aimlapi.com exposes a plain
+OpenAI Chat Completions endpoint, so no provider-specific client is needed — this is the
+"base URL override" route described in `python/packages/openai/AGENTS.md`.
+
+Shows both non-streaming and streaming responses.
+
+Environment Variables:
+- AIMLAPI_API_KEY: Your aimlapi.com API key (required). Create one at https://aimlapi.com/app/keys
+- AIMLAPI_MODEL: The model id to use (optional, defaults to `openai/gpt-4o-mini`).
+  Browse the catalog at https://api.aimlapi.com/v1/models
+"""
+
+# aimlapi.com speaks the OpenAI Chat Completions wire format at this base URL.
+# Note: only `/v1/chat/completions` and `/v1/responses` exist — there is no `/v1/completions`.
+AIMLAPI_BASE_URL = "https://api.aimlapi.com/v1"
+
+# Default model id. Model ids are namespaced (`<vendor>/<model>`); the catalog at
+# https://api.aimlapi.com/v1/models?include=all lists ids, aliases and capabilities.
+AIMLAPI_DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+# Attribution headers understood by aimlapi.com. `HTTP-Referer` and `X-Title` follow the
+# OpenRouter convention and identify the *calling* project (Agent Framework), while the two
+# `X-AIMLAPI-*` headers identify the integration channel. They are passed as
+# `default_headers` on the client, so they only ever ride requests to AIMLAPI_BASE_URL.
+AIMLAPI_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://github.com/microsoft/agent-framework",
+    "X-Title": "Microsoft Agent Framework",
+    "X-AIMLAPI-Partner-ID": "part_agentframework",
+    "X-AIMLAPI-Source": "agent/agent-framework",
+}
+
+
+def create_client() -> OpenAIChatCompletionClient:
+    """Build a chat completion client pointed at aimlapi.com."""
+    return OpenAIChatCompletionClient(
+        model=os.environ.get("AIMLAPI_MODEL", AIMLAPI_DEFAULT_MODEL),
+        api_key=os.environ["AIMLAPI_API_KEY"],
+        base_url=AIMLAPI_BASE_URL,
+        # A fresh dict per client: the module-level constant is never handed out or mutated.
+        default_headers={**AIMLAPI_ATTRIBUTION_HEADERS},
+    )
+
+
+async def non_streaming_example() -> None:
+    """Example of a non-streaming response (get the complete result at once)."""
+    print("=== Non-streaming Response Example ===")
+
+    agent = Agent(
+        client=create_client(),
+        name="HaikuAgent",
+        instructions="You are a concise assistant.",
+    )
+
+    query = "Why is the sky blue? Answer in one sentence."
+    print(f"User: {query}")
+    result = await agent.run(query)
+    print(f"Agent: {result}\n")
+
+
+async def streaming_example() -> None:
+    """Example of a streaming response (get results as they are generated)."""
+    print("=== Streaming Response Example ===")
+
+    agent = Agent(
+        client=create_client(),
+        name="HaikuAgent",
+        instructions="You are a concise assistant.",
+    )
+
+    query = "Name three primary colors."
+    print(f"User: {query}")
+    print("Agent: ", end="", flush=True)
+    async for chunk in agent.run(query, stream=True):
+        if chunk.text:
+            print(chunk.text, end="", flush=True)
+    print("\n")
+
+
+async def main() -> None:
+    print("=== aimlapi.com Chat Completion Client Agent Example ===\n")
+
+    await non_streaming_example()
+    await streaming_example()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+
+"""
+Sample output:
+=== aimlapi.com Chat Completion Client Agent Example ===
+
+=== Non-streaming Response Example ===
+User: Why is the sky blue? Answer in one sentence.
+Agent: The sky appears blue because molecules in Earth's atmosphere scatter shorter blue
+wavelengths of sunlight more than longer wavelengths.
+
+=== Streaming Response Example ===
+User: Name three primary colors.
+Agent: Red, blue, and yellow.
+"""

--- a/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_with_function_tools.py
+++ b/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_with_function_tools.py
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from random import randint
+from typing import Annotated
+
+from agent_framework import Agent, tool
+from agent_framework.openai import OpenAIChatCompletionClient
+from dotenv import load_dotenv
+from pydantic import Field
+
+# Load environment variables from .env file
+load_dotenv()
+
+"""
+aimlapi.com Chat Completion Client with Function Tools Example
+
+This sample demonstrates function tool integration with models served by aimlapi.com,
+over a session so the tool-calling loop runs across more than one turn.
+
+The multi-turn case is worth exercising explicitly: several models behind aimlapi.com
+reject a literal `"tools": null` in the request body with HTTP 400, which is what a host
+sends if it "clears" tools between turns by setting the field to None. Agent Framework
+builds request options by omitting unset keys rather than sending nulls
+(`_prepare_options` in `agent_framework_openai/_chat_completion_client.py` filters
+`v is not None`), so the second turn is a plain request without the key at all.
+
+Environment Variables:
+- AIMLAPI_API_KEY: Your aimlapi.com API key (required). Create one at https://aimlapi.com/app/keys
+- AIMLAPI_MODEL: The model id to use (optional, defaults to `openai/gpt-4o-mini`).
+  Not every model supports tool calling — the catalog at
+  https://api.aimlapi.com/v1/models?include=all reports a `capabilities` list per model,
+  though it is advisory: some models that do not advertise `tools` support them anyway.
+"""
+
+# aimlapi.com speaks the OpenAI Chat Completions wire format at this base URL.
+AIMLAPI_BASE_URL = "https://api.aimlapi.com/v1"
+
+# Default model id, chosen because it advertises and supports tool calling.
+AIMLAPI_DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+# Attribution headers understood by aimlapi.com. See the basic sample for details.
+AIMLAPI_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://github.com/microsoft/agent-framework",
+    "X-Title": "Microsoft Agent Framework",
+    "X-AIMLAPI-Partner-ID": "part_agentframework",
+    "X-AIMLAPI-Source": "agent/agent-framework",
+}
+
+
+def create_client() -> OpenAIChatCompletionClient:
+    """Build a chat completion client pointed at aimlapi.com."""
+    return OpenAIChatCompletionClient(
+        model=os.environ.get("AIMLAPI_MODEL", AIMLAPI_DEFAULT_MODEL),
+        api_key=os.environ["AIMLAPI_API_KEY"],
+        base_url=AIMLAPI_BASE_URL,
+        # A fresh dict per client: the module-level constant is never handed out or mutated.
+        default_headers={**AIMLAPI_ATTRIBUTION_HEADERS},
+    )
+
+
+# NOTE: approval_mode="never_require" is for sample brevity. Use "always_require" in production;
+# see samples/02-agents/tools/function_tool_with_approval.py
+# and samples/02-agents/tools/function_tool_with_approval_and_sessions.py.
+@tool(approval_mode="never_require")
+def get_weather(
+    location: Annotated[str, Field(description="The location to get the weather for.")],
+) -> str:
+    """Get the weather for a given location."""
+    conditions = ["sunny", "cloudy", "rainy", "stormy"]
+    return f"The weather in {location} is {conditions[randint(0, 3)]} with a high of {randint(10, 30)}°C."
+
+
+@tool(approval_mode="never_require")
+def get_time() -> str:
+    """Get the current UTC time."""
+    current_time = datetime.now(timezone.utc)
+    return f"The current UTC time is {current_time.strftime('%Y-%m-%d %H:%M:%S')}."
+
+
+async def multi_turn_tool_calling() -> None:
+    """Run two turns over one session, so the second request carries prior tool results."""
+    print("=== Multi-turn Tool Calling Example ===")
+
+    agent = Agent(
+        client=create_client(),
+        name="WeatherAgent",
+        instructions="You are a helpful assistant that can report weather and the current time.",
+        tools=[get_weather, get_time],
+    )
+
+    # A session keeps the message history, so turn 2 replays turn 1's tool call and result.
+    session = agent.create_session()
+
+    query1 = "What's the weather like in Seattle?"
+    print(f"User: {query1}")
+    result1 = await agent.run(query1, session=session)
+    print(f"Agent: {result1.text}\n")
+
+    query2 = "And what is the current UTC time? Also remind me which city I just asked about."
+    print(f"User: {query2}")
+    result2 = await agent.run(query2, session=session)
+    print(f"Agent: {result2.text}\n")
+
+
+async def main() -> None:
+    print("=== aimlapi.com Chat Completion Client Agent with Function Tools Example ===\n")
+
+    await multi_turn_tool_calling()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+
+"""
+Sample output:
+=== aimlapi.com Chat Completion Client Agent with Function Tools Example ===
+
+=== Multi-turn Tool Calling Example ===
+User: What's the weather like in Seattle?
+Agent: The weather in Seattle is cloudy with a high of 18°C.
+
+User: And what is the current UTC time? Also remind me which city I just asked about.
+Agent: The current UTC time is 2026-09-03 12:00:00. You just asked about Seattle.
+"""

--- a/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_with_function_tools.py
+++ b/python/samples/02-agents/providers/aimlapi/aimlapi_chat_completion_client_with_function_tools.py
@@ -45,7 +45,7 @@ AIMLAPI_DEFAULT_MODEL = "openai/gpt-4o-mini"
 AIMLAPI_ATTRIBUTION_HEADERS = {
     "HTTP-Referer": "https://github.com/microsoft/agent-framework",
     "X-Title": "Microsoft Agent Framework",
-    "X-AIMLAPI-Partner-ID": "part_agentframework",
+    "X-AIMLAPI-Partner-ID": "part_eIXDWUdHyVKVaVSZNotgkTZ5",
     "X-AIMLAPI-Source": "agent/agent-framework",
 }
 

--- a/python/tests/samples/providers/test_aimlapi_attribution.py
+++ b/python/tests/samples/providers/test_aimlapi_attribution.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Contract tests for the aimlapi.com provider samples.
+
+The four attribution headers the samples send are silently ignored by the service when
+malformed — a bad partner id is not rejected, it is simply not attributed — so a typo is
+invisible at runtime. These tests assert the shapes instead.
+
+The samples live in a script-style tree that is not an importable package, so they are
+loaded by path.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PYTHON_ROOT = Path(__file__).parents[3]
+SAMPLES_DIR = PYTHON_ROOT / "samples" / "02-agents" / "providers" / "aimlapi"
+
+SAMPLE_FILES = [
+    "aimlapi_chat_completion_client_basic.py",
+    "aimlapi_chat_completion_client_with_function_tools.py",
+]
+
+# Backend contract: /^part_[A-Za-z0-9]{1,64}$/ — alphanumerics only after the prefix.
+PARTNER_ID_PATTERN = re.compile(r"^part_[A-Za-z0-9]{1,64}$")
+
+# Backend contract: "<channel>/<client>", channel in {web, agent, mcp}, client [a-z0-9-]{1,32}.
+SOURCE_PATTERN = re.compile(r"^(web|agent|mcp)/[a-z0-9-]{1,32}$")
+
+EXPECTED_HEADER_KEYS = {
+    "HTTP-Referer",
+    "X-Title",
+    "X-AIMLAPI-Partner-ID",
+    "X-AIMLAPI-Source",
+}
+
+
+def load_sample(file_name: str) -> ModuleType:
+    """Import a sample module by path."""
+    path = SAMPLES_DIR / file_name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(params=SAMPLE_FILES)
+def sample(request: pytest.FixtureRequest) -> ModuleType:
+    return load_sample(request.param)
+
+
+def test_partner_id_is_well_formed(sample: ModuleType) -> None:
+    partner_id = sample.AIMLAPI_ATTRIBUTION_HEADERS["X-AIMLAPI-Partner-ID"]
+    assert PARTNER_ID_PATTERN.match(partner_id), f"malformed partner id: {partner_id!r}"
+
+
+def test_source_is_well_formed(sample: ModuleType) -> None:
+    source = sample.AIMLAPI_ATTRIBUTION_HEADERS["X-AIMLAPI-Source"]
+    assert SOURCE_PATTERN.match(source), f"malformed source: {source!r}"
+
+
+def test_referer_and_title_identify_the_host_project(sample: ModuleType) -> None:
+    """HTTP-Referer and X-Title name the calling project, not the model provider."""
+    headers = sample.AIMLAPI_ATTRIBUTION_HEADERS
+    assert set(headers) == EXPECTED_HEADER_KEYS
+    assert headers["HTTP-Referer"] == "https://github.com/microsoft/agent-framework"
+    assert headers["X-Title"] == "Microsoft Agent Framework"
+
+
+def test_headers_are_scoped_to_the_aimlapi_origin(sample: ModuleType) -> None:
+    """Attribution must not be able to ride a request to a different provider."""
+    assert sample.AIMLAPI_BASE_URL == "https://api.aimlapi.com/v1"
+
+
+def test_client_gets_a_copy_not_the_shared_constant(monkeypatch: pytest.MonkeyPatch, sample: ModuleType) -> None:
+    """Building a client must not hand out or mutate the module-level constant."""
+    monkeypatch.setenv("AIMLAPI_API_KEY", "test-key-not-a-real-one")
+    before = dict(sample.AIMLAPI_ATTRIBUTION_HEADERS)
+
+    client = sample.create_client()
+    assert client.default_headers is not sample.AIMLAPI_ATTRIBUTION_HEADERS
+    for key, value in before.items():
+        assert client.default_headers[key] == value
+
+    client.default_headers["X-Title"] = "mutated"
+    assert sample.AIMLAPI_ATTRIBUTION_HEADERS == before


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a provider option inside Agent Framework — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

### Motivation & Context

aimlapi.com exposes a plain OpenAI Chat Completions endpoint, so Agent Framework can already talk to it today — but nothing in the repo shows how, and that traffic carries no attribution. `python/packages/openai/AGENTS.md` documents the intended route for OpenAI-compatible endpoints that do not diverge from the wire format: a base-URL override on `OpenAIChatCompletionClient`, with a dedicated client reserved for endpoints that diverge substantially. This PR adds provider samples that follow exactly that route — no framework changes.

### Description & Review Guide

- **What are the major changes?**
  - `python/samples/02-agents/providers/aimlapi/` — new sample folder:
    - `aimlapi_chat_completion_client_basic.py` — basic agent via `OpenAIChatCompletionClient` with `base_url="https://api.aimlapi.com/v1"`, non-streaming and streaming.
    - `aimlapi_chat_completion_client_with_function_tools.py` — function tools across two turns of one session. Multi-turn is exercised deliberately: several models behind the endpoint reject a literal `"tools": null` with HTTP 400; `_prepare_options` builds requests by omitting unset keys rather than sending nulls, and this sample keeps that property visible.
    - `README.md` — catalog discovery, environment variables, attribution headers, notes on usage reporting.
  - Four attribution headers ride the client's existing `default_headers` argument (`HTTP-Referer`, `X-Title`, `X-AIMLAPI-Partner-ID`, `X-AIMLAPI-Source`), scoped to a client instance that is pinned to the aimlapi base URL — no framework changes needed.
  - `python/samples/02-agents/providers/README.md` — one row added to the provider table.
  - `python/tests/samples/providers/test_aimlapi_attribution.py` — contract tests for the header shapes: the service accepts a malformed partner id with a 200 and silently drops attribution, so a typo is invisible at runtime; the tests assert the shapes instead.
- **What is the impact of these changes?** Samples and tests only — no changes to any package, public API, or existing sample. 5 files, +415 lines, all additions.
- **What do you want reviewers to focus on?** Whether the base-URL-override route (vs a dedicated provider client) is the placement you want for this provider, per `python/packages/openai/AGENTS.md`.

### Related Issue

Fixes #8195

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**