### PR TITLE
.NET: fix: preserve agent continuation token when wrapped with UseOpenTelemetry

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
@@ -335,6 +335,7 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
                 AdditionalProperties = response.AdditionalProperties,
                 ContinuationToken = response.ContinuationToken,
                 ConversationId = (response.RawRepresentation as ChatResponse)?.ConversationId,
+                ModelId = (response.RawRepresentation as ChatResponse)?.ModelId,
                 CreatedAt = response.CreatedAt,
                 FinishReason = response.FinishReason,
                 Messages = response.Messages,

--- a/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
+++ b/dotnet/src/Microsoft.Agents.AI/OpenTelemetryAgent.cs
@@ -296,7 +296,7 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
             var response = await parentAgent.InnerAgent.RunAsync(messages, fo?.Session, fo?.Options, cancellationToken).ConfigureAwait(false);
 
             // Wrap the response in a ChatResponse so we can pass it back through OpenTelemetryChatClient.
-            return response.AsChatResponse();
+            return ToChatResponse(response);
         }
 
         public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
@@ -312,9 +312,59 @@ public sealed class OpenTelemetryAgent : DelegatingAIAgent, IDisposable
             await foreach (var update in parentAgent.InnerAgent.RunStreamingAsync(messages, fo?.Session, fo?.Options, cancellationToken).ConfigureAwait(false))
             {
                 // Wrap the response updates in ChatResponseUpdates so we can pass them back through OpenTelemetryChatClient.
-                yield return update.AsChatResponseUpdate();
+                yield return ToChatResponseUpdate(update);
             }
         }
+
+        /// <summary>
+        /// Wraps an <see cref="AgentResponse"/> in a <see cref="ChatResponse"/> that keeps the original response as its
+        /// <see cref="ChatResponse.RawRepresentation"/>, so <see cref="RunCoreAsync"/> can hand the
+        /// inner agent's own response back to the caller unchanged.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AgentResponseExtensions.AsChatResponse"/> isn't used here because it returns the inner agent's
+        /// <see cref="ChatResponse"/> directly whenever that is the response's raw representation. Round-tripping
+        /// through that <see cref="ChatResponse"/> discards agent-level state such as
+        /// <see cref="AgentResponse.ContinuationToken"/> and <see cref="AgentResponse.AgentId"/>, which for a
+        /// <see cref="ChatClientAgent"/> means the caller receives the underlying provider's continuation token rather
+        /// than the agent's own, and resuming with it fails.
+        /// </remarks>
+        private static ChatResponse ToChatResponse(AgentResponse response) =>
+            new()
+            {
+                AdditionalProperties = response.AdditionalProperties,
+                ContinuationToken = response.ContinuationToken,
+                ConversationId = (response.RawRepresentation as ChatResponse)?.ConversationId,
+                CreatedAt = response.CreatedAt,
+                FinishReason = response.FinishReason,
+                Messages = response.Messages,
+                RawRepresentation = response,
+                ResponseId = response.ResponseId,
+                Usage = response.Usage,
+            };
+
+        /// <summary>
+        /// Wraps an <see cref="AgentResponseUpdate"/> in a <see cref="ChatResponseUpdate"/> that keeps the original
+        /// update as its <see cref="ChatResponseUpdate.RawRepresentation"/>, so
+        /// <see cref="RunCoreStreamingAsync"/> can hand the inner agent's own update back to the
+        /// caller unchanged. See <see cref="ToChatResponse"/> for why
+        /// <see cref="AgentResponseExtensions.AsChatResponseUpdate"/> isn't used.
+        /// </summary>
+        private static ChatResponseUpdate ToChatResponseUpdate(AgentResponseUpdate update) =>
+            new()
+            {
+                AdditionalProperties = update.AdditionalProperties,
+                AuthorName = update.AuthorName,
+                Contents = update.Contents,
+                ContinuationToken = update.ContinuationToken,
+                ConversationId = (update.RawRepresentation as ChatResponseUpdate)?.ConversationId,
+                CreatedAt = update.CreatedAt,
+                FinishReason = update.FinishReason,
+                MessageId = update.MessageId,
+                RawRepresentation = update,
+                ResponseId = update.ResponseId,
+                Role = update.Role,
+            };
 
         public object? GetService(Type serviceType, object? serviceKey = null) =>
             // Delegate any inquiries made by the OpenTelemetryChatClient back to the parent agent.

--- a/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.UnitTests/OpenTelemetryAgentTests.cs
@@ -945,6 +945,81 @@ public class OpenTelemetryAgentTests
         Assert.Same(inputOptions, observedOptions);
         Assert.Same(token, observedOptions.ContinuationToken);
     }
+
+    [Fact]
+    public async Task RunAsync_WrappingChatClientAgent_PreservesAgentContinuationTokenAsync()
+    {
+        // Arrange
+        // The inner ChatClientAgent wraps the chat client's token in a ChatClientAgentContinuationToken. That
+        // wrapper must survive the AgentResponse -> ChatResponse -> AgentResponse round trip that this agent
+        // performs through OpenTelemetryChatClient, otherwise the caller gets the provider's raw token back and
+        // resuming with it fails.
+        var innerToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 });
+        var fakeChatClient = new AutoWireTestChatClient { ContinuationToken = innerToken };
+        var innerAgent = new ChatClientAgent(fakeChatClient);
+        using var agent = new OpenTelemetryAgent(innerAgent);
+        var session = await agent.CreateSessionAsync();
+
+        // Act
+        var response = await agent.RunAsync("hi", session, new AgentRunOptions { AllowBackgroundResponses = true });
+
+        // Assert
+        var agentToken = Assert.IsType<ChatClientAgentContinuationToken>(response.ContinuationToken);
+        Assert.Same(innerToken, agentToken.InnerToken);
+        Assert.Equal(innerAgent.Id, response.AgentId);
+    }
+
+    [Fact]
+    public async Task RunAsync_WrappingChatClientAgent_ResumesFromSerializedContinuationTokenAsync()
+    {
+        // Arrange
+        var innerToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 });
+        ChatOptions? observedChatOptions = null;
+        var fakeChatClient = new AutoWireTestChatClient
+        {
+            ContinuationToken = innerToken,
+            OnGetResponseAsync = (_, opts) => observedChatOptions = opts,
+        };
+        using var agent = new OpenTelemetryAgent(new ChatClientAgent(fakeChatClient));
+        var session = await agent.CreateSessionAsync();
+
+        var first = await agent.RunAsync("hi", session, new AgentRunOptions { AllowBackgroundResponses = true });
+
+        // Act
+        // Serialize and deserialize the token the way a caller resuming the run from another process would.
+        Assert.NotNull(first.ContinuationToken);
+        var restoredToken = ResponseContinuationToken.FromBytes(first.ContinuationToken.ToBytes());
+        _ = await agent.RunAsync(session, new AgentRunOptions { ContinuationToken = restoredToken });
+
+        // Assert
+        // The agent must have unwrapped the restored token and passed the chat client's own token back down.
+        Assert.NotNull(observedChatOptions?.ContinuationToken);
+        Assert.Equal(innerToken.ToBytes().ToArray(), observedChatOptions.ContinuationToken.ToBytes().ToArray());
+    }
+
+    [Fact]
+    public async Task RunStreamingAsync_WrappingChatClientAgent_PreservesAgentContinuationTokenAsync()
+    {
+        // Arrange
+        var innerToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 });
+        var fakeChatClient = new AutoWireTestChatClient { ContinuationToken = innerToken };
+        var innerAgent = new ChatClientAgent(fakeChatClient);
+        using var agent = new OpenTelemetryAgent(innerAgent);
+        var session = await agent.CreateSessionAsync();
+
+        // Act
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in agent.RunStreamingAsync("hi", session, new AgentRunOptions { AllowBackgroundResponses = true }))
+        {
+            updates.Add(update);
+        }
+
+        // Assert
+        var tokenUpdate = Assert.Single(updates, u => u.ContinuationToken is not null);
+        var agentToken = Assert.IsType<ChatClientAgentContinuationToken>(tokenUpdate.ContinuationToken);
+        Assert.Same(innerToken, agentToken.InnerToken);
+        Assert.Equal(innerAgent.Id, tokenUpdate.AgentId);
+    }
 #pragma warning restore MEAI001
 
     [Fact]
@@ -1198,18 +1273,23 @@ public class OpenTelemetryAgentTests
     {
         public Action<IEnumerable<ChatMessage>, ChatOptions?>? OnGetResponseAsync { get; set; }
 
+#pragma warning disable MEAI001 // ResponseContinuationToken is experimental.
+        /// <summary>Gets or sets the continuation token to report on the response, simulating a background response.</summary>
+        public ResponseContinuationToken? ContinuationToken { get; set; }
+
         public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
         {
             this.OnGetResponseAsync?.Invoke(messages, options);
-            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")) { ContinuationToken = this.ContinuationToken });
         }
 
         public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             this.OnGetResponseAsync?.Invoke(messages, options);
             await Task.Yield();
-            yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "ok") { ContinuationToken = this.ContinuationToken };
         }
+#pragma warning restore MEAI001
 
         public object? GetService(Type serviceType, object? serviceKey = null) =>
             serviceType?.IsInstanceOfType(this) == true ? this : null;


### PR DESCRIPTION
### Motivation & Context

Wrapping an agent with `UseOpenTelemetry` breaks background responses. The continuation token returned from a background `RunAsync` is the underlying provider's raw token rather than the agent's own `ChatClientAgentContinuationToken`, so an opaque `ToBytes`/`FromBytes` save-and-restore followed by a resume throws:

```
System.ArgumentException: Failed to create ChatClientAgentContinuationToken from provided token because it is not of the correct type. (Parameter 'token')
   at Microsoft.Agents.AI.ChatClientAgentContinuationToken.FromToken(ResponseContinuationToken token)
   at Microsoft.Agents.AI.ChatClientAgent.CreateConfiguredChatOptions(AgentRunOptions runOptions)
```

The same flow works when OpenTelemetry is not in the pipeline. This blocks the scenario where background responses are started by one process and polled or resumed by another, since that requires persisting a serialized session and token while still emitting telemetry for logging and traceability.

`OpenTelemetryAgent` delegates to the inner agent through `OpenTelemetryChatClient` and a `ForwardingChatClient`, so every response makes an `AgentResponse` -> `ChatResponse` -> `AgentResponse` round trip. `AgentResponseExtensions.AsChatResponse` returns the inner agent's own `ChatResponse` directly whenever that is the response's raw representation, which is exactly the case for `ChatClientAgent`. The wrapped continuation token and `AgentId` live only on the `AgentResponse`, so both were discarded on the way back out and `RunCoreAsync` rebuilt a response from the provider's `ChatResponse`, carrying the provider's raw token. `RunStreamingAsync` lost them the same way through `AsChatResponseUpdate`.

### Description & Review Guide

- **What are the major changes?**
  - `ForwardingChatClient` no longer uses `AsChatResponse`/`AsChatResponseUpdate`. It now builds the `ChatResponse`/`ChatResponseUpdate` that is handed to `OpenTelemetryChatClient` with the inner agent's own response as the `RawRepresentation`. `RunCoreAsync` and `RunCoreStreamingAsync` already looked for an `AgentResponse`/`AgentResponseUpdate` there, so they now return the inner agent's instance unchanged instead of reconstructing a lossy copy.
  - `ConversationId` is copied across from the inner `ChatResponse`/`ChatResponseUpdate` so the chat span keeps emitting `gen_ai.conversation.id`.
  - Three tests in `OpenTelemetryAgentTests`: continuation token preservation for `RunAsync` and `RunStreamingAsync`, and the reported scenario end to end - serialize the token with `ToBytes`, restore it with `FromBytes`, resume, and assert the chat client receives its own token back. All three fail without the source change.

- **What is the impact of these changes?**
  - Background responses, `AgentId`, and any other agent-level response state now survive a `UseOpenTelemetry` wrapper. Callers no longer need workarounds to reconstruct the agent token.
  - No public API change, and no behavior change for callers that do not use background responses. The fix is confined to the private `ForwardingChatClient`; `AsChatResponse`/`AsChatResponseUpdate` keep their documented short-circuit behavior and are untouched.

- **What do you want reviewers to focus on?**
  - Whether copying `ConversationId` from the raw representation is the right way to keep the chat span intact, or whether the span should take it from the request options instead.
  - Whether other `DelegatingAIAgent` implementations that perform the same round trip should share a helper rather than keeping this private to `OpenTelemetryAgent`.

### Related Issue

Fixes #8243

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
