### PR TITLE
Python: fix(python): stop executor named `__global__` from colliding with the global kwargs slot

### DIFF
--- a/python/packages/core/agent_framework/_workflows/_agent_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_agent_executor.py
@@ -15,7 +15,7 @@ from .._agents import SupportsAgentRun
 from .._sessions import AgentSession
 from .._types import AgentResponse, AgentResponseUpdate, Message, ResponseStream
 from ._agent_utils import resolve_agent_id
-from ._const import GLOBAL_KWARGS_KEY, INTERNAL_SOURCE_ID, WORKFLOW_RUN_KWARGS_KEY
+from ._const import EXECUTOR_KWARGS_KEY, GLOBAL_KWARGS_KEY, INTERNAL_SOURCE_ID, WORKFLOW_RUN_KWARGS_KEY
 from ._executor import Executor, handler
 from ._message_utils import normalize_messages_input
 from ._request_info_mixin import response_handler
@@ -614,8 +614,22 @@ class AgentExecutor(Executor):
         """
         if not isinstance(resolved, dict):
             return None
+        # the global slot stays absent for a pure per-executor mapping, so an
+        # untargeted executor still gets None; an explicitly empty global dict
+        # (``function_invocation_kwargs={}``) is preserved and merges to {}
         global_kwargs: Any = resolved.get(GLOBAL_KWARGS_KEY)
-        executor_kwargs: Any = resolved.get(self.id)
+        if EXECUTOR_KWARGS_KEY in resolved:
+            # post-#8310 shape: per-executor entries nest under the framework
+            # slot, so an executor named "__global__" cannot collide with the
+            # global kwargs slot
+            per_executor = resolved.get(EXECUTOR_KWARGS_KEY)
+            executor_kwargs: Any = (
+                cast(dict[str, Any], per_executor).get(self.id) if isinstance(per_executor, dict) else None
+            )
+        else:
+            # legacy pre-#8310 shape restored from an old checkpoint: bare
+            # executor IDs sit at the top level
+            executor_kwargs = resolved.get(self.id)
         if global_kwargs is None and executor_kwargs is None:
             return None
 

--- a/python/packages/core/agent_framework/_workflows/_const.py
+++ b/python/packages/core/agent_framework/_workflows/_const.py
@@ -25,6 +25,12 @@ RAW_CLIENT_KWARGS_KEY = "_raw_client_kwargs"
 # that apply to all executors (as opposed to per-executor keyed entries).
 GLOBAL_KWARGS_KEY = "__global__"
 
+# Framework slot holding the nested per-executor kwargs map. Executor-specific
+# entries nest under this key so an executor whose ID is "__global__" (or any
+# other reserved-looking string) can never collide with the global slot
+# (#8310).
+EXECUTOR_KWARGS_KEY = "__per_executor__"
+
 
 def INTERNAL_SOURCE_ID(executor_id: str) -> str:
     """Generate an internal source ID for a given executor."""

--- a/python/packages/core/agent_framework/_workflows/_workflow.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow.py
@@ -23,6 +23,7 @@ from ..observability import OtelAttr, capture_exception, create_workflow_span
 from ._checkpoint import CheckpointStorage
 from ._const import (
     DEFAULT_MAX_ITERATIONS,
+    EXECUTOR_KWARGS_KEY,
     GLOBAL_KWARGS_KEY,
     INTERNAL_SOURCE_ID,
     RAW_CLIENT_KWARGS_KEY,
@@ -1141,10 +1142,16 @@ class Workflow(DictConvertible):
             A dict containing normalized global or per-executor mappings.
         """
         if isinstance(kwargs, WorkflowInvocationKwargs):
-            resolved = {GLOBAL_KWARGS_KEY: dict(kwargs.global_kwargs)}
-            resolved.update({
-                executor_id: dict(executor_kwargs) for executor_id, executor_kwargs in kwargs.executor_kwargs.items()
-            })
+            resolved = {
+                GLOBAL_KWARGS_KEY: dict(kwargs.global_kwargs),
+                # Nest per-executor entries under the framework slot: an
+                # executor whose ID is "__global__" would otherwise overwrite
+                # the genuine global mapping on update() (#8310).
+                EXECUTOR_KWARGS_KEY: {
+                    executor_id: dict(executor_kwargs)
+                    for executor_id, executor_kwargs in kwargs.executor_kwargs.items()
+                },
+            }
             logger.info("Explicit global %s provided with executor-specific overrides.", param_name)
             return resolved
 
@@ -1157,13 +1164,13 @@ class Workflow(DictConvertible):
                 param_name,
                 matched_ids,
             )
-            return dict(kwargs)
+            return {EXECUTOR_KWARGS_KEY: dict(kwargs)}
 
         logger.info(
             "No executor IDs found in %s keys; treating as global kwargs for all executors.",
             param_name,
         )
-        return {GLOBAL_KWARGS_KEY: dict(kwargs)}
+        return {GLOBAL_KWARGS_KEY: dict(kwargs), EXECUTOR_KWARGS_KEY: {}}
 
     # Graph signature helpers
 

--- a/python/packages/core/agent_framework/_workflows/_workflow_executor.py
+++ b/python/packages/core/agent_framework/_workflows/_workflow_executor.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from ._workflow import Workflow
 
 from ._const import (
+    EXECUTOR_KWARGS_KEY,
     GLOBAL_KWARGS_KEY,
     RAW_CLIENT_KWARGS_KEY,
     RAW_FUNCTION_INVOCATION_KWARGS_KEY,
@@ -396,7 +397,12 @@ class WorkflowExecutor(Executor):
                 normalized: Any = parent_kwargs.get(key)
                 if isinstance(normalized, dict):
                     normalized_dict = cast(dict[str, Any], normalized)
-                    if len(normalized_dict) == 1 and GLOBAL_KWARGS_KEY in normalized_dict:
+                    if EXECUTOR_KWARGS_KEY in normalized_dict:
+                        # post-#8310 shape: unwrap the global slot only when no
+                        # per-executor entries ride alongside it
+                        if not normalized_dict.get(EXECUTOR_KWARGS_KEY):
+                            normalized = normalized_dict[GLOBAL_KWARGS_KEY]
+                    elif len(normalized_dict) == 1 and GLOBAL_KWARGS_KEY in normalized_dict:
                         normalized = normalized_dict[GLOBAL_KWARGS_KEY]
                 resolved = cast(WorkflowInvocationKwargs | Mapping[str, Any] | None, normalized)
             if resolved is not None:

--- a/python/packages/core/tests/workflow/test_agent_executor.py
+++ b/python/packages/core/tests/workflow/test_agent_executor.py
@@ -21,7 +21,7 @@ from agent_framework import (
 )
 from agent_framework._workflows._agent_executor import AgentExecutorResponse
 from agent_framework._workflows._checkpoint import InMemoryCheckpointStorage
-from agent_framework._workflows._const import GLOBAL_KWARGS_KEY
+from agent_framework._workflows._const import EXECUTOR_KWARGS_KEY, GLOBAL_KWARGS_KEY
 
 
 class _CountingAgent(BaseAgent):
@@ -866,3 +866,48 @@ async def test_agent_executor_request_info_uses_user_input_request_id() -> None:
 
 
 # endregion Tool approval emission
+
+
+async def test_resolve_executor_kwargs_nested_shape_no_collision() -> None:
+    """#8310: with the nested shape, an executor named __global__ reads its own
+    entry while another executor still gets the global mapping."""
+    agent = _CountingAgent(id="a", name="A")
+    global_exec = AgentExecutor(agent, id="__global__")
+    other_exec = AgentExecutor(agent, id="other")
+
+    resolved = {
+        GLOBAL_KWARGS_KEY: {"shared": "G", "overridden": "global"},
+        EXECUTOR_KWARGS_KEY: {"__global__": {"special": "A", "overridden": "specific"}},
+    }
+    assert global_exec._resolve_executor_kwargs(resolved) == {  # pyright: ignore[reportPrivateUsage]
+        "shared": "G",
+        "special": "A",
+        "overridden": "specific",
+    }
+    assert other_exec._resolve_executor_kwargs(resolved) == {  # pyright: ignore[reportPrivateUsage]
+        "shared": "G",
+        "overridden": "global",
+    }
+
+
+async def test_resolve_executor_kwargs_nested_shape_targets_real_global_executor() -> None:
+    """#8310 plain mapping keyed __global__: targets only that executor."""
+    agent = _CountingAgent(id="a", name="A")
+    global_exec = AgentExecutor(agent, id="__global__")
+    other_exec = AgentExecutor(agent, id="other")
+
+    resolved = {EXECUTOR_KWARGS_KEY: {"__global__": {"special": "A"}}}
+    assert global_exec._resolve_executor_kwargs(resolved) == {"special": "A"}  # pyright: ignore[reportPrivateUsage]
+    assert other_exec._resolve_executor_kwargs(resolved) is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_resolve_executor_kwargs_legacy_shape_still_routes() -> None:
+    """Old checkpoints serialized the pre-#8310 shape; bare executor IDs and a
+    bare __global__ slot must keep routing as before."""
+    agent = _CountingAgent(id="a", name="A")
+    exec_a = AgentExecutor(agent, id="exec_a")
+    exec_b = AgentExecutor(agent, id="exec_b")
+
+    legacy = {"exec_a": {"k": "v"}, GLOBAL_KWARGS_KEY: {"g": "1"}}
+    assert exec_a._resolve_executor_kwargs(legacy) == {"k": "v", "g": "1"}  # pyright: ignore[reportPrivateUsage]
+    assert exec_b._resolve_executor_kwargs(legacy) == {"g": "1"}  # pyright: ignore[reportPrivateUsage]

--- a/python/packages/core/tests/workflow/test_workflow_kwargs.py
+++ b/python/packages/core/tests/workflow/test_workflow_kwargs.py
@@ -840,8 +840,8 @@ async def test_continuation_tools_preserve_existing_invocation_kwargs() -> None:
 
     assert captured_run_kwargs == [
         {
-            "function_invocation_kwargs": {"__global__": function_kwargs},
-            "client_kwargs": {"__global__": client_kwargs},
+            "function_invocation_kwargs": {"__global__": function_kwargs, "__per_executor__": {}},
+            "client_kwargs": {"__global__": client_kwargs, "__per_executor__": {}},
         }
     ]
 
@@ -971,8 +971,8 @@ async def test_subworkflow_resume_tools_preserve_child_invocation_kwargs() -> No
 
     assert captured_child_kwargs == [
         {
-            "function_invocation_kwargs": {"__global__": function_kwargs},
-            "client_kwargs": {"__global__": client_kwargs},
+            "function_invocation_kwargs": {"__global__": function_kwargs, "__per_executor__": {}},
+            "client_kwargs": {"__global__": client_kwargs, "__per_executor__": {}},
         }
     ]
 
@@ -1397,6 +1397,57 @@ async def test_empty_client_kwargs_clears_previous() -> None:
 
     assert len(agent.captured_kwargs) >= 2
     assert agent.captured_kwargs[-1].get("client_kwargs") == {}
+
+
+# endregion
+
+
+# region __global__ collision (#8310)
+
+
+async def test_global_named_executor_keeps_its_kwargs_separate_from_global() -> None:
+    """An executor literally named "__global__" must not collide with the
+    global kwargs slot: the typed wrapper keeps both, and the per-executor
+    entry targets it while the global mapping still reaches the others."""
+    global_named = _KwargsCapturingAgent(name="__global__")
+    other = _KwargsCapturingAgent(name="other")
+    workflow = SequentialBuilder(participants=[global_named, other]).build()
+
+    fi_kwargs = WorkflowInvocationKwargs(
+        global_kwargs={"shared": "G", "overridden": "global"},
+        executor_kwargs={"__global__": {"special": "A", "overridden": "specific"}},
+    )
+
+    async for event in workflow.run("test", function_invocation_kwargs=fi_kwargs, stream=True):
+        if event.type == "status" and event.state == WorkflowRunState.IDLE:
+            break
+
+    g = global_named.captured_kwargs[0].get("function_invocation_kwargs")
+    o = other.captured_kwargs[0].get("function_invocation_kwargs")
+    # the "__global__" executor: global + its own entry, its entry winning
+    assert g == {"shared": "G", "special": "A", "overridden": "specific"}
+    # the other executor: global only, nothing leaked from "__global__"
+    assert o == {"shared": "G", "overridden": "global"}
+
+
+async def test_per_executor_mapping_keyed_global_targets_only_that_executor() -> None:
+    """A plain per-executor mapping keyed by "__global__" targets the real
+    executor with that ID and must not leak into unrelated executors."""
+    global_named = _KwargsCapturingAgent(name="__global__")
+    other = _KwargsCapturingAgent(name="other")
+    workflow = SequentialBuilder(participants=[global_named, other]).build()
+
+    async for event in workflow.run(
+        "test",
+        function_invocation_kwargs={"__global__": {"special": "A"}},
+        stream=True,
+    ):
+        if event.type == "status" and event.state == WorkflowRunState.IDLE:
+            break
+
+    assert global_named.captured_kwargs[0].get("function_invocation_kwargs") == {"special": "A"}
+    # per-executor convention: an untargeted executor gets None
+    assert other.captured_kwargs[0].get("function_invocation_kwargs") is None
 
 
 # endregion


### PR DESCRIPTION
### Motivation & Context

`WorkflowInvocationKwargs` exposes global and executor-specific kwargs as separate namespaces, but `_resolve_invocation_kwargs` normalizes both public input forms into one flat dict where the global mapping lives under the reserved `__global__` key alongside bare executor IDs. An executor whose ID is literally `__global__` then collides with that slot: in the typed form its entry replaces the genuine global mapping, and in the plain-mapping form its entry is later read back as the global mapping and leaks to every untargeted executor in the graph.

### Description & Review Guide

- **What are the major changes?** Per-executor entries now nest under a separate framework slot (`__per_executor__` in `_const.py`) so the two namespaces cannot overlap. The normalized shapes are: typed wrapper -> `{"__global__": ..., "__per_executor__": {...}}`; plain per-executor mapping -> `{"__per_executor__": {...}}` with the global slot absent, preserving the existing convention that an untargeted executor resolves to `None`; plain global mapping -> `{"__global__": ..., "__per_executor__": {}}`. `AgentExecutor._resolve_executor_kwargs` reads the nested shape and falls back to the legacy flat shape for checkpoints serialized before this change. `WorkflowExecutor` unwraps the nested shape so a subworkflow keeps receiving the plain mapping its own resolution expects.
- **What is the impact of these changes?** Routing for the `__global__`-named executor now matches the expected tables in the issue: its entry reaches only itself, the genuine global mapping is no longer lost in the typed form, and nothing leaks into unrelated executors. Existing checkpoints with the flat shape keep working through the legacy branch.
- **What do you want reviewers to focus on?** The shape sniff in `_resolve_executor_kwargs` (nested vs legacy) and the empty-global-slot semantics: an explicitly empty global dict still merges to `{}` (the "clear previous kwargs" path), while a pure per-executor mapping leaves the global slot absent so untargeted executors get `None`. Both conventions are pinned by existing tests, which now run against the new shape.

Heads-up on ordering with #8314 (also mine, also touching `_agent_executor.py`): that one adds a module-level `resolve_executor_run_kwargs` helper with the same routing logic. Whichever lands second should rebase and give that helper the same nested-shape branch. The conflict is small and mechanical either way.

### Related Issue

Fixes #8310

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
