### PR TITLE
.NET: Document ILoggerFactory for UseFunctionInvocation

### DIFF
--- a/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/Program.cs
@@ -122,7 +122,9 @@ var agent = new AIProjectClient(new Uri(endpoint), new DefaultAzureCredential())
         tools: [AIFunctionFactory.Create(GetWeatherAsync)],
         clientFactory: client => client
             .AsBuilder()
-            .UseFunctionInvocation()
+            // Pass ILoggerFactory so UseFunctionInvocation can log tool-execution exceptions (see #2352 / #2211).
+            // Alternative: pass the IServiceProvider to Build(serviceProvider) and let the pipeline resolve ILoggerFactory.
+            .UseFunctionInvocation(loggerFactory)
             .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true) // enable telemetry at the chat client level
             .Build())
     .AsBuilder()

--- a/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
+++ b/dotnet/samples/02-agents/AgentOpenTelemetry/README.md
@@ -81,7 +81,7 @@ Open your browser to: http://localhost:4318
 #### Step 3: Run the Console Application
 
 ```powershell
-cd dotnet/demos/AgentOpenTelemetry
+cd dotnet/samples/02-agents/AgentOpenTelemetry
 $env:OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 dotnet run
 ```
@@ -149,6 +149,39 @@ Open dashboard in Azure portal: <https://aka.ms/amg/dash/af-agent>
 Open dashboard in Azure portal: <https://aka.ms/amg/dash/af-workflow>
 ![Workflow Overview dashboard](https://github.com/Azure/azure-managed-grafana/raw/main/samples/assets/grafana-af-workflow.gif)
 
+
+## Providing `ILoggerFactory` for tool-execution logging
+
+`UseFunctionInvocation` is what logs tool-execution failures (message and stack trace). OpenTelemetry spans alone are not enough to surface the exception details for troubleshooting.
+
+Provide an `ILoggerFactory` in one of these ways:
+
+### Option 1: Pass `ILoggerFactory` to `UseFunctionInvocation`
+
+```csharp
+IChatClient instrumentedChatClient = chatClient
+    .AsBuilder()
+    .UseFunctionInvocation(loggerFactory) // logs tool failures
+    .UseOpenTelemetry(sourceName: SourceName, configure: cfg => cfg.EnableSensitiveData = true)
+    .Build();
+```
+
+This sample uses this approach with the `ILoggerFactory` created earlier in `Program.cs`.
+
+### Option 2: Pass `IServiceProvider` to `Build`
+
+If logging is registered in DI, pass the service provider into `Build` so every middleware in the chain (including `UseFunctionInvocation`) can resolve `ILoggerFactory`:
+
+```csharp
+IChatClient instrumentedChatClient = chatClient
+    .AsBuilder()
+    .UseFunctionInvocation()
+    .UseOpenTelemetry(sourceName: SourceName, configure: cfg => cfg.EnableSensitiveData = true)
+    .Build(serviceProvider); // resolves ILoggerFactory from DI
+```
+
+Without one of these, tool exceptions may be returned to the model as a generic failure string while the detailed exception is never logged.
+
 ## Key Features Demonstrated
 
 ### OpenTelemetry Integration
@@ -159,7 +192,7 @@ Open dashboard in Azure portal: <https://aka.ms/amg/dash/af-workflow>
 
 ### Agent Framework Features
 - **ChatClientAgent** created from `AIProjectClient`
-- **OpenTelemetry wrapper** using `.WithOpenTelemetry()`
+- **OpenTelemetry wrapper** using `.UseOpenTelemetry()` on the chat client and agent builders
 - **Conversation threading** for multi-turn conversations
 - **Error handling** with telemetry correlation
 


### PR DESCRIPTION
## Summary
- Pass the AgentOpenTelemetry sample's existing `ILoggerFactory` into `UseFunctionInvocation(loggerFactory)` so tool-execution exceptions are logged (as clarified in #2211).
- Document both approaches in the sample README: direct `ILoggerFactory` injection and `Build(IServiceProvider)`.
- Fix README inaccuracies (sample path; `.WithOpenTelemetry()` → `.UseOpenTelemetry()` for the agent pipeline).

Fixes #2352

## Test plan
- [ ] Spot-check README rendering
- [ ] Confirm sample still builds (`dotnet build` on `AgentOpenTelemetry.csproj`) when credentials are not required for compile