### PR TITLE
Python: count async FunctionTool invocation exceptions

### DIFF
--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -614,9 +614,8 @@ class FunctionTool(SerializationMixin):
             if func is None:
                 raise ToolException(f"Function '{self.name}' has no implementation.")
             # If we have a bound instance, call the function with self
-            if self._instance is not None:
-                return func(self._instance, *args, **kwargs)
-            return func(*args, **kwargs)
+            result = func(self._instance, *args, **kwargs) if self._instance is not None else func(*args, **kwargs)
+            return self._await_invocation_result(result) if inspect.isawaitable(result) else result
         except Exception:
             self.invocation_exception_count += 1
             raise
@@ -634,10 +633,9 @@ class FunctionTool(SerializationMixin):
         func = self.func.func if isinstance(self.func, FunctionTool) else self.func
         if inspect.iscoroutinefunction(func) or getattr(self, "_invoke_sync_on_event_loop", False):
             res = self.__call__(**call_kwargs)
-            return await self._await_invocation_result(res) if inspect.isawaitable(res) else res
-
-        res = await asyncio.to_thread(self.__call__, **call_kwargs)
-        return await self._await_invocation_result(res) if inspect.isawaitable(res) else res
+        else:
+            res = await asyncio.to_thread(self.__call__, **call_kwargs)
+        return await res if inspect.isawaitable(res) else res
 
     @overload
     async def invoke(

--- a/python/packages/core/agent_framework/_tools.py
+++ b/python/packages/core/agent_framework/_tools.py
@@ -621,15 +621,23 @@ class FunctionTool(SerializationMixin):
             self.invocation_exception_count += 1
             raise
 
+    async def _await_invocation_result(self, result: Any) -> Any:
+        """Await a function result and count exceptions raised by the awaitable."""
+        try:
+            return await result
+        except Exception:
+            self.invocation_exception_count += 1
+            raise
+
     async def _invoke_function(self, call_kwargs: Mapping[str, Any]) -> Any:
         """Run sync tools off the event loop during async invocation."""
         func = self.func.func if isinstance(self.func, FunctionTool) else self.func
         if inspect.iscoroutinefunction(func) or getattr(self, "_invoke_sync_on_event_loop", False):
             res = self.__call__(**call_kwargs)
-            return await res if inspect.isawaitable(res) else res
+            return await self._await_invocation_result(res) if inspect.isawaitable(res) else res
 
         res = await asyncio.to_thread(self.__call__, **call_kwargs)
-        return await res if inspect.isawaitable(res) else res
+        return await self._await_invocation_result(res) if inspect.isawaitable(res) else res
 
     @overload
     async def invoke(

--- a/python/packages/core/tests/core/test_tools.py
+++ b/python/packages/core/tests/core/test_tools.py
@@ -343,6 +343,27 @@ async def test_tool_decorator_with_async():
     assert (await async_test_tool(1, 2)) == 3
 
 
+async def test_async_tool_exception_limit_counts_awaited_failures() -> None:
+    """Async tool failures count toward the configured exception limit."""
+    from agent_framework.exceptions import ToolException
+
+    @tool(name="failing_async_tool", max_invocation_exceptions=1)
+    async def failing_async_tool() -> str:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await failing_async_tool.invoke(skip_parsing=True)
+
+    assert failing_async_tool.invocation_count == 1
+    assert failing_async_tool.invocation_exception_count == 1
+
+    with pytest.raises(ToolException, match="maximum exception limit"):
+        await failing_async_tool.invoke(skip_parsing=True)
+
+    assert failing_async_tool.invocation_count == 1
+    assert failing_async_tool.invocation_exception_count == 1
+
+
 def test_tool_decorator_in_class():
     """Test the tool decorator."""
 

--- a/python/packages/core/tests/core/test_tools.py
+++ b/python/packages/core/tests/core/test_tools.py
@@ -364,6 +364,51 @@ async def test_async_tool_exception_limit_counts_awaited_failures() -> None:
     assert failing_async_tool.invocation_exception_count == 1
 
 
+async def test_direct_async_tool_exception_limit_counts_awaited_failures() -> None:
+    """Direct async tool calls count failures toward the configured exception limit."""
+    from agent_framework.exceptions import ToolException
+
+    @tool(name="failing_direct_async_tool", max_invocation_exceptions=1)
+    async def failing_direct_async_tool() -> str:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await failing_direct_async_tool()
+
+    assert failing_direct_async_tool.invocation_count == 1
+    assert failing_direct_async_tool.invocation_exception_count == 1
+
+    with pytest.raises(ToolException, match="maximum exception limit"):
+        await failing_direct_async_tool()
+
+    assert failing_direct_async_tool.invocation_count == 1
+    assert failing_direct_async_tool.invocation_exception_count == 1
+
+
+async def test_sync_awaitable_tool_exception_limit_counts_awaited_failures() -> None:
+    """Sync tools returning awaitables count failures during async invocation."""
+    from agent_framework.exceptions import ToolException
+
+    @tool(name="failing_sync_awaitable_tool", max_invocation_exceptions=1)
+    def failing_sync_awaitable_tool() -> Any:
+        async def fail_later() -> str:
+            raise RuntimeError("boom")
+
+        return fail_later()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await failing_sync_awaitable_tool.invoke(skip_parsing=True)
+
+    assert failing_sync_awaitable_tool.invocation_count == 1
+    assert failing_sync_awaitable_tool.invocation_exception_count == 1
+
+    with pytest.raises(ToolException, match="maximum exception limit"):
+        await failing_sync_awaitable_tool.invoke(skip_parsing=True)
+
+    assert failing_sync_awaitable_tool.invocation_count == 1
+    assert failing_sync_awaitable_tool.invocation_exception_count == 1
+
+
 def test_tool_decorator_in_class():
     """Test the tool decorator."""
 


### PR DESCRIPTION
### Motivation & Context

`FunctionTool.max_invocation_exceptions` is documented as the maximum number of exceptions allowed during tool invocations. Before this change, exceptions raised while awaiting an async result were not counted consistently.

For native async tools, `FunctionTool.__call__` returned a coroutine successfully and the exception was raised only when that coroutine was awaited. The same gap affected synchronous functions that return an awaitable. Direct async calls also bypassed the tracked await path.

This allowed a failing async tool to continue running after its configured exception budget was exhausted. The separate `max_consecutive_errors_per_request` setting is request-scoped and does not replace the per-tool lifetime limit.

### Description & Review Guide

- **What are the major changes?**
  - Count exceptions raised at the await boundary through a shared `_await_invocation_result` helper.
  - Route direct async `FunctionTool` calls through the same tracked await path.
  - Preserve the existing synchronous exception-counting behavior without double-counting failures.
  - Add regression coverage for native async invocation, direct async calls, and synchronous wrappers returning awaitables.
- **What is the impact of these changes?**
  - `max_invocation_exceptions` is now enforced consistently across all supported async execution paths.
  - After the configured number of failures, the next call raises `ToolException` without invoking the underlying function again.
  - Request-level `max_consecutive_errors_per_request` behavior is unchanged.
- **What do you want reviewers to focus on?**
  - Verify that each failure is counted exactly once across `__call__`, `invoke()`, and the `asyncio.to_thread` path.
  - Verify that the second call is rejected and both invocation counters remain unchanged after the limit is reached.

#### Reproduction before this change

Ran the same public tool paths against the upstream baseline `c37de519b` with `max_invocation_exceptions=1`:

```text
native-invoke [(1, 'RuntimeError', 1, 0), (2, 'RuntimeError', 2, 0), (3, 'RuntimeError', 3, 0)]
native-direct [(1, 'RuntimeError', 1, 0), (2, 'RuntimeError', 2, 0), (3, 'RuntimeError', 3, 0)]
sync-awaitable-invoke [(1, 'RuntimeError', 1, 0), (2, 'RuntimeError', 2, 0), (3, 'RuntimeError', 3, 0)]
```

The final tuple fields are `invocation_count` and `invocation_exception_count`. The async failures were raised, but the exception counter remained zero and the invocation count continued to increase.

#### Verification after this change

Ran the identical reproduction against the current PR head `87afcbac8`:

```text
native-invoke [(1, 'RuntimeError', 1, 1), (2, 'ToolException', 1, 1), (3, 'ToolException', 1, 1)]
native-direct [(1, 'RuntimeError', 1, 1), (2, 'ToolException', 1, 1), (3, 'ToolException', 1, 1)]
sync-awaitable-invoke [(1, 'RuntimeError', 1, 1), (2, 'ToolException', 1, 1), (3, 'ToolException', 1, 1)]
```

This confirms that the first awaited failure is counted, the configured limit is enforced on the second call, and no additional underlying invocation is started.

#### Tests and checks

- `uv run pytest packages/core/tests -q -m 'not integration'` — passed.
- `uv run pytest packages/core/tests/core/test_tools.py::test_async_tool_exception_limit_counts_awaited_failures packages/core/tests/core/test_tools.py::test_direct_async_tool_exception_limit_counts_awaited_failures packages/core/tests/core/test_tools.py::test_sync_awaitable_tool_exception_limit_counts_awaited_failures packages/core/tests/core/test_tools.py -q -m 'not integration'` — passed.
- `uv run ruff format --check packages/core/agent_framework/_tools.py packages/core/tests/core/test_tools.py` — 2 files already formatted.
- `uv run ruff check packages/core/agent_framework/_tools.py packages/core/tests/core/test_tools.py` — all checks passed.
- `git diff --check` — no whitespace errors.

The implementation is limited to async invocation exception accounting and its regression coverage.

### Related Issue

Fixes #8277

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix) — a workflow keeps the label and title prefix in sync automatically.
