### PR TITLE
Python: Prevent replayed history from being re-persisted by CosmosHistoryProvider

### DIFF
--- a/python/packages/azure-cosmos/agent_framework_azure_cosmos/_history_provider.py
+++ b/python/packages/azure-cosmos/agent_framework_azure_cosmos/_history_provider.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from typing import Any, ClassVar, TypedDict
 
 from agent_framework import Message
-from agent_framework._sessions import HistoryProvider
+from agent_framework._sessions import HistoryProvider, filter_new_messages
 from agent_framework._settings import SecretString, load_settings
 from agent_framework._telemetry import get_user_agent, mark_feature_used
 from azure.core.credentials import TokenCredential
@@ -187,10 +187,15 @@ class CosmosHistoryProvider(HistoryProvider):
 
         await self._ensure_container_proxy()
         session_key = self._session_partition_key(session_id)
+        existing_messages = await self.get_messages(session_key, state=state, **kwargs)
+        new_messages = filter_new_messages(existing_messages, messages)
+
+        if not new_messages:
+            return
 
         base_sort_key = time.time_ns()
         operations: list[tuple[str, tuple[dict[str, Any]]]] = []
-        for index, message in enumerate(messages):
+        for index, message in enumerate(new_messages):
             document = {
                 "id": str(uuid.uuid4()),
                 "session_id": session_key,

--- a/python/packages/azure-cosmos/tests/test_cosmos_history_provider.py
+++ b/python/packages/azure-cosmos/tests/test_cosmos_history_provider.py
@@ -256,6 +256,47 @@ class TestCosmosHistoryProviderSaveMessages:
 
         mock_container.execute_item_batch.assert_not_awaited()
 
+    async def test_filters_replayed_transcript_prefix(self, mock_container: MagicMock) -> None:
+        existing_messages = [
+            Message(role="user", contents=["A"]),
+            Message(role="assistant", contents=["B"]),
+        ]
+        mock_container.query_items.return_value = _to_async_iter([
+            {"message": message.to_dict()} for message in existing_messages
+        ])
+        provider = CosmosHistoryProvider(source_id="mem", container_client=mock_container)
+        incoming_messages = [
+            Message(role="user", contents=["A"]),
+            Message(role="assistant", contents=["B"]),
+            Message(role="user", contents=["C"]),
+        ]
+
+        await provider.save_messages("s1", incoming_messages)
+
+        batch_operations = mock_container.execute_item_batch.await_args.kwargs["batch_operations"]
+        assert len(batch_operations) == 1
+        assert batch_operations[0][1][0]["message"]["contents"][0]["text"] == "C"
+        mock_container.query_items.assert_called_once()
+
+    async def test_skips_exact_replayed_transcript(self, mock_container: MagicMock) -> None:
+        existing_messages = [
+            Message(role="user", contents=["A"]),
+            Message(role="assistant", contents=["B"]),
+        ]
+        mock_container.query_items.return_value = _to_async_iter([
+            {"message": message.to_dict()} for message in existing_messages
+        ])
+        provider = CosmosHistoryProvider(source_id="mem", container_client=mock_container)
+        incoming_messages = [
+            Message(role="user", contents=["A"]),
+            Message(role="assistant", contents=["B"]),
+        ]
+
+        await provider.save_messages("s1", incoming_messages)
+
+        mock_container.query_items.assert_called_once()
+        mock_container.execute_item_batch.assert_not_awaited()
+
     async def test_batches_when_message_count_exceeds_limit(self, mock_container: MagicMock) -> None:
         provider = CosmosHistoryProvider(source_id="mem", container_client=mock_container)
         messages = [Message(role="user", contents=[f"msg-{index}"]) for index in range(101)]


### PR DESCRIPTION
### Motivation & Context

`CosmosHistoryProvider.save_messages()` currently upserts every supplied message under a fresh document ID. When a caller supplies a full accumulated transcript, the provider writes the already-persisted prefix again, causing silent duplicate and potentially superlinear persistent-history growth.

The core history contract already handles both append-only input and full-transcript replay through `filter_new_messages()`. Applying the same behavior to Cosmos closes a remaining provider-specific instance of the history replay problem addressed in #7242.

### Description & Review Guide

- **What are the major changes?** `CosmosHistoryProvider.save_messages()` now reads the existing history for the same session and source, applies `filter_new_messages()`, returns when the incoming sequence is an exact replay, and builds Cosmos batch operations only for genuinely new messages. Deterministic regression tests exercise the actual `query_items` seam and verify both that prefix replay writes only `C` for existing `[A, B]` plus incoming `[A, B, C]`, and that an exact replay writes nothing.
- **What is the impact of these changes?** Full-transcript callers no longer duplicate stored Cosmos messages. Append-only inputs remain supported, while document structure, ordering, and the 100-operation batch limit are unchanged. Each non-empty save now performs a session/source-scoped read before writing; there is no public API or storage-format change. As with the established Redis pattern, this does not make independent concurrent writers transactionally idempotent.
- **What do you want reviewers to focus on?** Please verify that using the existing session partition key for the read preserves Cosmos scoping, and that the regression tests sufficiently exercise the provider's actual read/write seam.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

Fixes #8268

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.