### PR TITLE
.NET: Implement same approval process for LocalCodeAct as is used by Hyperlight

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActApprovalMode.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActApprovalMode.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.LocalCodeAct;
+
+/// <summary>
+/// Controls the approval behavior for the <c>execute_code</c> tool exposed by
+/// <see cref="LocalCodeActProvider"/> and <see cref="LocalExecuteCodeFunction"/>.
+/// </summary>
+public enum LocalCodeActApprovalMode
+{
+    /// <summary>
+    /// <c>execute_code</c> always requires user approval before invocation.
+    /// </summary>
+    AlwaysRequire,
+
+    /// <summary>
+    /// Approval is derived from the provider-owned CodeAct tool registry.
+    /// If any configured tool is an
+    /// <see cref="ApprovalRequiredAIFunction"/>,
+    /// <c>execute_code</c> also requires approval. Otherwise it does not.
+    /// </summary>
+    NeverRequire,
+}

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProvider.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProvider.cs
@@ -36,6 +36,7 @@ public sealed class LocalCodeActProvider : AIContextProvider, IDisposable
     private static readonly IReadOnlyList<string> s_stateKeys = [FixedStateKey];
 
     private readonly CodeExecutor _executor;
+    private readonly LocalCodeActApprovalMode _approvalMode;
 
     private readonly ConcurrentDictionary<string, AIFunction> _tools = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, FileMount> _fileMounts = new(StringComparer.Ordinal);
@@ -65,6 +66,8 @@ public sealed class LocalCodeActProvider : AIContextProvider, IDisposable
                 options.AllowedBuiltins?.ToList(),
                 options.BlockedBuiltins?.ToList());
         }
+
+        this._approvalMode = options.ApprovalMode;
 
         this._executor = new CodeExecutor(
             pythonExecutablePath,
@@ -190,8 +193,15 @@ public sealed class LocalCodeActProvider : AIContextProvider, IDisposable
             this._fileMounts.Values.ToList());
 
         FeatureUsageMarker.MarkUsed();
+        var approvalRequired = ComputeApprovalRequired(this._approvalMode, snapshot.Tools);
+
         var description = InstructionBuilder.BuildExecuteCodeDescription(snapshot.Tools, snapshot.FileMounts);
-        var executeCode = new ExecuteCodeFunction(this._executor, snapshot, description);
+
+        AIFunction executeCode = new ExecuteCodeFunction(this._executor, snapshot, description);
+        if (approvalRequired)
+        {
+            executeCode = new ApprovalRequiredAIFunction(executeCode);
+        }
 
         var instructions = InstructionBuilder.BuildContextInstructions();
 
@@ -201,6 +211,18 @@ public sealed class LocalCodeActProvider : AIContextProvider, IDisposable
             Tools = [executeCode],
         });
     }
+
+    /// <summary>
+    /// Computes whether <c>execute_code</c> must require approval for the supplied tool set.
+    /// </summary>
+    /// <remarks>
+    /// Approval is bundled: because generated code can reach any registered tool through
+    /// <c>call_tool(...)</c> after execution has begun, a single approval-required tool escalates
+    /// the approval requirement to the whole <c>execute_code</c> invocation.
+    /// </remarks>
+    internal static bool ComputeApprovalRequired(LocalCodeActApprovalMode mode, IReadOnlyList<AIFunction> tools) =>
+        mode == LocalCodeActApprovalMode.AlwaysRequire
+            || tools.Any(t => t.GetService<ApprovalRequiredAIFunction>() is not null);
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(this._disposed, this);
 

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProviderOptions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalCodeActProviderOptions.cs
@@ -19,6 +19,19 @@ public sealed class LocalCodeActProviderOptions
     public IEnumerable<AIFunction>? Tools { get; set; }
 
     /// <summary>
+    /// Gets or sets the approval mode for <c>execute_code</c>.
+    /// Defaults to <see cref="LocalCodeActApprovalMode.NeverRequire"/>.
+    /// </summary>
+    /// <remarks>
+    /// Under <see cref="LocalCodeActApprovalMode.NeverRequire"/>, approval still propagates from the
+    /// tools in <see cref="Tools"/>: if any of them is an <see cref="ApprovalRequiredAIFunction"/>,
+    /// <c>execute_code</c> requires approval as well. This is required because generated code can
+    /// invoke any registered tool via <c>call_tool(...)</c> once execution has started, at which
+    /// point per-tool approval can no longer be enforced.
+    /// </remarks>
+    public LocalCodeActApprovalMode ApprovalMode { get; set; } = LocalCodeActApprovalMode.NeverRequire;
+
+    /// <summary>
     /// Gets or sets the initial set of file mounts exposed to generated code.
     /// </summary>
     public IEnumerable<FileMount>? FileMounts { get; set; }

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalExecuteCodeFunction.cs
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/LocalExecuteCodeFunction.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Agents.AI.LocalCodeAct;
 /// Use this when you want to expose code execution directly as a model-facing function without
 /// the <see cref="LocalCodeActProvider"/> indirection. Tools and file mounts are captured at
 /// construction time and immutable for the lifetime of the function.
+/// When the configuration requires approval (per
+/// <see cref="LocalCodeActProviderOptions.ApprovalMode"/> or because a configured tool is itself
+/// an <see cref="ApprovalRequiredAIFunction"/>), the instance surfaces an
+/// <see cref="ApprovalRequiredAIFunction"/> via <see cref="AITool.GetService(Type, object?)"/>,
+/// which is how the rest of the framework discovers approval requirements.
 /// </remarks>
 public sealed class LocalExecuteCodeFunction : AIFunction
 {
@@ -28,6 +33,8 @@ public sealed class LocalExecuteCodeFunction : AIFunction
     private readonly CodeExecutor _executor;
     private readonly CodeExecutor.RunSnapshot _snapshot;
     private readonly AIFunction _inner;
+    private readonly bool _approvalRequired;
+    private ApprovalRequiredAIFunction? _approvalProxy;
 
     /// <summary>Initializes a new instance of the <see cref="LocalExecuteCodeFunction"/> class.</summary>
     /// <param name="pythonExecutablePath">Path to the Python interpreter used for execution and validation.</param>
@@ -73,6 +80,8 @@ public sealed class LocalExecuteCodeFunction : AIFunction
                 Name = ExecuteCodeName,
                 Description = InstructionBuilder.BuildExecuteCodeDescription(tools, fileMounts),
             });
+
+        this._approvalRequired = LocalCodeActProvider.ComputeApprovalRequired(options.ApprovalMode, tools);
     }
 
     /// <inheritdoc/>
@@ -83,6 +92,19 @@ public sealed class LocalExecuteCodeFunction : AIFunction
 
     /// <inheritdoc/>
     public override JsonElement JsonSchema => this._inner.JsonSchema;
+
+    /// <inheritdoc/>
+    public override object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        if (serviceKey is null
+            && this._approvalRequired
+            && serviceType == typeof(ApprovalRequiredAIFunction))
+        {
+            return this._approvalProxy ??= new ApprovalRequiredAIFunction(this);
+        }
+
+        return base.GetService(serviceType, serviceKey);
+    }
 
     /// <inheritdoc/>
     protected override ValueTask<object?> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken) =>

--- a/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.LocalCodeAct/README.md
@@ -94,6 +94,33 @@ total = await call_tool("add", a=2, b=3)
 print(total)
 ```
 
+## Tool Approval
+
+Generated code reaches registered tools through `call_tool(...)`, which invokes
+them directly. A per-tool approval interaction cannot be surfaced at that point,
+so approval is **bundled** onto `execute_code` instead:
+
+* If any registered tool is an `ApprovalRequiredAIFunction`, `execute_code`
+  itself requires approval before the code runs.
+* `LocalCodeActApprovalMode.AlwaysRequire` makes `execute_code` require approval
+  regardless of the registered tools.
+
+```csharp
+var deploy = new ApprovalRequiredAIFunction(
+    AIFunctionFactory.Create(RunDeployment, name: "deploy"));
+
+using var provider = new LocalCodeActProvider("/usr/bin/python3", new LocalCodeActProviderOptions
+{
+    Tools = new[] { deploy },
+    // ApprovalMode = LocalCodeActApprovalMode.AlwaysRequire, // optional, opt-in
+});
+```
+
+For `LocalCodeActProvider`, approval is recomputed on every run, so tools added
+via `AddTools` after construction are taken into account. `LocalExecuteCodeFunction`
+captures its tools at construction time and exposes the approval requirement
+through `GetService<ApprovalRequiredAIFunction>()`.
+
 ## Code Validation
 
 By default, the package validates Python code against allow-lists before

--- a/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/ApprovalPropagationTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.LocalCodeAct.UnitTests/ApprovalPropagationTests.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Moq;
+
+namespace Microsoft.Agents.AI.LocalCodeAct.UnitTests;
+
+/// <summary>
+/// Regression tests for approval propagation from provider-owned CodeAct tools to the
+/// model-facing <c>execute_code</c> function.
+/// </summary>
+/// <remarks>
+/// Generated code reaches registered tools through <c>call_tool(...)</c>, which invokes them
+/// directly and therefore cannot surface a per-tool approval interaction. Approval must be
+/// bundled onto <c>execute_code</c> instead.
+/// </remarks>
+public sealed class ApprovalPropagationTests
+{
+    private static readonly AIAgent s_mockAgent = new Mock<AIAgent>().Object;
+
+    private static AIContextProvider.InvokingContext NewInvokingContext() =>
+        new(s_mockAgent, session: null, new AIContext());
+
+    private static ApprovalRequiredAIFunction GatedTool() =>
+        new(AIFunctionFactory.Create(() => "ok", name: "approval_gated_shell"));
+
+    [Fact]
+    public void ComputeApprovalRequired_AlwaysRequire_NoTools_ReturnsTrue()
+    {
+        // Act / Assert
+        Assert.True(LocalCodeActProvider.ComputeApprovalRequired(LocalCodeActApprovalMode.AlwaysRequire, tools: []));
+    }
+
+    [Fact]
+    public void ComputeApprovalRequired_AlwaysRequire_WithoutGatedTool_ReturnsTrue()
+    {
+        // Arrange
+        var tool = AIFunctionFactory.Create(() => "ok", name: "t");
+
+        // Act / Assert
+        Assert.True(LocalCodeActProvider.ComputeApprovalRequired(LocalCodeActApprovalMode.AlwaysRequire, tools: [tool]));
+    }
+
+    [Fact]
+    public void ComputeApprovalRequired_NeverRequire_NoTools_ReturnsFalse()
+    {
+        // Act / Assert
+        Assert.False(LocalCodeActProvider.ComputeApprovalRequired(LocalCodeActApprovalMode.NeverRequire, tools: []));
+    }
+
+    [Fact]
+    public void ComputeApprovalRequired_NeverRequire_WithoutGatedTool_ReturnsFalse()
+    {
+        // Arrange
+        var tool = AIFunctionFactory.Create(() => "ok", name: "t");
+
+        // Act / Assert
+        Assert.False(LocalCodeActProvider.ComputeApprovalRequired(LocalCodeActApprovalMode.NeverRequire, tools: [tool]));
+    }
+
+    [Fact]
+    public void ComputeApprovalRequired_NeverRequire_WithGatedTool_ReturnsTrue()
+    {
+        // Arrange
+        var tool = GatedTool();
+
+        // Act / Assert
+        Assert.True(LocalCodeActProvider.ComputeApprovalRequired(LocalCodeActApprovalMode.NeverRequire, tools: [tool]));
+    }
+
+    [Fact]
+    public async Task ProvideAIContextAsync_WithGatedTool_WrapsExecuteCodeInApprovalRequiredAsync()
+    {
+        // Arrange
+        using var provider = new LocalCodeActProvider(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                Tools = [GatedTool()],
+            });
+
+        // Act
+        var context = await provider.InvokingAsync(NewInvokingContext());
+
+        // Assert
+        var tool = Assert.IsType<ApprovalRequiredAIFunction>(context!.Tools!.Single());
+        Assert.Equal("execute_code", tool.Name);
+        Assert.NotNull(tool.GetService<ApprovalRequiredAIFunction>());
+    }
+
+    [Fact]
+    public async Task ProvideAIContextAsync_ToolAddedAfterConstruction_WrapsExecuteCodeInApprovalRequiredAsync()
+    {
+        // Arrange
+        using var provider = new LocalCodeActProvider(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions { ValidationDisabled = true });
+        provider.AddTools(GatedTool());
+
+        // Act
+        var context = await provider.InvokingAsync(NewInvokingContext());
+
+        // Assert
+        _ = Assert.IsType<ApprovalRequiredAIFunction>(context!.Tools!.Single());
+    }
+
+    [Fact]
+    public async Task ProvideAIContextAsync_AlwaysRequire_WrapsExecuteCodeInApprovalRequiredAsync()
+    {
+        // Arrange
+        using var provider = new LocalCodeActProvider(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                ApprovalMode = LocalCodeActApprovalMode.AlwaysRequire,
+            });
+
+        // Act
+        var context = await provider.InvokingAsync(NewInvokingContext());
+
+        // Assert
+        _ = Assert.IsType<ApprovalRequiredAIFunction>(context!.Tools!.Single());
+    }
+
+    [Fact]
+    public async Task ProvideAIContextAsync_WithoutGatedTool_DoesNotRequireApprovalAsync()
+    {
+        // Arrange
+        using var provider = new LocalCodeActProvider(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                Tools = [AIFunctionFactory.Create(() => "ok", name: "ping")],
+            });
+
+        // Act
+        var context = await provider.InvokingAsync(NewInvokingContext());
+
+        // Assert
+        var tool = Assert.IsAssignableFrom<AIFunction>(context!.Tools!.Single());
+        Assert.IsNotType<ApprovalRequiredAIFunction>(tool);
+        Assert.Null(tool.GetService<ApprovalRequiredAIFunction>());
+    }
+
+    [Fact]
+    public void LocalExecuteCodeFunction_WithGatedTool_ExposesApprovalRequiredService()
+    {
+        // Arrange
+        var function = new LocalExecuteCodeFunction(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                Tools = [GatedTool()],
+            });
+
+        // Act
+        var marker = function.GetService<ApprovalRequiredAIFunction>();
+
+        // Assert
+        Assert.NotNull(marker);
+        Assert.Same(marker, function.GetService<ApprovalRequiredAIFunction>());
+        Assert.Equal("execute_code", marker!.Name);
+    }
+
+    [Fact]
+    public void LocalExecuteCodeFunction_AlwaysRequire_ExposesApprovalRequiredService()
+    {
+        // Arrange
+        var function = new LocalExecuteCodeFunction(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                ApprovalMode = LocalCodeActApprovalMode.AlwaysRequire,
+            });
+
+        // Act / Assert
+        Assert.NotNull(function.GetService<ApprovalRequiredAIFunction>());
+    }
+
+    [Fact]
+    public void LocalExecuteCodeFunction_WithoutGatedTool_DoesNotExposeApprovalRequiredService()
+    {
+        // Arrange
+        var function = new LocalExecuteCodeFunction(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                Tools = [AIFunctionFactory.Create(() => "ok", name: "ping")],
+            });
+
+        // Act / Assert
+        Assert.Null(function.GetService<ApprovalRequiredAIFunction>());
+    }
+
+    [Fact]
+    public void LocalExecuteCodeFunction_WithServiceKey_DoesNotExposeApprovalRequiredService()
+    {
+        // Arrange
+        var function = new LocalExecuteCodeFunction(
+            "/usr/bin/python3",
+            new LocalCodeActProviderOptions
+            {
+                ValidationDisabled = true,
+                Tools = [GatedTool()],
+            });
+
+        // Act / Assert
+        Assert.Null(function.GetService(typeof(ApprovalRequiredAIFunction), serviceKey: "key"));
+    }
+}


### PR DESCRIPTION
### Motivation & Context

Bring consistency to the different CodeAct implementations as to how approvals are processed.

### Description & Review Guide

<!-- Describe your changes, the overall approach, the underlying design.
     Highlight what you want the reviewers to focus on.
     These notes will help understanding how your code works. Thanks! -->

- **What are the major changes?**
- **What is the impact of these changes?**
- **What do you want reviewers to focus on?**
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->


### Related Issue

<!-- Which issue does this PR fix? Link it using a GitHub closing keyword so it is
     closed automatically when this PR is merged, e.g. "Fixes #123" or "Closes #123".
     PRs that are not linked to an issue may be closed, no matter how valid the change is.
     Also check whether an open PR already exists for this issue; if so,
     explain how this PR is different. -->

Fixes #

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
