### PR TITLE
.NET: update remaining dependencies

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.9.0" />
     <!-- Google Gemini  -->
     <PackageVersion Include="Google.GenAI" Version="1.21.0" />
-    <PackageVersion Include="Mscc.GenerativeAI.Microsoft" Version="2.9.3" />
+    <PackageVersion Include="Mscc.GenerativeAI.Microsoft" Version="3.1.0" />
     <!-- Microsoft.Azure.* -->
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.63.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.12" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="DotNetEnv" Version="3.2.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.9.0" />
     <!-- Google Gemini  -->
-    <PackageVersion Include="Google.GenAI" Version="1.6.0" />
+    <PackageVersion Include="Google.GenAI" Version="1.21.0" />
     <PackageVersion Include="Mscc.GenerativeAI.Microsoft" Version="2.9.3" />
     <!-- Microsoft.Azure.* -->
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.63.0" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -110,11 +110,11 @@
     <!-- Agent SDKs -->
     <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.11" />
     <PackageVersion Include="ResponsibleAI.AgentHooks" Version="0.1.0-alpha.5" />
-    <PackageVersion Include="Microsoft.Agents.CopilotStudio.Client" Version="1.9.28-beta" />
+    <PackageVersion Include="Microsoft.Agents.CopilotStudio.Client" Version="1.9.35-beta" />
     <!-- M365 Agents SDK -->
     <PackageVersion Include="AdaptiveCards" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Agents.Authentication.Msal" Version="1.9.28-beta" />
-    <PackageVersion Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.9.28-beta" />
+    <PackageVersion Include="Microsoft.Agents.Authentication.Msal" Version="1.9.35-beta" />
+    <PackageVersion Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.9.35-beta" />
     <!-- A2A -->
     <PackageVersion Include="A2A" Version="1.0.0-preview2" />
     <PackageVersion Include="A2A.AspNetCore" Version="1.0.0-preview2" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Anthropic" Version="12.45.0" />
     <PackageVersion Include="Anthropic.Foundry" Version="0.7.1" />
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireAppHostSdkVersion)" />
-    <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.0.0-preview.1.25560.3" />
+    <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.5.3-preview.1.26425.3" />
     <PackageVersion Include="Aspire.Azure.AI.Inference" Version="13.5.3-preview.1.26425.3" />
     <PackageVersion Include="Aspire.Hosting.Azure.AIFoundry" Version="13.1.3-preview.1.26166.8" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireAppHostSdkVersion)" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="System.ClientModel" Version="1.15.0" />
     <PackageVersion Include="System.CodeDom" Version="10.0.12" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.12" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.2.25502.107" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.12" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.12" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.12" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.12" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -151,7 +151,7 @@
     <PackageVersion Include="Moq" Version="[4.18.4]" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
     <PackageVersion Include="xRetry.v3" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.2" />
     <!-- Symbols -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <!-- Toolset -->

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -126,7 +126,7 @@
     <PackageVersion Include="Hyperlight.HyperlightSandbox.Guest.Python" Version="0.6.0" />
     <!-- Inference SDKs -->
     <PackageVersion Include="Dapr.AI.Microsoft.Extensions" Version="1.18.5" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.10.0" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntimeGenAI" Version="0.15.2" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenAI" Version="2.13.0" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -131,7 +131,7 @@
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenAI" Version="2.13.0" />
     <!-- Identity -->
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.88.0" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.89.0" />
     <!-- Workflows -->
     <PackageVersion Include="Microsoft.Agents.ObjectModel" Version="2026.5.5" />
     <PackageVersion Include="Microsoft.Agents.ObjectModel.Json" Version="2026.5.5" />

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -156,8 +156,8 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <!-- Toolset -->
     <PackageVersion Include="ReferenceTrimmer" Version="3.5.9" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.401" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">

--- a/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory.csproj
+++ b/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="AgentMemory" Version="1.5.0" />
     <PackageReference Include="AgentMemory.AgentFramework" Version="1.5.0" />
     <!-- Microsoft Agent Framework (matches AgentMemory's target) + the OpenAI/Foundry chat & embedding clients. -->
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.12" />

--- a/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory.csproj
+++ b/dotnet/samples/02-agents/AgentWithMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory/AgentWithMemory_Step06_MemoryUsingAgentMemory.csproj
@@ -41,10 +41,10 @@
     <PackageReference Include="AgentMemory" Version="1.5.0" />
     <PackageReference Include="AgentMemory.AgentFramework" Version="1.5.0" />
     <!-- Microsoft Agent Framework (matches AgentMemory's target) + the OpenAI/Foundry chat & embedding clients. -->
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.20.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.12" />
     <!-- Transitive dependency of Microsoft.Agents.AI; pinned explicitly (CPM is off here) because the
          version it would otherwise resolve to, 1.12.0, has a known moderate severity vulnerability
          (GHSA-g94r-2vxg-569j) that fails the repo's NuGet audit (NU1902 as error). Matches the version

--- a/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
+++ b/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.5.0" />
     <PackageReference Include="Neo4j.AgentFramework.GraphRAG" Version="0.1.0-preview.2" />
     <PackageReference Include="Neo4j.Driver" Version="5.28.0" />
   </ItemGroup>

--- a/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
+++ b/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.5.0" />
     <PackageReference Include="Neo4j.AgentFramework.GraphRAG" Version="0.1.0-preview.2" />
-    <PackageReference Include="Neo4j.Driver" Version="5.28.0" />
+    <PackageReference Include="Neo4j.Driver" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
+++ b/dotnet/samples/02-agents/AgentWithRAG/AgentWithRAG_Step05_Neo4jGraphRAG/AgentWithRAG_Step05_Neo4jGraphRAG.csproj
@@ -21,8 +21,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.5.0" />
+    <!-- both those dependencies need to be kept behind until https://github.com/neo4j-labs/neo4j-maf-provider/pull/6 is merged and released -->
     <PackageReference Include="Neo4j.AgentFramework.GraphRAG" Version="0.1.0-preview.2" />
-    <PackageReference Include="Neo4j.Driver" Version="6.3.0" />
+    <PackageReference Include="Neo4j.Driver" Version="5.28.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/invocations/Hosted-Invocations-EchoAgent/Hosted-Invocations-EchoAgent.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/invocations/Hosted-Invocations-EchoAgent/Hosted-Invocations-EchoAgent.csproj
@@ -27,12 +27,12 @@
     <RootNamespace>HostedInvocationsEchoAgent</RootNamespace>
     <AssemblyName>HostedInvocationsEchoAgent</AssemblyName>
     <UserSecretsId>27e5c7df-546c-477b-ab05-d1e070a1b78a</UserSecretsId>
-    <AgentFrameworkVersion>1.15.0</AgentFrameworkVersion>
+    <AgentFrameworkVersion>1.20.0</AgentFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI.Abstractions" Version="$(AgentFrameworkVersion)" />
-    <PackageReference Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.6" />
+    <PackageReference Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.18.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageReference Include="DotNetEnv" Version="3.2.0" />

--- a/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-LocalCodeAct/HostedLocalCodeAct.csproj
+++ b/dotnet/samples/04-hosting/FoundryHostedAgents/responses/Hosted-LocalCodeAct/HostedLocalCodeAct.csproj
@@ -27,7 +27,7 @@
     <RootNamespace>HostedLocalCodeAct</RootNamespace>
     <AssemblyName>HostedLocalCodeAct</AssemblyName>
     <UserSecretsId>dd574e14-75e7-41f0-8ee6-b7c62d6952cb</UserSecretsId>
-    <AgentFrameworkVersion>1.17.0-preview.260804.1</AgentFrameworkVersion>
+    <AgentFrameworkVersion>1.20.0-preview.260831.1</AgentFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation & Context  

Keep the .NET dependency set current with recent Agent Framework, provider SDK, hosting, command-line, analyzer, testing, and sample dependency releases. This reduces version drift across the .NET tree and keeps sample projects aligned with the package versions they demonstrate.  

### Description & Review Guide

- **What are the major changes?** 

- Updates centrally managed package versions in `Directory.Packages.props`, including Aspire Azure OpenAI, Google GenAI, Mscc Generative AI, System.CommandLine, Copilot Studio client/auth/hosting packages, OnnxRuntime GenAI, MSAL extensions, code coverage tooling, and Roslyn analyzer/compiler packages.
- Updates sample-specific package references for `Microsoft.Agents.AI`, `Microsoft.Extensions.Hosting`, `Microsoft.Agents.AI.Foundry`, and Foundry hosted agent invocation packages.
- Moves Foundry hosted agent samples to the latest applicable `AgentFrameworkVersion` values used by this branch. 

- **What is the impact of these changes?**   

- Consumers and samples build against newer dependency versions without changing framework behavior or public API surface.   
- Sample projects stay compatible with the latest provider and hosting package versions covered by this dependency refresh. 

- **What do you want reviewers to focus on?**   
- Confirm the selected versions are the intended dependency targets for this update batch.
- Pay particular attention to the larger version jumps for Roslyn packages, Neo4j.Driver, System.CommandLine, and the Microsoft.Agents package family.  

### Related Issue  Fixes #<issue-number> 

### Contribution Checklist  

- [ ] The code builds clean without any errors or warnings 
- [ ] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md) 
- [ ] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above). 
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) 
— a workflow keeps the label and title prefix in sync automatically
