### PR TITLE
Python: Validate on_checkpoint_save returns dict at save time (#8183)

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_runner.py
+++ b/python/packages/core/agent_framework/_workflows/_runner.py
@@ -401,6 +401,11 @@ class RunnerImpl:
             # Try the updated behavior only if backward compatibility did not yield state
             try:
                 state_dict = await executor.on_checkpoint_save()
+                # Validate at save time so restore cannot fail later on a non-dict payload (#8183).
+                if not isinstance(state_dict, dict) or not all(isinstance(k, str) for k in state_dict):
+                    raise WorkflowCheckpointException(
+                        f"Executor state for {exec_id} is not a dict[str, Any]. Unable to save."
+                    )
                 await self._set_executor_state(exec_id, state_dict)
             except WorkflowCheckpointException:
                 raise

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -567,6 +567,26 @@ async def test_runner_capture_and_restore_checkpoint_object_roundtrip():
     assert runner._previous_checkpoint_id == checkpoint.checkpoint_id  # pyright: ignore[reportPrivateUsage]
 
 
+async def test_save_executor_states_rejects_non_dict_on_checkpoint_save():
+    """Issue #8183: non-dict on_checkpoint_save must fail at save, not only at restore."""
+
+    class BadStateExecutor(Executor):
+        @handler
+        async def handle(self, message: MockMessage, ctx: WorkflowContext[Any, int]) -> None:
+            await ctx.yield_output(message.data)
+
+        async def on_checkpoint_save(self) -> dict[str, Any]:
+            return ["not", "a", "dict"]  # type: ignore[return-value]
+
+    executor = BadStateExecutor(id="bad")
+    state = State()
+    ctx = InProcRunnerContext()
+    runner = Runner([], {executor.id: executor}, state, ctx, "test_name", graph_signature_hash="test_hash")
+
+    with pytest.raises(WorkflowCheckpointException, match="is not a dict\\[str, Any\\]. Unable to save"):
+        await runner._save_executor_states()  # pyright: ignore[reportPrivateUsage]
+
+
 class CollectingExecutor(Executor):
     """A fan-in target that records every aggregated batch it receives."""
 

--- a/python/packages/core/tests/workflow/test_runner.py
+++ b/python/packages/core/tests/workflow/test_runner.py
@@ -576,7 +576,7 @@ async def test_save_executor_states_rejects_non_dict_on_checkpoint_save():
             await ctx.yield_output(message.data)
 
         async def on_checkpoint_save(self) -> dict[str, Any]:
-            return ["not", "a", "dict"]  # type: ignore[return-value]
+            return ["not", "a", "dict"]  # type: ignore[return-value]  # pyrefly: ignore[bad-return]  # ty: ignore[invalid-return-type]
 
     executor = BadStateExecutor(id="bad")
     state = State()


### PR DESCRIPTION
### Motivation & Context

Executor `on_checkpoint_save` return values were validated only at restore time. A non-`dict` state could be written successfully and then fail on any later restore. Validating at save time matches the restore contract and fails fast.

Fixes #8183.

### Description & Review Guide

- **What are the major changes?**
  - In `_save_executor_states`, reject non-`dict[str, Any]` return values from `on_checkpoint_save` with `WorkflowCheckpointException` at save time.
- **What is the impact of these changes?**
  - Unrestorable executor state is refused before it is persisted.
- **What do you want reviewers to focus on?**
  - Save-time validation parity with restore-time checks and the regression tests.

### Related Issue

Fixes #8183

This replaces closed PR #8194 (closed for missing PR template). Same issue; no other open PR for #8183.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
