### PR TITLE
Python: handle concurrent FileCheckpointStorage deletion

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint.py
@@ -414,11 +414,12 @@ class FileCheckpointStorage:
         file_path = self._validate_file_path(checkpoint_id)
 
         def _delete() -> bool:
-            if file_path.exists():
+            try:
                 file_path.unlink()
-                logger.info(f"Deleted checkpoint {checkpoint_id} from {file_path}")
-                return True
-            return False
+            except FileNotFoundError:
+                return False
+            logger.info(f"Deleted checkpoint {checkpoint_id} from {file_path}")
+            return True
 
         return await asyncio.to_thread(_delete)
 

--- a/python/packages/core/tests/workflow/test_checkpoint.py
+++ b/python/packages/core/tests/workflow/test_checkpoint.py
@@ -1,11 +1,14 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import asyncio
 import json
 import tempfile
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -1256,6 +1259,35 @@ async def test_file_checkpoint_storage_delete():
         # Try to delete again
         result = await storage.delete(checkpoint.checkpoint_id)
         assert result is False
+
+
+async def test_file_checkpoint_storage_concurrent_delete():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        storage = FileCheckpointStorage(temp_dir)
+        checkpoint = WorkflowCheckpoint(
+            workflow_name="test-workflow",
+            graph_signature_hash="test-hash",
+            checkpoint_id="same",
+        )
+        await storage.save(checkpoint)
+
+        file_path = (Path(temp_dir) / "same.json").resolve()
+        original_exists = Path.exists
+        barrier = threading.Barrier(2)
+
+        def synchronized_exists(path: Path) -> bool:
+            result = original_exists(path)
+            if path.resolve() == file_path:
+                barrier.wait(timeout=5)
+            return result
+
+        with patch.object(Path, "exists", synchronized_exists):
+            results = await asyncio.gather(
+                storage.delete(checkpoint.checkpoint_id),
+                storage.delete(checkpoint.checkpoint_id),
+            )
+
+        assert sorted(results) == [False, True]
 
 
 async def test_file_checkpoint_storage_directory_creation():


### PR DESCRIPTION
### Motivation & Context

`FileCheckpointStorage.delete()` checked for existence before unlinking the checkpoint file. Concurrent callers could both observe the file, after which one caller removed it and the other leaked an undocumented `FileNotFoundError` instead of returning `False` as required by the storage contract.

### Description & Review Guide

- **What are the major changes?** The file storage now attempts `unlink()` directly and treats `FileNotFoundError` as a missing checkpoint. A deterministic regression test synchronizes the previous existence checks to reproduce the race.
- **What is the impact of these changes?** Concurrent deletes return one `True` and one `False`; other filesystem failures continue to propagate unchanged.
- **What do you want reviewers to focus on?** Please review the exception boundary, specifically that only `FileNotFoundError` is converted to `False`.

### Related Issue

Fixes #8255

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after a language prefix) — a workflow keeps the label and title prefix in sync automatically.