### PR TITLE
Python: docs: fix 'rather then' typo in CODING_STANDARD

### DIFF
--- a/python/CODING_STANDARD.md
+++ b/python/CODING_STANDARD.md
@@ -31,7 +31,7 @@ We use typing as a helper, it is not a goal in and of itself, so be pragmatic ab
 In general, the public interfaces of our classes, are important to get right, internally it is okay to have loosely typed code, as long as tests cover the code itself.
 This includes making a conscious choice when to program defensively, you can always do `getattr(item, 'attribute')` but that might end up causing you issues down the road
 because the type of `item` in this case, should have that attribute and if it doesn't it points to a larger issue, so if the type is expected to have that attribute, you should
-use `item.attribute` to ensure it fails at that point, rather then somewhere downstream where a value is expected but none was found.
+use `item.attribute` to ensure it fails at that point, rather than somewhere downstream where a value is expected but none was found.
 
 ### Future Annotations
 


### PR DESCRIPTION
Tiny docs grammar fix.