### PR TITLE
Python: preserve functional workflow state on response-only HITL resume

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_functional.py
+++ b/python/packages/core/agent_framework/_workflows/_functional.py
@@ -739,6 +739,7 @@ class FunctionalWorkflow:
         self._last_message: Any = None
         self._last_step_cache: dict[tuple[str, int], Any] = {}
         self._last_step_cache_auto_request_info_counts: dict[tuple[str, int], int] = {}
+        self._last_state: dict[str, Any] = {}
         self._last_pending_request_ids: set[str] = set()
 
         # Signature arity is validated once at decoration time.
@@ -1015,6 +1016,7 @@ class FunctionalWorkflow:
                 message = self._last_message
             ctx._step_cache = dict(self._last_step_cache)
             ctx._step_cache_auto_request_info_counts = dict(self._last_step_cache_auto_request_info_counts)
+            ctx._state = dict(self._last_state)
 
         # Store message for future replays
         if message is not None:
@@ -1064,6 +1066,7 @@ class FunctionalWorkflow:
                 # Persist step cache for response-only replay
                 self._last_step_cache = dict(ctx._step_cache)
                 self._last_step_cache_auto_request_info_counts = dict(ctx._step_cache_auto_request_info_counts)
+                self._last_state = dict(ctx._state)
 
             # Yield collected events.
             # NOTE: Events are buffered during _execute() and yielded after
@@ -1091,6 +1094,7 @@ class FunctionalWorkflow:
                 self._last_message = None
                 self._last_step_cache = {}
                 self._last_step_cache_auto_request_info_counts = {}
+                self._last_state = {}
                 self._last_pending_request_ids = set()
                 yield _framework_event(WorkflowEvent.status, WorkflowRunState.IDLE)
 
@@ -1100,6 +1104,7 @@ class FunctionalWorkflow:
             # Persist step cache for response-only replay
             self._last_step_cache = dict(ctx._step_cache)
             self._last_step_cache_auto_request_info_counts = dict(ctx._step_cache_auto_request_info_counts)
+            self._last_state = dict(ctx._state)
             self._last_pending_request_ids = set(ctx._pending_requests)
 
             # HITL interruption — yield events collected so far

--- a/python/packages/core/tests/workflow/test_functional_workflow.py
+++ b/python/packages/core/tests/workflow/test_functional_workflow.py
@@ -1470,6 +1470,31 @@ def caplog_context(target_logger: logging.Logger) -> Iterator[list[str]]:
 class TestHITLInStepWithCaching:
     """Regression tests: request_info inside @step combined with caching and bypass."""
 
+    async def test_response_only_resume_restores_state_from_cached_step(self):
+        """Response-only HITL resumes must preserve state written before a cached step."""
+        seed_calls = 0
+
+        @step
+        async def seed_state(ctx: RunContext) -> str:
+            nonlocal seed_calls
+            seed_calls += 1
+            ctx.set_state("marker", "ok")
+            return "seeded"
+
+        @built_workflow
+        async def wf(data: str, ctx: RunContext) -> str:
+            value = await seed_state()
+            answer = await ctx.request_info("question", response_type=str, request_id="r1")
+            return f"{ctx.get_state('marker', 'MISSING')}:{value}:{answer}"
+
+        result1 = await wf.run("input")
+        assert result1.get_final_state() == WorkflowRunState.IDLE_WITH_PENDING_REQUESTS
+
+        result2 = await wf.run(responses={"r1": "ok"})
+
+        assert seed_calls == 1
+        assert result2.get_outputs() == ["ok:seeded:ok"]
+
     async def test_preceding_step_bypassed_on_hitl_resume(self):
         """When a step after a completed step calls request_info and interrupts,
         resuming should bypass the first step (cached) and re-execute the HITL step."""


### PR DESCRIPTION
### Motivation & Context

Functional workflow state is documented as persisting across HITL interruptions, but response-only resumes currently restore only cached step results. When a cached step wrote user state before requesting input, the resumed workflow completes with missing state and can silently produce an incorrect result.

This is reproducible through the public `FunctionalWorkflow.run` API on the upstream commit used for this change:

```text
First run:  IDLE_WITH_PENDING_REQUESTS
Before fix, response-only resume: ['MISSING:seeded:ok']
```

The same scenario resumed with a `checkpoint_id` already preserved `ok:seeded:ok`, confirming that state persistence is intended. The issue is tracked in #8299, and the original functional workflow review in #4238 identified the same unresolved response-only state restoration gap.

### Description & Review Guide

- **What are the major changes?**
  - Snapshot the active user state alongside the existing response-only step cache when a functional workflow is interrupted.
  - Restore that state when resuming with `responses={...}` without a checkpoint.
  - Clear the replayed state on clean completion, matching the existing replay-cache lifecycle.
  - Add a regression test that writes state in a cached `@step`, pauses for HITL input, verifies the step is not executed again, and verifies the state remains available after response-only resume.

- **What is the impact of these changes?**
  - Response-only HITL resumes now preserve state-dependent workflow behavior while retaining cached-step replay.
  - The verified post-fix result is `['ok:seeded:ok']` with `seed_calls == 1`.
  - Checkpoint restore behavior and the public API remain unchanged.
  - The focused workflow tests, the full core unit suite (`5039 passed, 131 skipped, 2 xfailed`), formatting, linting, and changed-file Pyright checks pass.

- **What do you want reviewers to focus on?**
  - Whether the state snapshot/restore points cover both `WorkflowInterrupted` and normal completion without allowing stale state to cross independent workflow runs.
  - Whether the regression test accurately represents a cached step that initializes state before a response-only HITL resume.

### Related Issue

Fixes #8299

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix) — a workflow keeps the label and title prefix in sync automatically.
