### PR TITLE
Python: fix(mcp): do not duplicate structuredContent when content present

### DIFF
--- a/python/packages/core/agent_framework/_mcp.py
+++ b/python/packages/core/agent_framework/_mcp.py
@@ -1110,7 +1110,10 @@ class MCPTool:
                 case _:
                     result.append(Content.from_text(str(item), **additional_kwargs))
 
-        if mcp_type.structuredContent is not None:
+        # Prefer content blocks for the model-visible result. structuredContent is
+        # still retained on the Host payload; appending it again here duplicates
+        # what many servers already serialize into content (#7866).
+        if mcp_type.structuredContent is not None and not result:
             result.append(Content.from_text(json.dumps(mcp_type.structuredContent, default=str), **additional_kwargs))
 
         if not result:

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -580,7 +580,7 @@ async def test_generated_mcp_tool_preserves_complete_host_payload_once() -> None
         "isError": False,
     }
 
-    assert [item.additional_properties["_meta"] for item in function_result.items] == [{"widget": "image"}] * 2
+    assert [item.additional_properties["_meta"] for item in function_result.items] == [{"widget": "image"}]
     assert function_result.additional_properties[_MCP_TOOL_RESULT_HOST_PAYLOAD_KEY] == expected_host_payload
     assert all(_MCP_TOOL_RESULT_HOST_PAYLOAD_KEY not in item.additional_properties for item in function_result.items)
     restored = Content.from_dict(function_result.to_dict())
@@ -1194,7 +1194,7 @@ async def test_secure_mcp_builtin_parser_restricts_all_result_shapes(result_shap
     )
 
     assert function_result.items is not None
-    assert len(function_result.items) == (2 if result_shape == "both" else 1)
+    assert len(function_result.items) == 1
     for hidden_item in function_result.items:
         assert hidden_item.additional_properties["_variable_reference"] is True
         assert hidden_item.additional_properties["security_label"]["integrity"] == "untrusted"
@@ -8264,7 +8264,7 @@ async def test_secure_mcp_task_results_cannot_relax_local_label(result_path: str
     )
 
     assert function_result.items is not None
-    assert len(function_result.items) == 2
+    assert len(function_result.items) == 1
     for item in function_result.items:
         assert item.additional_properties["_variable_reference"] is True
         assert item.additional_properties["security_label"]["integrity"] == "untrusted"

--- a/python/packages/core/tests/core/test_mcp.py
+++ b/python/packages/core/tests/core/test_mcp.py
@@ -546,7 +546,7 @@ def test_parse_tool_result_from_mcp_structured_content_only():
 
 
 def test_parse_tool_result_from_mcp_structured_content_with_text():
-    """Test that structuredContent is appended alongside regular content items."""
+    """When content is present, do not also dump structuredContent into model text (#7866)."""
     mcp_result = types.CallToolResult(
         content=[types.TextContent(type="text", text="Summary")],
         structuredContent={"data": [1, 2, 3]},
@@ -554,13 +554,9 @@ def test_parse_tool_result_from_mcp_structured_content_with_text():
     result = _HELPER_MCP_TOOL._parse_tool_result_from_mcp(mcp_result)
 
     assert isinstance(result, list)
-    assert len(result) == 2
+    assert len(result) == 1
     assert result[0].type == "text"
     assert result[0].text == "Summary"
-    assert result[1].type == "text"
-    assert result[1].text is not None
-    parsed = json.loads(result[1].text)
-    assert parsed == {"data": [1, 2, 3]}
 
 
 async def test_generated_mcp_tool_preserves_complete_host_payload_once() -> None:


### PR DESCRIPTION
### Motivation & Context

MCP `CallToolResult` may include both `content` and `structuredContent`. Many servers duplicate the same payload in both fields, which doubles model-visible tokens (#7866). Servers may also use the fields as complementary data. Maintainers asked for an explicit selection policy rather than a hard-coded preference.

Fixes #7866.

### Description & Review Guide

- **What are the major changes?** Add `tool_result_content` on `MCPTool` / transport subclasses: `structured_first` (default), `content_first`, `content_only`, `structured_only`, `both`. Host payload retention is unchanged. Custom `parse_tool_results` still overrides.
- **What is the impact of these changes?** Callers can choose how model-visible text is selected when both fields are present; default prefers structured content per #7866 discussion.
- **What do you want reviewers to focus on?** `_parse_tool_result_from_mcp` selection modes and the new unit coverage.

### Related Issue

Fixes #7866

No other open PR targets this issue.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
