### PR TITLE
Python: register built-in orchestration types for checkpoint restore

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/__init__.py
@@ -17,10 +17,14 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
 
+from agent_framework import register_checkpoint_type
+
 from ._base_group_chat_orchestrator import (
     BaseGroupChatOrchestrator,
+    GroupChatParticipantMessage,
     GroupChatRequestMessage,
     GroupChatRequestSentEvent,
+    GroupChatResponseMessage,
     GroupChatResponseReceivedEvent,
     TerminationCondition,
 )
@@ -108,3 +112,37 @@ __all__ = [
     "clean_conversation_for_handoff",
     "create_completion_message",
 ]
+
+
+# Framework-owned types that cross a checkpoint boundary.
+#
+# Checkpoint restore runs pickle through a restricted unpickler whose default allowlist
+# auto-trusts the ``agent_framework.`` prefix. That prefix is dotted, so it covers core but
+# not sibling distributions such as this one -- deliberately, since dropping the dot would
+# auto-trust any installed package merely named ``agent_framework_*``. Built-in orchestration
+# envelopes therefore have to opt in by name, or users have to hand-maintain
+# ``allowed_checkpoint_types`` with framework-internal module paths (#7789).
+#
+# Each entry below crosses the boundary for a stated reason. Nothing belongs here that only
+# travels as a dict: ``_MagenticTaskLedger``, for instance, is persisted through
+# ``to_dict()``/``from_dict()`` and never reaches the unpickler.
+for _checkpoint_type in (
+    # Executor-to-executor message envelopes.
+    GroupChatRequestMessage,
+    GroupChatParticipantMessage,
+    GroupChatResponseMessage,
+    MagenticResetSignal,
+    # ``request_info`` payloads and their response types, which are checkpointed as
+    # pending request-info events while a workflow waits on a human.
+    HandoffAgentUserRequest,
+    AgentRequestInfoResponse,
+    MagenticPlanReviewRequest,
+    MagenticPlanReviewResponse,
+    # Nested inside ``MagenticPlanReviewRequest.current_progress``. The unpickler resolves
+    # nested classes too, so registering only the outer request is not enough.
+    MagenticProgressLedger,
+    MagenticProgressLedgerItem,
+):
+    register_checkpoint_type(_checkpoint_type)
+
+del _checkpoint_type

--- a/python/packages/orchestrations/tests/test_checkpoint_types.py
+++ b/python/packages/orchestrations/tests/test_checkpoint_types.py
@@ -16,15 +16,18 @@ nested type left unregistered.
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import pytest
-from agent_framework import AgentResponse, Message, WorkflowCheckpoint
+from agent_framework import AgentResponse, Executor, Message, WorkflowCheckpoint, WorkflowContext, handler
 from agent_framework._workflows._checkpoint import FileCheckpointStorage
 
 from agent_framework_orchestrations import (
     AgentRequestInfoResponse,
+    GroupChatBuilder,
     HandoffAgentUserRequest,
     MagenticPlanReviewRequest,
     MagenticPlanReviewResponse,
@@ -153,3 +156,60 @@ def test_registration_happens_on_package_import() -> None:
         "agent_framework_orchestrations._magentic:MagenticProgressLedgerItem",
     }
     assert expected <= registered
+
+
+class _CustomParticipant(Executor):
+    """A non-agent group-chat participant.
+
+    Defined at module scope on purpose: with ``from __future__ import annotations`` a
+    handler declared inside a function body cannot resolve its own context annotation.
+    """
+
+    @handler
+    async def on_request(
+        self, message: GroupChatRequestMessage, ctx: WorkflowContext[GroupChatResponseMessage]
+    ) -> None:
+        await ctx.send_message(GroupChatResponseMessage(message=Message(role="assistant", contents=["custom reply"])))
+
+    @handler
+    async def on_broadcast(self, message: GroupChatParticipantMessage, ctx: WorkflowContext) -> None:
+        pass
+
+
+async def test_group_chat_with_a_custom_executor_participant_keeps_every_checkpoint_readable() -> None:
+    """End-to-end: the scenario that actually produces the envelopes, restored from disk.
+
+    The orchestrator only wraps traffic in the group-chat envelopes for participants that
+    are **not** agents (``_base_group_chat_orchestrator.py:434,467``); agent participants
+    get a core ``AgentExecutorRequest``, which the default allowlist already trusts. So a
+    group chat built purely from agents never hit this bug, and neither did the existing
+    suite -- which is why it shipped.
+
+    The symptom is worse than a failed ``load()``. ``list_checkpoints`` logs and skips a
+    checkpoint it cannot decode, so unregistered types make checkpoints silently vanish
+    from listings and ``get_latest`` hands back a stale one instead of raising. This test
+    therefore counts the files on disk rather than trusting the listing.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage = FileCheckpointStorage(temp_dir)  # deliberately no allowed_checkpoint_types
+        workflow = GroupChatBuilder(
+            participants=[_CustomParticipant(id="custom")],
+            max_rounds=2,
+            checkpoint_storage=storage,
+            selection_func=lambda state: "custom",
+        ).build()
+
+        async for _ in workflow.run("test task", stream=True):
+            pass
+
+        on_disk = await asyncio.to_thread(lambda: sorted(p.stem for p in Path(temp_dir).glob("*.json")))
+        assert on_disk, "the run produced no checkpoints, so this test proves nothing"
+
+        # Every checkpoint on disk must load individually...
+        for checkpoint_id in on_disk:
+            await storage.load(checkpoint_id)
+
+        # ...and the listing must agree with the disk, rather than quietly dropping the
+        # ones it could not decode.
+        listed = await storage.list_checkpoints(workflow_name=workflow.name)
+        assert sorted(cp.checkpoint_id for cp in listed) == on_disk

--- a/python/packages/orchestrations/tests/test_checkpoint_types.py
+++ b/python/packages/orchestrations/tests/test_checkpoint_types.py
@@ -1,0 +1,155 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Built-in orchestration types must survive a checkpoint round trip.
+
+Checkpoint restore runs pickle through a restricted unpickler. Its default allowlist
+auto-trusts the dotted ``agent_framework.`` prefix, which covers core but not sibling
+distributions like ``agent_framework_orchestrations``, so framework-owned orchestration
+envelopes have to opt in by name. Importing the package is what registers them (#7789).
+
+These tests use a ``FileCheckpointStorage`` built with **no** ``allowed_checkpoint_types``,
+because the bug was precisely that users had to supply framework-internal module paths
+themselves. Each payload is fully populated: the unpickler resolves nested classes as well
+as the outer one, so a test that only round-trips an empty shell would still pass with a
+nested type left unregistered.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+import pytest
+from agent_framework import AgentResponse, Message, WorkflowCheckpoint
+from agent_framework._workflows._checkpoint import FileCheckpointStorage
+
+from agent_framework_orchestrations import (
+    AgentRequestInfoResponse,
+    HandoffAgentUserRequest,
+    MagenticPlanReviewRequest,
+    MagenticPlanReviewResponse,
+    MagenticProgressLedger,
+    MagenticProgressLedgerItem,
+    MagenticResetSignal,
+)
+from agent_framework_orchestrations._base_group_chat_orchestrator import (
+    GroupChatParticipantMessage,
+    GroupChatRequestMessage,
+    GroupChatResponseMessage,
+)
+
+
+def _ledger() -> MagenticProgressLedger:
+    """A fully populated progress ledger; every field is a nested dataclass."""
+    return MagenticProgressLedger(
+        is_request_satisfied=MagenticProgressLedgerItem(reason="not yet", answer=False),
+        is_in_loop=MagenticProgressLedgerItem(reason="no repeats", answer=False),
+        is_progress_being_made=MagenticProgressLedgerItem(reason="advancing", answer=True),
+        next_speaker=MagenticProgressLedgerItem(reason="their turn", answer="researcher"),
+        instruction_or_question=MagenticProgressLedgerItem(reason="needs detail", answer="Find the source."),
+    )
+
+
+def _payloads() -> list[tuple[str, Any]]:
+    """One populated instance of every orchestration type that crosses a checkpoint."""
+    msg = Message(role="assistant", contents=["hello"])
+    return [
+        ("GroupChatRequestMessage", GroupChatRequestMessage(additional_instruction="go", metadata={"round": 1})),
+        ("GroupChatParticipantMessage", GroupChatParticipantMessage(messages=[msg])),
+        ("GroupChatResponseMessage", GroupChatResponseMessage(message=msg)),
+        ("MagenticResetSignal", MagenticResetSignal()),
+        ("HandoffAgentUserRequest", HandoffAgentUserRequest(agent_response=AgentResponse(messages=[msg]))),
+        ("AgentRequestInfoResponse", AgentRequestInfoResponse(messages=[msg])),
+        ("MagenticPlanReviewResponse", MagenticPlanReviewResponse(review=[msg])),
+        (
+            # The nested case: `current_progress` is non-None, so restoring this request
+            # forces the unpickler to resolve MagenticProgressLedger and
+            # MagenticProgressLedgerItem as well. Registering only the outer request would
+            # leave this failing.
+            "MagenticPlanReviewRequest",
+            MagenticPlanReviewRequest(plan=msg, current_progress=_ledger(), is_stalled=True),
+        ),
+    ]
+
+
+@pytest.mark.parametrize("name,payload", _payloads(), ids=[n for n, _ in _payloads()])
+async def test_orchestration_type_survives_checkpoint_round_trip(name: str, payload: Any) -> None:
+    """Saving and restoring a built-in orchestration payload needs no user allowlist."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage = FileCheckpointStorage(temp_dir)  # deliberately no allowed_checkpoint_types
+        await storage.save(
+            WorkflowCheckpoint(
+                workflow_name="orchestration",
+                graph_signature_hash="test-hash",
+                checkpoint_id=f"ck-{name}",
+                state={"payload": payload},
+            )
+        )
+        restored = await storage.load(f"ck-{name}")
+
+    assert type(restored.state["payload"]) is type(payload)
+
+
+async def test_plan_review_request_restores_its_nested_progress_ledger() -> None:
+    """The nested ledger must come back with its values, not merely resolve as a class.
+
+    Separate from the round-trip case above because the failure it guards is different: a
+    missing registration for `MagenticProgressLedgerItem` raises during unpickling, while a
+    ledger that resolves but loses its contents would pass a type-only assertion.
+    """
+    request = MagenticPlanReviewRequest(
+        plan=Message(role="assistant", contents=["the plan"]),
+        current_progress=_ledger(),
+        is_stalled=True,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage = FileCheckpointStorage(temp_dir)
+        await storage.save(
+            WorkflowCheckpoint(
+                workflow_name="magentic",
+                graph_signature_hash="test-hash",
+                checkpoint_id="ck-nested",
+                state={"payload": request},
+            )
+        )
+        restored = await storage.load("ck-nested")
+
+    payload = restored.state["payload"]
+    assert isinstance(payload, MagenticPlanReviewRequest)
+    assert payload.is_stalled is True
+
+    progress = payload.current_progress
+    assert isinstance(progress, MagenticProgressLedger)
+    assert isinstance(progress.next_speaker, MagenticProgressLedgerItem)
+    assert progress.next_speaker.answer == "researcher"
+    assert progress.is_request_satisfied.answer is False
+    assert progress.instruction_or_question.reason == "needs detail"
+
+
+def test_registration_happens_on_package_import() -> None:
+    """Importing the package is what makes restore work, so pin that it registers.
+
+    A checkpoint written by a process that imported the orchestrations package can only be
+    restored by one that also imports it. That import-order dependency is the cost of
+    opting in by name rather than widening the trusted module prefix, and it is worth
+    stating in a test rather than leaving implicit.
+    """
+    from agent_framework._workflows._checkpoint_encoding import _REGISTERED_CHECKPOINT_TYPE_KEYS
+
+    prefix = "agent_framework_orchestrations."
+    registered = {key for key in _REGISTERED_CHECKPOINT_TYPE_KEYS if key.startswith(prefix)}
+
+    expected = {
+        "agent_framework_orchestrations._base_group_chat_orchestrator:GroupChatRequestMessage",
+        "agent_framework_orchestrations._base_group_chat_orchestrator:GroupChatParticipantMessage",
+        "agent_framework_orchestrations._base_group_chat_orchestrator:GroupChatResponseMessage",
+        "agent_framework_orchestrations._handoff:HandoffAgentUserRequest",
+        "agent_framework_orchestrations._orchestration_request_info:AgentRequestInfoResponse",
+        "agent_framework_orchestrations._magentic:MagenticResetSignal",
+        "agent_framework_orchestrations._magentic:MagenticPlanReviewRequest",
+        "agent_framework_orchestrations._magentic:MagenticPlanReviewResponse",
+        "agent_framework_orchestrations._magentic:MagenticProgressLedger",
+        "agent_framework_orchestrations._magentic:MagenticProgressLedgerItem",
+    }
+    assert expected <= registered


### PR DESCRIPTION
### Motivation & Context

Checkpoint restore runs pickle through a restricted unpickler. Its default allowlist auto-trusts the
`agent_framework.` prefix -- dotted, so it covers core but not sibling distributions like
`agent_framework_orchestrations`. The built-in group-chat, handoff and Magentic envelopes are
therefore rejected on restore.

**Who is actually affected, and how.** I built the end-to-end scenario rather than trusting the
issue text, and it narrowed the trigger in one direction and widened the impact in another.

The orchestrator only wraps traffic in the group-chat envelopes for participants that are **not**
agents (`_base_group_chat_orchestrator.py:434,467`); agent participants get a core
`AgentExecutorRequest`, which is already trusted. So a group chat built purely from agents never
hits this, which is why the existing suite did not catch it -- and the suite's other checkpoint
tests use `InMemoryCheckpointStorage`, which `deepcopy`s and never reaches the unpickler at all.

The symptom is worse than a failed `load()`. Running a two-round group chat with one custom
executor participant and a `FileCheckpointStorage` writes six checkpoints; on `main`, four of them
cannot be decoded, and `list_checkpoints` logs and *skips* them rather than raising:

```text
Failed to read checkpoint file ...json: Failed to decode pickled checkpoint data:
Checkpoint deserialization blocked for type
'agent_framework_orchestrations._base_group_chat_orchestrator:GroupChatResponseMessage'.
```

So the listing silently returns 2 of 6 and `get_latest` hands back a stale checkpoint instead of
failing. That is the same silent-invisibility behaviour reported in #7831, which cross-references
this issue. With the registration in place all six list and load.

The only workaround today is for users to hand-maintain `allowed_checkpoint_types` with
framework-internal module paths that can move between releases.

Worth flagging for sequencing: #8214 adds save-time encode/decode validation, which turns this into
a **save**-time failure. After it lands a affected workflow fails on its first checkpoint rather
than losing them quietly -- louder, and better, but it makes this more urgent, not less.

### Description & Review Guide

- **What are the major changes?** Ten framework-owned types are registered through the existing
  public `register_checkpoint_type` when `agent_framework_orchestrations` is imported. No core
  change, no new API, no behaviour change to the orchestrations themselves.

- **Why these ten.** Each was verified against the tree rather than inferred from the issue text:

  | Type | Crosses the boundary via |
  |---|---|
  | `GroupChatRequestMessage` | `send_message`, `_base_group_chat_orchestrator.py:486` |
  | `GroupChatParticipantMessage` | `send_message`, same file |
  | `GroupChatResponseMessage` | `handle_participant_response` parameter, `:238` |
  | `MagenticResetSignal` | `send_message` and its handler |
  | `HandoffAgentUserRequest` | `ctx.request_info(...)`, `_handoff.py:439` |
  | `AgentRequestInfoResponse` | request_info response type, `_orchestration_request_info.py:101` |
  | `MagenticPlanReviewRequest` / `Response` | `ctx.request_info(...)`, `_magentic.py:1048` |
  | `MagenticProgressLedger` / `Item` | nested inside `MagenticPlanReviewRequest.current_progress` |

  `_MagenticTaskLedger` is excluded on purpose — it is persisted through `to_dict()`/`from_dict()`
  and never reaches the unpickler.

- **The alternative I did not take.** Dropping the dot from `_FRAMEWORK_MODULE_PREFIX` fixes the
  whole class in one line and would cover declarative, ag-ui and every future sibling too. I think
  it should not be done: this is a *pickle* allowlist, and the undotted prefix auto-trusts any
  installed distribution merely named `agent_framework_*`, which is a name that can be taken on
  PyPI. That is a security-boundary change and a maintainer decision, so it is not in this PR. Happy
  to open it as a separate discussion if you want the structural fix.

- **What is the impact of these changes?** Built-in orchestrations restore from checkpoints without
  users supplying framework-internal module paths. Two properties worth stating plainly: the
  allowlist is process-wide, so importing this package widens what any checkpoint storage in the
  process will unpickle; and registration happens at import, so a process restoring one of these
  checkpoints must import `agent_framework_orchestrations`. In practice it already does — the
  checkpoints cannot exist otherwise — but it is the cost of opting in by name instead of widening
  the prefix, and there is a test pinning it. All ten registered types are plain dataclasses with no
  `__reduce__`, `__setstate__` or `__new__` overrides, so none of them adds a construction hook.

- **Credit.** #7791 by @atty57 reached the same shape first and was closed on 2026-09-04 as a stale
  draft rather than on approach. This follows that approach and addresses the Copilot review comment
  left open there — that a test asserting only the outer request class would still pass with the
  nested ledger types unregistered. The tests here round-trip fully populated payloads through a
  storage built with **no** `allowed_checkpoint_types`; removing only `MagenticProgressLedger` and
  `MagenticProgressLedgerItem` from the registration leaves every other case green and fails exactly
  three tests.

- **What do you want reviewers to focus on?** Whether the ten are the right ten — I would rather
  register too few and be corrected than widen the unpickling surface speculatively. Also whether
  `GroupChatParticipantMessage` and `GroupChatResponseMessage` should join `__all__`; they are
  imported here for registration but deliberately left unexported, since expanding public API is not
  a bug fix's business.

  Validation: orchestrations 206 passing with `poe check -P orchestrations` clean across all five
  type checkers, and core 5128 passing unchanged. Every new test fails against the unregistered
  tree.

  Related, not claimed: #7618 reports the same root cause reaching foundry hosting. I have not
  verified its downstream `unknown request Id` cascade, so this links only #7789.

### Related Issue

Fixes #7789

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**
