### PR TITLE
Python: preserve MCP request ownership on low-level sends

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -58,7 +58,7 @@ else:
     from typing_extensions import Self  # pragma: no cover
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Request, Response
     from mcp import types
     from mcp.client.session import ClientSession
     from mcp.shared.context import RequestContext
@@ -436,6 +436,10 @@ class _MCPHeaderScopedClient:
 
     def stream(self, *args: Any, **kwargs: Any) -> Any:
         return self._client.stream(*args, **self._tagged_kwargs(kwargs))
+
+    async def send(self, request: Request, **kwargs: Any) -> Response:
+        request.extensions[_MCP_HEADER_OWNER_EXTENSION] = self._owner
+        return await self._client.send(request, **kwargs)
 
     async def delete(self, *args: Any, **kwargs: Any) -> Any:
         return await self._client.delete(*args, **self._tagged_kwargs(kwargs))
@@ -3682,7 +3686,7 @@ class MCPStreamableHTTPTool(MCPTool):
         Returns:
             An async context manager for the streamable HTTP client transport.
         """
-        from httpx import URL, AsyncClient, Request, Timeout
+        from httpx import URL, AsyncClient, Timeout
 
         http_client = self._httpx_client
         if self._header_provider is not None:

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -7464,6 +7464,29 @@ async def test_mcp_streamable_http_tool_keeps_header_hook_until_cancelled_close_
         await user_client.aclose()
 
 
+async def test_mcp_header_scoped_client_tags_send_requests():
+    """The transport wrapper must identify requests sent through AsyncClient.send."""
+    import httpx
+
+    from agent_framework._mcp import _MCP_HEADER_OWNER_EXTENSION, _MCPHeaderScopedClient
+
+    owner = object()
+    observed_owners: list[object | None] = []
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        observed_owners.append(request.extensions.get(_MCP_HEADER_OWNER_EXTENSION))
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as user_client:
+        wrapper = _MCPHeaderScopedClient(user_client, owner)
+        request = user_client.build_request("POST", "http://example.com/mcp")
+
+        response = await wrapper.send(request)
+
+    assert response.status_code == 200
+    assert observed_owners == [owner]
+
+
 async def test_mcp_header_scoped_client_delegates_unwrapped_attributes():
     """The transport wrapper must stay a drop-in for the caller's httpx client."""
     import httpx


### PR DESCRIPTION
### Motivation & Context

Supported MCP dependencies can issue streamable HTTP requests through `AsyncClient.send()`. That path bypassed the transport wrapper's request ownership marker, so `header_provider` hooks ignored those requests.

### Description & Review Guide

- **What are the major changes?** Add a focused `send()` wrapper that applies the same private request marker as the existing stream and delete paths, plus a regression test for that invariant.
- **What is the impact of these changes?** Request-scoped headers continue to work on the low-level send path. The rebased focused suite passes all 75 cases, together with core syntax, source typing, and test typing checks.
- **What do you want reviewers to focus on?** Confirm that marking the request immediately before delegation preserves the existing client ownership and lifecycle behavior.

### Related Issue

Related to microsoft/agent-framework#7841.

Follow-up to #8225, which supplies run kwargs during connection setup; this change preserves request ownership when the MCP dependency sends through `AsyncClient.send()`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
