### PR TITLE
Python: reject malformed checkpoint Base64 payloads

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
+++ b/python/packages/core/agent_framework/_workflows/_checkpoint_encoding.py
@@ -403,7 +403,7 @@ def _base64_to_unpickle(encoded: str, *, allowed_types: frozenset[str] | None = 
             format is incompatible, or a disallowed type is encountered.
     """
     try:
-        pickled = base64.b64decode(encoded.encode("ascii"))
+        pickled = base64.b64decode(encoded.encode("ascii"), validate=True)
         if allowed_types is not None:
             return _RestrictedUnpickler(pickled, allowed_types).load()
         return pickle.loads(pickled)  # nosec  # ruff:ignore[suspicious-pickle-usage]

--- a/python/packages/core/tests/workflow/test_checkpoint_decode.py
+++ b/python/packages/core/tests/workflow/test_checkpoint_decode.py
@@ -8,6 +8,7 @@ import pytest
 
 from agent_framework import WorkflowCheckpointException
 from agent_framework._workflows._checkpoint_encoding import (
+    _PICKLE_MARKER,  # type: ignore
     _TYPE_MARKER,  # type: ignore
     decode_checkpoint_value,
     encode_checkpoint_value,
@@ -185,6 +186,16 @@ def test_decode_raises_on_type_mismatch() -> None:
     encoded[_TYPE_MARKER] = "nonexistent.module:FakeClass"
 
     with pytest.raises(WorkflowCheckpointException, match="Type mismatch"):
+        decode_checkpoint_value(encoded)
+
+
+def test_decode_raises_on_malformed_base64() -> None:
+    """Test that decoding rejects non-Base64 characters in a pickle payload."""
+    encoded = encode_checkpoint_value((1, 2, 3))
+    assert isinstance(encoded, dict)
+    encoded[_PICKLE_MARKER] = cast(str, encoded[_PICKLE_MARKER]) + "!!!!"
+
+    with pytest.raises(WorkflowCheckpointException, match="Failed to decode pickled checkpoint data"):
         decode_checkpoint_value(encoded)
 
 


### PR DESCRIPTION
### Motivation & Context

`base64.b64decode()` is permissive by default and silently discards non-Base64 characters. As a result, a malformed checkpoint pickle payload can be accepted and decoded instead of producing the documented `WorkflowCheckpointException`.

### Description & Review Guide

- **What are the major changes?** Enable strict Base64 validation for pickled checkpoint payloads and add a regression test using an otherwise-valid payload with illegal trailing characters.
- **What is the impact of these changes?** Malformed pickle envelopes now fail through the existing checkpoint exception path; payloads emitted by `encode_checkpoint_value()` are unchanged.
- **What do you want reviewers to focus on?** Whether strict validation is the desired compatibility boundary for externally supplied checkpoint envelopes.

### Related Issue

Fixes #8257

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.