### PR TITLE
Python: add public API compatibility checks

### DIFF
--- a/.github/scripts/check_python_api_compatibility.py
+++ b/.github/scripts/check_python_api_compatibility.py
@@ -1,0 +1,236 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Check Python API compatibility against a pull request's base commit."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from importlib.metadata import version
+from pathlib import Path
+
+from griffe import (
+    Alias,
+    AliasResolutionError,
+    ExplanationStyle,
+    Object,
+    find_breaking_changes,
+    load,
+)
+
+_EXPERIMENTAL_DECORATOR = "agent_framework._feature_stage.experimental"
+_GRIFFE_VERSION = version("griffe")
+_PACKAGE_STATUS_ROW = re.compile(
+    r"^\| `(?P<name>[^`]+)` \| `(?P<path>python/packages/[^`]+)` \| `(?P<state>[^`]+)` \|$"
+)
+
+
+@dataclass(frozen=True, order=True)
+class ModuleSpec:
+    """A top-level import package and its owning distribution."""
+
+    module: str
+    search_path: Path
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+@contextmanager
+def _base_source(repo: Path, base_sha: str) -> Iterator[Path]:
+    archive = subprocess.run(
+        ["git", "archive", base_sha, "python"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    ).stdout
+    with tempfile.TemporaryDirectory(prefix="python-api-base-") as directory:
+        subprocess.run(
+            ["tar", "-xf", "-", "-C", directory],
+            input=archive,
+            check=True,
+        )
+        yield Path(directory)
+
+
+def _package_states(repo: Path, base_sha: str) -> dict[Path, str]:
+    status_document = _git(repo, "show", f"{base_sha}:python/PACKAGE_STATUS.md")
+    states: dict[Path, str] = {}
+
+    for line in status_document.splitlines():
+        match = _PACKAGE_STATUS_ROW.match(line)
+        if match:
+            states[Path(match["path"])] = match["state"]
+
+    if not states:
+        raise RuntimeError(
+            "No package lifecycle states were found in python/PACKAGE_STATUS.md"
+        )
+
+    return states
+
+
+def _module_specs(
+    repo: Path, base_sha: str, package_states: dict[Path, str]
+) -> list[ModuleSpec]:
+    tracked_files = _git(
+        repo, "ls-tree", "-r", "--name-only", base_sha, "--", "python/packages"
+    )
+    specs: set[ModuleSpec] = set()
+
+    for file_name in tracked_files.splitlines():
+        parts = Path(file_name).parts
+        if (
+            len(parts) != 5
+            or parts[:2] != ("python", "packages")
+            or parts[4] != "__init__.py"
+            or parts[3] in {"build", "tests"}
+        ):
+            continue
+
+        package_path = Path(*parts[:3])
+        if package_path.name == "lab":
+            continue
+        if package_path not in package_states:
+            raise RuntimeError(
+                f"{package_path} is missing from python/PACKAGE_STATUS.md"
+            )
+        if package_states[package_path] != "released":
+            continue
+
+        specs.add(ModuleSpec(module=parts[3], search_path=package_path))
+
+    return sorted(specs)
+
+
+def _resolved(obj: Object | Alias) -> Object | None:
+    try:
+        return obj.final_target if isinstance(obj, Alias) else obj
+    except AliasResolutionError:
+        return None
+
+
+def _experimental_owner(obj: Object | Alias) -> str | None:
+    current = _resolved(obj)
+    while current is not None:
+        decorators = getattr(current, "decorators", ())
+        if any(
+            decorator.callable_path == _EXPERIMENTAL_DECORATOR
+            for decorator in decorators
+        ):
+            return str(current.path)
+        current = current.parent
+    return None
+
+
+def _write_summary(
+    *,
+    checked: int,
+    breakages: int,
+    acknowledged: bool,
+) -> None:
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    lines = [
+        "## Python public API compatibility",
+        "",
+        f"Compared {checked} released import packages with the PR base using Griffe {_GRIFFE_VERSION}.",
+        "",
+        f"- Published API breakages: {breakages}",
+    ]
+    if breakages and acknowledged:
+        lines.extend(
+            [
+                "",
+                "Published API breakages were acknowledged by the `breaking change` label.",
+            ]
+        )
+    elif breakages:
+        lines.extend(
+            [
+                "",
+                "Restore compatibility or acknowledge the intentional break with the `breaking change` label.",
+            ]
+        )
+
+    with Path(summary_path).open("a") as summary:
+        summary.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-sha", required=True, help="Trusted pull request base commit"
+    )
+    parser.add_argument(
+        "--repo", type=Path, default=Path.cwd(), help="Pull request checkout"
+    )
+    parser.add_argument("--acknowledge-breaking-changes", action="store_true")
+    args = parser.parse_args()
+
+    repo = args.repo.resolve()
+    os.chdir(repo)
+    package_states = _package_states(repo, args.base_sha)
+    specs = _module_specs(repo, args.base_sha, package_states)
+    breakage_count = 0
+
+    with _base_source(repo, args.base_sha) as base_source:
+        for spec in specs:
+            print(f"::group::{spec.module}")
+            old_package = load(
+                spec.module,
+                search_paths=[base_source / spec.search_path],
+                allow_inspection=False,
+                resolve_aliases=True,
+            )
+            new_package = load(
+                spec.module,
+                search_paths=[spec.search_path],
+                allow_inspection=False,
+                resolve_aliases=True,
+            )
+
+            for breakage in find_breaking_changes(old_package, new_package):
+                try:
+                    old_breakage_obj = old_package.modules_collection.get_member(
+                        breakage.obj.path
+                    )
+                except KeyError:
+                    old_breakage_obj = breakage.obj
+                experimental_owner = _experimental_owner(old_breakage_obj)
+
+                if experimental_owner is None:
+                    breakage_count += 1
+                    print(breakage.explain(style=ExplanationStyle.GITHUB))
+
+            print("::endgroup::")
+
+    _write_summary(
+        checked=len(specs),
+        breakages=breakage_count,
+        acknowledged=args.acknowledge_breaking_changes,
+    )
+
+    if breakage_count and not args.acknowledge_breaking_changes:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_python_api_compatibility.py
+++ b/.github/scripts/check_python_api_compatibility.py
@@ -199,12 +199,21 @@ def main() -> int:
                 allow_inspection=False,
                 resolve_aliases=True,
             )
-            new_package = load(
-                spec.module,
-                search_paths=[spec.search_path],
-                allow_inspection=False,
-                resolve_aliases=True,
-            )
+            try:
+                new_package = load(
+                    spec.module,
+                    search_paths=[spec.search_path],
+                    allow_inspection=False,
+                    resolve_aliases=True,
+                )
+            except ModuleNotFoundError:
+                breakage_count += 1
+                print(
+                    f"::warning title={spec.module}::"
+                    "Released public import package was removed"
+                )
+                print("::endgroup::")
+                continue
 
             for breakage in find_breaking_changes(old_package, new_package):
                 try:

--- a/.github/tests/test_python_api_compatibility.py
+++ b/.github/tests/test_python_api_compatibility.py
@@ -1,0 +1,200 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+# ruff:file-ignore[implicit-namespace-package, undocumented-public-class, undocumented-public-method]
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1] / "scripts" / "check_python_api_compatibility.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "check_python_api_compatibility", SCRIPT_PATH
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT_PATH}")
+api_checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = api_checker
+SPEC.loader.exec_module(api_checker)
+
+
+class ApiCompatibilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        self.run_git("init", "-q")
+        self.run_git("config", "user.email", "test@example.com")
+        self.run_git("config", "user.name", "Test")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def write_status(self, packages: list[tuple[str, str, str]]) -> None:
+        rows = [
+            "# Python Package Status",
+            "",
+            "| Package | Path | State |",
+            "| --- | --- | --- |",
+        ]
+        rows.extend(
+            f"| `{name}` | `python/packages/{path}` | `{state}` |"
+            for name, path, state in packages
+        )
+        status_path = self.repo / "python" / "PACKAGE_STATUS.md"
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text("\n".join(rows) + "\n")
+
+    def write_module(self, package: str, module: str, files: dict[str, str]) -> Path:
+        module_path = self.repo / "python" / "packages" / package / module
+        module_path.mkdir(parents=True, exist_ok=True)
+        for relative_path, content in files.items():
+            (module_path / relative_path).write_text(content)
+        return module_path
+
+    def commit(self) -> str:
+        self.run_git("add", ".")
+        self.run_git("commit", "-qm", "baseline")
+        return self.run_git("rev-parse", "HEAD")
+
+    def run_checker(
+        self, base_sha: str, *, acknowledged: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        summary_path = self.repo / "summary.md"
+        command = [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--base-sha",
+            base_sha,
+            "--repo",
+            str(self.repo),
+        ]
+        if acknowledged:
+            command.append("--acknowledge-breaking-changes")
+        env = {**os.environ, "GITHUB_STEP_SUMMARY": str(summary_path)}
+        return subprocess.run(
+            command, capture_output=True, text=True, env=env, check=False
+        )
+
+    def test_discovers_only_released_non_lab_modules(self) -> None:
+        self.write_status(
+            [
+                ("agent-framework-stable", "stable", "released"),
+                ("agent-framework-beta", "beta", "beta"),
+                ("agent-framework-lab", "lab", "released"),
+            ]
+        )
+        self.write_module("stable", "stable_api", {"__init__.py": ""})
+        self.write_module("beta", "beta_api", {"__init__.py": ""})
+        self.write_module("lab", "lab_api", {"__init__.py": ""})
+        base_sha = self.commit()
+
+        states = api_checker._package_states(self.repo, base_sha)
+        specs = api_checker._module_specs(self.repo, base_sha, states)
+
+        self.assertEqual([spec.module for spec in specs], ["stable_api"])
+
+    def test_filters_base_experimental_apis_but_not_head_only_decorators(self) -> None:
+        self.write_status([("agent-framework-core", "core", "released")])
+        self.write_module(
+            "core",
+            "agent_framework",
+            {
+                "__init__.py": (
+                    "from ._api import ExperimentalBase, PublicChild, experimental_function, stable_function\n"
+                    '__all__ = ["ExperimentalBase", "PublicChild", "experimental_function", "stable_function"]\n'
+                ),
+                "_feature_stage.py": "def experimental(*, feature_id):\n    return lambda obj: obj\n",
+                "_api.py": (
+                    "from ._feature_stage import experimental\n\n"
+                    '@experimental(feature_id="TEST")\n'
+                    "class ExperimentalBase:\n"
+                    "    def inherited(self, value): pass\n\n"
+                    "class PublicChild(ExperimentalBase): pass\n\n"
+                    '@experimental(feature_id="TEST")\n'
+                    "def experimental_function(value): pass\n\n"
+                    "def stable_function(value): pass\n"
+                ),
+            },
+        )
+        base_sha = self.commit()
+        api_path = self.repo / "python/packages/core/agent_framework/_api.py"
+        api_path.write_text(
+            "from ._feature_stage import experimental\n\n"
+            '@experimental(feature_id="TEST")\n'
+            "class ExperimentalBase:\n"
+            "    def inherited(self): pass\n\n"
+            "class PublicChild(ExperimentalBase): pass\n\n"
+            '@experimental(feature_id="TEST")\n'
+            "def experimental_function(): pass\n\n"
+            '@experimental(feature_id="TEST")\n'
+            "def stable_function(): pass\n"
+        )
+
+        result = self.run_checker(base_sha)
+
+        self.assertEqual(result.returncode, 1)
+        warnings = [
+            line for line in result.stdout.splitlines() if line.startswith("::warning ")
+        ]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("stable_function(value)", warnings[0])
+
+    def test_removed_top_level_module_is_reported_and_acknowledgeable(self) -> None:
+        self.write_status([("agent-framework-stable", "stable", "released")])
+        module_path = self.write_module(
+            "stable",
+            "stable_api",
+            {"__init__.py": "def public_function(value): pass\n"},
+        )
+        base_sha = self.commit()
+        shutil.rmtree(module_path)
+
+        result = self.run_checker(base_sha)
+        acknowledged_result = self.run_checker(base_sha, acknowledged=True)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "::warning title=stable_api::Released public import package was removed",
+            result.stdout,
+        )
+        self.assertIn(
+            "- Published API breakages: 1", (self.repo / "summary.md").read_text()
+        )
+        self.assertEqual(acknowledged_result.returncode, 0)
+
+    def test_compatible_api_is_successful_and_writes_summary(self) -> None:
+        self.write_status([("agent-framework-stable", "stable", "released")])
+        self.write_module(
+            "stable",
+            "stable_api",
+            {"__init__.py": "def public_function(value): pass\n"},
+        )
+        base_sha = self.commit()
+
+        result = self.run_checker(base_sha)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn(
+            "- Published API breakages: 0", (self.repo / "summary.md").read_text()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/github-automation-tests.yml
+++ b/.github/workflows/github-automation-tests.yml
@@ -8,6 +8,8 @@ on:
       - ".github/tests/**"
       - ".github/workflows/python-test-coverage.yml"
       - ".github/workflows/github-automation-tests.yml"
+      - "python/pyproject.toml"
+      - "python/uv.lock"
   push:
     branches:
       - main
@@ -17,6 +19,8 @@ on:
       - ".github/tests/**"
       - ".github/workflows/python-test-coverage.yml"
       - ".github/workflows/github-automation-tests.yml"
+      - "python/pyproject.toml"
+      - "python/uv.lock"
 
 permissions:
   contents: read
@@ -35,8 +39,38 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.9"
+
       - name: Run JavaScript tests
         run: node --test .github/tests/*.js
 
       - name: Run Python tests
         run: python .github/tests/test_python_check_coverage.py
+
+      - name: Run Python API compatibility tests
+        working-directory: ${{ runner.temp }}
+        env:
+          UV_NO_CONFIG: "1"
+        run: |
+          griffe_requirement="$(
+            python3 - "$GITHUB_WORKSPACE/python/pyproject.toml" <<'PY'
+          import sys
+          import tomllib
+
+          with open(sys.argv[1], "rb") as pyproject_file:
+              dev_dependencies = tomllib.load(pyproject_file)["dependency-groups"]["dev"]
+          requirements = [
+              dependency for dependency in dev_dependencies if dependency.startswith("griffe")
+          ]
+          if len(requirements) != 1:
+              raise SystemExit("Expected exactly one Griffe development dependency")
+          print(requirements[0])
+          PY
+          )"
+
+          uv --no-config run \
+            --no-project \
+            --with "$griffe_requirement" \
+            python "$GITHUB_WORKSPACE/.github/tests/test_python_api_compatibility.py"

--- a/.github/workflows/python-api-compatibility.yml
+++ b/.github/workflows/python-api-compatibility.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -25,24 +27,82 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: true
+          enable-cache: false
+          version: "0.12.9"
+
+      - name: Verify breaking change acknowledgement
+        id: breaking-change-ack
+        if: contains(github.event.pull_request.labels.*.name, 'breaking change')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const labelName = 'breaking change';
+            const events = await github.paginate(github.rest.issues.listEvents, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const latestLabelEvent = events
+              .filter((event) =>
+                ['labeled', 'unlabeled'].includes(event.event)
+                && event.label?.name?.toLowerCase() === labelName
+              )
+              .sort((left, right) => left.id - right.id)
+              .at(-1);
+
+            if (!latestLabelEvent || latestLabelEvent.event !== 'labeled') {
+              core.setOutput('acknowledged', 'false');
+              core.warning('The breaking change label has no matching label event.');
+              return;
+            }
+
+            const actor = latestLabelEvent.actor?.login;
+            if (!actor) {
+              core.setOutput('acknowledged', 'false');
+              core.warning('The breaking change label event has no actor.');
+              return;
+            }
+
+            let permissionData;
+            try {
+              const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                ...context.repo,
+                username: actor,
+              });
+              permissionData = response.data;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            const acknowledged = permissionData?.user?.permissions?.push === true
+              || ['admin', 'maintain', 'write'].includes(permissionData?.permission);
+            core.setOutput('acknowledged', acknowledged ? 'true' : 'false');
+            if (acknowledged) {
+              core.info(`Breaking changes were acknowledged by write-capable collaborator ${actor}.`);
+            } else {
+              core.warning(`The breaking change label was last applied by ${actor}, who does not have write permission.`);
+            }
 
       - name: Compare public API with the PR base
+        working-directory: ${{ runner.temp }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BREAKING_CHANGE_ACKNOWLEDGED: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change') }}
+          BREAKING_CHANGE_ACKNOWLEDGED: ${{ steps.breaking-change-ack.outputs.acknowledged == 'true' }}
+          UV_NO_CONFIG: "1"
         shell: bash
         run: |
-          git show "$BASE_SHA:.github/scripts/check_python_api_compatibility.py" \
+          git -C "$GITHUB_WORKSPACE" show "$BASE_SHA:.github/scripts/check_python_api_compatibility.py" \
             > "$RUNNER_TEMP/check_python_api_compatibility.py"
-          git show "$BASE_SHA:python/pyproject.toml" \
+          git -C "$GITHUB_WORKSPACE" show "$BASE_SHA:python/pyproject.toml" \
             > "$RUNNER_TEMP/python-pyproject.toml"
 
           griffe_requirement="$(
@@ -69,7 +129,7 @@ jobs:
             args+=(--acknowledge-breaking-changes)
           fi
 
-          uv run \
+          uv --no-config run \
             --no-project \
             --with "$griffe_requirement" \
             python "$RUNNER_TEMP/check_python_api_compatibility.py" "${args[@]}"

--- a/.github/workflows/python-api-compatibility.yml
+++ b/.github/workflows/python-api-compatibility.yml
@@ -1,0 +1,75 @@
+name: Python - API Compatibility
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "python/**"
+      - ".github/scripts/check_python_api_compatibility.py"
+      - ".github/workflows/python-api-compatibility.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  api-compatibility:
+    name: Public API Compatibility
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Compare public API with the PR base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BREAKING_CHANGE_ACKNOWLEDGED: ${{ contains(github.event.pull_request.labels.*.name, 'breaking change') }}
+        shell: bash
+        run: |
+          git show "$BASE_SHA:.github/scripts/check_python_api_compatibility.py" \
+            > "$RUNNER_TEMP/check_python_api_compatibility.py"
+          git show "$BASE_SHA:python/pyproject.toml" \
+            > "$RUNNER_TEMP/python-pyproject.toml"
+
+          griffe_requirement="$(
+            python3 - "$RUNNER_TEMP/python-pyproject.toml" <<'PY'
+          import sys
+          import tomllib
+
+          with open(sys.argv[1], "rb") as pyproject_file:
+              dev_dependencies = tomllib.load(pyproject_file)["dependency-groups"]["dev"]
+          requirements = [
+              dependency for dependency in dev_dependencies if dependency.startswith("griffe")
+          ]
+          if len(requirements) != 1:
+              raise SystemExit("Expected exactly one Griffe development dependency")
+          print(requirements[0])
+          PY
+          )"
+
+          args=(
+            --base-sha "$BASE_SHA"
+            --repo "$GITHUB_WORKSPACE"
+          )
+          if [[ "$BREAKING_CHANGE_ACKNOWLEDGED" == "true" ]]; then
+            args+=(--acknowledge-breaking-changes)
+          fi
+
+          uv run \
+            --no-project \
+            --with "$griffe_requirement" \
+            python "$RUNNER_TEMP/check_python_api_compatibility.py" "${args[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,9 @@ Python pull requests run a non-blocking [Griffe](https://mkdocstrings.github.io/
 check that compares the pull request's public API with its base commit. The workflow only
 runs when Python files change, and reports potential breaking changes as annotations and
 in the job summary. The experimental `agent-framework-lab` package is excluded. The
-workflow runs from the trusted base branch, checks out the pull request commit with
-read-only permissions, and statically parses source without importing it.
+workflow runs from the trusted base branch, checks out GitHub's synthetic merge commit
+with read-only permissions, and statically parses source without importing it. This keeps
+the comparison current when a pull request branch is behind `main`.
 
 Only APIs from packages marked `released` in `python/PACKAGE_STATUS.md` are checked.
 Prerelease packages and APIs marked with `@experimental`—including members of an
@@ -91,11 +92,13 @@ finding. The Griffe version is pinned with the other Python development dependen
 `python/pyproject.toml`; the workflow reads that pin from the trusted base commit.
 
 If a breaking change is intentional and approved by maintainers, add the `breaking change`
-label to the pull request or add `[BREAKING]` to its title. The existing title/label
-automation keeps those signals synchronized. The compatibility workflow still reports the
-detected changes, but treats them as acknowledged and succeeds. Without that label, the
-comparison step fails; the job is configured as non-blocking so it cannot prevent a merge
-while the workflow is being evaluated.
+label to the pull request. The workflow accepts the label as an acknowledgement only when
+its latest application was performed by a collaborator with write access. Adding
+`[BREAKING]` to the title still marks the pull request through the existing title/label
+automation, but a write-capable collaborator must remove and reapply the label to approve
+the break. The compatibility workflow still reports acknowledged changes but succeeds.
+Without an approved label, the comparison step fails; the job is configured as
+non-blocking so it cannot prevent a merge while the workflow is being evaluated.
 
 #### Automated API Compatibility Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,29 @@ Contributions must maintain API signature and behavioral compatibility. Contribu
 that include breaking changes will be rejected. Please file an issue to discuss
 your idea or change if you believe that a breaking change is warranted.
 
+#### Python Public API Compatibility
+
+Python pull requests run a non-blocking [Griffe](https://mkdocstrings.github.io/griffe/)
+check that compares the pull request's public API with its base commit. The workflow only
+runs when Python files change, and reports potential breaking changes as annotations and
+in the job summary. The experimental `agent-framework-lab` package is excluded. The
+workflow runs from the trusted base branch, checks out the pull request commit with
+read-only permissions, and statically parses source without importing it.
+
+Only APIs from packages marked `released` in `python/PACKAGE_STATUS.md` are checked.
+Prerelease packages and APIs marked with `@experimental`—including members of an
+experimental class—are excluded. Package state and experimental markers are read from the
+base commit, so changing either in the same pull request cannot suppress a compatibility
+finding. The Griffe version is pinned with the other Python development dependencies in
+`python/pyproject.toml`; the workflow reads that pin from the trusted base commit.
+
+If a breaking change is intentional and approved by maintainers, add the `breaking change`
+label to the pull request or add `[BREAKING]` to its title. The existing title/label
+automation keeps those signals synchronized. The compatibility workflow still reports the
+detected changes, but treats them as acknowledged and succeeds. Without that label, the
+comparison step fails; the job is configured as non-blocking so it cannot prevent a merge
+while the workflow is being evaluated.
+
 #### Automated API Compatibility Validation
 
 The .NET projects use [Package Validation](https://learn.microsoft.com/dotnet/fundamentals/package-validation/overview)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "rich>=13.7.1,<16.0.0",
     "tomli==2.4.1",
     "prek==0.5.2",
+    "griffe==2.2.0",
 ]
 test = [
     "azure-monitor-opentelemetry",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -124,6 +124,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "flit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "griffe", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "mypy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -156,6 +157,7 @@ requires-dist = [{ name = "agent-framework-core", extras = ["all"], editable = "
 [package.metadata.requires-dev]
 dev = [
     { name = "flit", specifier = "==4.0.2" },
+    { name = "griffe", specifier = "==2.2.0" },
     { name = "mypy", specifier = "==2.3.1" },
     { name = "opentelemetry-sdk" },
     { name = "pandas", specifier = ">=2,<4" },
@@ -2401,12 +2403,38 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.1.0"
+name = "griffe"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+dependencies = [
+    { name = "griffecli", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "griffelib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/a0/927cf9416f527f623f4ccd9220337fca0cd85303b7e82adeab1e53669cd3/griffe-2.2.0.tar.gz", hash = "sha256:9c0dd9a7feda9e169d783507d777c6fb2f2fc2919b139747a5b4f5357517a611", size = 246229, upload-time = "2026-08-16T14:04:57.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/51/c9f9cb144e2bd21cbcb6ebd7978ecb5b9f5a375e78313744158338c8039c/griffe-2.2.0-py3-none-any.whl", hash = "sha256:db20672b31c3de2a1af5a18a3b3d8c186ccc2425e10290486b4f0364d25929e9", size = 5070, upload-time = "2026-08-16T14:04:51.971Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "griffelib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/75/3cf2fb1ae21fb55a3b917b45d24426a620ee916f4bdbd03f350c69d3d892/griffecli-2.2.0.tar.gz", hash = "sha256:b9e763131218eb19887ed52de20fe944252d811bfb4a3e339874908a588f0044", size = 58066, upload-time = "2026-08-16T14:04:55.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/83/04652213d82afeecc8e8a31231eeb87cc484dcc055fd96ecb0bfd9860405/griffecli-2.2.0-py3-none-any.whl", hash = "sha256:8ebb7ae1dcc2617f5d39f00e4c238dd6b5cd0b13157b0ce22c1ea4ca8b4c5d1d", size = 11480, upload-time = "2026-08-16T14:04:53.14Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation & Context

Python packages currently have no automated check that surfaces accidental breaking changes to released public APIs. This adds a non-blocking PR signal comparable to the existing .NET API compatibility validation while respecting Python package and feature lifecycle stages.

### Description & Review Guide

- **What are the major changes?** Add a trusted `pull_request_target` workflow that uses Griffe to compare released Python package APIs with the PR base, excludes Lab, prerelease packages, and APIs already marked `@experimental`, and recognizes the existing `breaking change` label as an explicit acknowledgement. Pin Griffe with the Python development dependencies and document the workflow.
- **What is the impact of these changes?** Python PRs receive GitHub annotations and a job summary for detected public API breakages. The job is non-blocking, does not run for .NET-only changes, and does not import or install code from the PR checkout.
- **What do you want reviewers to focus on?** Please review the `pull_request_target` trust boundary, base-commit lifecycle/decorator filtering, and whether the `breaking change` label is the right acknowledgement mechanism.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

N/A — this draft explores the requested Python API compatibility workflow and is not linked to an existing issue.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.