### PR TITLE
.NET: fix: inspect for delemiter value before adding headers

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -230,6 +230,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
             httpRequest.Content = new StringContent(request.Body, Encoding.UTF8);
             // Replace the default content-type header (including charset) with the declared type.
             httpRequest.Content.Headers.Remove("Content-Type");
+            ValidateHeaderValue("Content-Type", contentType);
             httpRequest.Content.Headers.TryAddWithoutValidation("Content-Type", contentType);
         }
 
@@ -241,6 +242,8 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
                 {
                     continue;
                 }
+
+                ValidateHeader(header.Key, header.Value);
 
                 // Content-* headers belong on HttpContent; all others belong on the request.
                 if (header.Key.StartsWith("Content-", StringComparison.OrdinalIgnoreCase) && httpRequest.Content is not null)
@@ -259,6 +262,27 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
 
         return httpRequest;
     }
+
+    private static void ValidateHeader(string name, string value)
+    {
+        if (ContainsHttpHeaderDelimiter(name))
+        {
+            throw new ArgumentException($"HTTP header name '{name}' contains invalid characters.", nameof(name));
+        }
+
+        ValidateHeaderValue(name, value);
+    }
+
+    private static void ValidateHeaderValue(string name, string value)
+    {
+        if (ContainsHttpHeaderDelimiter(value))
+        {
+            throw new ArgumentException($"HTTP header '{name}' contains invalid characters.", nameof(value));
+        }
+    }
+
+    private static bool ContainsHttpHeaderDelimiter(string value) =>
+        value.IndexOfAny(['\r', '\n', '\0']) >= 0;
 
     private static HttpClient CreateOwnedHttpClient()
     {

--- a/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows.Declarative/DefaultHttpRequestHandler.cs
@@ -267,7 +267,7 @@ public sealed class DefaultHttpRequestHandler : IHttpRequestHandler, IAsyncDispo
     {
         if (ContainsHttpHeaderDelimiter(name))
         {
-            throw new ArgumentException($"HTTP header name '{name}' contains invalid characters.", nameof(name));
+            throw new ArgumentException("HTTP header name contains invalid characters.", nameof(name));
         }
 
         ValidateHeaderValue(name, value);

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -255,6 +256,33 @@ public sealed class DefaultHttpRequestHandlerTests
         // Assert
         Assert.Equal("Bearer secret", messageHandler.LastRequest!.Headers.Authorization!.ToString());
         Assert.Contains(messageHandler.LastRequest.Headers.Accept, mediaType => mediaType.MediaType == "application/json");
+    }
+
+    [Fact]
+    public async Task SendAsyncRejectsHeaderValuesContainingCrlfBeforeSendingAsync()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await using RawHttpServer server = new();
+        using HttpClient httpClient = new();
+        await using DefaultHttpRequestHandler handler = new(httpClient);
+        HttpRequestInfo request = new()
+        {
+            Method = "GET",
+            Url = server.Url,
+            Headers = new Dictionary<string, string>
+            {
+                ["X-User-Note"] = "safe\r\n\r\nDELETE /admin HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+            },
+        };
+
+        // Act
+        Exception? exception = await Record.ExceptionAsync(() => handler.SendAsync(request, cancellationToken));
+        string? rawRequest = await server.TryReadRequestAsync(TimeSpan.FromMilliseconds(500));
+
+        // Assert
+        Assert.Null(rawRequest);
+        Assert.IsType<ArgumentException>(exception);
     }
 
     [Fact]
@@ -1071,6 +1099,91 @@ public sealed class DefaultHttpRequestHandlerTests
                 this.RequestBodies.Add(null);
             }
             return await this._responseFactory(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class RawHttpServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly Task<string?> _rawRequestTask;
+
+        public RawHttpServer()
+        {
+            this._listener = new TcpListener(IPAddress.Loopback, 0);
+            this._listener.Start();
+            int port = ((IPEndPoint)this._listener.LocalEndpoint).Port;
+            this.Url = $"http://127.0.0.1:{port}/public";
+            this._rawRequestTask = Task.Run(this.AcceptAndRespond);
+        }
+
+        public string Url { get; }
+
+        public async Task<string?> TryReadRequestAsync(TimeSpan timeout)
+        {
+            Task completedTask = await Task.WhenAny(this._rawRequestTask, Task.Delay(timeout)).ConfigureAwait(false);
+            return completedTask == this._rawRequestTask
+                ? await this._rawRequestTask.ConfigureAwait(false)
+                : null;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            this._listener.Dispose();
+            await this._rawRequestTask.ConfigureAwait(false);
+        }
+
+        private string? AcceptAndRespond()
+        {
+            TcpClient client;
+            try
+            {
+                client = this._listener.AcceptTcpClient();
+            }
+            catch (SocketException)
+            {
+                return null;
+            }
+            catch (ObjectDisposedException)
+            {
+                return null;
+            }
+
+            using (client)
+            {
+                client.ReceiveTimeout = 250;
+                using NetworkStream stream = client.GetStream();
+                using MemoryStream rawRequest = new();
+                byte[] buffer = new byte[1024];
+
+                while (true)
+                {
+                    int bytesRead;
+                    try
+                    {
+                        bytesRead = stream.Read(buffer, 0, buffer.Length);
+                    }
+                    catch (IOException)
+                    {
+                        break;
+                    }
+
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    rawRequest.Write(buffer, 0, bytesRead);
+                    string currentRequest = Encoding.ASCII.GetString(rawRequest.ToArray());
+                    if (currentRequest.Contains("DELETE /admin", StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+                }
+
+                byte[] responseBytes = Encoding.ASCII.GetBytes("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+                stream.Write(responseBytes, 0, responseBytes.Length);
+                return Encoding.ASCII.GetString(rawRequest.ToArray());
+            }
         }
     }
 

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -286,6 +286,30 @@ public sealed class DefaultHttpRequestHandlerTests
     }
 
     [Fact]
+    public async Task SendAsyncRejectsBodyContentTypeContainingCrlfBeforeSendingAsync()
+    {
+        // Arrange
+        TestHttpMessageHandler messageHandler = new((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using HttpClient httpClient = new(messageHandler);
+        await using DefaultHttpRequestHandler handler = new(httpClient);
+        HttpRequestInfo request = new()
+        {
+            Method = "POST",
+            Url = TestUrl,
+            Body = "safe",
+            BodyContentType = "text/plain\r\nX-Injected: value",
+        };
+
+        // Act
+        async Task actAsync() => await handler.SendAsync(request);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(actAsync);
+        Assert.Null(messageHandler.LastRequest);
+    }
+
+    [Fact]
     public async Task SendAsyncRoutesContentHeadersToBodyAsync()
     {
         // Arrange

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.Declarative.UnitTests/DefaultHttpRequestHandlerTests.cs
@@ -290,7 +290,7 @@ public sealed class DefaultHttpRequestHandlerTests
     {
         // Arrange
         TestHttpMessageHandler messageHandler = new((_, _) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+            throw new InvalidOperationException("The request should be rejected before transport."));
         using HttpClient httpClient = new(messageHandler);
         await using DefaultHttpRequestHandler handler = new(httpClient);
         HttpRequestInfo request = new()
@@ -1152,7 +1152,11 @@ public sealed class DefaultHttpRequestHandlerTests
 
         public async ValueTask DisposeAsync()
         {
+#if NET
             this._listener.Dispose();
+#else
+            this._listener.Stop();
+#endif
             await this._rawRequestTask.ConfigureAwait(false);
         }
 


### PR DESCRIPTION
adding headers without validation can lead to corrupted http requests. This fixes the issue by inspecting for end of line characters