### PR TITLE
Python: Fix WorkflowAgent non-streaming return type

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_agent.py
+++ b/python/packages/core/agent_framework/_workflows/_agent.py
@@ -162,7 +162,7 @@ class WorkflowAgent(BaseAgent):
         | Mapping[str, Any]
         | None = None,
         client_kwargs: WorkflowInvocationKwargs | Mapping[str, Mapping[str, Any]] | Mapping[str, Any] | None = None,
-    ) -> ResponseStream[AgentResponseUpdate, AgentResponse]: ...
+    ) -> Awaitable[AgentResponse]: ...
 
     @overload
     def run(

--- a/python/packages/core/tests/workflow/test_workflow_agent.py
+++ b/python/packages/core/tests/workflow/test_workflow_agent.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, overload
 
 import pytest
-from typing_extensions import Never
+from typing_extensions import Never, assert_type
 
 from agent_framework import (
     AgentExecutorRequest,
@@ -31,6 +31,13 @@ from agent_framework import (
     response_handler,
 )
 from agent_framework._workflows._typing_utils import deserialize_type
+
+
+def _assert_workflow_agent_run_return_types(agent: WorkflowAgent) -> None:
+    """Verify WorkflowAgent.run overloads expose distinct non-streaming and streaming types."""
+    assert_type(agent.run(), Awaitable[AgentResponse])
+    assert_type(agent.run(stream=False), Awaitable[AgentResponse])
+    assert_type(agent.run(stream=True), ResponseStream[AgentResponseUpdate, AgentResponse])
 
 
 @dataclass


### PR DESCRIPTION
### Motivation & Context

<!-- Thank you for your contribution to the Agent Framework repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue below.
-->

`WorkflowAgent.run(stream=False)` currently exposes a `ResponseStream[AgentResponseUpdate, AgentResponse]` return type even though the runtime false branch returns the non-streaming `_run_impl()` awaitable. This disagrees with `SupportsAgentRun`, the method documentation, and nearby agent implementations, so type checkers and IDEs see the wrong public pre-await return type.

Runtime execution is already correct. This change aligns the overload with existing behavior and the common agent contract.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
  - Correct the `Literal[False]` overload of `WorkflowAgent.run()` to return `Awaitable[AgentResponse]`.
  - Add focused `assert_type` coverage for omitted/default `stream`, explicit `stream=False`, and `stream=True`.
- **What is the impact of these changes?**
  - Static typing now matches the existing runtime behavior.
  - `stream=True` typing and runtime execution are unchanged.
  - There are no changes to storage, serialization, checkpoints, workflow execution, network calls, or provider behavior.
  - Local validation passed all five core typing checkers, focused WorkflowAgent tests, strict Pyright, Ruff syntax checks, the full core check, package builds, and `git diff --check`.
- **What do you want reviewers to focus on?**
  - Whether the corrected overload matches the common `SupportsAgentRun` contract.
  - Whether the `assert_type` coverage is the preferred regression mechanism.
  - Whether any public or generated stub requires a matching edit; the root `.pyi` currently re-exports the concrete class directly.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #8286

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.