### PR TITLE
Python: Lazily load Foundry and OpenAI integrations

### DIFF
--- a/python/packages/foundry/agent_framework_foundry/__init__.py
+++ b/python/packages/foundry/agent_framework_foundry/__init__.py
@@ -1,34 +1,57 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import importlib.metadata
+from typing import TYPE_CHECKING, Any, Final
 
-from ._agent import (
-    FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY,
-    FoundryAgent,
-    FoundryAgentOptions,
-    RawFoundryAgent,
-    RawFoundryAgentChatClient,
-)
-from ._chat_client import FoundryChatClient, FoundryChatOptions, RawFoundryChatClient
-from ._embedding_client import (
-    FoundryEmbeddingClient,
-    FoundryEmbeddingOptions,
-    FoundryEmbeddingSettings,
-    RawFoundryEmbeddingClient,
-)
-from ._foundry_evals import (
-    FoundryEvals,
-    GeneratedEvaluatorRef,
-    evaluate_foundry_target,
-    evaluate_traces,
-)
-from ._memory_provider import FoundryMemoryProvider
-from ._to_prompt_agent import to_prompt_agent
+if TYPE_CHECKING:
+    from ._agent import (
+        FoundryAgent,
+        FoundryAgentOptions,
+        RawFoundryAgent,
+        RawFoundryAgentChatClient,
+    )
+    from ._chat_client import FoundryChatClient, FoundryChatOptions, RawFoundryChatClient
+    from ._constants import FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY
+    from ._embedding_client import (
+        FoundryEmbeddingClient,
+        FoundryEmbeddingOptions,
+        FoundryEmbeddingSettings,
+        RawFoundryEmbeddingClient,
+    )
+    from ._foundry_evals import (
+        FoundryEvals,
+        GeneratedEvaluatorRef,
+        evaluate_foundry_target,
+        evaluate_traces,
+    )
+    from ._memory_provider import FoundryMemoryProvider
+    from ._to_prompt_agent import to_prompt_agent
 
 try:
     __version__ = importlib.metadata.version(__name__)
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
+
+_LAZY_EXPORTS: Final[dict[str, str]] = {
+    "FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY": "._constants",
+    "FoundryAgent": "._agent",
+    "FoundryAgentOptions": "._agent",
+    "FoundryChatClient": "._chat_client",
+    "FoundryChatOptions": "._chat_client",
+    "FoundryEmbeddingClient": "._embedding_client",
+    "FoundryEmbeddingOptions": "._embedding_client",
+    "FoundryEmbeddingSettings": "._embedding_client",
+    "FoundryEvals": "._foundry_evals",
+    "FoundryMemoryProvider": "._memory_provider",
+    "GeneratedEvaluatorRef": "._foundry_evals",
+    "RawFoundryAgent": "._agent",
+    "RawFoundryAgentChatClient": "._agent",
+    "RawFoundryChatClient": "._chat_client",
+    "RawFoundryEmbeddingClient": "._embedding_client",
+    "evaluate_foundry_target": "._foundry_evals",
+    "evaluate_traces": "._foundry_evals",
+    "to_prompt_agent": "._to_prompt_agent",
+}
 
 __all__ = [
     "FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY",
@@ -51,3 +74,17 @@ __all__ = [
     "evaluate_traces",
     "to_prompt_agent",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve public Foundry exports."""
+    if module_name := _LAZY_EXPORTS.get(name):
+        value = getattr(importlib.import_module(module_name, __name__), name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return public names for interactive discovery."""
+    return sorted(set(globals()) | set(__all__))

--- a/python/packages/foundry/agent_framework_foundry/_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_agent.py
@@ -41,6 +41,7 @@ from azure.core.credentials_async import AsyncTokenCredential
 
 from agent_framework_foundry._oauth_helpers import try_parse_oauth_consent_event
 
+from ._constants import FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY
 from ._feature_usage import (
     FeatureIndex,
     create_feature_usage_policy,
@@ -92,9 +93,6 @@ class FoundryAgentSettings(TypedDict, total=False):
     project_endpoint: str | None
     agent_name: str | None
     agent_version: str | None
-
-
-FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY = "foundry_hosted_agent_session_id"
 
 
 class FoundryAgentOptions(OpenAIChatOptions, total=False):

--- a/python/packages/foundry/agent_framework_foundry/_constants.py
+++ b/python/packages/foundry/agent_framework_foundry/_constants.py
@@ -1,0 +1,3 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY = "foundry_hosted_agent_session_id"

--- a/python/packages/foundry/agent_framework_foundry/_feature_usage.py
+++ b/python/packages/foundry/agent_framework_foundry/_feature_usage.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from __future__ import annotations
+
 from enum import IntEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_framework._telemetry import (
     USER_AGENT_KEY,
@@ -13,7 +15,9 @@ from agent_framework_openai._feature_usage import (
     create_feature_usage_http_client,
 )
 from azure.core.pipeline.policies import SansIOHTTPPolicy
-from openai import DefaultAsyncHttpxClient
+
+if TYPE_CHECKING:
+    from openai import DefaultAsyncHttpxClient
 
 
 class FeatureIndex(IntEnum):
@@ -37,7 +41,7 @@ def create_foundry_feature_usage_http_client() -> DefaultAsyncHttpxClient:
     return create_feature_usage_http_client(approved_origin_suffixes=_FOUNDRY_ORIGIN_SUFFIXES)
 
 
-def create_feature_usage_policy() -> "FeatureUsagePolicy":
+def create_feature_usage_policy() -> FeatureUsagePolicy:
     """Create the destination-aware policy that stamps each actual request hop."""
     return FeatureUsagePolicy()
 

--- a/python/packages/foundry/agent_framework_foundry/_foundry_evals.py
+++ b/python/packages/foundry/agent_framework_foundry/_foundry_evals.py
@@ -922,6 +922,8 @@ class FoundryEvals:
 
         # Auto-create a FoundryChatClient from env vars when no client is provided
         if client is None and project_client is None:
+            from ._chat_client import FoundryChatClient
+
             client = FoundryChatClient(model=model or "gpt-4o")
 
         self._client = _resolve_openai_client(client, project_client)

--- a/python/packages/foundry/agent_framework_foundry/_foundry_evals.py
+++ b/python/packages/foundry/agent_framework_foundry/_foundry_evals.py
@@ -45,14 +45,15 @@ from agent_framework._evaluation import (
 from agent_framework._feature_stage import ExperimentalFeature, experimental
 from agent_framework._telemetry import mark_feature_used
 from agent_framework._types import Message
-from openai import AsyncOpenAI
 
-from ._chat_client import FoundryChatClient
 from ._feature_usage import FeatureIndex
 
 if TYPE_CHECKING:
     from azure.ai.projects.aio import AIProjectClient
+    from openai import AsyncOpenAI
     from openai.types.evals import RunRetrieveResponse
+
+    from ._chat_client import FoundryChatClient
 
 logger = logging.getLogger(__name__)
 
@@ -726,6 +727,10 @@ def _resolve_openai_client(
     project_client: AIProjectClient | None = None,
 ) -> AsyncOpenAI:
     """Resolve an AsyncOpenAI client from a FoundryChatClient, raw client, or project_client."""
+    from openai import AsyncOpenAI
+
+    from ._chat_client import FoundryChatClient
+
     if client is not None:
         if isinstance(client, FoundryChatClient):
             return client.client

--- a/python/packages/foundry/agent_framework_foundry/_memory_provider.py
+++ b/python/packages/foundry/agent_framework_foundry/_memory_provider.py
@@ -21,10 +21,8 @@ from agent_framework import (
     load_settings,
 )
 from agent_framework._telemetry import IS_TELEMETRY_ENABLED, get_user_agent, mark_feature_used
-from azure.ai.projects.aio import AIProjectClient
 from azure.core.credentials import TokenCredential
 from azure.core.credentials_async import AsyncTokenCredential
-from openai.types.responses import ResponseInputItemParam
 
 from ._feature_usage import FeatureIndex, create_feature_usage_policy
 
@@ -35,6 +33,8 @@ else:
 
 if TYPE_CHECKING:
     from agent_framework import SupportsAgentRun
+    from azure.ai.projects.aio import AIProjectClient
+    from openai.types.responses import ResponseInputItemParam
 
 
 logger = logging.getLogger(__name__)
@@ -110,6 +110,8 @@ class FoundryMemoryProvider(ContextProvider):
         )
 
         if project_client is None:
+            from azure.ai.projects.aio import AIProjectClient
+
             resolved_endpoint = foundry_settings.get("project_endpoint")
             if not resolved_endpoint:
                 raise ValueError(

--- a/python/packages/foundry/agent_framework_foundry/_to_prompt_agent.py
+++ b/python/packages/foundry/agent_framework_foundry/_to_prompt_agent.py
@@ -34,8 +34,6 @@ from agent_framework import FunctionTool
 from agent_framework._feature_stage import ExperimentalFeature, experimental
 from agent_framework._mcp import MCPTool
 
-from ._chat_client import RawFoundryChatClient
-
 if TYPE_CHECKING:
     from agent_framework import Agent
     from azure.ai.projects.models import (
@@ -44,6 +42,8 @@ if TYPE_CHECKING:
         StructuredInputDefinition,
         Tool,
     )
+
+    from ._chat_client import RawFoundryChatClient
 
 
 @experimental(feature_id=ExperimentalFeature.TO_PROMPT_AGENT)
@@ -81,6 +81,8 @@ def to_prompt_agent(
         tools, and generation parameters. Pass it to
         ``AIProjectClient.agents.create_version(...)`` to publish.
     """
+    from ._chat_client import RawFoundryChatClient
+
     if not isinstance(agent.client, RawFoundryChatClient):
         raise TypeError(
             "Creating a Foundry Prompt Agent requires an Agent whose client is a FoundryChatClient; "

--- a/python/packages/foundry/tests/foundry/test_foundry_memory_provider.py
+++ b/python/packages/foundry/tests/foundry/test_foundry_memory_provider.py
@@ -82,7 +82,7 @@ def test_init_default_update_delay(mock_project_client: AsyncMock) -> None:
 
 
 def test_init_with_project_endpoint_and_credential(mock_project_client: AsyncMock, mock_credential: Mock) -> None:
-    with patch("agent_framework_foundry._memory_provider.AIProjectClient") as mock_ai_project_client:
+    with patch("azure.ai.projects.aio.AIProjectClient") as mock_ai_project_client:
         mock_ai_project_client.return_value = mock_project_client
         provider = FoundryMemoryProvider(
             project_endpoint="https://test.project.endpoint",

--- a/python/packages/foundry/tests/test_foundry_evals.py
+++ b/python/packages/foundry/tests/test_foundry_evals.py
@@ -541,7 +541,7 @@ class TestFoundryEvals:
         import os
         from unittest.mock import patch
 
-        with patch.dict(os.environ, {}, clear=True), pytest.raises((ValueError, Exception)):
+        with patch.dict(os.environ, {}, clear=True), pytest.raises(ValueError):
             FoundryEvals(model="gpt-4o")
 
     def test_name_property(self) -> None:

--- a/python/packages/foundry/tests/test_foundry_imports.py
+++ b/python/packages/foundry/tests/test_foundry_imports.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(code: str) -> None:
+    subprocess.run([sys.executable, "-I", "-c", textwrap.dedent(code)], check=True)
+
+
+def test_package_import_is_lazy() -> None:
+    _run_isolated(
+        """
+        import sys
+
+        import agent_framework_foundry
+
+        assert "agent_framework_foundry._chat_client" not in sys.modules
+        assert "agent_framework_foundry._memory_provider" not in sys.modules
+        assert not any(name == "openai" or name.startswith("openai.") for name in sys.modules)
+        """
+    )
+
+
+def test_lightweight_exports_do_not_import_openai() -> None:
+    _run_isolated(
+        """
+        import sys
+
+        from agent_framework_foundry import (
+            FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY,
+            FoundryEmbeddingClient,
+            FoundryEvals,
+            FoundryMemoryProvider,
+            to_prompt_agent,
+        )
+
+        assert FOUNDRY_HOSTED_AGENT_SESSION_ID_KEY == "foundry_hosted_agent_session_id"
+        assert FoundryEmbeddingClient.__name__ == "FoundryEmbeddingClient"
+        assert FoundryEvals.__name__ == "FoundryEvals"
+        assert FoundryMemoryProvider.__name__ == "FoundryMemoryProvider"
+        assert callable(to_prompt_agent)
+        assert not any(name == "openai" or name.startswith("openai.") for name in sys.modules)
+        """
+    )

--- a/python/packages/foundry_hosting/agent_framework_foundry_hosting/__init__.py
+++ b/python/packages/foundry_hosting/agent_framework_foundry_hosting/__init__.py
@@ -1,26 +1,43 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 import importlib.metadata
+from typing import TYPE_CHECKING, Any, Final
 
-from ._invocations import InvocationsHostServer
-from ._responses import ResponsesHostServer
-from ._state_store import (
-    AgentSessionStoreProvider,
-    CheckpointStoreProvider,
-    ContextScopedStoreProvider,
-    FoundryAgentSessionStore,
-    FoundryCheckpointStore,
-    FoundryFunctionApprovalStore,
-    FunctionApprovalStore,
-    FunctionApprovalStoreProvider,
-    StoreProvider,
-)
-from ._toolbox import FoundryToolbox
+if TYPE_CHECKING:
+    from ._invocations import InvocationsHostServer
+    from ._responses import ResponsesHostServer
+    from ._state_store import (
+        AgentSessionStoreProvider,
+        CheckpointStoreProvider,
+        ContextScopedStoreProvider,
+        FoundryAgentSessionStore,
+        FoundryCheckpointStore,
+        FoundryFunctionApprovalStore,
+        FunctionApprovalStore,
+        FunctionApprovalStoreProvider,
+        StoreProvider,
+    )
+    from ._toolbox import FoundryToolbox
 
 try:
     __version__ = importlib.metadata.version(__name__)
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
+
+_LAZY_EXPORTS: Final[dict[str, str]] = {
+    "AgentSessionStoreProvider": "._state_store",
+    "CheckpointStoreProvider": "._state_store",
+    "ContextScopedStoreProvider": "._state_store",
+    "FoundryAgentSessionStore": "._state_store",
+    "FoundryCheckpointStore": "._state_store",
+    "FoundryFunctionApprovalStore": "._state_store",
+    "FoundryToolbox": "._toolbox",
+    "FunctionApprovalStore": "._state_store",
+    "FunctionApprovalStoreProvider": "._state_store",
+    "InvocationsHostServer": "._invocations",
+    "ResponsesHostServer": "._responses",
+    "StoreProvider": "._state_store",
+}
 
 __all__ = [
     "AgentSessionStoreProvider",
@@ -36,3 +53,17 @@ __all__ = [
     "ResponsesHostServer",
     "StoreProvider",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve public Foundry Hosting exports."""
+    if module_name := _LAZY_EXPORTS.get(name):
+        value = getattr(importlib.import_module(module_name, __name__), name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return public names for interactive discovery."""
+    return sorted(set(globals()) | set(__all__))

--- a/python/packages/foundry_hosting/tests/test_foundry_hosting_imports.py
+++ b/python/packages/foundry_hosting/tests/test_foundry_hosting_imports.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_package_import_is_lazy() -> None:
+    code = textwrap.dedent(
+        """
+        import sys
+
+        import agent_framework_foundry_hosting
+
+        assert "agent_framework_foundry_hosting._invocations" not in sys.modules
+        assert "agent_framework_foundry_hosting._responses" not in sys.modules
+        assert "agent_framework_foundry_hosting._state_store" not in sys.modules
+        assert "agent_framework_foundry_hosting._toolbox" not in sys.modules
+        """
+    )
+    subprocess.run([sys.executable, "-I", "-c", code], check=True)

--- a/python/packages/openai/agent_framework_openai/__init__.py
+++ b/python/packages/openai/agent_framework_openai/__init__.py
@@ -7,28 +7,47 @@ including clients for the Responses API and Chat Completions API.
 """
 
 import importlib.metadata
+from typing import TYPE_CHECKING, Any, Final
 
-from ._chat_client import (
-    OpenAIChatClient,
-    OpenAIChatOptions,
-    OpenAIContinuationToken,
-    RawOpenAIChatClient,
-)
-from ._chat_completion_client import (
-    OpenAIChatCompletionClient,
-    OpenAIChatCompletionOptions,
-    OpenAIChatMessagePreparer,
-    OpenAIChatResponseContentsParser,
-    RawOpenAIChatCompletionClient,
-)
-from ._embedding_client import OpenAIEmbeddingClient, OpenAIEmbeddingOptions
-from ._exceptions import ContentFilterResultSeverity, OpenAIContentFilterException
-from ._shared import OpenAISettings
+if TYPE_CHECKING:
+    from ._chat_client import (
+        OpenAIChatClient,
+        OpenAIChatOptions,
+        OpenAIContinuationToken,
+        RawOpenAIChatClient,
+    )
+    from ._chat_completion_client import (
+        OpenAIChatCompletionClient,
+        OpenAIChatCompletionOptions,
+        OpenAIChatMessagePreparer,
+        OpenAIChatResponseContentsParser,
+        RawOpenAIChatCompletionClient,
+    )
+    from ._embedding_client import OpenAIEmbeddingClient, OpenAIEmbeddingOptions
+    from ._exceptions import ContentFilterResultSeverity, OpenAIContentFilterException
+    from ._shared import OpenAISettings
 
 try:
     __version__ = importlib.metadata.version("agent-framework-openai")
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
+
+_LAZY_EXPORTS: Final[dict[str, str]] = {
+    "ContentFilterResultSeverity": "._exceptions",
+    "OpenAIChatClient": "._chat_client",
+    "OpenAIChatCompletionClient": "._chat_completion_client",
+    "OpenAIChatCompletionOptions": "._chat_completion_client",
+    "OpenAIChatMessagePreparer": "._chat_completion_client",
+    "OpenAIChatOptions": "._chat_client",
+    "OpenAIChatResponseContentsParser": "._chat_completion_client",
+    "OpenAIContentFilterException": "._exceptions",
+    "OpenAIContinuationToken": "._chat_client",
+    "OpenAIEmbeddingClient": "._embedding_client",
+    "OpenAIEmbeddingOptions": "._embedding_client",
+    "OpenAISettings": "._shared",
+    "RawOpenAIChatClient": "._chat_client",
+    "RawOpenAIChatCompletionClient": "._chat_completion_client",
+}
 
 __all__ = [
     "ContentFilterResultSeverity",
@@ -47,3 +66,17 @@ __all__ = [
     "RawOpenAIChatCompletionClient",
     "__version__",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve public OpenAI integration exports."""
+    if module_name := _LAZY_EXPORTS.get(name):
+        value = getattr(importlib.import_module(module_name, __name__), name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return public names for interactive discovery."""
+    return sorted(set(globals()) | set(__all__))

--- a/python/packages/openai/agent_framework_openai/_feature_usage.py
+++ b/python/packages/openai/agent_framework_openai/_feature_usage.py
@@ -1,14 +1,18 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 from collections.abc import MutableMapping
 from enum import IntEnum
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 from urllib.parse import urlsplit
 
 from agent_framework._telemetry import USER_AGENT_KEY, apply_feature_token, remove_feature_token
-from openai import DefaultAsyncHttpxClient
+
+if TYPE_CHECKING:
+    from openai import DefaultAsyncHttpxClient
 
 
 class FeatureIndex(IntEnum):
@@ -32,16 +36,6 @@ class _HttpRequest(Protocol):
     def url(self) -> object: ...
 
 
-class _FeatureUsageAsyncHttpxClient(DefaultAsyncHttpxClient):
-    """OpenAI-default HTTP client that preserves the SDK's GC cleanup behavior."""
-
-    def __del__(self) -> None:
-        if self.is_closed:
-            return
-        with contextlib.suppress(Exception):
-            asyncio.get_running_loop().create_task(self.aclose())
-
-
 def _is_approved_origin(url: str, suffixes: tuple[str, ...]) -> bool:
     parsed_url = urlsplit(url)
     host = (parsed_url.hostname or "").rstrip(".").lower()
@@ -53,6 +47,16 @@ def create_feature_usage_http_client(
     approved_origin_suffixes: tuple[str, ...] = _AZURE_OPENAI_ORIGIN_SUFFIXES,
 ) -> DefaultAsyncHttpxClient:
     """Create the OpenAI SDK default client with destination-aware feature stamping."""
+    from openai import DefaultAsyncHttpxClient
+
+    class _FeatureUsageAsyncHttpxClient(DefaultAsyncHttpxClient):
+        """OpenAI-default HTTP client that preserves the SDK's GC cleanup behavior."""
+
+        def __del__(self) -> None:
+            if self.is_closed:
+                return
+            with contextlib.suppress(Exception):
+                asyncio.get_running_loop().create_task(self.aclose())
 
     async def stamp_feature_usage(request: _HttpRequest) -> None:  # ruff:ignore[unused-async]
         user_agent = request.headers.get(USER_AGENT_KEY, "")

--- a/python/packages/openai/tests/openai/test_openai_imports.py
+++ b/python/packages/openai/tests/openai/test_openai_imports.py
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_package_import_is_lazy() -> None:
+    code = textwrap.dedent(
+        """
+        import sys
+
+        import agent_framework_openai
+
+        assert "agent_framework_openai._chat_client" not in sys.modules
+        assert "agent_framework_openai._chat_completion_client" not in sys.modules
+        assert not any(name == "openai" or name.startswith("openai.") for name in sys.modules)
+        """
+    )
+    subprocess.run([sys.executable, "-I", "-c", code], check=True)


### PR DESCRIPTION
### Motivation & Context

The OpenAI Python SDK eagerly loads hundreds of generated type modules, as reported in openai/openai-python#2819. Agent Framework's Foundry and OpenAI integration package facades imported their implementation modules eagerly, so applications paid that cost during startup even when they did not use an OpenAI-backed client. This particularly affects CLI tools and short-lived processes.

Across 25 isolated Python 3.13.1 processes, the median cold imports were 1,362.1 ms for `agent_framework_foundry`, 607.8 ms for `agent_framework_foundry_hosting`, and 944.0 ms for `agent_framework_openai`.

### Description & Review Guide

- **What are the major changes?** The Foundry, Foundry Hosting, and OpenAI integration package facades now resolve public exports through module `__getattr__` while retaining `TYPE_CHECKING` imports and the existing `__all__` surfaces. OpenAI SDK types, the Foundry project client, eval clients, prompt-agent conversion dependencies, and the feature-usage HTTP client are deferred until their runtime paths are used. Isolated-process regression tests enforce the lazy boundaries and public export behavior.
- **What is the impact of these changes?** Median cold import time drops from 1,362.1 ms to 48.1 ms for `agent_framework_foundry`, from 607.8 ms to 68.3 ms for `agent_framework_foundry_hosting`, and from 944.0 ms to 63.1 ms for `agent_framework_openai`. A plain Foundry import now loads zero OpenAI modules instead of 869. OpenAI-backed chat and agent implementations still load the SDK when requested.
- **What do you want reviewers to focus on?** Please focus on compatibility of the lazy public export maps and whether the remaining runtime import boundaries align with when each dependency is first required.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Related to openai/openai-python#2819. No matching Agent Framework issue or open pull request was found.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.