### PR TITLE
Python: deduplicate MessagePack FileHistoryProvider writes

### DIFF
--- a/python/packages/core/agent_framework/_sessions.py
+++ b/python/packages/core/agent_framework/_sessions.py
@@ -2335,8 +2335,12 @@ class FileHistoryProvider(HistoryProvider):
                             for message in new_messages:
                                 file_handle.write(f"{self._serialize_json_message(message)}\n")
                     return
+                existing_messages = self._read_msgpack_messages(file_path) if file_path.exists() else []
+                new_messages = filter_new_messages(existing_messages, messages)
+                if not new_messages:
+                    return
                 with file_path.open("ab") as file_handle:
-                    for message in messages:
+                    for message in new_messages:
                         serialized = _DEFAULT_MSGPACK_ENCODER.encode(message.to_dict())
                         file_handle.write(len(serialized).to_bytes(self._MSGPACK_RECORD_HEADER_BYTES, "big"))
                         file_handle.write(serialized)

--- a/python/packages/core/tests/core/test_sessions.py
+++ b/python/packages/core/tests/core/test_sessions.py
@@ -1637,6 +1637,28 @@ class TestFileHistoryProvider:
         assert raw[4 : 4 + first_record_length] == msgspec.msgpack.encode(messages[0].to_dict())
 
     @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
+    async def test_save_messages_deduplicates_replayed_transcript(
+        self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
+    ) -> None:
+        provider = FileHistoryProvider(tmp_path, serialization_format=serialization_format)
+        first_turn = [
+            Message(role="user", contents=["hello"]),
+            Message(role="assistant", contents=["hi there"]),
+        ]
+        full_transcript = [
+            Message(role="user", contents=["hello"]),
+            Message(role="assistant", contents=["hi there"]),
+            Message(role="user", contents=["follow-up"]),
+            Message(role="assistant", contents=["reply"]),
+        ]
+
+        await provider.save_messages("replayed-transcript", first_turn)
+        await provider.save_messages("replayed-transcript", full_transcript)
+
+        loaded = await provider.get_messages("replayed-transcript")
+        assert [message.text for message in loaded] == ["hello", "hi there", "follow-up", "reply"]
+
+    @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
     async def test_round_trips_marked_refusal_text(
         self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
     ) -> None:
@@ -1913,9 +1935,12 @@ class TestFileHistoryProvider:
         loaded = await provider.get_messages(session_id)
         assert [message.text for message in loaded] == ["first", "second"]
 
-    async def test_save_messages_deduplicates_identical_messages(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
+    async def test_save_messages_deduplicates_identical_messages(
+        self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
+    ) -> None:
         """Test that FileHistoryProvider does not re-append already persisted messages."""
-        provider = FileHistoryProvider(tmp_path)
+        provider = FileHistoryProvider(tmp_path, serialization_format=serialization_format)
 
         msg1 = Message(role="user", contents=["hello"])
         msg2 = Message(role="assistant", contents=["hi there"])
@@ -1928,9 +1953,12 @@ class TestFileHistoryProvider:
         loaded = await provider.get_messages("s1")
         assert len(loaded) == 2
 
-    async def test_save_messages_only_appends_new_messages(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
+    async def test_save_messages_only_appends_new_messages(
+        self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
+    ) -> None:
         """Test that FileHistoryProvider filters out old messages and only appends new ones"""
-        provider = FileHistoryProvider(tmp_path)
+        provider = FileHistoryProvider(tmp_path, serialization_format=serialization_format)
 
         msg1 = Message(role="user", contents=["hello"])
         msg2 = Message(role="assistant", contents=["hi there"])
@@ -1945,9 +1973,12 @@ class TestFileHistoryProvider:
         assert len(loaded) == 3
         assert loaded[2].text == "how are you?"
 
-    async def test_save_messages_different_roles_same_text_not_deduplicated(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
+    async def test_save_messages_different_roles_same_text_not_deduplicated(
+        self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
+    ) -> None:
         """Test that messages with the same text but different roles are kept separate."""
-        provider = FileHistoryProvider(tmp_path)
+        provider = FileHistoryProvider(tmp_path, serialization_format=serialization_format)
 
         msg1 = Message(role="user", contents=["ping"])
         msg2 = Message(role="assistant", contents=["ping"])
@@ -1974,9 +2005,12 @@ class TestFileHistoryProvider:
         raw_lines = (await asyncio.to_thread(session_file.read_text, encoding="utf-8")).splitlines()
         assert len(raw_lines) == 3
 
-    async def test_save_messages_preserves_duplicate_content(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("serialization_format", ["json", "msgpack"])
+    async def test_save_messages_preserves_duplicate_content(
+        self, tmp_path: Path, serialization_format: Literal["json", "msgpack"]
+    ) -> None:
         """Test that two identical user turns in the same batch are both persisted."""
-        provider = FileHistoryProvider(tmp_path)
+        provider = FileHistoryProvider(tmp_path, serialization_format=serialization_format)
 
         yes_1 = Message(role="user", contents=["yes"])
         yes_2 = Message(role="user", contents=["yes"])


### PR DESCRIPTION
### Motivation & Context

`FileHistoryProvider` supports JSONL by default and length-prefixed MessagePack as an opt-in format. The existing deduplication fix in #7242 applies `filter_new_messages()` to the JSONL write path, but the MessagePack write path appends every supplied message. As a result, a client that replays a complete transcript on every turn gets different persistence and replay behavior depending only on the serialization format.

This is a follow-up to #7242 and fixes a real, deterministic persistence bug. On upstream `main` at `018056a52`, I reproduced it with a real `Agent` / `AgentSession` / `FileHistoryProvider` lifecycle using a fixed session, ten turns, unique assistant responses, and a complete transcript supplied on every turn. Before this change, the stored history was:

| scenario | JSONL | MessagePack |
| --- | ---: | ---: |
| Agent lifecycle: 10 full-transcript turns | 20 records / 3,000 bytes | 110 records / 13,530 bytes |
| Direct provider: 10 cumulative transcript writes | 20 records / 2,840 bytes | 110 records / 12,870 bytes |

The baseline Agent client-message counts were `[1, 5, 9, 13, 17, 21, 25, 29, 33, 37]` for JSONL and `[1, 5, 11, 19, 29, 41, 55, 71, 89, 109]` for MessagePack. No exception was raised; loading the session returned repeated turns, increasing storage and later history/model-context size. A delta-only control stored 20 records in both formats, isolating the defect to full-transcript replay.

### Description & Review Guide

- **What are the major changes?**
  - Read existing length-prefixed MessagePack records while holding the existing per-session write lock.
  - Apply the same `filter_new_messages(existing_messages, messages)` logic already used by the JSONL path before appending.
  - Skip the write when the incoming transcript contains no new messages.
  - Parameterize FileHistoryProvider deduplication tests over `json` and `msgpack`, including replayed transcripts, repeated writes, suffix-only appends, role-sensitive identity, and legitimate identical messages within one batch.
  - No public API, file format, or existing MessagePack record compatibility changes.

- **What is the impact of these changes?**
  - After the change, the same real Agent lifecycle stores 20 records in both formats. The post-fix run measured JSONL `20 records / 3,061 bytes` and MessagePack `20 records / 2,521 bytes`; client-message counts matched in both runs: `[1, 5, 9, 13, 17, 21, 25, 29, 33, 37]`.
  - The direct cumulative-transcript control also measured JSONL `20 records / 2,770 bytes` and MessagePack `20 records / 2,270 bytes` after the fix.
  - MessagePack remains length-prefixed and readable by the existing loader. The write path now has the same read-before-append behavior as JSONL, so the two formats have consistent transcript persistence semantics.
  - The change is intentionally limited to FileHistoryProvider persistence. It does not address the separate open AG-UI context-composition issue in #8135 or AG-UI snapshot-resume issue in #8149.

- **What do you want reviewers to focus on?**
  - Whether reading existing MessagePack records under the existing lock preserves the intended append-only and corruption handling behavior.
  - Whether `filter_new_messages()` preserves legitimate duplicate turns within one incoming batch while removing replayed prefixes.
  - Whether the format-parameterized regression coverage is sufficient for existing and full-transcript callers.

The following checks were run on Python 3.12.14:

- `uv run pytest packages/core/tests/core/test_sessions.py -q` passed on the focused session suite.
- `uv run poe test --package core` passed: `5023 passed, 131 skipped, 2 xfailed` (the run reported existing warnings).
- `uv run poe syntax --package core` passed both core formatting and lint tasks.
- `uv build --package agent-framework-core` completed successfully.
- `git diff --check` and `git show --check` passed.
- `mypy :: core` and `zuban :: core` passed through the test-typing task. The aggregate `ty` / `pyrefly` sweeps were blocked by the environment missing the optional `agent_hooks` package, and Pyright could not start because the environment provides Node 12 while the installed Pyright bundle requires newer JavaScript syntax; neither failure reported a diagnostic in the changed implementation.

### Related Issue

Fixes #8223

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.