### PR TITLE
Python: Bump package versions for 1.18.0 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-09-10
+
+### Changed
+- **tests**: Update the Python type-checking development dependencies ([#8208](https://github.com/microsoft/agent-framework/pull/8208))
+
+### Fixed
+- **agent-framework-core**: Validate workflow executor checkpoint state when saving instead of deferring invalid-state failures until restore ([#8215](https://github.com/microsoft/agent-framework/pull/8215))
+- **agent-framework-core**: Keep MCP-provided security labels subordinate to locally configured FIDES policy ([#8187](https://github.com/microsoft/agent-framework/pull/8187))
+
 ## [1.17.0] - 2026-09-03
 
 ### Added
@@ -1606,7 +1615,8 @@ Release candidate for **agent-framework-core** and **agent-framework-azure-ai** 
 
 For more information, see the [announcement blog post](https://devblogs.microsoft.com/foundry/introducing-microsoft-agent-framework-the-open-source-engine-for-agentic-ai-apps/).
 
-[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.17.0...HEAD
+[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.17.1...HEAD
+[1.17.1]: https://github.com/microsoft/agent-framework/compare/python-1.17.0...python-1.17.1
 [1.17.0]: https://github.com/microsoft/agent-framework/compare/python-1.16.0...python-1.17.0
 [1.16.0]: https://github.com/microsoft/agent-framework/compare/python-1.15.0...python-1.16.0
 [1.15.0]: https://github.com/microsoft/agent-framework/compare/python-1.14.0...python-1.15.0

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,14 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.17.1] - 2026-09-10
+## [1.18.0] - 2026-09-10
+
+### Added
+- **samples**: Add Magentic custom-manager prompts and MLflow observability examples ([#7876](https://github.com/microsoft/agent-framework/pull/7876), [#8085](https://github.com/microsoft/agent-framework/pull/8085))
+- **agent-framework-core**: Add shared vector-store abstractions, portable filters, and an in-memory vector store ([#8014](https://github.com/microsoft/agent-framework/pull/8014), [#8115](https://github.com/microsoft/agent-framework/pull/8115))
+- **agent-framework-core**: Add a maximum-duration bound and stop-reason signal to the tool invocation loop ([#7772](https://github.com/microsoft/agent-framework/pull/7772))
+- **agent-framework-core**: Support mixed workflow invocation keyword arguments ([#7963](https://github.com/microsoft/agent-framework/pull/7963))
+- **agent-framework-ag-ui**: Add `emit_messages_snapshot` configuration for suppressing the terminal message snapshot ([#7808](https://github.com/microsoft/agent-framework/pull/7808))
+- **agent-framework-ag-ui**, **agent-framework-core**: Add supported MCP Host-history conversion for persisted AG-UI conversations ([#8130](https://github.com/microsoft/agent-framework/pull/8130))
+- **agent-framework-azure-ai-search**, **agent-framework-core**: Add an Azure AI Search implementation of the shared vector-store APIs ([#8153](https://github.com/microsoft/agent-framework/pull/8153))
+- **agent-framework-redis**, **agent-framework-core**: Add Redis HASH and JSON vector stores ([#8156](https://github.com/microsoft/agent-framework/pull/8156))
+- **agent-framework-qdrant**: Add the alpha Qdrant vector-store connector ([#8154](https://github.com/microsoft/agent-framework/pull/8154))
+- **agent-framework-postgres**: Add the alpha PostgreSQL/pgvector connector ([#8155](https://github.com/microsoft/agent-framework/pull/8155))
 
 ### Changed
-- **tests**: Update the Python type-checking development dependencies ([#8208](https://github.com/microsoft/agent-framework/pull/8208))
+- **agent-framework**, **agent-framework-core**, **agent-framework-foundry**, **agent-framework-lab**: [BREAKING] Isolate Lab dependency resolution, remove Lab from `core[all]`, and support Azure AI Projects through 2.6 with OpenAI 3.x ([#8188](https://github.com/microsoft/agent-framework/pull/8188))
+- **agent-framework-core**: [BREAKING - experimental] Add ranged file reads and move the line-numbering contract onto `AgentFileStore` ([#7669](https://github.com/microsoft/agent-framework/pull/7669))
+- **agent-framework-core**: [BREAKING - experimental] Centralize file, memory, session, and skill path normalization ([#8123](https://github.com/microsoft/agent-framework/pull/8123))
+- **agent-framework-anthropic**, **agent-framework-azure-ai-search**, **agent-framework-azure-cosmos**, **agent-framework-bedrock**, **agent-framework-copilotstudio**, **agent-framework-core**, **agent-framework-foundry**, **agent-framework-gemini**, **agent-framework-mem0**, **agent-framework-openai**: [BREAKING] Make `SecretString` a masked value wrapper rather than a `str` subclass and align provider credential handling ([#8127](https://github.com/microsoft/agent-framework/pull/8127))
+- **agent-framework-github-copilot**: [BREAKING] Make workspace file hooks opt-in and document `enable_file_hooks` migration ([#7517](https://github.com/microsoft/agent-framework/pull/7517))
+- **agent-framework-foundry-hosting**: [BREAKING - beta] Restrict checkpoint deserialization by default and allow applications to register additional checkpoint types ([#8045](https://github.com/microsoft/agent-framework/pull/8045))
+- **agent-framework-core**, **agent-framework-foundry**: Move Foundry evaluation serialization into the Foundry integration ([#8031](https://github.com/microsoft/agent-framework/pull/8031))
+- **agent-framework-github-copilot**: Update the GitHub Copilot SDK dependency to 1.0.11 and align file-operation behavior ([#8002](https://github.com/microsoft/agent-framework/pull/8002))
+- **agent-framework-ag-ui**, **agent-framework-devui**: Expand compatibility through FastAPI 0.141 ([#8052](https://github.com/microsoft/agent-framework/pull/8052))
+- **agent-framework-core**, **agent-framework-hyperlight**: Update Hyperlight Sandbox to 0.6 and enable supported Python 3.14 installations ([#8174](https://github.com/microsoft/agent-framework/pull/8174))
+- **agent-framework-foundry**, **agent-framework-foundry-hosting**, **agent-framework-openai**: Lazily load Foundry and OpenAI integrations to avoid unnecessary import-time dependencies ([#8219](https://github.com/microsoft/agent-framework/pull/8219))
+- **agent-framework-devui**: Update frontend transitive dependencies ([#8019](https://github.com/microsoft/agent-framework/pull/8019), [#8009](https://github.com/microsoft/agent-framework/pull/8009), [#8175](https://github.com/microsoft/agent-framework/pull/8175))
+- **agent-framework**: Replace stale Python documentation placeholders with live documentation links ([#7777](https://github.com/microsoft/agent-framework/pull/7777))
+- **docs**: Repair external links, document anonymous Parallel Search MCP usage, and correct Python documentation wording ([#8090](https://github.com/microsoft/agent-framework/pull/8090), [#8084](https://github.com/microsoft/agent-framework/pull/8084), [#7942](https://github.com/microsoft/agent-framework/pull/7942))
+- **tests**: Update uv, Ruff, Zuban, ty, pytest, and Python type-checking dependencies; isolate Lab test dependencies; and make the optional Lightning test robust to nested import failures ([#8038](https://github.com/microsoft/agent-framework/pull/8038), [#8036](https://github.com/microsoft/agent-framework/pull/8036), [#8037](https://github.com/microsoft/agent-framework/pull/8037), [#8062](https://github.com/microsoft/agent-framework/pull/8062), [#8110](https://github.com/microsoft/agent-framework/pull/8110), [#8064](https://github.com/microsoft/agent-framework/pull/8064), [#8071](https://github.com/microsoft/agent-framework/pull/8071), [#8209](https://github.com/microsoft/agent-framework/pull/8209), [#8207](https://github.com/microsoft/agent-framework/pull/8207), [#8208](https://github.com/microsoft/agent-framework/pull/8208))
 
 ### Fixed
-- **agent-framework-core**: Validate workflow executor checkpoint state when saving instead of deferring invalid-state failures until restore ([#8215](https://github.com/microsoft/agent-framework/pull/8215))
-- **agent-framework-core**: Keep MCP-provided security labels subordinate to locally configured FIDES policy ([#8187](https://github.com/microsoft/agent-framework/pull/8187))
+- **agent-framework-purview**: Request inline policy evaluation while the protection-scope cache is cold ([#7976](https://github.com/microsoft/agent-framework/pull/7976))
+- **agent-framework-anthropic**, **agent-framework-gemini**: Wrap provider SDK failures consistently in `ChatClientException` ([#7855](https://github.com/microsoft/agent-framework/pull/7855))
+- **agent-framework-a2a**: Avoid `AttributeError` and preserve caller ownership when an `A2AAgent` uses a supplied HTTP client ([#8095](https://github.com/microsoft/agent-framework/pull/8095), [#7951](https://github.com/microsoft/agent-framework/pull/7951))
+- **agent-framework-chatkit**: Preserve ChatKit input tags when converting user messages ([#8097](https://github.com/microsoft/agent-framework/pull/8097))
+- **agent-framework-claude**, **agent-framework-github-copilot**: Reject MCP servers passed through provider-agent tool collections ([#7835](https://github.com/microsoft/agent-framework/pull/7835))
+- **agent-framework-claude**: Preserve message roles in Claude prompt history ([#8122](https://github.com/microsoft/agent-framework/pull/8122))
+- **agent-framework-declarative**: Preserve URL query parameters and correctly route DevUI message input in declarative workflows ([#7765](https://github.com/microsoft/agent-framework/pull/7765), [#7839](https://github.com/microsoft/agent-framework/pull/7839))
+- **agent-framework-core**: Preserve runtime raw representations and recursively serialize nested container values ([#8023](https://github.com/microsoft/agent-framework/pull/8023), [#7790](https://github.com/microsoft/agent-framework/pull/7790))
+- **agent-framework-core**: Scope MCP headers to transport requests, clean up failed HTTP connections, and retain bounded MCP Host payload metadata ([#8039](https://github.com/microsoft/agent-framework/pull/8039), [#8126](https://github.com/microsoft/agent-framework/pull/8126), [#8128](https://github.com/microsoft/agent-framework/pull/8128))
+- **agent-framework-core**: Finalize abandoned functional-workflow streams, restore fan-in edge buffers, and validate checkpoint state when saving ([#7798](https://github.com/microsoft/agent-framework/pull/7798), [#7948](https://github.com/microsoft/agent-framework/pull/7948), [#8215](https://github.com/microsoft/agent-framework/pull/8215))
+- **agent-framework-core**: Include tool trajectory details in summarizer input ([#8087](https://github.com/microsoft/agent-framework/pull/8087))
+- **agent-framework-core**: Preserve the `Param` unset sentinel with current `typing-extensions` releases ([#8145](https://github.com/microsoft/agent-framework/pull/8145))
+- **agent-framework-core**: Preserve empty signed Anthropic thinking blocks during streaming replay ([#8171](https://github.com/microsoft/agent-framework/pull/8171))
+- **agent-framework-core**: Revalidate discovered skill paths immediately before use ([#8151](https://github.com/microsoft/agent-framework/pull/8151))
+- **agent-framework-core**: Isolate FIDES state per session, enforce labels on expanded variables, preserve confidentiality through security tools, and keep MCP labels subordinate to local policy ([#8138](https://github.com/microsoft/agent-framework/pull/8138), [#8139](https://github.com/microsoft/agent-framework/pull/8139), [#8141](https://github.com/microsoft/agent-framework/pull/8141), [#8187](https://github.com/microsoft/agent-framework/pull/8187))
+- **agent-framework-ag-ui**: Stamp checkpoint ownership, surface workflow intermediate events as reasoning, and preserve function-call/result ordering ([#8011](https://github.com/microsoft/agent-framework/pull/8011), [#8003](https://github.com/microsoft/agent-framework/pull/8003), [#8005](https://github.com/microsoft/agent-framework/pull/8005))
+- **agent-framework-ag-ui**: Scope internal session identifiers and reject empty scope-resolver results ([#8158](https://github.com/microsoft/agent-framework/pull/8158), [#8197](https://github.com/microsoft/agent-framework/pull/8197))
+- **agent-framework-ag-ui**, **agent-framework-core**: Preserve complete MCP Host payloads in live events and snapshots while keeping model history safe ([#8129](https://github.com/microsoft/agent-framework/pull/8129))
+- **agent-framework-ag-ui**, **agent-framework-core**: Preserve multimodal content in AG-UI chat-client requests and synchronized namespace exports ([#8116](https://github.com/microsoft/agent-framework/pull/8116))
+- **agent-framework-ag-ui**, **agent-framework-core**: Bind FIDES approvals to exact invocation occurrences across interruption, persistence, and resume ([#8142](https://github.com/microsoft/agent-framework/pull/8142))
+- **agent-framework-hyperlight**: Bound code-execution output attachments ([#8176](https://github.com/microsoft/agent-framework/pull/8176))
+- **agent-framework-devui**, **samples**: Patch vulnerable frontend `ajv`, `brace-expansion`, and `nanoid` dependency resolutions ([#8172](https://github.com/microsoft/agent-framework/pull/8172))
 
 ## [1.17.0] - 2026-09-03
 
@@ -1615,8 +1661,8 @@ Release candidate for **agent-framework-core** and **agent-framework-azure-ai** 
 
 For more information, see the [announcement blog post](https://devblogs.microsoft.com/foundry/introducing-microsoft-agent-framework-the-open-source-engine-for-agentic-ai-apps/).
 
-[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.17.1...HEAD
-[1.17.1]: https://github.com/microsoft/agent-framework/compare/python-1.17.0...python-1.17.1
+[Unreleased]: https://github.com/microsoft/agent-framework/compare/python-1.18.0...HEAD
+[1.18.0]: https://github.com/microsoft/agent-framework/compare/python-1.17.0...python-1.18.0
 [1.17.0]: https://github.com/microsoft/agent-framework/compare/python-1.16.0...python-1.17.0
 [1.16.0]: https://github.com/microsoft/agent-framework/compare/python-1.15.0...python-1.16.0
 [1.15.0]: https://github.com/microsoft/agent-framework/compare/python-1.14.0...python-1.15.0

--- a/python/packages/a2a/pyproject.toml
+++ b/python/packages/a2a/pyproject.toml
@@ -4,7 +4,7 @@ description = "A2A integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/ag-ui/pyproject.toml
+++ b/python/packages/ag-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-framework-ag-ui"
-version = "1.2.2"
+version = "1.3.0"
 description = "AG-UI protocol integration for Agent Framework"
 readme = "README.md"
 license-files = ["LICENSE"]
@@ -22,7 +22,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.17.0,<2",
+    "agent-framework-core>=1.18.0,<2",
     "ag-ui-protocol>=0.1.19,<0.2",
     "fastapi>=0.121.0,<0.142.0",
     "httpx>=0.28.1,<1",

--- a/python/packages/anthropic/pyproject.toml
+++ b/python/packages/anthropic/pyproject.toml
@@ -4,7 +4,7 @@ description = "Anthropic integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260827"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/azure-ai-search/pyproject.toml
+++ b/python/packages/azure-ai-search/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure AI Search integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260827"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.17.0,<2",
+    "agent-framework-core>=1.18.0,<2",
     "aiohttp>=3.11.11,<4",
     # Stable/GA (12.0.0) targets Azure AI Search api-version 2026-04-01; the preview
     # line (e.g. 12.1.0b2, installed with --pre) targets api-version 2026-08-01-preview.

--- a/python/packages/azure-cosmos/pyproject.toml
+++ b/python/packages/azure-cosmos/pyproject.toml
@@ -4,7 +4,7 @@ description = "Azure Cosmos DB history provider integration for Microsoft Agent 
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260821"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/bedrock/pyproject.toml
+++ b/python/packages/bedrock/pyproject.toml
@@ -4,7 +4,7 @@ description = "Amazon Bedrock integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/chatkit/pyproject.toml
+++ b/python/packages/chatkit/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI ChatKit integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/claude/pyproject.toml
+++ b/python/packages/claude/pyproject.toml
@@ -4,7 +4,7 @@ description = "Claude Agent SDK integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/copilotstudio/pyproject.toml
+++ b/python/packages/copilotstudio/pyproject.toml
@@ -4,7 +4,7 @@ description = "Copilot Studio integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.17.1"
+version = "1.18.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/core/pyproject.toml
+++ b/python/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.17.0"
+version = "1.17.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/declarative/pyproject.toml
+++ b/python/packages/declarative/pyproject.toml
@@ -4,7 +4,7 @@ description = "Declarative specification support for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.3"
+version = "1.0.4"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/devui/pyproject.toml
+++ b/python/packages/devui/pyproject.toml
@@ -4,7 +4,7 @@ description = "Debug UI for Microsoft Agent Framework with OpenAI-compatible API
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://github.com/microsoft/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/foundry/pyproject.toml
+++ b/python/packages/foundry/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Foundry integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.12.0"
+version = "1.13.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/foundry_hosting/pyproject.toml
+++ b/python/packages/foundry_hosting/pyproject.toml
@@ -4,7 +4,7 @@ description = "Foundry Hosting integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/gemini/pyproject.toml
+++ b/python/packages/gemini/pyproject.toml
@@ -4,7 +4,7 @@ description = "Google Gemini integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/github_copilot/pyproject.toml
+++ b/python/packages/github_copilot/pyproject.toml
@@ -4,7 +4,7 @@ description = "GitHub Copilot integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.0.3"
+version = "2.0.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/hyperlight/pyproject.toml
+++ b/python/packages/hyperlight/pyproject.toml
@@ -4,7 +4,7 @@ description = "Hyperlight CodeAct integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/lab/pyproject.toml
+++ b/python/packages/lab/pyproject.toml
@@ -4,7 +4,7 @@ description = "Experimental modules for Microsoft Agent Framework"
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/lab/uv.lock
+++ b/python/packages/lab/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-lab"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 source = { editable = "." }
 dependencies = [
     { name = "agent-framework-core" },

--- a/python/packages/mem0/pyproject.toml
+++ b/python/packages/mem0/pyproject.toml
@@ -4,7 +4,7 @@ description = "Mem0 integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/openai/pyproject.toml
+++ b/python/packages/openai/pyproject.toml
@@ -4,7 +4,7 @@ description = "OpenAI integrations for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.14.2"
+version = "1.14.3"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/postgres/pyproject.toml
+++ b/python/packages/postgres/pyproject.toml
@@ -4,7 +4,7 @@ description = "PostgreSQL and pgvector integration for Microsoft Agent Framework
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260908"
+version = "1.0.0a260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.17.0,<2",
+    "agent-framework-core>=1.18.0,<2",
     "psycopg[binary,pool]>=3.3.5,<4",
     "pgvector>=0.5.0,<0.6",
 ]

--- a/python/packages/purview/pyproject.toml
+++ b/python/packages/purview/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Purview (Graph dataSecurityAndGovernance) integration f
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://github.com/microsoft/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"

--- a/python/packages/qdrant/pyproject.toml
+++ b/python/packages/qdrant/pyproject.toml
@@ -4,7 +4,7 @@ description = "Qdrant vector stores for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0a260908"
+version = "1.0.0a260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -22,7 +22,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.17.0,<2",
+    "agent-framework-core>=1.18.0,<2",
     "qdrant-client>=1.16.2,<2",
 ]
 

--- a/python/packages/redis/pyproject.toml
+++ b/python/packages/redis/pyproject.toml
@@ -4,7 +4,7 @@ description = "Redis integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core>=1.17.0,<2",
+    "agent-framework-core>=1.18.0,<2",
     "redis>=6.4.0,<7.2.1",
     "redisvl>=0.11.0,<0.16",
     "numpy>=2.2.6,<3"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.17.1"
+version = "1.18.0"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core[all]==1.17.1",
+    "agent-framework-core[all]==1.18.0",
 ]
 
 [dependency-groups]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ description = "Microsoft Agent Framework for building AI Agents with Python. Thi
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-version = "1.17.0"
+version = "1.17.1"
 license-files = ["LICENSE"]
 urls.homepage = "https://aka.ms/agent-framework"
 urls.source = "https://github.com/microsoft/agent-framework/tree/main/python"
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "agent-framework-core[all]==1.17.0",
+    "agent-framework-core[all]==1.17.1",
 ]
 
 [dependency-groups]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.17.1"
+version = "1.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -184,7 +184,7 @@ test = [
 
 [[package]]
 name = "agent-framework-a2a"
-version = "1.0.0b260821"
+version = "1.0.0b260910"
 source = { editable = "packages/a2a" }
 dependencies = [
     { name = "a2a-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -199,7 +199,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-ag-ui"
-version = "1.2.2"
+version = "1.3.0"
 source = { editable = "packages/ag-ui" }
 dependencies = [
     { name = "ag-ui-protocol", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -241,7 +241,7 @@ test = [{ name = "agent-framework-orchestrations", editable = "packages/orchestr
 
 [[package]]
 name = "agent-framework-anthropic"
-version = "1.0.0b260827"
+version = "1.0.0b260910"
 source = { editable = "packages/anthropic" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -256,7 +256,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azure-ai-search"
-version = "1.0.0b260827"
+version = "1.0.0b260910"
 source = { editable = "packages/azure-ai-search" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -294,7 +294,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-azure-cosmos"
-version = "1.0.0b260821"
+version = "1.0.0b260910"
 source = { editable = "packages/azure-cosmos" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-bedrock"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 source = { editable = "packages/bedrock" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -374,7 +374,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-chatkit"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 source = { editable = "packages/chatkit" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -389,7 +389,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-claude"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 source = { editable = "packages/claude" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -404,7 +404,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-copilotstudio"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 source = { editable = "packages/copilotstudio" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -423,7 +423,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.17.1"
+version = "1.18.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -523,7 +523,7 @@ dev = [
 
 [[package]]
 name = "agent-framework-declarative"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "packages/declarative" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -550,7 +550,7 @@ dev = [{ name = "types-pyyaml", specifier = "==6.0.12.20260518" }]
 
 [[package]]
 name = "agent-framework-devui"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 source = { editable = "packages/devui" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-foundry"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "packages/foundry" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -626,7 +626,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-foundry-hosting"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 source = { editable = "packages/foundry_hosting" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -666,7 +666,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-gemini"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 source = { editable = "packages/gemini" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -681,7 +681,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-github-copilot"
-version = "1.0.3"
+version = "2.0.0"
 source = { editable = "packages/github_copilot" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -787,7 +787,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-hyperlight"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 source = { editable = "packages/hyperlight" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -806,7 +806,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-mem0"
-version = "1.0.0b260813"
+version = "1.0.0b260910"
 source = { editable = "packages/mem0" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -866,7 +866,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-openai"
-version = "1.14.2"
+version = "1.14.3"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -892,7 +892,7 @@ requires-dist = [{ name = "agent-framework-core", editable = "packages/core" }]
 
 [[package]]
 name = "agent-framework-postgres"
-version = "1.0.0a260908"
+version = "1.0.0a260910"
 source = { editable = "packages/postgres" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -909,7 +909,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-purview"
-version = "1.0.0b260730"
+version = "1.0.0b260910"
 source = { editable = "packages/purview" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -926,7 +926,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-qdrant"
-version = "1.0.0a260908"
+version = "1.0.0a260910"
 source = { editable = "packages/qdrant" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -941,7 +941,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-redis"
-version = "1.0.0b260903"
+version = "1.0.0b260910"
 source = { editable = "packages/redis" }
 dependencies = [
     { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.17.0"
+version = "1.17.1"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -423,7 +423,7 @@ requires-dist = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
### Motivation & Context

Prepare the next Python package release from the changes merged since `python-1.17.0`. This publishes new vector-store capabilities, workflow and tool-loop enhancements, FIDES security improvements, provider updates, and accumulated fixes across the independently versioned Python distributions.

### Description & Review Guide

- **What are the major changes?** Adds the `1.18.0` CHANGELOG section covering 75 Python PRs; bumps 25 changed distributions according to their lifecycle stages; updates the root package's exact Core pin; raises the Core dependency floor for AG-UI and the Azure AI Search, PostgreSQL, Qdrant, and Redis vector connectors; and refreshes the root and Lab lockfile package versions.
- **What is the impact of these changes?** Core and the root package move to `1.18.0`; AG-UI moves to `1.3.0`; Foundry moves to `1.13.0`; GitHub Copilot moves to `2.0.0` for its stable breaking default change; Declarative and OpenAI receive patch releases; and changed alpha/beta packages receive the `260910` Pacific date stamp.
- **What do you want reviewers to focus on?** Confirm the CHANGELOG categorization and package coverage, the released-package semver decisions, the intentionally selective prerelease bumps, and the five Core floor updates.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

N/A - scheduled Python release preparation.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) - a workflow keeps the label and title prefix in sync automatically.
