### PR TITLE
docs: hyphenate compound modifiers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ dotnet add package Azure.Identity
 
 ### Learning Resources
 
-- **[Overview](https://learn.microsoft.com/agent-framework/overview/agent-framework-overview)** - High level overview of the framework
+- **[Overview](https://learn.microsoft.com/agent-framework/overview/agent-framework-overview)** - High-level overview of the framework
 - **[Quick Start](https://learn.microsoft.com/agent-framework/tutorials/quick-start)** - Get started with a simple agent
-- **[Tutorials](https://learn.microsoft.com/agent-framework/tutorials/overview)** - Step by step tutorials
+- **[Tutorials](https://learn.microsoft.com/agent-framework/tutorials/overview)** - Step-by-step tutorials
 - **[User Guide](https://learn.microsoft.com/en-us/agent-framework/user-guide/overview)** - In-depth user guide for building agents and workflows
 - **[Migration from Semantic Kernel](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel)** - Guide to migrate from Semantic Kernel
 - **[Migration from AutoGen](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-autogen)** - Guide to migrate from AutoGen


### PR DESCRIPTION
Hyphenates two compound modifiers in the README learning resources list: High-level overview and Step-by-step tutorials. Tiny unsolicited documentation grammar fix; no code or behavior changes.