### PR TITLE
Python: keep agent compaction configuration when HandoffBuilder clones participants

### DIFF
--- a/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
+++ b/python/packages/orchestrations/agent_framework_orchestrations/_handoff.py
@@ -299,6 +299,11 @@ class HandoffAgentExecutor(AgentExecutor):
             context_providers=agent.context_providers,
             middleware=agent.middleware,
             require_per_service_call_history_persistence=agent.require_per_service_call_history_persistence,
+            # Shared by reference rather than deep-copied, like `context_providers` and
+            # `middleware` above: both hold immutable configuration the clone never mutates,
+            # and a tokenizer can carry a vocabulary that is expensive or unsafe to copy.
+            compaction_strategy=agent.compaction_strategy,
+            tokenizer=agent.tokenizer,
             default_options=cloned_options,  # type: ignore[assignment]
             additional_properties=deepcopy(agent.additional_properties),
         )

--- a/python/packages/orchestrations/tests/test_handoff.py
+++ b/python/packages/orchestrations/tests/test_handoff.py
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import ast
+import inspect
 import os
 import re
+import textwrap
 from collections.abc import AsyncIterable, Awaitable, Mapping, Sequence
 from typing import Annotated, Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -12,6 +15,7 @@ from agent_framework import (
     AgentContext,
     AgentResponse,
     AgentResponseUpdate,
+    CharacterEstimatorTokenizer,
     ChatOptions,
     ChatResponse,
     ChatResponseUpdate,
@@ -20,6 +24,7 @@ from agent_framework import (
     InMemoryHistoryProvider,
     Message,
     ResponseStream,
+    ToolResultCompactionStrategy,
     WorkflowEvent,
     WorkflowRunState,
     agent_middleware,
@@ -983,6 +988,98 @@ async def test_handoff_clone_preserves_additional_properties() -> None:
     cloned_additional_properties = cast(Agent, executor.agent).additional_properties
     assert cloned_additional_properties == {"tenant": "contoso", "trace_tag": "triage"}
     assert cloned_additional_properties is not coordinator.additional_properties
+
+
+async def test_handoff_clone_preserves_compaction_strategy_and_tokenizer() -> None:
+    """Handoff clones must keep agent-level compaction configuration (#8320).
+
+    Both live outside ``default_options``, so rebuilding the agent through its constructor
+    drops them unless they are forwarded explicitly. The clone then silently falls back to
+    no compaction, and a long handoff conversation grows unbounded until it trips the
+    model's context limit -- a failure that shows up as cost and latency long before it
+    shows up as an error.
+    """
+    strategy = ToolResultCompactionStrategy()
+    tokenizer = CharacterEstimatorTokenizer()
+
+    coordinator = Agent(
+        id="coordinator",
+        name="coordinator",
+        client=MockChatClient(name="coordinator"),
+        compaction_strategy=strategy,
+        tokenizer=tokenizer,
+        require_per_service_call_history_persistence=True,
+    )
+    specialist = Agent(
+        id="specialist",
+        name="specialist",
+        client=MockChatClient(name="specialist"),
+        require_per_service_call_history_persistence=True,
+    )
+
+    workflow = (
+        HandoffBuilder(
+            participants=_as_handoff_agents(coordinator, specialist),
+            termination_condition=lambda conversation: any(msg.role == "assistant" for msg in conversation),
+        )
+        .with_start_agent(_as_handoff_agent(coordinator))
+        .build()
+    )
+
+    await _drain(workflow.run("hello", stream=True))
+
+    executor = workflow.executors[resolve_agent_id(coordinator)]
+    assert isinstance(executor, HandoffAgentExecutor)
+    cloned = cast(Agent, executor.agent)
+
+    # Shared by reference, like context_providers and middleware: these hold immutable
+    # configuration, and a tokenizer may carry a vocabulary that is costly to copy.
+    assert cloned.compaction_strategy is strategy
+    assert cloned.tokenizer is tokenizer
+
+
+def test_handoff_clone_forwards_every_agent_constructor_field() -> None:
+    """Guard against the next field being dropped the way #8320 dropped two.
+
+    ``_clone_chat_agent`` rebuilds the agent by listing constructor arguments by hand, so
+    every parameter added to ``Agent.__init__`` has to be added here too or it is silently
+    lost. That has already happened repeatedly -- the ``test_handoff_clone_preserves_*``
+    tests above were each written after a field went missing. This asserts the inverse:
+    every constructor parameter is either forwarded or named below as deliberately handled
+    another way, so a new parameter fails here instead of in a user's workflow.
+    """
+    handled_elsewhere = {
+        # Recombined with `agent.mcp_tools` and passed through `default_options["tools"]`,
+        # because the constructor re-separates MCP tools from regular ones.
+        "tools",
+        # Carried inside `default_options` rather than as its own argument.
+        "instructions",
+    }
+
+    parameters = {
+        name
+        for name, param in inspect.signature(Agent.__init__).parameters.items()
+        if name != "self" and param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
+    }
+
+    # Read the keyword names off the `Agent(...)` call itself rather than substring-matching
+    # the source: a commented-out argument would satisfy a substring check, and renaming the
+    # local would break every match at once.
+    tree = ast.parse(textwrap.dedent(inspect.getsource(HandoffAgentExecutor._clone_chat_agent)))
+    forwarded = {
+        keyword.arg
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Agent"
+        for keyword in node.keywords
+        if keyword.arg is not None
+    }
+    assert forwarded, "could not find the Agent(...) call in _clone_chat_agent; this guard needs updating"
+
+    missing = parameters - forwarded - handled_elsewhere
+    assert not missing, (
+        f"_clone_chat_agent does not forward {sorted(missing)}; add them to the Agent(...) "
+        f"call, or to `handled_elsewhere` with a comment saying why."
+    )
 
 
 def test_clean_conversation_for_handoff_keeps_text_only_history() -> None:


### PR DESCRIPTION
### Motivation & Context

`HandoffAgentExecutor._clone_chat_agent` rebuilds each participant through `Agent(...)` to inject
handoff tools and middleware, listing constructor arguments by hand. `compaction_strategy` and
`tokenizer` live outside `default_options` and were missing from that list, so the clone got `None`
for both:

```text
compaction_strategy   original=ToolResultCompactionStrategy   clone=None   *** DROPPED ***
tokenizer             original=CharacterEstimatorTokenizer    clone=None   *** DROPPED ***
instructions          KEPT          name  KEPT
```

Nothing raises. The participant simply runs with no compaction, so a long handoff conversation grows
unbounded until it trips the model's context limit — surfacing as cost and latency well before it
surfaces as an error.

One note on the issue text: it says "the cloned executor agent gets `None` for **both**" and "forward
**both** fields", but only ever names `compaction_strategy`. The second field is `tokenizer`. A fix
written from the title alone would close half the bug.

### Description & Review Guide

- **What are the major changes?** Two arguments forwarded in `_clone_chat_agent`, plus two tests.
  No API change, no change to compaction behaviour itself.

- **Why by reference and not `deepcopy`.** Both are forwarded as-is, matching `context_providers`
  and `middleware` on the lines above. I checked that the strategies hold only immutable
  configuration — `ToolResultCompactionStrategy` stores one threshold, `ContextWindowCompactionStrategy`
  ten — and `CharacterEstimatorTokenizer` is stateless, so clones cannot interfere through them.
  `additional_properties` stays deep-copied because it is a mutable mapping the clone does own.

- **Why not replace the hand-rolled constructor with a copy.** `Agent` inherits `__copy__` and
  `__deepcopy__` from `SerializationMixin`, which copy every instance field and would have fixed this
  class of bug permanently — so I checked whether they could be used here. They cannot:
  `Agent.__init__` re-separates MCP tools from regular tools, which is exactly why this method
  recombines `agent.mcp_tools` into the tools list before calling it. Copying the instance would skip
  that separation, and `copy` would additionally share `default_options` with the original, so
  mutating `allow_multiple_tool_calls` on the clone would reach back into the caller's agent.
  Rebuilding through the constructor is deliberate and stays.

- **The second test is the point.** Every parameter added to `Agent.__init__` has to be added to this
  call or it is silently dropped, and the `test_handoff_clone_preserves_*` tests directly above were
  each written after that already happened — this is at least the fourth field to go missing.
  `test_handoff_clone_forwards_every_agent_constructor_field` reads the keyword names off the
  `Agent(...)` call with `ast` and asserts every constructor parameter is either forwarded or named in
  `handled_elsewhere` with a reason. The next new parameter fails there instead of in a user's
  workflow. Reading the AST rather than substring-matching the source is deliberate: I verified that a
  *commented-out* argument still fails the guard, which a substring check would have passed.

- **What is the impact of these changes?** Compaction configured on a handoff participant now takes
  effect. That is a behaviour change in the sense that previously-ignored configuration starts
  working, so a long-running handoff conversation will begin compacting where it did not before. I
  have not marked it a breaking change because it makes documented configuration behave as
  documented, but say if you would rather label it.

- **What do you want reviewers to focus on?** Whether by-reference is the sharing you want for these
  two, and whether the drift guard is welcome — it is a little unusual for this suite, and I would
  rather drop it than have it be a maintenance burden. `_clone_chat_agent` is the only
  clone-by-reconstruct site in the repo, so there is no sibling instance to fix.

  Validation: orchestrations 211 passing with `poe check -P orchestrations` clean across all five
  type checkers, and core 5329 passing unchanged. Both new tests fail against the unfixed tree.

### Related Issue

Fixes #8320

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.**

