### PR TITLE
.NET: Dotnet: reset $LASTEXITCODE per command in persistent PowerShell sessions

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellSession.cs
@@ -574,8 +574,8 @@ internal sealed class ShellSession : IAsyncDisposable
                 "& {" +
                 " $__af_rc = 0;" +
                 // $LASTEXITCODE persists across commands and cmdlets do not update it.
-                // Snapshot it so only a value changed by this command is reported.
-                " $__af_last = $LASTEXITCODE;" +
+                // Clear it so any value after invocation belongs to this command.
+                " $global:LASTEXITCODE = $null;" +
                 " try {" +
                 $"   $__af_cmd = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{encoded}'));" +
                 // Force the user command's success output through the same
@@ -594,7 +594,7 @@ internal sealed class ShellSession : IAsyncDisposable
                 // Capture the pipeline status before flushing overwrites it.
                 "   $__af_ok = $?;" +
                 "   [Console]::Out.Flush();" +
-                "   if ($LASTEXITCODE -ne $__af_last) { $__af_rc = $LASTEXITCODE }" +
+                "   if ($LASTEXITCODE -ne $null) { $__af_rc = $LASTEXITCODE }" +
                 "   elseif (-not $__af_ok) { $__af_rc = 1 }" +
                 " } catch {" +
                 "   [Console]::Error.WriteLine($_.ToString());" +

--- a/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Tools.Shell/ShellSession.cs
@@ -573,6 +573,9 @@ internal sealed class ShellSession : IAsyncDisposable
             return
                 "& {" +
                 " $__af_rc = 0;" +
+                // $LASTEXITCODE persists across commands and cmdlets do not update it.
+                // Snapshot it so only a value changed by this command is reported.
+                " $__af_last = $LASTEXITCODE;" +
                 " try {" +
                 $"   $__af_cmd = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{encoded}'));" +
                 // Force the user command's success output through the same
@@ -588,9 +591,11 @@ internal sealed class ShellSession : IAsyncDisposable
                 "       [Console]::WriteLine(($_ | Out-String).TrimEnd());" +
                 "     }" +
                 "   };" +
+                // Capture the pipeline status before flushing overwrites it.
+                "   $__af_ok = $?;" +
                 "   [Console]::Out.Flush();" +
-                "   if ($LASTEXITCODE -ne $null) { $__af_rc = $LASTEXITCODE }" +
-                "   elseif (-not $?) { $__af_rc = 1 }" +
+                "   if ($LASTEXITCODE -ne $__af_last) { $__af_rc = $LASTEXITCODE }" +
+                "   elseif (-not $__af_ok) { $__af_rc = 1 }" +
                 " } catch {" +
                 "   [Console]::Error.WriteLine($_.ToString());" +
                 "   $__af_rc = 1" +

--- a/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
@@ -330,16 +330,18 @@ public sealed class LocalShellExecutorTests
         });
 
         // Act
-        var failing = await shell.RunAsync("cmd /c exit 3");
+        var firstFailure = await shell.RunAsync("cmd /c exit 3");
         var succeeding = await shell.RunAsync("Write-Output ok");
+        var repeatedFailure = await shell.RunAsync("cmd /c exit 3");
         var readback = await shell.RunAsync("Write-Output $LASTEXITCODE");
 
         // Assert
-        Assert.Equal(3, failing.ExitCode);
+        Assert.Equal(3, firstFailure.ExitCode);
         Assert.Equal(0, succeeding.ExitCode);
         Assert.Contains("ok", succeeding.Stdout, StringComparison.Ordinal);
+        Assert.Equal(3, repeatedFailure.ExitCode);
         Assert.Equal(0, readback.ExitCode);
-        Assert.Equal("3", readback.Stdout.Trim());
+        Assert.Empty(readback.Stdout.Trim());
     }
 
     [Fact]

--- a/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Tools.Shell.UnitTests/LocalShellExecutorTests.cs
@@ -314,6 +314,35 @@ public sealed class LocalShellExecutorTests
     }
 
     [Fact]
+    public async Task Persistent_PowerShell_DoesNotInheritPreviousExitCodeAsync()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        // Arrange
+        await using var shell = new LocalShellExecutor(new()
+        {
+            Mode = ShellMode.Persistent,
+            Shell = "powershell.exe",
+            Timeout = TimeSpan.FromSeconds(20),
+        });
+
+        // Act
+        var failing = await shell.RunAsync("cmd /c exit 3");
+        var succeeding = await shell.RunAsync("Write-Output ok");
+        var readback = await shell.RunAsync("Write-Output $LASTEXITCODE");
+
+        // Assert
+        Assert.Equal(3, failing.ExitCode);
+        Assert.Equal(0, succeeding.ExitCode);
+        Assert.Contains("ok", succeeding.Stdout, StringComparison.Ordinal);
+        Assert.Equal(0, readback.ExitCode);
+        Assert.Equal("3", readback.Stdout.Trim());
+    }
+
+    [Fact]
     public async Task Persistent_Timeout_ReturnsExitCode124Async()
     {
         await using var shell = new LocalShellExecutor(new()


### PR DESCRIPTION
### Motivation & Context

Dotnet equivalent of #8206

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
- **What is the impact of these changes?**
- **What do you want reviewers to focus on?**
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
