### PR TITLE
docs: fix 'allow to' grammar in ADR 0011

### DIFF
--- a/docs/decisions/0011-create-get-agent-api.md
+++ b/docs/decisions/0011-create-get-agent-api.md
@@ -107,7 +107,7 @@ var agent3 = new AssistantClient(...).CreateAIAgent(...); // Creates a remote ag
 
 ### Possible Python implementations
 
-Methods like `create_agent` and `get_agent` should be implemented separately or defined on some stateless component that will allow to create multiple agents from the same instance/place.
+Methods like `create_agent` and `get_agent` should be implemented separately or defined on some stateless component that will allow creating multiple agents from the same instance/place.
 
 Possible options:
 


### PR DESCRIPTION
## Description
Tiny docs grammar fix in `docs/decisions/0011-create-get-agent-api.md`: "will allow to create" → "will allow creating".

Validated against the surrounding Python `create_agent` / `get_agent` discussion.

## Checklist
- [x] Docs-only change
- [x] Context validated